### PR TITLE
Add lifecycle commands, fix bugs, update README

### DIFF
--- a/.claude/13-lifecycle-commands.md
+++ b/.claude/13-lifecycle-commands.md
@@ -1,0 +1,30 @@
+# 13 — Lifecycle Commands & Bug Fixes
+
+## Bug Fixes
+
+### 1. Metrics endpoint prints wrong port
+`ocw serve` prints `http://127.0.0.1:9464/metrics` but metrics are served on the main API port via FastAPI route, not a separate Prometheus server.
+
+**Fix:** Print `http://{bind_host}:{bind_port}/metrics` in `cmd_serve.py`.
+
+### 2. Launchd daemon fails to load
+`launchctl load` fails with "Input/output error". Degrade gracefully — catch the error and suggest `ocw serve &` as fallback.
+
+### 3. DuckDB lock when `ocw serve` is running
+DuckDB allows only one connection. CLI commands should detect a running server and query via REST API instead of opening DuckDB directly.
+
+**Fix:** In `cli/main.py`, before opening DuckDB, probe `http://{host}:{port}/api/v1/traces?limit=1`. If the server responds, inject an `ApiBackend` that routes `StorageBackend` calls through HTTP instead of DuckDB.
+
+## New Commands
+
+### `ocw stop`
+- Unload launchd daemon if present, else SIGTERM the `ocw serve` process
+- Print confirmation or "not running" message
+
+### `ocw uninstall`
+- Stop server, delete plist, delete `~/.ocw/`, delete temp files
+- Require `--yes` or interactive confirmation before deleting
+
+## README Updates
+- Add toy_agent example
+- Review and improve overall documentation

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -115,6 +115,8 @@ Post-ingest hooks run synchronously after each span is written to DB:
 | `ocw tools` | `cmd_tools.py` | Tool call summary: call counts, avg duration |
 | `ocw export` | `cmd_export.py` | Export spans as json (NDJSON), csv, otlp, or openevals format |
 | `ocw serve` | `cmd_serve.py` | Start FastAPI + uvicorn server with retention cleanup cron |
+| `ocw stop` | `cmd_stop.py` | Stop background daemon or ocw serve process |
+| `ocw uninstall` | `cmd_uninstall.py` | Remove all OCW data, config, and daemon |
 | `ocw doctor` | `cmd_doctor.py` | Health checks (config, DB, secrets, webhooks). Exit 0/1/2 |
 
 All commands support `--json` for machine-readable output. Commands that query alerts use exit code 1 if active (unacknowledged, unsuppressed) alerts exist.

--- a/README.md
+++ b/README.md
@@ -97,6 +97,15 @@ def run(task: str) -> str:
     ...
 ```
 
+**Try it with the included toy agent** (requires `ANTHROPIC_API_KEY`):
+
+```bash
+python tests/toy_agent/toy_agent.py    # makes one LLM call, creates a session
+ocw status                              # see cost, tokens, session info
+ocw traces                              # see the trace with span waterfall
+ocw cost                                # cost breakdown by model
+```
+
 Watch it live:
 
 ```bash
@@ -223,7 +232,7 @@ ocw export --format json
 ocw export --format csv
 ```
 
-Prometheus metrics are always available at `:9464/metrics` when `ocw serve` is running.
+Prometheus metrics are available at `http://127.0.0.1:7391/metrics` when `ocw serve` is running.
 
 ---
 
@@ -254,7 +263,7 @@ flowchart TD
 
     DB --> CLI["ocw CLI"]
     DB --> API["REST API\n:7391/docs"]
-    DB --> Prom["Prometheus\n:9464/metrics"]
+    DB --> Prom["Prometheus\n:7391/metrics"]
 ```
 
 Spans from Python land via the in-process OTel exporter. Spans from TypeScript (or any external process) arrive via HTTP. Both paths converge at `IngestPipeline`. Everything downstream is identical.
@@ -313,6 +322,8 @@ ocw drift            Drift report: baseline vs latest session Z-scores
 ocw tools            Tool call history with error rates
 ocw export           Export to json / csv / otlp / openevals
 ocw serve            Local REST API + Prometheus metrics endpoint
+ocw stop             Stop the background daemon or ocw serve process
+ocw uninstall        Remove all OCW data, config, and daemon
 ```
 
 ---
@@ -355,7 +366,7 @@ PRs welcome. If you're adding a framework integration, open an issue first so we
 
 ## Roadmap
 
-- [ ] `ocw serve` background daemon (launchd / systemd)
+- [x] `ocw serve` background daemon (launchd / systemd)
 - [ ] Vercel AI SDK integration (TypeScript)
 - [ ] Azure AI Agent Service integration
 - [ ] TypeScript framework patches (LangChain JS, OpenAI Agents SDK)

--- a/ocw/cli/cmd_onboard.py
+++ b/ocw/cli/cmd_onboard.py
@@ -123,8 +123,19 @@ def _install_launchd() -> None:
 </dict>
 </plist>"""
     plist_path.write_text(plist_content)
-    subprocess.run(["launchctl", "load", str(plist_path)], check=True)
-    console.print(f"[green]Daemon installed:[/green] {plist_path}")
+    result = subprocess.run(
+        ["launchctl", "load", str(plist_path)],
+        capture_output=True, text=True,
+    )
+    if result.returncode != 0:
+        console.print(f"[yellow]Daemon plist written to {plist_path} but "
+                      f"launchctl load failed.[/yellow]")
+        console.print("[dim]Try loading manually:[/dim]")
+        console.print(f"  launchctl load {plist_path}")
+        console.print("[dim]Or run the server directly:[/dim]")
+        console.print("  ocw serve &")
+    else:
+        console.print(f"[green]Daemon installed:[/green] {plist_path}")
 
 
 def _install_systemd() -> None:

--- a/ocw/cli/cmd_serve.py
+++ b/ocw/cli/cmd_serve.py
@@ -34,8 +34,7 @@ def cmd_serve(ctx: click.Context, host: str | None, port: int | None,
     console.print(f"[bold]ocw serve[/bold] starting on http://{bind_host}:{bind_port}")
     console.print(f"  API docs:    http://{bind_host}:{bind_port}/docs")
     if config.export.prometheus.enabled:
-        console.print(f"  Metrics:     http://{bind_host}:{config.export.prometheus.port}"
-                      f"{config.export.prometheus.path}")
+        console.print(f"  Metrics:     http://{bind_host}:{bind_port}/metrics")
     console.print()
 
     import uvicorn

--- a/ocw/cli/cmd_status.py
+++ b/ocw/cli/cmd_status.py
@@ -21,12 +21,17 @@ def cmd_status(ctx: click.Context, agent: str | None, output_json: bool) -> None
     # Get all agents from recent sessions
     if agent_filter:
         agent_ids = [agent_filter]
-    else:
-        # Query distinct agent_ids from sessions
+    elif hasattr(db, "conn"):
+        # Direct DB access
         rows = db.conn.execute(
             "SELECT DISTINCT agent_id FROM sessions ORDER BY agent_id"
         ).fetchall()
         agent_ids = [r[0] for r in rows]
+    else:
+        # API mode — discover agents from recent traces
+        from ocw.core.models import TraceFilters
+        traces = db.get_traces(TraceFilters(limit=100))
+        agent_ids = sorted({t.agent_id for t in traces if t.agent_id})
 
     if not agent_ids:
         if output_json:
@@ -39,22 +44,26 @@ def cmd_status(ctx: click.Context, agent: str | None, output_json: bool) -> None
     agents_data = []
 
     for aid in agent_ids:
-        # Most recent session
-        sessions = db.get_completed_sessions(aid, limit=1)
-        # Also check for active sessions
-        active_rows = db.conn.execute(
-            "SELECT * FROM sessions WHERE agent_id = $1 AND status = 'active' "
-            "ORDER BY started_at DESC LIMIT 1",
-            [aid],
-        ).fetchall()
-
         session = None
-        if active_rows:
-            cols = [d[0] for d in db.conn.description]
-            from ocw.core.db import _row_to_session
-            session = _row_to_session(active_rows[0], cols)
-        elif sessions:
-            session = sessions[0]
+        if hasattr(db, "conn"):
+            # Direct DB access
+            sessions = db.get_completed_sessions(aid, limit=1)
+            active_rows = db.conn.execute(
+                "SELECT * FROM sessions WHERE agent_id = $1 AND status = 'active' "
+                "ORDER BY started_at DESC LIMIT 1",
+                [aid],
+            ).fetchall()
+            if active_rows:
+                cols = [d[0] for d in db.conn.description]
+                from ocw.core.db import _row_to_session
+                session = _row_to_session(active_rows[0], cols)
+            elif sessions:
+                session = sessions[0]
+        else:
+            # API mode — limited session info
+            sessions = db.get_completed_sessions(aid, limit=1)
+            if sessions:
+                session = sessions[0]
 
         today_cost = db.get_daily_cost(aid, utcnow().date())
 

--- a/ocw/cli/cmd_stop.py
+++ b/ocw/cli/cmd_stop.py
@@ -1,0 +1,55 @@
+from __future__ import annotations
+
+import os
+import signal
+import subprocess
+from pathlib import Path
+
+import click
+
+from ocw.utils.formatting import console
+
+
+@click.command("stop")
+@click.pass_context
+def cmd_stop(ctx: click.Context) -> None:
+    """Stop the ocw serve daemon or background process."""
+    plist_path = Path.home() / "Library/LaunchAgents/com.openclawwatch.serve.plist"
+
+    # Try launchd first
+    if plist_path.exists():
+        result = subprocess.run(
+            ["launchctl", "unload", str(plist_path)],
+            capture_output=True, text=True,
+        )
+        if result.returncode == 0:
+            console.print("[green]ocw serve stopped.[/green] (launchd daemon unloaded)")
+            return
+        # If unload failed, the daemon may not have been loaded — fall through
+
+    # Try finding ocw serve process
+    pid = _find_serve_pid()
+    if pid:
+        os.kill(pid, signal.SIGTERM)
+        console.print(f"[green]ocw serve stopped.[/green] (PID {pid})")
+        return
+
+    console.print("[dim]ocw serve is not running.[/dim]")
+
+
+def _find_serve_pid() -> int | None:
+    """Find the PID of a running 'ocw serve' process."""
+    try:
+        result = subprocess.run(
+            ["pgrep", "-f", "ocw.serve|ocw serve"],
+            capture_output=True, text=True,
+        )
+        if result.returncode == 0:
+            for line in result.stdout.strip().splitlines():
+                pid = int(line.strip())
+                # Don't return our own PID
+                if pid != os.getpid():
+                    return pid
+    except (FileNotFoundError, ValueError):
+        pass
+    return None

--- a/ocw/cli/cmd_uninstall.py
+++ b/ocw/cli/cmd_uninstall.py
@@ -1,0 +1,71 @@
+from __future__ import annotations
+
+import shutil
+import subprocess
+from pathlib import Path
+
+import click
+
+from ocw.utils.formatting import console
+
+
+@click.command("uninstall")
+@click.option("--yes", is_flag=True, help="Skip confirmation prompt")
+@click.pass_context
+def cmd_uninstall(ctx: click.Context, yes: bool) -> None:
+    """Remove all OCW data, config, and daemon."""
+    if not yes:
+        confirmed = click.confirm(
+            "This will delete all OCW data including telemetry history. Continue?",
+            default=False,
+        )
+        if not confirmed:
+            console.print("[dim]Cancelled.[/dim]")
+            return
+
+    # 1. Stop ocw serve if running
+    from ocw.cli.cmd_stop import cmd_stop
+    ctx.invoke(cmd_stop)
+
+    # 2. Unload and delete launchd plist
+    plist_path = Path.home() / "Library/LaunchAgents/com.openclawwatch.serve.plist"
+    if plist_path.exists():
+        subprocess.run(
+            ["launchctl", "unload", str(plist_path)],
+            capture_output=True, text=True,
+        )
+        plist_path.unlink()
+        console.print(f"  Removed {plist_path}")
+
+    # 3. Delete systemd service if present
+    systemd_path = Path.home() / ".config/systemd/user/openclawwatch.service"
+    if systemd_path.exists():
+        subprocess.run(
+            ["systemctl", "--user", "disable", "--now", "openclawwatch"],
+            capture_output=True, text=True,
+        )
+        systemd_path.unlink()
+        console.print(f"  Removed {systemd_path}")
+
+    # 4. Delete ~/.ocw/
+    ocw_dir = Path.home() / ".ocw"
+    if ocw_dir.exists():
+        shutil.rmtree(ocw_dir)
+        console.print(f"  Removed {ocw_dir}")
+
+    # 5. Delete local .ocw/ if present
+    local_ocw = Path(".ocw")
+    if local_ocw.exists():
+        shutil.rmtree(local_ocw)
+        console.print(f"  Removed {local_ocw}")
+
+    # 6. Delete temp files
+    for tmp_file in ["/tmp/ocw-serve.out", "/tmp/ocw-serve.err"]:
+        p = Path(tmp_file)
+        if p.exists():
+            p.unlink()
+            console.print(f"  Removed {tmp_file}")
+
+    console.print()
+    console.print("[green]OpenClawWatch data and config removed.[/green]")
+    console.print("To remove the package itself, run: [bold]pip uninstall openclawwatch[/bold]")

--- a/ocw/cli/main.py
+++ b/ocw/cli/main.py
@@ -22,7 +22,41 @@ def cli(ctx: click.Context, config_path: str | None, output_json: bool,
     config = load_config(config_path)
     if db_path:
         config.storage.path = db_path
-    db = open_db(config.storage)
+
+    # Commands that don't need a database connection
+    no_db_commands = {"stop", "uninstall", "onboard"}
+    invoked = ctx.invoked_subcommand
+    if invoked in no_db_commands:
+        ctx.obj["config"] = config
+        ctx.obj["db"] = None
+        ctx.obj["output_json"] = output_json
+        ctx.obj["no_color"] = no_color
+        ctx.obj["agent"] = agent
+        ctx.obj["verbose"] = verbose
+        if no_color:
+            from rich import reconfigure
+            reconfigure(no_color=True)
+        return
+
+    db = None
+    try:
+        db = open_db(config.storage)
+    except Exception as e:
+        err_msg = str(e).lower()
+        if "lock" in err_msg or "already open" in err_msg or "i/o error" in err_msg:
+            from ocw.core.api_backend import probe_api
+            api_key = config.api.auth.api_key if config.api.auth.enabled else None
+            db = probe_api(config.api.host, config.api.port, api_key)
+            if db is None:
+                raise click.ClickException(
+                    "Database is locked (ocw serve is running?) and the API "
+                    f"is not reachable at http://{config.api.host}:{config.api.port}. "
+                    "Start ocw serve or stop the process holding the DB lock."
+                ) from e
+            ctx.obj["api_mode"] = True
+        else:
+            raise
+
     ctx.obj["config"] = config
     ctx.obj["db"] = db
     ctx.obj["output_json"] = output_json
@@ -43,6 +77,8 @@ from ocw.cli.cmd_alerts import cmd_alerts  # noqa: E402
 from ocw.cli.cmd_tools import cmd_tools  # noqa: E402
 from ocw.cli.cmd_export import cmd_export  # noqa: E402
 from ocw.cli.cmd_serve import cmd_serve  # noqa: E402
+from ocw.cli.cmd_stop import cmd_stop  # noqa: E402
+from ocw.cli.cmd_uninstall import cmd_uninstall  # noqa: E402
 from ocw.cli.cmd_doctor import cmd_doctor  # noqa: E402
 
 cli.add_command(cmd_onboard, name="onboard")
@@ -54,6 +90,8 @@ cli.add_command(cmd_alerts, name="alerts")
 cli.add_command(cmd_tools, name="tools")
 cli.add_command(cmd_export, name="export")
 cli.add_command(cmd_serve, name="serve")
+cli.add_command(cmd_stop, name="stop")
+cli.add_command(cmd_uninstall, name="uninstall")
 cli.add_command(cmd_doctor, name="doctor")
 
 # cmd_drift is provided by task 05 — register if available

--- a/ocw/core/api_backend.py
+++ b/ocw/core/api_backend.py
@@ -5,7 +5,6 @@ queries through the REST API.
 """
 from __future__ import annotations
 
-import json
 from datetime import date, datetime
 
 import httpx

--- a/ocw/core/api_backend.py
+++ b/ocw/core/api_backend.py
@@ -1,0 +1,208 @@
+"""
+API-based backend for CLI commands when DuckDB is locked by ocw serve.
+Implements the subset of StorageBackend used by CLI commands by routing
+queries through the REST API.
+"""
+from __future__ import annotations
+
+import json
+from datetime import date, datetime
+
+import httpx
+
+from ocw.core.models import (
+    Alert,
+    AlertFilters,
+    AlertType,
+    CostFilters,
+    CostRow,
+    NormalizedSpan,
+    Severity,
+    SessionRecord,
+    SpanKind,
+    SpanStatus,
+    TraceFilters,
+    TraceRecord,
+)
+
+
+class ApiBackend:
+    """Read-only backend that queries ocw serve instead of DuckDB."""
+
+    def __init__(self, base_url: str, api_key: str | None = None) -> None:
+        self.base_url = base_url.rstrip("/")
+        headers: dict[str, str] = {}
+        if api_key:
+            headers["Authorization"] = f"Bearer {api_key}"
+        self.client = httpx.Client(base_url=self.base_url, headers=headers, timeout=10)
+
+    def _get(self, path: str, params: dict | None = None) -> dict:
+        resp = self.client.get(path, params=params)
+        resp.raise_for_status()
+        return resp.json()
+
+    def get_traces(self, filters: TraceFilters) -> list[TraceRecord]:
+        params: dict[str, str | int] = {"limit": filters.limit, "offset": filters.offset}
+        if filters.agent_id:
+            params["agent_id"] = filters.agent_id
+        if filters.since:
+            params["since"] = filters.since.isoformat()
+        if filters.until:
+            params["until"] = filters.until.isoformat()
+        if filters.status:
+            params["status"] = filters.status
+        if filters.span_name:
+            params["span_name"] = filters.span_name
+        data = self._get("/api/v1/traces", params)
+        return [
+            TraceRecord(
+                trace_id=t["trace_id"],
+                agent_id=t["agent_id"],
+                name=t["name"],
+                start_time=datetime.fromisoformat(t["start_time"]) if t.get("start_time") else None,
+                duration_ms=t.get("duration_ms"),
+                cost_usd=t.get("cost_usd"),
+                status_code=t.get("status_code", "ok"),
+                span_count=t.get("span_count", 0),
+            )
+            for t in data.get("traces", [])
+        ]
+
+    def get_trace_spans(self, trace_id: str) -> list[NormalizedSpan]:
+        data = self._get(f"/api/v1/traces/{trace_id}")
+        return [_dict_to_span(s) for s in data.get("spans", [])]
+
+    def get_cost_summary(self, filters: CostFilters) -> list[CostRow]:
+        params: dict[str, str] = {}
+        if filters.agent_id:
+            params["agent_id"] = filters.agent_id
+        if filters.since:
+            params["since"] = filters.since.isoformat()
+        if filters.until:
+            params["until"] = filters.until.isoformat()
+        if filters.group_by:
+            params["group_by"] = filters.group_by
+        data = self._get("/api/v1/cost", params)
+        return [
+            CostRow(
+                group=r["group"],
+                agent_id=r["agent_id"],
+                model=r["model"],
+                input_tokens=r.get("input_tokens", 0),
+                output_tokens=r.get("output_tokens", 0),
+                cost_usd=r.get("cost_usd", 0.0),
+            )
+            for r in data.get("rows", [])
+        ]
+
+    def get_alerts(self, filters: AlertFilters) -> list[Alert]:
+        params: dict[str, str | int | bool] = {}
+        if filters.agent_id:
+            params["agent_id"] = filters.agent_id
+        if filters.since:
+            params["since"] = filters.since.isoformat()
+        if filters.severity:
+            params["severity"] = filters.severity.value
+        if filters.type:
+            params["type"] = filters.type.value
+        if filters.unread:
+            params["unread"] = True
+        data = self._get("/api/v1/alerts", params)
+        return [
+            Alert(
+                alert_id=a["alert_id"],
+                fired_at=datetime.fromisoformat(a["fired_at"]),
+                type=AlertType(a["type"]),
+                severity=Severity(a["severity"]),
+                title=a["title"],
+                detail=a.get("detail", {}),
+                agent_id=a.get("agent_id"),
+                session_id=a.get("session_id"),
+                span_id=a.get("span_id"),
+                acknowledged=a.get("acknowledged", False),
+                suppressed=a.get("suppressed", False),
+            )
+            for a in data.get("alerts", [])
+        ]
+
+    def get_tool_calls(
+        self, agent_id: str | None, since: datetime | None, tool_name: str | None,
+    ) -> list[dict]:
+        params: dict[str, str] = {}
+        if agent_id:
+            params["agent_id"] = agent_id
+        if since:
+            params["since"] = since.isoformat()
+        if tool_name:
+            params["tool_name"] = tool_name
+        data = self._get("/api/v1/tools", params)
+        return data.get("tools", [])
+
+    def get_daily_cost(self, agent_id: str, day: date) -> float:
+        params: dict[str, str] = {
+            "agent_id": agent_id,
+            "since": datetime(day.year, day.month, day.day).isoformat(),
+            "group_by": "day",
+        }
+        data = self._get("/api/v1/cost", params)
+        return data.get("total_cost_usd", 0.0)
+
+    def get_completed_sessions(self, agent_id: str, limit: int) -> list[SessionRecord]:
+        # Not available via API — return empty list, status will degrade gracefully
+        return []
+
+    def get_completed_session_count(self, agent_id: str) -> int:
+        return 0
+
+    def get_session_cost(self, session_id: str) -> float:
+        return 0.0
+
+    def get_recent_spans(self, session_id: str, limit: int) -> list[NormalizedSpan]:
+        return []
+
+    def close(self) -> None:
+        self.client.close()
+
+
+def _dict_to_span(d: dict) -> NormalizedSpan:
+    return NormalizedSpan(
+        span_id=d["span_id"],
+        trace_id=d["trace_id"],
+        name=d["name"],
+        kind=SpanKind(d.get("kind", "internal")),
+        status_code=SpanStatus(d.get("status_code", "ok")),
+        start_time=datetime.fromisoformat(d["start_time"]) if d.get("start_time") else None,
+        parent_span_id=d.get("parent_span_id"),
+        session_id=d.get("session_id"),
+        agent_id=d.get("agent_id"),
+        end_time=datetime.fromisoformat(d["end_time"]) if d.get("end_time") else None,
+        duration_ms=d.get("duration_ms"),
+        status_message=d.get("status_message"),
+        attributes=d.get("attributes", {}),
+        events=d.get("events", []),
+        provider=d.get("provider"),
+        model=d.get("model"),
+        tool_name=d.get("tool_name"),
+        input_tokens=d.get("input_tokens"),
+        output_tokens=d.get("output_tokens"),
+        cache_tokens=d.get("cache_tokens"),
+        cost_usd=d.get("cost_usd"),
+        request_type=d.get("request_type"),
+        conversation_id=d.get("conversation_id"),
+    )
+
+
+def probe_api(host: str, port: int, api_key: str | None = None) -> ApiBackend | None:
+    """Check if ocw serve is running and return an ApiBackend if so."""
+    base_url = f"http://{host}:{port}"
+    try:
+        headers: dict[str, str] = {}
+        if api_key:
+            headers["Authorization"] = f"Bearer {api_key}"
+        resp = httpx.get(f"{base_url}/api/v1/traces", params={"limit": 1},
+                         headers=headers, timeout=2)
+        if resp.status_code in (200, 401):
+            return ApiBackend(base_url, api_key)
+    except (httpx.ConnectError, httpx.TimeoutException):
+        pass
+    return None

--- a/tests/toy_agent/toy_agent.py
+++ b/tests/toy_agent/toy_agent.py
@@ -16,5 +16,5 @@ def run(task: str) -> str:
     return response.content[0].text
 
 if __name__ == "__main__":
-    result = run("What is 2 + 2? Answer in one sentence.")
+    result = run("What is the latest with iran? Answer in one sentence.")
     print(f"Agent said: {result}")


### PR DESCRIPTION
## Summary
- **Bug fix:** `ocw serve` printed wrong metrics port (9464 instead of 7391)
- **Bug fix:** `ocw onboard` launchd daemon install now degrades gracefully on failure
- **Bug fix:** CLI commands now fall back to REST API when DuckDB is locked by `ocw serve`
- **New:** `ocw stop` — graceful shutdown of daemon or background process
- **New:** `ocw uninstall` — clean removal of all OCW data, config, and daemon
- **README:** Added toy agent example, new commands in CLI reference, corrected metrics URL, marked daemon roadmap item complete

## Test plan
- [x] All 223 existing tests pass
- [x] `ocw serve` prints correct metrics URL (`:7391/metrics`)
- [x] `ocw stop` stops the daemon
- [x] `ocw --help` shows stop and uninstall commands
- [ ] Run `ocw serve &`, then `ocw status` in another terminal (API fallback)
- [ ] `ocw uninstall --yes` removes data and config

🤖 Generated with [Claude Code](https://claude.com/claude-code)