### PR TITLE
Release v0.1.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,24 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/),
 and this project adheres to [Semantic Versioning](https://semver.org/).
 
+## [0.1.1] - 2026-04-06
+
+### Fixed
+- `ocw export` returning empty output due to corrupted DuckDB span indexes
+- `ocw status` showing `?` instead of `●` for completed sessions
+- `ocw status` showing `$0.000000` cost due to `date.today()` vs UTC date mismatch
+- `ocw cost` showing spurious `$0.000000` row from session-level spans with no model
+
+### Added
+- `ocw trace` prefix matching — short trace IDs now resolve like git short hashes
+- PyPI and npm publish workflows (`publish-pypi.yml`, `publish-npm.yml`)
+- PyPI metadata: README as long description, classifiers, project URLs
+- `CODEOWNERS` requiring review from @anilmurty
+
+### Changed
+- Renamed npm package from `@ocw/sdk` to `@openclawwatch/sdk`
+- Consolidated `AGENTS.md` to point at `CLAUDE.md` as source of truth
+
 ## [0.1.0] - 2026-04-05
 
 ### Added

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "openclawwatch"
-version = "0.1.0"
+version = "0.1.1"
 description = "Local-first OTel-native observability for Autonomous AI agents"
 readme = "README.md"
 requires-python = ">=3.10"


### PR DESCRIPTION
## Summary
Bump version to 0.1.1 with changelog covering all changes since v0.1.0-alpha.

### Fixed
- `ocw export` empty output (corrupted DuckDB span indexes)
- `ocw status` showing `?` for completed sessions
- `ocw status` showing `$0.000000` cost (date.today vs UTC mismatch)
- `ocw cost` spurious zero-cost row from session spans

### Added
- Trace ID prefix matching in `ocw trace`
- PyPI/npm publish workflows
- PyPI metadata (README, classifiers, project URLs)
- CODEOWNERS

### Changed
- npm package renamed to `@openclawwatch/sdk`
- AGENTS.md consolidated to point at CLAUDE.md

## Test plan
- [ ] Merge PR, then create GitHub release with tag `v0.1.1`
- [ ] `publish-pypi.yml` triggers and publishes to PyPI with updated metadata

🤖 Generated with [Claude Code](https://claude.com/claude-code)