### PR TITLE
Add PyPI and npm publish workflows

### DIFF
--- a/.claude/12-publish-workflows.md
+++ b/.claude/12-publish-workflows.md
@@ -1,0 +1,24 @@
+# 12 — Publish Workflows
+
+GitHub Actions workflows for publishing releases to PyPI and npm.
+
+## publish-pypi.yml
+
+- **Trigger:** `on: release: types: [published]`, only if tag starts with `v`
+- **Job:** `publish-pypi`, `ubuntu-latest`
+- **Permissions:** `id-token: write` for PyPI trusted publishing
+- **Environment:** `pypi`
+- **Steps:** checkout → setup Python 3.12 → install build → run test suite → `python -m build` → `pypa/gh-action-pypi-publish@release/v1` (no API token — trusted publishing)
+- Tests must pass before publishing; if they fail, the publish step is skipped
+
+## publish-npm.yml
+
+- **Trigger:** `on: release: types: [published]`, only if tag starts with `v`
+- **Job:** `publish-npm`, `ubuntu-latest`
+- **Steps:** checkout → setup Node 20 (registry-url: `https://registry.npmjs.org`) → `cd sdk-ts` → `npm install` → `npm test` → `npm run build` → `npm publish --access public`
+- Uses `NPM_TOKEN` secret as `NODE_AUTH_TOKEN` env var
+- Tests must pass before publishing; if they fail, the publish step is skipped
+
+## Package name change
+
+`sdk-ts/package.json` name changed from `@ocw/sdk` to `@openclawwatch/sdk`.

--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -1,0 +1,35 @@
+name: Publish to npm
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  publish-npm:
+    if: startsWith(github.ref_name, 'v')
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+          registry-url: https://registry.npmjs.org
+
+      - name: Install dependencies
+        working-directory: sdk-ts
+        run: npm install
+
+      - name: Run tests
+        working-directory: sdk-ts
+        run: npm test
+
+      - name: Build
+        working-directory: sdk-ts
+        run: npm run build
+
+      - name: Publish
+        working-directory: sdk-ts
+        run: npm publish --access public
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/publish-pypi.yml
+++ b/.github/workflows/publish-pypi.yml
@@ -1,0 +1,31 @@
+name: Publish to PyPI
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  publish-pypi:
+    if: startsWith(github.ref_name, 'v')
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+    environment: pypi
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Install dependencies
+        run: pip install build ".[dev]"
+
+      - name: Run tests
+        run: pytest tests/unit/ tests/synthetic/ tests/agents/ tests/integration/ -x
+
+      - name: Build package
+        run: python -m build
+
+      - name: Publish to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1

--- a/sdk-ts/package.json
+++ b/sdk-ts/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@ocw/sdk",
+  "name": "@openclawwatch/sdk",
   "version": "0.1.0",
   "description": "TypeScript SDK for OpenClawWatch — local-first observability for AI agents",
   "main": "dist/index.js",


### PR DESCRIPTION
## Summary
- Add `publish-pypi.yml` workflow: triggers on release, runs tests, publishes via PyPI trusted publishing
- Add `publish-npm.yml` workflow: triggers on release, runs tests, publishes with `NPM_TOKEN` secret
- Rename TS SDK package from `@ocw/sdk` to `@openclawwatch/sdk`
- Add `.claude/12-publish-workflows.md` spec doc

## Test plan
- [ ] Verify workflows appear in Actions tab
- [ ] Create a test release with `v`-prefixed tag to validate both pipelines
- [ ] Confirm PyPI trusted publishing environment `pypi` is configured in repo settings
- [ ] Confirm `NPM_TOKEN` secret is set in repo settings

🤖 Generated with [Claude Code](https://claude.com/claude-code)