### PR TITLE
Add PyPI metadata: readme, classifiers, project URLs

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,10 +5,23 @@ build-backend = "hatchling.build"
 [project]
 name = "openclawwatch"
 version = "0.1.0"
-description = "Local-first OTel-native observability for AI agents"
+description = "Local-first OTel-native observability for Autonomous AI agents"
+readme = "README.md"
 requires-python = ">=3.10"
 license = { text = "MIT" }
+authors = [{ name = "Anil Murty", email = "anil@metabldr.com" }]
 keywords = ["ai", "agents", "observability", "opentelemetry", "llm"]
+classifiers = [
+    "Development Status :: 4 - Beta",
+    "Intended Audience :: Developers",
+    "License :: OSI Approved :: MIT License",
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
+    "Topic :: Software Development :: Libraries",
+    "Topic :: System :: Monitoring",
+]
 
 dependencies = [
     "click>=8.1",
@@ -29,6 +42,11 @@ dependencies = [
     "apscheduler>=3.10",
     "websockets>=12.0",
 ]
+
+[project.urls]
+Homepage = "https://opencla.watch"
+Repository = "https://github.com/Metabuilder-Labs/openclawwatch"
+Issues = "https://github.com/Metabuilder-Labs/openclawwatch/issues"
 
 [project.optional-dependencies]
 langchain = ["langchain>=0.2"]


### PR DESCRIPTION
## Summary
- Add `readme = "README.md"` so PyPI renders the project description
- Add `authors`, `classifiers`, and `[project.urls]` (Homepage, Repository, Issues)
- Update description to "Local-first OTel-native observability for Autonomous AI agents"

PyPI will pick up these changes on the next release.

## Test plan
- [ ] `python -m build` succeeds
- [ ] Next release shows README on PyPI project page

🤖 Generated with [Claude Code](https://claude.com/claude-code)