### PR TITLE
Rename npm package from @ocw/sdk to @openclawwatch/sdk

### DIFF
--- a/.claude/10-ts-sdk.md
+++ b/.claude/10-ts-sdk.md
@@ -7,7 +7,7 @@
 
 ## What this task covers
 
-The `@ocw/sdk` TypeScript package under `sdk-ts/`. This is a completely standalone
+The `@openclawwatch/sdk` TypeScript package under `sdk-ts/`. This is a completely standalone
 package — it does not share code with the Python package. It communicates with the
 Python backend via HTTP only.
 
@@ -19,7 +19,7 @@ Python backend via HTTP only.
 
 ```json
 {
-  "name": "@ocw/sdk",
+  "name": "@openclawwatch/sdk",
   "version": "0.1.0",
   "description": "TypeScript SDK for OpenClawWatch",
   "main": "./dist/index.js",
@@ -295,7 +295,7 @@ export { patchOpenAI }                           from "./integrations/openai.js"
 ## Usage example
 
 ```typescript
-import { watch, recordLlmCall, patchOpenAI, HttpTransport } from "@ocw/sdk";
+import { watch, recordLlmCall, patchOpenAI, HttpTransport } from "@openclawwatch/sdk";
 
 const transport = new HttpTransport({
   baseUrl:      "http://127.0.0.1:7391",

--- a/.claude/12-publish-workflows.md
+++ b/.claude/12-publish-workflows.md
@@ -21,4 +21,4 @@ GitHub Actions workflows for publishing releases to PyPI and npm.
 
 ## Package name change
 
-`sdk-ts/package.json` name changed from `@ocw/sdk` to `@openclawwatch/sdk`.
+`sdk-ts/package.json` name changed from `@openclawwatch/sdk` to `@openclawwatch/sdk`.

--- a/.claude/README.md
+++ b/.claude/README.md
@@ -147,10 +147,10 @@ from ocw.sdk.integrations.nemoclaw          import watch_nemoclaw         # Nemo
 | Pydantic AI | Built-in |
 | Semantic Kernel | Built-in |
 
-**TypeScript / Node.js** — `@ocw/sdk` provides `OcwClient` and `SpanBuilder` for sending spans to `ocw serve` from any TypeScript agent:
+**TypeScript / Node.js** — `@openclawwatch/sdk` provides `OcwClient` and `SpanBuilder` for sending spans to `ocw serve` from any TypeScript agent:
 
 ```typescript
-import { OcwClient, SpanBuilder } from "@ocw/sdk";
+import { OcwClient, SpanBuilder } from "@openclawwatch/sdk";
 
 const client = new OcwClient({
   baseUrl:      "http://127.0.0.1:7391",
@@ -236,7 +236,7 @@ Your agent code
     │       │
     │       └── OcwSpanExporter ──────────────────────┐
     │                                                  │
-    └── TypeScript SDK (@ocw/sdk)                      │
+    └── TypeScript SDK (@openclawwatch/sdk)                      │
             │  OcwClient + SpanBuilder                 │
             └── POST /api/v1/spans ────────────────────┤
                                                        ▼
@@ -375,7 +375,7 @@ PRs welcome. If you're adding a framework integration, open an issue first so we
 
 <div align="center">
 
-**[opencla.watch](https://opencla.watch)** · [PyPI](https://pypi.org/project/openclawwatch/) · [npm](https://www.npmjs.com/package/@ocw/sdk)
+**[opencla.watch](https://opencla.watch)** · [PyPI](https://pypi.org/project/openclawwatch/) · [npm](https://www.npmjs.com/package/@openclawwatch/sdk)
 
 MIT License · Built by [Metabuilder Labs](https://github.com/Metabuilder-Labs)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 - CLI commands: `onboard`, `status`, `traces`, `cost`, `alerts`, `drift`, `tools`, `export`, `serve`, `doctor`
 - REST API with OTLP JSON ingest endpoint and Prometheus metrics
 - Python SDK: `@watch()` decorator, `patch_anthropic()`, `patch_openai()`, and 9 more provider/framework integrations
-- TypeScript SDK (`@ocw/sdk`): `OcwClient` and `SpanBuilder` for Node.js agents
+- TypeScript SDK (`@openclawwatch/sdk`): `OcwClient` and `SpanBuilder` for Node.js agents
 - Auto-bootstrap: TracerProvider initializes lazily on first `@watch()` or `patch_*()` call
 - Community-maintained model pricing table (`pricing/models.toml`)
 - Session continuity via `conversation_id` across process restarts

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -48,7 +48,7 @@ openclawwatch/
 │   ├── api/                FastAPI local REST API
 │   ├── sdk/                Python instrumentation SDK
 │   └── utils/              Formatting, time parsing, ID generation
-├── sdk-ts/                 TypeScript SDK (@ocw/sdk)
+├── sdk-ts/                 TypeScript SDK (@openclawwatch/sdk)
 ├── pricing/                models.toml — community-maintained model pricing (USD per million tokens)
 └── tests/
     ├── factories.py        Span factory — use this in ALL tests

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -42,7 +42,7 @@ ocw/api/               FastAPI routes
 ocw/sdk/               @watch() decorator and provider/framework patches
 ocw/otel/              OTel TracerProvider and span exporter wiring
 ocw/utils/             Formatting, time parsing, ID generation
-sdk-ts/src/            TypeScript SDK (@ocw/sdk)
+sdk-ts/src/            TypeScript SDK (@openclawwatch/sdk)
 pricing/models.toml    Community-maintained model pricing — PRs welcome here
 tests/factories.py     Span factory — use this in all synthetic tests, never
                        construct NormalizedSpan directly

--- a/README.md
+++ b/README.md
@@ -147,10 +147,10 @@ from ocw.sdk.integrations.nemoclaw          import watch_nemoclaw         # Nemo
 | Pydantic AI | Built-in |
 | Semantic Kernel | Built-in |
 
-**TypeScript / Node.js** — `@ocw/sdk` provides `OcwClient` and `SpanBuilder` for sending spans to `ocw serve` from any TypeScript agent:
+**TypeScript / Node.js** — `@openclawwatch/sdk` provides `OcwClient` and `SpanBuilder` for sending spans to `ocw serve` from any TypeScript agent:
 
 ```typescript
-import { OcwClient, SpanBuilder } from "@ocw/sdk";
+import { OcwClient, SpanBuilder } from "@openclawwatch/sdk";
 
 const client = new OcwClient({
   baseUrl:      "http://127.0.0.1:7391",
@@ -234,7 +234,7 @@ flowchart TD
     Agent["Your agent code"]
 
     Agent --> PythonSDK["Python SDK\n@watch + patch_* integrations"]
-    Agent --> TypeScriptSDK["TypeScript SDK\n@ocw/sdk"]
+    Agent --> TypeScriptSDK["TypeScript SDK\n@openclawwatch/sdk"]
 
     PythonSDK --> Exporter["OcwSpanExporter"]
     TypeScriptSDK --> HTTP["POST /api/v1/spans"]
@@ -368,7 +368,7 @@ PRs welcome. If you're adding a framework integration, open an issue first so we
 
 <div align="center">
 
-**[opencla.watch](https://opencla.watch)** · [PyPI](https://pypi.org/project/openclawwatch/) · [npm](https://www.npmjs.com/package/@ocw/sdk)
+**[opencla.watch](https://opencla.watch)** · [PyPI](https://pypi.org/project/openclawwatch/) · [npm](https://www.npmjs.com/package/@openclawwatch/sdk)
 
 MIT License · Built by [Metabuilder Labs](https://github.com/Metabuilder-Labs)
 

--- a/sdk-ts/package-lock.json
+++ b/sdk-ts/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "@ocw/sdk",
+  "name": "@openclawwatch/sdk",
   "version": "0.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "@ocw/sdk",
+      "name": "@openclawwatch/sdk",
       "version": "0.1.0",
       "license": "MIT",
       "devDependencies": {


### PR DESCRIPTION
## Summary
- Replace all `@ocw/sdk` references with `@openclawwatch/sdk` across 8 files
- Covers docs (README, CHANGELOG, CONTRIBUTING, CLAUDE.md), spec files (.claude/), and sdk-ts/package-lock.json
- `sdk-ts/package.json` was already renamed in PR #1

## Test plan
- [x] `grep -r "@ocw/sdk" .` returns zero results

🤖 Generated with [Claude Code](https://claude.com/claude-code)