### PR TITLE
Add comprehensive example agents for all supported integrations

### DIFF
--- a/.claude/14-comprehensive-agent-examples.md
+++ b/.claude/14-comprehensive-agent-examples.md
@@ -1,0 +1,227 @@
+# Task: Create example agents in `examples/`
+
+## Structure
+
+Create an `examples/` top-level directory organized by complexity:
+
+```
+examples/
+├── README.md
+├── single_provider/
+│   ├── anthropic_agent.py
+│   ├── openai_agent.py
+│   ├── gemini_agent.py
+│   ├── bedrock_agent.py
+│   └── openai_agents_sdk_agent.py
+├── single_framework/
+│   ├── langchain_agent.py
+│   ├── langgraph_agent.py
+│   ├── crewai_agent.py
+│   ├── autogen_agent.py
+│   └── llamaindex_agent.py
+├── multi/
+│   ├── router_agent.py
+│   ├── research_team.py
+│   └── rag_pipeline.py
+└── alerts_and_drift/
+    ├── sensitive_actions_demo.py
+    ├── budget_breach_demo.py
+    └── drift_demo.py
+```
+
+---
+
+## Cross-Cutting Guidelines
+
+These apply to ALL examples.
+
+### 1. Env var gate
+
+Every example that requires an API key must check at startup and exit with a clear message:
+
+```python
+import os, sys
+
+if not os.environ.get("OPENAI_API_KEY"):
+    sys.exit("Set OPENAI_API_KEY to run this example.\n  export OPENAI_API_KEY='sk-...'")
+```
+
+No cryptic stack traces. Fail fast, fail helpfully.
+
+### 2. `ocw serve` check (for OTLP-based integrations)
+
+`openai_agents_sdk_agent.py` and `llamaindex_agent.py` export via OTLP HTTP to `ocw serve`, not in-process. These must check connectivity at startup:
+
+```python
+import httpx, sys
+
+try:
+    httpx.get("http://127.0.0.1:8787/api/v1/traces", timeout=2)
+except httpx.ConnectError:
+    sys.exit(
+        "This example requires ocw serve to be running.\n"
+        "Start it with: ocw serve &"
+    )
+```
+
+Do NOT start the server programmatically. Just check and exit with a clear message.
+
+### 3. Observation block
+
+Every example must end with a printed observation block:
+
+```python
+print("\n--- What to observe ---")
+print("  ocw status          → see this agent's session")
+print("  ocw traces          → see all spans from this run")
+print("  ocw cost --since 1h → see cost breakdown")
+```
+
+### 4. Single-command runnable
+
+Every example runs with: `python examples/<tier>/<name>.py`
+
+### 5. All examples use `@watch()` decorator
+
+So sessions show up in `ocw status` immediately.
+
+### 6. Dependency comments
+
+List extra pip deps in a comment at the top of each file. Example:
+```python
+# Extra deps: pip install langchain-core langchain-openai
+```
+
+---
+
+## Single-Provider Examples
+
+Each demonstrates one provider integration with `@watch()` and the relevant `patch_*` call.
+
+| File | Integration | What it does |
+|---|---|---|
+| `anthropic_agent.py` | `patch_anthropic` | Tool-use agent — Claude calls functions (calculator, weather stub), shows tool call spans and cost tracking. Adapted from `tests/toy_agent/toy_agent.py` (do NOT move the original — copy and expand). |
+| `openai_agent.py` | `patch_openai` | Chat agent that calls GPT-4o, streams a response, uses a tool (web search stub). Shows streaming + tool use spans. |
+| `gemini_agent.py` | `patch_gemini` | Summarization agent — takes a long text, returns a summary via Gemini. Shows Google provider path. |
+| `bedrock_agent.py` | `patch_bedrock` | **Advanced.** Agent that calls Claude-on-Bedrock via boto3. Shows AWS path with stream re-wrapping. See prominent setup note below. |
+| `openai_agents_sdk_agent.py` | `patch_openai_agents` | Uses the OpenAI Agents SDK with a handoff between two agents. Shows native OTel integration path (no monkey-patching). Requires `ocw serve` running (uses OTLP HTTP export). |
+
+### Bedrock setup note
+
+`bedrock_agent.py` must include this prominent note at the top:
+
+```python
+"""
+AWS Bedrock Agent Example — ADVANCED SETUP REQUIRED
+
+Before running, you need:
+1. AWS credentials configured (aws configure, or IAM role, or env vars
+   AWS_ACCESS_KEY_ID + AWS_SECRET_ACCESS_KEY)
+2. A Bedrock-enabled AWS region (e.g., us-east-1, us-west-2)
+3. Model access enabled in the AWS Bedrock console for the model you want
+   to use (e.g., anthropic.claude-3-haiku-20240307-v1:0)
+
+  export AWS_DEFAULT_REGION=us-east-1
+  python examples/single_provider/bedrock_agent.py
+"""
+```
+
+---
+
+## Single-Framework Examples
+
+Each demonstrates one framework integration showing how `ocw` captures framework-level spans.
+
+| File | Integration | What it does |
+|---|---|---|
+| `langchain_agent.py` | `patch_langchain` | ReAct agent with a calculator and Wikipedia tool. The canonical LangChain pattern. |
+| `langgraph_agent.py` | `patch_langgraph` | Multi-step graph: plan → research → draft → review. Shows graph-level span capture with conditional edges. |
+| `crewai_agent.py` | `patch_crewai` | Two-agent crew: researcher + writer collaborating on a blog post. Shows multi-agent task orchestration. |
+| `autogen_agent.py` | `patch_autogen` | Two ConversableAgents debating a topic with back-and-forth. Shows chat initiation + reply generation spans. |
+| `llamaindex_agent.py` | `patch_llamaindex` | RAG pipeline: `SimpleDirectoryReader` + `VectorStoreIndex` with in-memory storage → query → synthesize answer. No FAISS. Shows native OTel instrumentation path. Requires `ocw serve` running (uses OTLP HTTP export). |
+
+---
+
+## Multi-Integration Examples
+
+These are the showcase — real-world patterns combining multiple integrations. They should exercise `ocw` features heavily: cost tracking across providers, alerts, multi-agent sessions with different budgets.
+
+### `router_agent.py` — Provider router
+- Uses `patch_openai()` + `patch_anthropic()` + `patch_gemini()`
+- Routes requests to different providers based on task type (quick Q&A → Gemini Flash, coding → Claude, creative → GPT-4o)
+- **Shows:** cost comparison across providers in `ocw cost`, multi-provider spans in a single trace
+
+### `research_team.py` — Multi-framework research team
+- Uses `patch_anthropic()` + CrewAI for orchestration + LangChain for tool execution
+- A "lead researcher" agent delegates sub-tasks to specialist agents, each with tools (web search stub, file reader, calculator)
+- **Shows:** deep span trees, multi-agent session tracking, tool call patterns visible in `ocw tools`
+
+### `rag_pipeline.py` — RAG with fallback
+- Uses LlamaIndex `SimpleDirectoryReader` + `VectorStoreIndex` (in-memory, no FAISS) for indexing/retrieval + `patch_openai()` for generation + `patch_anthropic()` as fallback
+- Include 3-4 small .txt files in `examples/multi/sample_docs/`
+- Answers questions, falls back to Anthropic if OpenAI fails or exceeds token budget
+- **Shows:** budget alerts firing, provider fallback visible in traces, schema validation on structured output
+
+---
+
+## Alerts and Drift Examples
+
+These demonstrate the features that differentiate `ocw` from LangSmith, Langfuse, and every other tool. These are the most important examples for showing what makes this product unique.
+
+**All alerts/drift examples use simulated instrumentation by default** — `record_llm_call()` and `record_tool_call()` from `ocw.sdk.agent`. This means:
+- Zero API keys required
+- Zero cost
+- Runnable by anyone cloning the repo
+- The point is demonstrating `ocw` features, not making real LLM calls
+
+Each example should accept an optional `--live` flag (or `OCW_LIVE=1` env var) that switches to real API calls for users who want to see it end-to-end with actual providers.
+
+### `sensitive_actions_demo.py` — Sensitive action alerts
+- Agent that performs actions configured as sensitive: `send_email`, `delete_file`, `submit_form`
+- Creates temp files, "sends" emails (writes to a log file), "submits" a form (prints to stdout)
+- Include the companion `ocw.toml` snippet in a comment block showing how to configure the sensitive actions and alert channels
+- Uses `record_tool_call()` for each sensitive action
+- **Shows:** alerts firing in real time, visible in `ocw alerts`
+
+### `budget_breach_demo.py` — Budget alerts
+- Agent in a loop that deliberately exceeds a very low budget ($0.05 daily, $0.02 session)
+- Uses `record_llm_call()` with high token counts to simulate expensive calls
+- **Shows:** `ocw cost` tracking spend in real time, `ocw alerts` showing the budget breach, what happens when the limit is hit
+
+### `drift_demo.py` — Behavioral drift detection
+- Phase 1: Runs 12 identical "normal" sessions using `record_llm_call()` + `record_tool_call()` to build a statistical baseline (same agent_id, similar token usage, same tool sequence)
+- Phase 2: Runs 1 anomalous session — different prompt that triggers 5x the normal token count and different tool calls
+- All via `record_llm_call()` — zero cost, zero API keys
+- **Shows:** `ocw alerts` showing DRIFT_DETECTED, baseline vs observed comparison
+
+---
+
+## `examples/README.md`
+
+Create a README that:
+- Lists every example with a one-line description
+- Groups by tier (single provider → single framework → multi-integration → alerts/drift)
+- Shows required env vars per example
+- Marks which examples need `ocw serve` running
+- Explains how to verify with `ocw` commands
+- Notes that alerts/drift examples work with zero API keys
+
+---
+
+## Updates to existing files
+
+- Do NOT move `tests/toy_agent/toy_agent.py` — copy and expand into `examples/single_provider/anthropic_agent.py`
+- Add an "Examples" section to the repo `README.md` after "Quickstart" with a brief summary and link to `examples/`
+- Update `CLAUDE.md` repo layout section to include `examples/`
+
+---
+
+## Verification
+
+- Every example in `single_provider/` runs with just the relevant API key set
+- Every example produces spans visible in `ocw traces`
+- The alerts/drift examples run with zero API keys and produce alerts visible in `ocw alerts`
+- Examples requiring `ocw serve` exit cleanly with instructions if server isn't running
+- Examples missing required env vars exit cleanly with instructions
+- `ruff check examples/` passes
+- All existing tests still pass (no test modifications)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -48,6 +48,11 @@ openclawwatch/
 │   ├── api/                FastAPI local REST API
 │   ├── sdk/                Python instrumentation SDK
 │   └── utils/              Formatting, time parsing, ID generation
+├── examples/               Runnable example agents (see examples/README.md)
+│   ├── single_provider/    One file per LLM provider integration
+│   ├── single_framework/   One file per framework integration
+│   ├── multi/              Multi-provider/framework examples + sample_docs/
+│   └── alerts_and_drift/   Alert and drift demos (no API keys needed)
 ├── sdk-ts/                 TypeScript SDK (@openclawwatch/sdk)
 ├── pricing/                models.toml — community-maintained model pricing (USD per million tokens)
 └── tests/
@@ -155,6 +160,7 @@ When a span has a `conversation_id` matching an existing session, it's attribute
 10. **Use semconv constants** — reference `GenAIAttributes` and `OcwAttributes` from `ocw/otel/semconv.py` instead of hardcoding OTel attribute name strings.
 11. **OTel TracerProvider is global and set-once** — `trace.set_tracer_provider()` only works once per process. In tests, set the provider once at module level (not per-test in a fixture) and clear spans between tests. Use a custom `_CollectingExporter(SpanExporter)` since `InMemorySpanExporter` is not available in the installed OTel version. See `tests/agents/test_mock_scenarios.py` for the SDK test pattern and `tests/integration/test_full_pipeline.py` for the pipeline pattern.
 12. **New SDK integrations must call `ensure_initialised()`** — every `patch_*()` convenience function must call `from ocw.sdk.bootstrap import ensure_initialised; ensure_initialised()` before installing hooks. This lazily bootstraps the TracerProvider + IngestPipeline on first use.
+13. **PyPI package name is `openclawwatch`, not `ocw`** — `pip install openclawwatch` is the correct install command. The CLI command is `ocw` and the Python package directory is `ocw/`, but the published package name on PyPI is `openclawwatch`. Never write `pip install ocw` in docs, examples, or comments.
 
 ## Config
 

--- a/README.md
+++ b/README.md
@@ -344,6 +344,24 @@ Those tools were built for LLM developers — tracing API calls, comparing promp
 
 ---
 
+## Examples
+
+The [`examples/`](examples/) directory contains runnable agents for every supported integration:
+
+- **Single provider** — Anthropic, OpenAI, Gemini, Bedrock, OpenAI Agents SDK
+- **Single framework** — LangChain, LangGraph, CrewAI, AutoGen, LlamaIndex
+- **Multi-integration** — provider router, CrewAI + LangChain research team, RAG with fallback
+- **Alerts and drift** — sensitive action alerts, budget breach, behavioral drift detection (no API keys needed)
+
+```bash
+python examples/single_provider/anthropic_agent.py   # tool-use agent
+python examples/alerts_and_drift/drift_demo.py       # zero-cost drift detection demo
+```
+
+See [`examples/README.md`](examples/README.md) for the full list with required env vars and setup notes.
+
+---
+
 ## Contributing
 
 ```bash

--- a/examples/README.md
+++ b/examples/README.md
@@ -1,0 +1,105 @@
+# OCW Examples
+
+Example agents demonstrating [ocw](https://github.com/Metabuilder-Labs/openclawwatch) integrations, from single-provider basics to complex multi-agent workflows.
+
+## Quick Start
+
+```bash
+pip install -e ".[dev]"           # install ocw in dev mode
+export ANTHROPIC_API_KEY=sk-...   # set your API key
+python examples/single_provider/anthropic_agent.py
+```
+
+After running any example, inspect the results with:
+
+```bash
+ocw status       # agent session overview
+ocw traces       # list all spans from the run
+ocw cost --since 1h   # cost breakdown
+ocw alerts       # any fired alerts
+```
+
+---
+
+## Single Provider
+
+One integration per file. Simplest way to see ocw in action with your provider of choice.
+
+| Example | Env Vars | Extra Deps | Description |
+|---|---|---|---|
+| [`anthropic_agent.py`](single_provider/anthropic_agent.py) | `ANTHROPIC_API_KEY` | `anthropic` | Tool-use agent with calculator and weather tools |
+| [`openai_agent.py`](single_provider/openai_agent.py) | `OPENAI_API_KEY` | `openai` | Function-calling agent with streaming response |
+| [`gemini_agent.py`](single_provider/gemini_agent.py) | `GOOGLE_API_KEY` or `GEMINI_API_KEY` | `google-generativeai` | Text summarization via Gemini Flash |
+| [`bedrock_agent.py`](single_provider/bedrock_agent.py) | `AWS_DEFAULT_REGION` + AWS creds | `boto3` | Claude on AWS Bedrock (advanced setup) |
+| [`openai_agents_sdk_agent.py`](single_provider/openai_agents_sdk_agent.py) | `OPENAI_API_KEY` | `openai-agents httpx` | Multi-agent handoff via OpenAI Agents SDK |
+
+> **Note:** `openai_agents_sdk_agent.py` requires `ocw serve` running (`ocw serve &`).
+
+---
+
+## Single Framework
+
+One framework integration per file. Shows how ocw captures framework-level spans.
+
+| Example | Env Vars | Extra Deps | Description |
+|---|---|---|---|
+| [`langchain_agent.py`](single_framework/langchain_agent.py) | `OPENAI_API_KEY` | `langchain-core langchain-openai` | Tool-calling agent with calculator and word counter |
+| [`langgraph_agent.py`](single_framework/langgraph_agent.py) | `OPENAI_API_KEY` | `langgraph langchain-openai` | Plan-execute-review graph pipeline |
+| [`crewai_agent.py`](single_framework/crewai_agent.py) | `OPENAI_API_KEY` | `crewai` | Researcher + writer crew collaboration |
+| [`autogen_agent.py`](single_framework/autogen_agent.py) | `OPENAI_API_KEY` | `pyautogen` | Two-agent debate with back-and-forth |
+| [`llamaindex_agent.py`](single_framework/llamaindex_agent.py) | `OPENAI_API_KEY` | `llama-index` | RAG query engine over sample documents |
+
+> **Note:** `llamaindex_agent.py` requires `ocw serve` running (`ocw serve &`).
+
+---
+
+## Multi-Integration
+
+Complex real-world patterns combining multiple providers and frameworks. These showcase ocw's ability to track cost, performance, and behavior across a heterogeneous agent stack.
+
+| Example | Env Vars | Extra Deps | Description |
+|---|---|---|---|
+| [`router_agent.py`](multi/router_agent.py) | `ANTHROPIC_API_KEY` `OPENAI_API_KEY` `GOOGLE_API_KEY` | `anthropic openai google-generativeai` | Routes tasks to the cheapest/best provider |
+| [`research_team.py`](multi/research_team.py) | `ANTHROPIC_API_KEY` `OPENAI_API_KEY` | `anthropic crewai langchain-core` | CrewAI agents with LangChain tools |
+| [`rag_pipeline.py`](multi/rag_pipeline.py) | `OPENAI_API_KEY` `ANTHROPIC_API_KEY` | `llama-index openai anthropic` | RAG with OpenAI-to-Anthropic fallback |
+
+> **Note:** `rag_pipeline.py` requires `ocw serve` running (`ocw serve &`).
+
+---
+
+## Alerts and Drift
+
+These examples demonstrate what makes ocw unique: real-time alerting and behavioral drift detection. **No API keys required** -- they use simulated instrumentation via `record_llm_call()` and `record_tool_call()`.
+
+| Example | Env Vars | Description |
+|---|---|---|
+| [`sensitive_actions_demo.py`](alerts_and_drift/sensitive_actions_demo.py) | None | Fires alerts when agent calls sensitive tools |
+| [`budget_breach_demo.py`](alerts_and_drift/budget_breach_demo.py) | None | Exceeds budget limits, shows cost alerts |
+| [`drift_demo.py`](alerts_and_drift/drift_demo.py) | None | Builds baseline, then triggers drift detection |
+
+These examples include the required `ocw.toml` config snippets as comments at the top of each file. Copy the relevant config to your `ocw.toml` before running.
+
+```bash
+# No API keys needed -- just run:
+python examples/alerts_and_drift/budget_breach_demo.py
+
+# Then inspect:
+ocw alerts       # see budget-breach alerts
+ocw cost --since 1h   # see cost tracking
+```
+
+---
+
+## Which examples need `ocw serve`?
+
+Most examples use in-process telemetry (spans go directly to the local DuckDB). These two integrations export via OTLP HTTP and require the server:
+
+- `openai_agents_sdk_agent.py`
+- `llamaindex_agent.py`
+- `rag_pipeline.py` (uses LlamaIndex)
+
+Start the server before running them:
+
+```bash
+ocw serve &
+```

--- a/examples/alerts_and_drift/budget_breach_demo.py
+++ b/examples/alerts_and_drift/budget_breach_demo.py
@@ -1,0 +1,110 @@
+"""
+Budget Breach Alert Demo
+
+Simulates an agent that exceeds a very low budget ($0.05 daily, $0.02 session).
+Shows how ocw tracks costs and fires budget alerts.
+
+No API keys required — uses simulated instrumentation.
+
+# --- Required ocw.toml config ---
+# Add this to your ocw.toml (or ~/.config/ocw/config.toml):
+#
+# [[agents]]
+# id = "budget-demo"
+#
+# [agents.budget]
+# daily_usd = 0.05
+# session_usd = 0.02
+#
+# [[alerts.channels]]
+# type = "stdout"
+"""
+from __future__ import annotations
+
+import time
+
+from ocw.sdk.agent import watch, record_llm_call, record_tool_call
+
+
+# ---------------------------------------------------------------------------
+# Pricing reference (from pricing/models.toml for claude-sonnet-4-20250514):
+#   input  = $3.00 / MTok  -> $0.000003 per token
+#   output = $15.00 / MTok -> $0.000015 per token
+#
+# With 1000 input + 500 output tokens per call:
+#   cost = 1000*3e-6 + 500*15e-6 = 0.003 + 0.0075 = $0.0105 per call
+#
+# Session budget of $0.02 should be breached after ~2 calls.
+# Daily budget of $0.05 should be breached after ~5 calls.
+# ---------------------------------------------------------------------------
+
+@watch(agent_id="budget-demo")
+def run_expensive_agent() -> None:
+    """Simulate an agent that blows through its budget."""
+
+    cumulative_cost = 0.0
+
+    for i in range(1, 11):
+        # Escalate token counts each iteration to accelerate spending
+        input_tokens = 1000 + (i * 200)
+        output_tokens = 500 + (i * 100)
+
+        # Estimate cost (using claude-sonnet-4-20250514 rates)
+        est_cost = (input_tokens * 3e-6) + (output_tokens * 15e-6)
+        cumulative_cost += est_cost
+
+        print(f"  Call {i:2d}: {input_tokens:5d} in / {output_tokens:4d} out "
+              f"  ~${est_cost:.4f}  (cumulative ~${cumulative_cost:.4f})")
+
+        record_llm_call(
+            model="claude-sonnet-4-20250514",
+            provider="anthropic",
+            input_tokens=input_tokens,
+            output_tokens=output_tokens,
+        )
+
+        # Occasional tool call to make the session look realistic
+        if i % 3 == 0:
+            record_tool_call(
+                "web_search",
+                tool_input={"query": f"research topic {i}"},
+                tool_output={"results": [f"result_{i}_a", f"result_{i}_b"]},
+            )
+
+        time.sleep(0.1)  # Small gap so spans get distinct timestamps
+
+    print(f"\n  Estimated total spend: ${cumulative_cost:.4f}")
+
+
+# ---------------------------------------------------------------------------
+# Main
+# ---------------------------------------------------------------------------
+
+if __name__ == "__main__":
+    from ocw.sdk.bootstrap import ensure_initialised
+    ensure_initialised()
+
+    print("=" * 60)
+    print("OCW Budget Breach Alert Demo")
+    print("=" * 60)
+    print(
+        "\nMaking 10 LLM calls with escalating token counts.\n"
+        "Session budget ($0.02) should breach after ~2 calls.\n"
+        "Daily budget  ($0.05) should breach after ~5 calls.\n"
+    )
+
+    run_expensive_agent()
+
+    print("\n" + "=" * 60)
+    print("What to observe:")
+    print("=" * 60)
+    print(
+        "If your ocw.toml has the budget config shown at the top of\n"
+        "this file, ocw should have fired budget alerts.\n"
+        "\n"
+        "Run these commands to inspect:\n"
+        "\n"
+        "  ocw cost --since 1h         # cost breakdown for the last hour\n"
+        "  ocw alerts                  # see budget-breach alerts\n"
+        "  ocw status                  # agent overview with cost totals\n"
+    )

--- a/examples/alerts_and_drift/drift_demo.py
+++ b/examples/alerts_and_drift/drift_demo.py
@@ -1,0 +1,142 @@
+"""
+Behavioral Drift Detection Demo
+
+Phase 1: Builds a baseline from 12 normal sessions (same agent, consistent
+         behavior).
+Phase 2: Runs 1 anomalous session with 5x token usage and different tool calls.
+
+Shows how ocw detects statistical drift and fires DRIFT_DETECTED alerts.
+
+No API keys required — uses simulated instrumentation.
+
+# --- Required ocw.toml config ---
+# Add this to your ocw.toml (or ~/.config/ocw/config.toml):
+#
+# [[agents]]
+# id = "drift-demo"
+#
+# [agents.drift]
+# enabled = true
+# baseline_sessions = 10
+# token_threshold = 2.0
+# tool_sequence_diff = 0.4
+#
+# [[alerts.channels]]
+# type = "stdout"
+"""
+from __future__ import annotations
+
+import time
+
+from ocw.sdk.agent import AgentSession, record_llm_call, record_tool_call
+from ocw.utils.ids import new_uuid
+
+
+# ---------------------------------------------------------------------------
+# Session runners
+# ---------------------------------------------------------------------------
+
+def run_normal_session(session_num: int) -> None:
+    """Run a single baseline session with consistent, predictable behavior."""
+    with AgentSession(agent_id="drift-demo", conversation_id=new_uuid()):
+        # 3 LLM calls with stable token counts
+        for _ in range(3):
+            record_llm_call(
+                model="claude-haiku-4-5",
+                provider="anthropic",
+                input_tokens=200,
+                output_tokens=100,
+            )
+
+        # 2 tool calls -- always the same tools in the same order
+        record_tool_call(
+            "search",
+            tool_input={"query": f"topic for session {session_num}"},
+            tool_output={"results": ["result_a", "result_b"]},
+        )
+        record_tool_call(
+            "summarize",
+            tool_input={"text": "Some content to summarize."},
+            tool_output={"summary": "A brief summary."},
+        )
+
+
+def run_anomalous_session() -> None:
+    """Run a single anomalous session -- 5x tokens, different tools."""
+    with AgentSession(agent_id="drift-demo", conversation_id=new_uuid()):
+        # 8 LLM calls with 5x token counts
+        for _ in range(8):
+            record_llm_call(
+                model="claude-haiku-4-5",
+                provider="anthropic",
+                input_tokens=1000,
+                output_tokens=500,
+            )
+
+        # 5 tool calls -- completely different tool names
+        record_tool_call(
+            "fetch_data",
+            tool_input={"url": "https://example.com/data"},
+            tool_output={"rows": 1500},
+        )
+        record_tool_call(
+            "parse_html",
+            tool_input={"html": "<div>...</div>"},
+            tool_output={"elements": 42},
+        )
+        record_tool_call(
+            "extract_entities",
+            tool_input={"text": "Long document text..."},
+            tool_output={"entities": ["Entity1", "Entity2", "Entity3"]},
+        )
+        record_tool_call(
+            "classify",
+            tool_input={"text": "Classify this content."},
+            tool_output={"label": "finance", "confidence": 0.92},
+        )
+        record_tool_call(
+            "store_results",
+            tool_input={"key": "analysis_001", "value": "..."},
+            tool_output={"stored": True},
+        )
+
+
+# ---------------------------------------------------------------------------
+# Main
+# ---------------------------------------------------------------------------
+
+if __name__ == "__main__":
+    from ocw.sdk.bootstrap import ensure_initialised
+    ensure_initialised()
+
+    print("=" * 60)
+    print("OCW Behavioral Drift Detection Demo")
+    print("=" * 60)
+
+    # Phase 1 -- build baseline
+    print("\nPhase 1: Building baseline (12 normal sessions)...")
+    for i in range(1, 13):
+        run_normal_session(i)
+        print(f"  Session {i:2d}/12 complete")
+        time.sleep(0.05)  # Distinct timestamps between sessions
+
+    # Phase 2 -- anomalous session
+    print("\nPhase 2: Running anomalous session...")
+    run_anomalous_session()
+    print("  Anomalous session complete")
+
+    print("\n" + "=" * 60)
+    print("What to observe:")
+    print("=" * 60)
+    print(
+        "The anomalous session used 5x the normal token count and\n"
+        "a completely different set of tool calls. If drift detection\n"
+        "is enabled in your ocw.toml, a DRIFT_DETECTED alert should\n"
+        "fire when the anomalous session ends.\n"
+        "\n"
+        "Run these commands to inspect:\n"
+        "\n"
+        "  ocw alerts                          # see drift alerts\n"
+        "  ocw status --agent drift-demo       # agent overview\n"
+        "  ocw traces                          # list all 13 traces\n"
+    )

--- a/examples/alerts_and_drift/sensitive_actions_demo.py
+++ b/examples/alerts_and_drift/sensitive_actions_demo.py
@@ -1,0 +1,149 @@
+"""
+Sensitive Actions Alert Demo
+
+Simulates an agent that performs sensitive actions (send_email, delete_file,
+submit_form). Shows how ocw detects and alerts on configured sensitive tools.
+
+No API keys required — uses simulated instrumentation.
+
+# --- Required ocw.toml config ---
+# Add this to your ocw.toml (or ~/.config/ocw/config.toml):
+#
+# [[agents]]
+# id = "sensitive-demo"
+#
+# [[agents.sensitive_actions]]
+# name = "send_email"
+# severity = "warning"
+#
+# [[agents.sensitive_actions]]
+# name = "delete_file"
+# severity = "critical"
+#
+# [[agents.sensitive_actions]]
+# name = "submit_form"
+# severity = "warning"
+#
+# [[alerts.channels]]
+# type = "stdout"
+"""
+from __future__ import annotations
+
+import json
+import os
+import tempfile
+
+from ocw.sdk.agent import watch, record_llm_call, record_tool_call
+
+
+# ---------------------------------------------------------------------------
+# Fake tool implementations (no real side-effects)
+# ---------------------------------------------------------------------------
+
+def send_email(to: str, subject: str, body: str) -> dict:
+    """Write an email record to a temp log file."""
+    log_path = os.path.join(tempfile.gettempdir(), "ocw_email_log.txt")
+    with open(log_path, "a") as f:
+        f.write(f"To: {to}\nSubject: {subject}\nBody: {body}\n---\n")
+    return {"status": "sent", "log": log_path}
+
+
+def delete_file(path: str) -> dict:
+    """Create a temp file and delete it to simulate file deletion."""
+    tmp = tempfile.NamedTemporaryFile(delete=False, suffix="_demo.txt")
+    tmp.write(b"temporary content for demo")
+    tmp.close()
+    os.unlink(tmp.name)
+    return {"status": "deleted", "path": tmp.name}
+
+
+def submit_form(url: str, data: dict) -> dict:
+    """Print form submission to stdout (no network call)."""
+    print(f"  [simulated] POST {url} with data={json.dumps(data)}")
+    return {"status": "submitted", "url": url}
+
+
+# ---------------------------------------------------------------------------
+# Agent workflow
+# ---------------------------------------------------------------------------
+
+@watch(agent_id="sensitive-demo")
+def run_sensitive_agent() -> None:
+    """Simulate an agent that triggers three sensitive actions."""
+
+    # Step 1 -- LLM decides to send an email
+    print("\n[Step 1] Agent decides to send an email...")
+    record_llm_call(
+        model="claude-sonnet-4-20250514",
+        provider="anthropic",
+        input_tokens=500,
+        output_tokens=150,
+    )
+    email_input = {
+        "to": "alice@example.com",
+        "subject": "Weekly report",
+        "body": "Attached is the weekly summary.",
+    }
+    result = send_email(**email_input)
+    record_tool_call("send_email", tool_input=email_input, tool_output=result)
+    print(f"  -> send_email completed: {result['status']}")
+
+    # Step 2 -- LLM decides to delete a file
+    print("\n[Step 2] Agent decides to delete a file...")
+    record_llm_call(
+        model="claude-sonnet-4-20250514",
+        provider="anthropic",
+        input_tokens=500,
+        output_tokens=150,
+    )
+    delete_input = {"path": "/tmp/old_report.txt"}
+    result = delete_file(delete_input["path"])
+    record_tool_call("delete_file", tool_input=delete_input, tool_output=result)
+    print(f"  -> delete_file completed: {result['status']}")
+
+    # Step 3 -- LLM decides to submit a form
+    print("\n[Step 3] Agent decides to submit a form...")
+    record_llm_call(
+        model="claude-sonnet-4-20250514",
+        provider="anthropic",
+        input_tokens=500,
+        output_tokens=150,
+    )
+    form_input = {
+        "url": "https://example.com/api/feedback",
+        "data": {"rating": 5, "comment": "Great service"},
+    }
+    result = submit_form(form_input["url"], form_input["data"])
+    record_tool_call("submit_form", tool_input=form_input, tool_output=result)
+    print(f"  -> submit_form completed: {result['status']}")
+
+    print("\nAgent workflow complete.")
+
+
+# ---------------------------------------------------------------------------
+# Main
+# ---------------------------------------------------------------------------
+
+if __name__ == "__main__":
+    from ocw.sdk.bootstrap import ensure_initialised
+    ensure_initialised()
+
+    print("=" * 60)
+    print("OCW Sensitive Actions Alert Demo")
+    print("=" * 60)
+
+    run_sensitive_agent()
+
+    print("\n" + "=" * 60)
+    print("What to observe:")
+    print("=" * 60)
+    print(
+        "If your ocw.toml has the sensitive_actions config shown at the\n"
+        "top of this file, ocw should have fired alerts for each tool.\n"
+        "\n"
+        "Run these commands to inspect:\n"
+        "\n"
+        "  ocw alerts                  # see fired sensitive-action alerts\n"
+        "  ocw status                  # agent overview with alert count\n"
+        "  ocw traces                  # list recent traces\n"
+    )

--- a/examples/multi/rag_pipeline.py
+++ b/examples/multi/rag_pipeline.py
@@ -1,0 +1,164 @@
+"""
+RAG Pipeline with Provider Fallback — LlamaIndex + OpenAI/Anthropic.
+
+Demonstrates a retrieval-augmented generation pipeline that falls back from
+OpenAI to Anthropic when the primary provider fails. Requires `ocw serve`
+running on localhost:8787 for span ingestion.
+
+Extra deps:
+    pip install llama-index openai anthropic
+
+Required env vars:
+    OPENAI_API_KEY, ANTHROPIC_API_KEY
+
+Prerequisite:
+    ocw serve   (must be running on localhost:8787)
+"""
+from __future__ import annotations
+
+import os
+import sys
+from pathlib import Path
+
+import httpx
+
+from ocw.sdk import watch, patch_llamaindex, patch_openai, patch_anthropic
+from ocw.sdk.agent import record_tool_call
+
+# ---------------------------------------------------------------------------
+# Env-var gate
+# ---------------------------------------------------------------------------
+REQUIRED_KEYS = ["OPENAI_API_KEY", "ANTHROPIC_API_KEY"]
+missing = [k for k in REQUIRED_KEYS if not os.environ.get(k)]
+if missing:
+    sys.exit(f"Missing env vars: {', '.join(missing)}")
+
+# ---------------------------------------------------------------------------
+# Connectivity check — ocw serve must be running
+# ---------------------------------------------------------------------------
+try:
+    resp = httpx.get("http://localhost:8787/api/v1/spans", timeout=3)
+except httpx.ConnectError:
+    sys.exit(
+        "Cannot connect to ocw serve on localhost:8787. "
+        "Start it first: ocw serve"
+    )
+
+# ---------------------------------------------------------------------------
+# Activate patches
+# ---------------------------------------------------------------------------
+patch_llamaindex()
+patch_openai()
+patch_anthropic()
+
+
+# ---------------------------------------------------------------------------
+# Document loading and index construction
+# ---------------------------------------------------------------------------
+DOCS_DIR = Path(__file__).parent / "sample_docs"
+
+
+def build_index():
+    """Load sample docs and build an in-memory vector index."""
+    from llama_index.core import (
+        SimpleDirectoryReader,
+        VectorStoreIndex,
+    )
+
+    documents = SimpleDirectoryReader(str(DOCS_DIR)).load_data()
+    print(f"Loaded {len(documents)} documents from {DOCS_DIR}")
+    index = VectorStoreIndex.from_documents(documents)
+    return index
+
+
+# ---------------------------------------------------------------------------
+# Query with provider fallback
+# ---------------------------------------------------------------------------
+def query_with_fallback(
+    index,
+    question: str,
+    force_fallback: bool = False,
+) -> str:
+    """
+    Query the index with OpenAI; fall back to Anthropic on failure.
+
+    When force_fallback is True, the OpenAI path is skipped to demonstrate
+    the fallback branch in the trace.
+    """
+    from llama_index.core import Settings
+
+    # Record the retrieval step
+    record_tool_call(
+        "retrieval",
+        tool_input={"question": question},
+        tool_output={"source": "sample_docs", "chunks_retrieved": 3},
+    )
+
+    # --- Primary: OpenAI ---
+    if not force_fallback:
+        try:
+            from llama_index.llms.openai import OpenAI as LlamaOpenAI
+
+            Settings.llm = LlamaOpenAI(model="gpt-4o-mini")
+            engine = index.as_query_engine()
+            response = engine.query(question)
+            print(f"  [OpenAI] {response}")
+            return str(response)
+        except Exception as exc:
+            print(f"  [OpenAI failed: {exc}] Falling back to Anthropic...")
+
+    # --- Fallback: Anthropic ---
+    try:
+        from llama_index.llms.anthropic import Anthropic as LlamaAnthropic
+
+        Settings.llm = LlamaAnthropic(model="claude-sonnet-4-20250514")
+        engine = index.as_query_engine()
+        response = engine.query(question)
+        print(f"  [Anthropic fallback] {response}")
+        return str(response)
+    except Exception as exc:
+        error_msg = f"Both providers failed: {exc}"
+        print(f"  {error_msg}")
+        return error_msg
+
+
+# ---------------------------------------------------------------------------
+# Main agent
+# ---------------------------------------------------------------------------
+@watch(agent_id="rag-pipeline")
+def main() -> None:
+    index = build_index()
+
+    questions = [
+        ("What are the key pillars of observability?", False),
+        # Force fallback on the second question to show both providers
+        ("How can I reduce LLM API costs?", True),
+        ("What safety guardrails should AI agents have?", False),
+    ]
+
+    for question, force_fallback in questions:
+        label = " [forced fallback]" if force_fallback else ""
+        print(f"\nQ: {question}{label}")
+        query_with_fallback(index, question, force_fallback=force_fallback)
+
+
+if __name__ == "__main__":
+    main()
+
+# ---------------------------------------------------------------------------
+# Observation
+# ---------------------------------------------------------------------------
+# After running, inspect the RAG session:
+#
+#   ocw traces --since 10m
+#       -> Single trace showing retrieval + LLM spans
+#
+#   ocw trace <trace-id>
+#       -> Waterfall: session -> retrieval tool calls -> LLM calls
+#          The second question shows both OpenAI (skipped) and Anthropic spans
+#
+#   ocw cost --since 1h
+#       -> Cost comparison between OpenAI and Anthropic calls
+#
+#   ocw tools
+#       -> "retrieval" tool call count matching the number of questions

--- a/examples/multi/research_team.py
+++ b/examples/multi/research_team.py
@@ -1,0 +1,189 @@
+"""
+Multi-Framework Research Team — CrewAI agents with LangChain tools.
+
+Demonstrates deep span trees from combining CrewAI multi-agent orchestration
+with LangChain tool abstractions, all captured in a single ocw session.
+
+Extra deps:
+    pip install anthropic crewai langchain-core
+
+Required env vars:
+    ANTHROPIC_API_KEY, OPENAI_API_KEY
+"""
+from __future__ import annotations
+
+import os
+import sys
+from pathlib import Path
+
+from ocw.sdk import watch, patch_anthropic, patch_crewai, patch_langchain
+
+# ---------------------------------------------------------------------------
+# Env-var gate
+# ---------------------------------------------------------------------------
+REQUIRED_KEYS = ["ANTHROPIC_API_KEY", "OPENAI_API_KEY"]
+missing = [k for k in REQUIRED_KEYS if not os.environ.get(k)]
+if missing:
+    sys.exit(f"Missing env vars: {', '.join(missing)}")
+
+# ---------------------------------------------------------------------------
+# Activate patches BEFORE importing framework classes
+# ---------------------------------------------------------------------------
+patch_anthropic()
+patch_crewai()
+patch_langchain()
+
+# ---------------------------------------------------------------------------
+# LangChain tool stubs
+# ---------------------------------------------------------------------------
+from langchain_core.tools import BaseTool  # noqa: E402
+
+
+class WebSearchTool(BaseTool):
+    """Simulated web search returning fake results."""
+
+    name: str = "web_search"
+    description: str = "Search the web for information on a topic."
+
+    def _run(self, query: str) -> str:
+        return (
+            f"Search results for '{query}':\n"
+            "1. Recent advances in renewable energy storage (Nature, 2025)\n"
+            "2. Global renewable capacity grew 15% year-over-year (IEA)\n"
+            "3. Battery costs fell below $100/kWh milestone (BloombergNEF)"
+        )
+
+
+class CalculatorTool(BaseTool):
+    """Simple calculator that evaluates math expressions."""
+
+    name: str = "calculator"
+    description: str = "Evaluate a mathematical expression."
+
+    def _run(self, expression: str) -> str:
+        try:
+            result = eval(expression, {"__builtins__": {}})  # noqa: S307
+            return f"{expression} = {result}"
+        except Exception as exc:
+            return f"Error evaluating '{expression}': {exc}"
+
+
+class FileReaderTool(BaseTool):
+    """Reads a sample document from the sample_docs directory."""
+
+    name: str = "file_reader"
+    description: str = "Read a document file by name from sample_docs."
+
+    def _run(self, filename: str) -> str:
+        docs_dir = Path(__file__).parent / "sample_docs"
+        target = docs_dir / filename
+        if not target.exists():
+            available = [f.name for f in docs_dir.glob("*.txt")]
+            return f"File '{filename}' not found. Available: {available}"
+        return target.read_text()[:500]
+
+
+# ---------------------------------------------------------------------------
+# CrewAI setup
+# ---------------------------------------------------------------------------
+from crewai import Agent, Task, Crew  # noqa: E402
+
+
+def build_crew() -> Crew:
+    """Create a research crew with three specialized agents."""
+    tools = [WebSearchTool(), CalculatorTool(), FileReaderTool()]
+
+    lead_researcher = Agent(
+        role="Lead Researcher",
+        goal="Coordinate the research team to produce a concise report",
+        backstory=(
+            "You are an experienced research lead who delegates effectively."
+        ),
+        tools=tools,
+        verbose=True,
+    )
+
+    data_analyst = Agent(
+        role="Data Analyst",
+        goal="Analyze numerical data and compute statistics",
+        backstory="You specialize in quantitative analysis and calculations.",
+        tools=[CalculatorTool()],
+        verbose=True,
+    )
+
+    writer = Agent(
+        role="Report Writer",
+        goal="Synthesize findings into a clear, concise report",
+        backstory="You turn raw research into polished written output.",
+        tools=[FileReaderTool()],
+        verbose=True,
+    )
+
+    research_task = Task(
+        description=(
+            "Search the web for the latest trends in renewable energy "
+            "and summarize the top three findings."
+        ),
+        expected_output="A bullet-point list of 3 key findings.",
+        agent=lead_researcher,
+    )
+
+    analysis_task = Task(
+        description=(
+            "If global renewable capacity was 3,500 GW last year and grew "
+            "15%, calculate the new total capacity. Also compute the cost "
+            "savings if battery prices dropped from $130 to $97 per kWh "
+            "for a 100 MWh installation."
+        ),
+        expected_output="Numerical results with brief explanations.",
+        agent=data_analyst,
+    )
+
+    report_task = Task(
+        description=(
+            "Read the cost_management.txt sample document for context, "
+            "then combine the research findings and analysis into a "
+            "200-word executive summary."
+        ),
+        expected_output="A polished executive summary paragraph.",
+        agent=writer,
+    )
+
+    return Crew(
+        agents=[lead_researcher, data_analyst, writer],
+        tasks=[research_task, analysis_task, report_task],
+        verbose=True,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Main agent
+# ---------------------------------------------------------------------------
+@watch(agent_id="research-team")
+def main() -> None:
+    crew = build_crew()
+    result = crew.kickoff()
+    print("\n=== Final Report ===")
+    print(result)
+
+
+if __name__ == "__main__":
+    main()
+
+# ---------------------------------------------------------------------------
+# Observation
+# ---------------------------------------------------------------------------
+# After running, explore the multi-agent session:
+#
+#   ocw traces --since 10m
+#       -> Single trace containing all three agents' activity
+#
+#   ocw trace <trace-id>
+#       -> Deep span tree: session -> agent tasks -> LLM calls + tool calls
+#
+#   ocw tools
+#       -> Breakdown of web_search, calculator, and file_reader usage
+#          showing call counts and average durations
+#
+#   ocw cost --since 1h
+#       -> Total session cost across all LLM calls made by the crew

--- a/examples/multi/router_agent.py
+++ b/examples/multi/router_agent.py
@@ -1,0 +1,149 @@
+"""
+Provider Router Agent — routes tasks to the best LLM provider.
+
+Demonstrates multi-provider observability with ocw: each routing decision
+and LLM call appears as a span in a single trace, enabling cost comparison
+across providers.
+
+Extra deps:
+    pip install anthropic openai google-generativeai
+
+Required env vars:
+    ANTHROPIC_API_KEY, OPENAI_API_KEY, GOOGLE_API_KEY (or GEMINI_API_KEY)
+"""
+from __future__ import annotations
+
+import os
+import sys
+
+from ocw.sdk import watch
+from ocw.sdk.agent import record_tool_call
+from ocw.sdk.integrations.anthropic import patch_anthropic
+from ocw.sdk.integrations.gemini import patch_gemini
+from ocw.sdk.integrations.openai import patch_openai
+
+# ---------------------------------------------------------------------------
+# Env-var gate
+# ---------------------------------------------------------------------------
+REQUIRED_KEYS = ["ANTHROPIC_API_KEY", "OPENAI_API_KEY"]
+GOOGLE_KEY = os.environ.get("GOOGLE_API_KEY") or os.environ.get(
+    "GEMINI_API_KEY"
+)
+missing = [k for k in REQUIRED_KEYS if not os.environ.get(k)]
+if not GOOGLE_KEY:
+    missing.append("GOOGLE_API_KEY or GEMINI_API_KEY")
+if missing:
+    sys.exit(f"Missing env vars: {', '.join(missing)}")
+
+# ---------------------------------------------------------------------------
+# Activate provider patches BEFORE creating any clients
+# ---------------------------------------------------------------------------
+patch_openai()
+patch_anthropic()
+patch_gemini()
+
+
+# ---------------------------------------------------------------------------
+# Provider helpers
+# ---------------------------------------------------------------------------
+def route(task_type: str) -> str:
+    """Pick the best provider for a given task type."""
+    mapping = {
+        "factual": "gemini",
+        "code": "anthropic",
+        "creative": "openai",
+    }
+    return mapping.get(task_type, "openai")
+
+
+def ask_gemini(prompt: str) -> str:
+    """Send a prompt to Gemini Flash."""
+    import google.generativeai as genai  # type: ignore[import-untyped]
+
+    genai.configure(api_key=GOOGLE_KEY)
+    model = genai.GenerativeModel("gemini-2.0-flash")
+    response = model.generate_content(prompt)
+    return response.text
+
+
+def ask_claude(prompt: str) -> str:
+    """Send a prompt to Claude."""
+    import anthropic
+
+    client = anthropic.Anthropic()
+    message = client.messages.create(
+        model="claude-sonnet-4-20250514",
+        max_tokens=1024,
+        messages=[{"role": "user", "content": prompt}],
+    )
+    return message.content[0].text
+
+
+def ask_openai(prompt: str) -> str:
+    """Send a prompt to GPT-4o."""
+    import openai
+
+    client = openai.OpenAI()
+    response = client.chat.completions.create(
+        model="gpt-4o",
+        messages=[{"role": "user", "content": prompt}],
+        max_tokens=1024,
+    )
+    return response.choices[0].message.content or ""
+
+
+PROVIDERS = {
+    "gemini": ask_gemini,
+    "anthropic": ask_claude,
+    "openai": ask_openai,
+}
+
+
+# ---------------------------------------------------------------------------
+# Main agent
+# ---------------------------------------------------------------------------
+@watch(agent_id="router-agent")
+def main() -> None:
+    tasks = [
+        ("factual", "What is the capital of France?"),
+        ("code", "Write a Python function to find prime numbers"),
+        ("creative", "Write a short poem about debugging"),
+    ]
+
+    for task_type, prompt in tasks:
+        provider = route(task_type)
+
+        # Record the routing decision as a tool call span
+        record_tool_call(
+            "route",
+            tool_input={"task_type": task_type},
+            tool_output={"provider": provider},
+        )
+
+        print(f"\n[{task_type}] Routed to: {provider}")
+        print(f"  Prompt: {prompt}")
+
+        handler = PROVIDERS[provider]
+        response = handler(prompt)
+        print(f"  Response: {response[:200]}...")
+
+
+if __name__ == "__main__":
+    main()
+
+# ---------------------------------------------------------------------------
+# Observation
+# ---------------------------------------------------------------------------
+# After running this script, inspect the trace and cost breakdown:
+#
+#   ocw traces --since 5m
+#       -> Shows a single trace with spans for each provider call
+#
+#   ocw trace <trace-id>
+#       -> Waterfall view: session span -> route tool calls + LLM calls
+#
+#   ocw cost --since 1h
+#       -> Compare cost across gemini, anthropic, and openai in one session
+#
+#   ocw tools
+#       -> Shows the "route" tool call count and timing

--- a/examples/multi/sample_docs/agent_patterns.txt
+++ b/examples/multi/sample_docs/agent_patterns.txt
@@ -1,0 +1,21 @@
+Common AI Agent Design Patterns
+
+AI agents follow several recurring architectural patterns. The simplest is the
+single-loop agent: receive input, call an LLM, optionally invoke tools, and
+return a response. This works well for straightforward tasks but struggles with
+complex multi-step problems.
+
+The router pattern directs each sub-task to the best-suited model or provider.
+A cheap, fast model handles simple lookups while a more capable model tackles
+reasoning-heavy work. This optimizes cost and latency across a session.
+
+Multi-agent teams assign specialized roles to different agents. A lead agent
+decomposes a goal into sub-tasks and delegates them to worker agents, each with
+its own tools and system prompt. Frameworks like CrewAI and AutoGen formalize
+this pattern with role definitions and communication protocols.
+
+The RAG pattern augments LLM calls with retrieved context. Documents are chunked,
+embedded, and stored in a vector index. At query time, relevant chunks are
+retrieved and injected into the prompt, grounding the model's response in
+source material and reducing hallucinations. Fallback chains add resilience
+by switching providers when the primary one fails.

--- a/examples/multi/sample_docs/cost_management.txt
+++ b/examples/multi/sample_docs/cost_management.txt
@@ -1,0 +1,23 @@
+Managing LLM API Costs
+
+LLM API costs scale with token volume, making cost management essential for any
+production agent system. The primary levers are model selection, prompt
+engineering, and caching.
+
+Model selection has the largest impact. Routing simple queries to smaller, cheaper
+models while reserving expensive frontier models for complex reasoning can reduce
+costs by an order of magnitude. A tiered approach assigns tasks based on
+complexity scores or task type heuristics.
+
+Prompt engineering reduces input tokens by trimming unnecessary context, using
+concise system prompts, and summarizing conversation history instead of passing
+full transcripts. Output token limits prevent runaway generation.
+
+Caching avoids redundant calls. Semantic caches match new queries against
+previous responses using embedding similarity. Provider-level prompt caching
+(like Anthropic's cache_read tokens) discounts repeated prefixes.
+
+Budget alerts provide a safety net. Setting per-session and per-day cost
+thresholds triggers warnings before spend spirals. Observability tools that
+track cost per span, per model, and per agent make it easy to identify the
+most expensive components and optimize them first.

--- a/examples/multi/sample_docs/observability.txt
+++ b/examples/multi/sample_docs/observability.txt
@@ -1,0 +1,21 @@
+Observability in AI Systems
+
+Observability is the ability to understand the internal state of a system by
+examining its external outputs. In traditional software, observability relies on
+three pillars: logs, metrics, and traces. AI agent systems add new dimensions
+that demand richer telemetry.
+
+Token usage drives both cost and latency, making it a first-class observable.
+Each LLM call consumes input and output tokens whose counts must be captured at
+the span level. Traces become trees of nested spans: a session span wrapping
+multiple LLM calls and tool invocations, revealing where time and money are
+spent.
+
+Semantic conventions standardize attribute names so that different providers and
+frameworks produce comparable data. OpenTelemetry's GenAI semantic conventions
+define attributes like gen_ai.request.model and gen_ai.usage.input_tokens.
+
+Local-first observability stores telemetry on the developer's machine, avoiding
+the need for a cloud backend during prototyping. This approach keeps data
+private, reduces latency, and eliminates signup friction while still supporting
+export to production observability platforms when needed.

--- a/examples/multi/sample_docs/safety.txt
+++ b/examples/multi/sample_docs/safety.txt
@@ -1,0 +1,24 @@
+AI Agent Safety and Guardrails
+
+Autonomous AI agents can take actions with real-world consequences, making safety
+guardrails a critical design concern. Effective guardrails operate at multiple
+layers: input validation, output filtering, action approval, and behavioral
+monitoring.
+
+Input validation screens user prompts for injection attacks and out-of-scope
+requests before they reach the LLM. Output filtering checks model responses for
+harmful content, PII leakage, and hallucinated facts before they are returned to
+the user or passed to downstream tools.
+
+Action approval gates prevent agents from executing high-risk operations without
+human confirmation. A tool allowlist restricts which external APIs an agent can
+call, while rate limits cap the number of actions per session.
+
+Behavioral monitoring detects drift from expected patterns. If an agent suddenly
+makes far more tool calls than usual, repeats the same action in a loop, or its
+error rate spikes, an alert should fire. Statistical methods like Z-score
+analysis on span metrics can identify anomalous sessions in real time.
+
+Defense in depth combines all these layers so that no single failure leads to
+unsafe behavior. Logging every decision in an observable trace makes post-incident
+analysis possible and builds trust in autonomous agent systems.

--- a/examples/single_framework/autogen_agent.py
+++ b/examples/single_framework/autogen_agent.py
@@ -1,0 +1,85 @@
+"""
+AutoGen agent example with OCW observability.
+
+Creates two ConversableAgent debaters that argue for and against a position.
+OCW patches ConversableAgent.generate_reply and .initiate_chat for span capture.
+
+Extra deps: pip install pyautogen
+Run:        python examples/single_framework/autogen_agent.py
+"""
+import os
+import sys
+
+if not os.environ.get("OPENAI_API_KEY"):
+    sys.exit(
+        "OPENAI_API_KEY not set.\n"
+        "Export it before running: export OPENAI_API_KEY=sk-..."
+    )
+
+from autogen import ConversableAgent  # noqa: E402
+
+from ocw.sdk import watch, patch_autogen  # noqa: E402
+
+# Patch AutoGen BEFORE creating agents
+patch_autogen()
+
+TOPIC = "AI agents should always have observability built in"
+
+
+@watch(agent_id="autogen-demo")
+def main():
+    llm_config = {
+        "model": "gpt-4o-mini",
+        "api_key": os.environ["OPENAI_API_KEY"],
+    }
+
+    debater_for = ConversableAgent(
+        name="debater_for",
+        system_message=(
+            f"You argue FOR the position: '{TOPIC}'. "
+            "Keep responses to 2-3 sentences. Be persuasive but concise."
+        ),
+        llm_config=llm_config,
+        human_input_mode="NEVER",
+    )
+
+    debater_against = ConversableAgent(
+        name="debater_against",
+        system_message=(
+            f"You argue AGAINST the position: '{TOPIC}'. "
+            "Keep responses to 2-3 sentences. Be persuasive but concise."
+        ),
+        llm_config=llm_config,
+        human_input_mode="NEVER",
+    )
+
+    print(f"Debate topic: {TOPIC}\n")
+    print("Starting 3-turn debate...\n")
+
+    # initiate_chat is patched by OCW to create a span
+    chat_result = debater_for.initiate_chat(
+        debater_against,
+        message=(
+            f"I'll start: {TOPIC}. "
+            "Every AI agent in production needs observability -- without it, "
+            "you're flying blind when things go wrong."
+        ),
+        max_turns=3,
+    )
+
+    print("\n--- Chat History ---")
+    for msg in chat_result.chat_history:
+        role = msg.get("role", "unknown")
+        content = msg.get("content", "")
+        print(f"[{role}] {content}\n")
+
+    # --- Observation ---
+    print("--- OCW Observation ---")
+    print("AutoGen integration captured spans for:")
+    print("  - Chat initiation via ConversableAgent.initiate_chat")
+    print("  - Reply generation via ConversableAgent.generate_reply")
+    print("Run 'ocw traces' to see the captured telemetry.")
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/single_framework/crewai_agent.py
+++ b/examples/single_framework/crewai_agent.py
@@ -1,0 +1,89 @@
+"""
+CrewAI agent example with OCW observability.
+
+Creates a 2-agent crew (researcher + writer) that collaborates on a task.
+OCW patches Task.execute and Agent.execute_task to capture spans automatically.
+
+Extra deps: pip install crewai
+Run:        python examples/single_framework/crewai_agent.py
+"""
+import os
+import sys
+
+if not os.environ.get("OPENAI_API_KEY"):
+    sys.exit(
+        "OPENAI_API_KEY not set.\n"
+        "Export it before running: export OPENAI_API_KEY=sk-..."
+    )
+
+from crewai import Agent, Task, Crew  # noqa: E402
+
+from ocw.sdk import watch, patch_crewai  # noqa: E402
+
+# Patch CrewAI BEFORE creating agents and tasks
+patch_crewai()
+
+
+@watch(agent_id="crewai-demo")
+def main():
+    # Create agents
+    researcher = Agent(
+        role="Senior Researcher",
+        goal="Find key facts about the given topic",
+        backstory=(
+            "You are an experienced researcher who excels at finding "
+            "and synthesizing information on technical topics."
+        ),
+        verbose=True,
+    )
+
+    writer = Agent(
+        role="Technical Writer",
+        goal="Write clear, concise summaries",
+        backstory=(
+            "You are a skilled technical writer who distills complex "
+            "research into accessible summaries."
+        ),
+        verbose=True,
+    )
+
+    # Create tasks
+    research_task = Task(
+        description=(
+            "Research the benefits of observability in AI agent systems. "
+            "Identify the top 3 benefits and explain each briefly."
+        ),
+        expected_output="A list of 3 key benefits with brief explanations.",
+        agent=researcher,
+    )
+
+    write_task = Task(
+        description=(
+            "Based on the research findings, write a 3-sentence summary "
+            "about why observability matters for AI agents."
+        ),
+        expected_output="A concise 3-sentence summary paragraph.",
+        agent=writer,
+    )
+
+    # Create and run the crew
+    crew = Crew(
+        agents=[researcher, writer],
+        tasks=[research_task, write_task],
+        verbose=True,
+    )
+
+    print("Starting CrewAI crew...\n")
+    result = crew.kickoff()
+    print(f"\n--- Crew Result ---\n{result}\n")
+
+    # --- Observation ---
+    print("--- OCW Observation ---")
+    print("CrewAI integration captured spans for:")
+    print("  - Task execution via Task.execute")
+    print("  - Agent task execution via Agent.execute_task")
+    print("Run 'ocw traces' to see the captured telemetry.")
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/single_framework/langchain_agent.py
+++ b/examples/single_framework/langchain_agent.py
@@ -1,0 +1,104 @@
+"""
+LangChain agent example with OCW observability.
+
+Uses ChatOpenAI with tool bindings to demonstrate LangChain integration.
+OCW patches BaseLLM.generate and BaseTool.run to capture spans automatically.
+
+Extra deps: pip install langchain-core langchain-openai
+Run:        python examples/single_framework/langchain_agent.py
+"""
+import os
+import sys
+
+if not os.environ.get("OPENAI_API_KEY"):
+    sys.exit(
+        "OPENAI_API_KEY not set.\n"
+        "Export it before running: export OPENAI_API_KEY=sk-..."
+    )
+
+from langchain_core.tools import BaseTool  # noqa: E402
+from langchain_openai import ChatOpenAI  # noqa: E402
+
+from ocw.sdk import watch, patch_langchain  # noqa: E402
+
+# Patch LangChain BEFORE creating any LangChain objects
+patch_langchain()
+
+
+class CalculatorTool(BaseTool):
+    name: str = "calculator"
+    description: str = "Evaluate a math expression and return the result."
+
+    def _run(self, expression: str) -> str:
+        try:
+            result = eval(expression, {"__builtins__": {}}, {})  # noqa: S307
+            return str(result)
+        except Exception as exc:
+            return f"Error: {exc}"
+
+
+class WordCounterTool(BaseTool):
+    name: str = "word_counter"
+    description: str = "Count the number of words in a given string."
+
+    def _run(self, text: str) -> str:
+        count = len(text.split())
+        return f"{count} words"
+
+
+@watch(agent_id="langchain-demo")
+def main():
+    llm = ChatOpenAI(model="gpt-4o-mini", temperature=0)
+    tools = [CalculatorTool(), WordCounterTool()]
+    llm_with_tools = llm.bind_tools(tools)
+
+    question = (
+        "How many words are in 'the quick brown fox jumps over the lazy dog' "
+        "and what is 42 * 17?"
+    )
+    print(f"Question: {question}\n")
+
+    # First LLM call -- may request tool calls
+    response = llm_with_tools.invoke(question)
+    print(f"LLM response: {response.content}")
+
+    # Process tool calls if present
+    tool_map = {t.name: t for t in tools}
+    tool_results = []
+
+    if response.tool_calls:
+        for tc in response.tool_calls:
+            tool_name = tc["name"]
+            tool_args = tc["args"]
+            print(f"\nTool call: {tool_name}({tool_args})")
+            tool = tool_map[tool_name]
+            # BaseTool.run is patched by OCW
+            result = tool.run(tool_args)
+            print(f"Tool result: {result}")
+            tool_results.append({"tool_call_id": tc["id"], "result": result})
+
+    # If we got tool results, send them back to the LLM for a final answer
+    if tool_results:
+        from langchain_core.messages import HumanMessage, AIMessage, ToolMessage
+
+        messages = [
+            HumanMessage(content=question),
+            AIMessage(content=response.content, tool_calls=response.tool_calls),
+        ]
+        for tr in tool_results:
+            messages.append(
+                ToolMessage(content=tr["result"], tool_call_id=tr["tool_call_id"])
+            )
+        final = llm_with_tools.invoke(messages)
+        print(f"\nFinal answer: {final.content}")
+
+    # --- Observation ---
+    print("\n--- OCW Observation ---")
+    print("LangChain integration captured spans for:")
+    print("  - LLM calls via ChatOpenAI")
+    print("  - Tool calls via BaseTool.run")
+    print("Run 'ocw traces' to see the captured telemetry.")
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/single_framework/langgraph_agent.py
+++ b/examples/single_framework/langgraph_agent.py
@@ -1,0 +1,116 @@
+"""
+LangGraph agent example with OCW observability.
+
+Builds a simple 3-node StateGraph (plan -> execute -> review) and runs it.
+OCW patches CompiledGraph.invoke to capture the graph execution as a span,
+and BaseLLM.generate to capture individual LLM calls within each node.
+
+Extra deps: pip install langgraph langchain-openai
+Run:        python examples/single_framework/langgraph_agent.py
+"""
+import os
+import sys
+
+if not os.environ.get("OPENAI_API_KEY"):
+    sys.exit(
+        "OPENAI_API_KEY not set.\n"
+        "Export it before running: export OPENAI_API_KEY=sk-..."
+    )
+
+from typing import TypedDict  # noqa: E402
+
+from langchain_openai import ChatOpenAI  # noqa: E402
+from langgraph.graph import StateGraph, START, END  # noqa: E402
+
+from ocw.sdk import watch, patch_langgraph, patch_langchain  # noqa: E402
+
+# Patch both LangGraph and LangChain (LangGraph uses LangChain LLMs)
+patch_langgraph()
+patch_langchain()
+
+llm = ChatOpenAI(model="gpt-4o-mini", temperature=0.7)
+
+
+class WorkflowState(TypedDict):
+    task: str
+    plan: str
+    result: str
+    review: str
+
+
+def plan_node(state: WorkflowState) -> WorkflowState:
+    """Use the LLM to create a plan for the given task."""
+    prompt = (
+        f"Create a brief 3-step plan for the following task. "
+        f"Return only the numbered steps.\n\nTask: {state['task']}"
+    )
+    response = llm.invoke(prompt)
+    plan = response.content
+    print(f"[plan] {plan}\n")
+    return {**state, "plan": plan}
+
+
+def execute_node(state: WorkflowState) -> WorkflowState:
+    """Use the LLM to execute the plan."""
+    prompt = (
+        f"Execute the following plan and produce the final output.\n\n"
+        f"Task: {state['task']}\nPlan:\n{state['plan']}"
+    )
+    response = llm.invoke(prompt)
+    result = response.content
+    print(f"[execute] {result}\n")
+    return {**state, "result": result}
+
+
+def review_node(state: WorkflowState) -> WorkflowState:
+    """Use the LLM to review the output."""
+    prompt = (
+        f"Review the following output for the given task. "
+        f"Provide a brief quality assessment (2-3 sentences).\n\n"
+        f"Task: {state['task']}\nOutput:\n{state['result']}"
+    )
+    response = llm.invoke(prompt)
+    review = response.content
+    print(f"[review] {review}\n")
+    return {**state, "review": review}
+
+
+@watch(agent_id="langgraph-demo")
+def main():
+    # Build the graph: START -> plan -> execute -> review -> END
+    graph = StateGraph(WorkflowState)
+    graph.add_node("plan", plan_node)
+    graph.add_node("execute", execute_node)
+    graph.add_node("review", review_node)
+    graph.add_edge(START, "plan")
+    graph.add_edge("plan", "execute")
+    graph.add_edge("execute", "review")
+    graph.add_edge("review", END)
+
+    compiled = graph.compile()
+
+    task = "Write a haiku about observability"
+    print(f"Task: {task}\n")
+
+    result = compiled.invoke({
+        "task": task,
+        "plan": "",
+        "result": "",
+        "review": "",
+    })
+
+    print("--- Final State ---")
+    print(f"Plan:\n{result['plan']}\n")
+    print(f"Result:\n{result['result']}\n")
+    print(f"Review:\n{result['review']}\n")
+
+    # --- Observation ---
+    print("--- OCW Observation ---")
+    print("LangGraph integration captured spans for:")
+    print("  - Graph invocation via CompiledGraph.invoke")
+    print("  - Individual LLM calls within each node (via LangChain patch)")
+    print("Run 'ocw traces' to see the captured telemetry.")
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/single_framework/llamaindex_agent.py
+++ b/examples/single_framework/llamaindex_agent.py
@@ -1,0 +1,116 @@
+"""
+LlamaIndex agent example with OCW observability.
+
+Uses LlamaIndex's native OTel support to export spans to ocw serve.
+Builds a VectorStoreIndex from sample documents and queries it.
+
+IMPORTANT: This example requires `ocw serve` to be running because
+LlamaIndex integration exports spans over HTTP (not in-process).
+
+Extra deps: pip install llama-index opentelemetry-instrumentation-llama-index
+Run:        ocw serve &
+            python examples/single_framework/llamaindex_agent.py
+"""
+import os
+import sys
+
+if not os.environ.get("OPENAI_API_KEY"):
+    sys.exit(
+        "OPENAI_API_KEY not set.\n"
+        "Export it before running: export OPENAI_API_KEY=sk-..."
+    )
+
+import httpx  # noqa: E402
+
+try:
+    httpx.get("http://127.0.0.1:8787/api/v1/traces", timeout=2)
+except httpx.ConnectError:
+    sys.exit(
+        "This example requires ocw serve to be running.\n"
+        "Start it with: ocw serve &"
+    )
+
+from pathlib import Path  # noqa: E402
+
+from llama_index.core import Document, VectorStoreIndex  # noqa: E402
+
+from ocw.sdk import watch, patch_llamaindex  # noqa: E402
+
+# Configure LlamaIndex's native OTel to export to ocw serve
+patch_llamaindex()
+
+# Sample documents directory: examples/multi/sample_docs/
+# If those files exist, load them; otherwise use inline fallback documents.
+SAMPLE_DOCS_DIR = Path(__file__).parent.parent / "multi" / "sample_docs"
+
+
+def load_documents() -> list[Document]:
+    """Load documents from sample_docs dir or create inline fallbacks."""
+    if SAMPLE_DOCS_DIR.is_dir():
+        docs = []
+        for path in sorted(SAMPLE_DOCS_DIR.glob("*.txt")):
+            text = path.read_text()
+            if text.strip():
+                docs.append(Document(text=text, metadata={"source": path.name}))
+        if docs:
+            print(f"Loaded {len(docs)} documents from {SAMPLE_DOCS_DIR}")
+            return docs
+
+    # Fallback: inline sample documents
+    print("Using inline fallback documents (sample_docs not found)")
+    return [
+        Document(
+            text=(
+                "Observability in AI agents involves collecting traces, metrics, "
+                "and logs from agent runtimes. Unlike traditional monitoring which "
+                "focuses on infrastructure health, agent observability tracks "
+                "LLM calls, token usage, tool invocations, and decision chains. "
+                "This enables developers to understand why an agent made specific "
+                "choices, identify cost anomalies, and detect behavioral drift "
+                "over time."
+            ),
+            metadata={"source": "observability_overview.txt"},
+        ),
+        Document(
+            text=(
+                "OpenTelemetry (OTel) provides a vendor-neutral standard for "
+                "distributed tracing. When applied to AI agents, each LLM call "
+                "becomes a span with attributes like model name, token counts, "
+                "and latency. Tool calls are captured as child spans, creating "
+                "a full execution tree. This structured telemetry can be exported "
+                "to any OTel-compatible backend for analysis and alerting."
+            ),
+            metadata={"source": "otel_for_agents.txt"},
+        ),
+    ]
+
+
+@watch(agent_id="llamaindex-demo")
+def main():
+    documents = load_documents()
+
+    print("Building vector index...\n")
+    index = VectorStoreIndex.from_documents(documents)
+    query_engine = index.as_query_engine()
+
+    questions = [
+        "What is observability in the context of AI agents?",
+        "How does OpenTelemetry help with agent monitoring?",
+    ]
+
+    for question in questions:
+        print(f"Q: {question}")
+        response = query_engine.query(question)
+        print(f"A: {response}\n")
+
+    # --- Observation ---
+    print("--- OCW Observation ---")
+    print("LlamaIndex integration captured spans via native OTel support:")
+    print("  - Document indexing and embedding calls")
+    print("  - Query engine retrieval and LLM synthesis")
+    print("  - Spans exported to ocw serve over HTTP")
+    print("Run 'ocw traces' to see the captured telemetry.")
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/single_provider/anthropic_agent.py
+++ b/examples/single_provider/anthropic_agent.py
@@ -1,0 +1,188 @@
+"""
+Anthropic tool-use agent with OCW observability.
+
+Demonstrates the full Anthropic tool-use loop: message -> tool_use -> tool_result -> final
+response, with each tool invocation recorded via ocw's record_tool_call().
+
+Requirements:
+    pip install anthropic openclawwatch
+
+Environment:
+    ANTHROPIC_API_KEY  — required
+
+Usage:
+    python examples/single_provider/anthropic_agent.py
+"""
+from __future__ import annotations
+
+import json
+import os
+import sys
+
+import anthropic
+
+from ocw.sdk import watch
+from ocw.sdk.agent import record_tool_call
+from ocw.sdk.integrations.anthropic import patch_anthropic
+
+if not os.environ.get("ANTHROPIC_API_KEY"):
+    print("ERROR: ANTHROPIC_API_KEY environment variable is required.")
+    print("  export ANTHROPIC_API_KEY=sk-ant-...")
+    sys.exit(1)
+
+# Monkey-patch the Anthropic client BEFORE creating any instances.
+patch_anthropic()
+
+# ---------------------------------------------------------------------------
+# Tool definitions (Anthropic format)
+# ---------------------------------------------------------------------------
+
+TOOLS = [
+    {
+        "name": "calculator",
+        "description": "Evaluate a mathematical expression and return the result.",
+        "input_schema": {
+            "type": "object",
+            "properties": {
+                "expression": {
+                    "type": "string",
+                    "description": "Math expression to evaluate, e.g. '42 * 17'",
+                },
+            },
+            "required": ["expression"],
+        },
+    },
+    {
+        "name": "get_weather",
+        "description": "Get the current weather for a given city.",
+        "input_schema": {
+            "type": "object",
+            "properties": {
+                "city": {
+                    "type": "string",
+                    "description": "City name, e.g. 'San Francisco'",
+                },
+            },
+            "required": ["city"],
+        },
+    },
+]
+
+
+# ---------------------------------------------------------------------------
+# Local tool implementations
+# ---------------------------------------------------------------------------
+
+
+def calculator(expression: str) -> dict:
+    """Safely evaluate a math expression."""
+    try:
+        result = eval(expression, {"__builtins__": {}}, {})  # noqa: S307
+        return {"result": float(result)}
+    except Exception as exc:
+        return {"error": str(exc)}
+
+
+def get_weather(city: str) -> dict:
+    """Return stub weather data for demo purposes."""
+    return {
+        "city": city,
+        "temperature_f": 62,
+        "condition": "Partly cloudy",
+        "humidity_pct": 73,
+    }
+
+
+TOOL_DISPATCH = {
+    "calculator": calculator,
+    "get_weather": get_weather,
+}
+
+
+# ---------------------------------------------------------------------------
+# Agent entry point
+# ---------------------------------------------------------------------------
+
+
+@watch(agent_id="anthropic-tool-agent")
+def run() -> str:
+    client = anthropic.Anthropic()
+    messages: list[dict] = [
+        {
+            "role": "user",
+            "content": (
+                "What's the weather in San Francisco right now, "
+                "and what is 42 * 17?"
+            ),
+        },
+    ]
+
+    # Step 1 — initial request (model will request tool calls)
+    response = client.messages.create(
+        model="claude-haiku-4-5",
+        max_tokens=1024,
+        tools=TOOLS,
+        messages=messages,
+    )
+
+    # Step 2 — process tool_use blocks and collect results
+    while response.stop_reason == "tool_use":
+        tool_results = []
+        for block in response.content:
+            if block.type != "tool_use":
+                continue
+
+            tool_name = block.name
+            tool_input = block.input
+            func = TOOL_DISPATCH.get(tool_name)
+            if func is None:
+                tool_output = {"error": f"Unknown tool: {tool_name}"}
+            else:
+                tool_output = func(**tool_input)
+
+            # Record the tool call in ocw for observability
+            record_tool_call(
+                tool_name=tool_name,
+                tool_input=tool_input,
+                tool_output=tool_output,
+            )
+
+            tool_results.append(
+                {
+                    "type": "tool_result",
+                    "tool_use_id": block.id,
+                    "content": json.dumps(tool_output),
+                }
+            )
+
+        # Send tool results back to the model
+        messages.append({"role": "assistant", "content": response.content})
+        messages.append({"role": "user", "content": tool_results})
+
+        response = client.messages.create(
+            model="claude-haiku-4-5",
+            max_tokens=1024,
+            tools=TOOLS,
+            messages=messages,
+        )
+
+    # Step 3 — extract final text response
+    final_text = ""
+    for block in response.content:
+        if hasattr(block, "text"):
+            final_text += block.text
+    return final_text
+
+
+# ---------------------------------------------------------------------------
+# Main
+# ---------------------------------------------------------------------------
+
+if __name__ == "__main__":
+    result = run()
+    print(f"\nAgent response:\n{result}")
+
+    print("\n--- OCW Observation ---")
+    print("Session and tool spans have been recorded.")
+    print("Run 'ocw status --agent anthropic-tool-agent' to view telemetry.")
+    print("Run 'ocw tools --agent anthropic-tool-agent' to see tool call stats.")

--- a/examples/single_provider/bedrock_agent.py
+++ b/examples/single_provider/bedrock_agent.py
@@ -1,0 +1,102 @@
+"""
+AWS Bedrock agent with OCW observability.
+
+Demonstrates calling Claude via AWS Bedrock's invoke_model API. All LLM calls
+are captured by ocw via the Bedrock integration patch.
+
+SETUP NOTES:
+    This example requires valid AWS credentials configured in your environment.
+    Bedrock must be enabled in your AWS account, and you must have requested
+    access to the Anthropic Claude models in the Bedrock console for your region.
+
+    Typical setup:
+        export AWS_ACCESS_KEY_ID=AKIA...
+        export AWS_SECRET_ACCESS_KEY=...
+        export AWS_DEFAULT_REGION=us-east-1   # or us-west-2, etc.
+
+    Alternatively, configure credentials via ~/.aws/credentials or an IAM role.
+    The region must have Bedrock model access enabled for the model used below.
+
+Requirements:
+    pip install boto3 openclawwatch
+
+Environment:
+    AWS_DEFAULT_REGION or AWS_REGION  — required (must have Bedrock access)
+
+Usage:
+    python examples/single_provider/bedrock_agent.py
+"""
+from __future__ import annotations
+
+import json
+import os
+import sys
+
+region = os.environ.get("AWS_DEFAULT_REGION") or os.environ.get("AWS_REGION")
+if not region:
+    print("ERROR: AWS_DEFAULT_REGION or AWS_REGION environment variable is required.")
+    print("  export AWS_DEFAULT_REGION=us-east-1")
+    print()
+    print("You also need valid AWS credentials (AWS_ACCESS_KEY_ID / AWS_SECRET_ACCESS_KEY)")
+    print("and Bedrock model access enabled in the specified region.")
+    sys.exit(1)
+
+import boto3  # noqa: E402
+
+from ocw.sdk import watch  # noqa: E402
+from ocw.sdk.integrations.bedrock import patch_bedrock  # noqa: E402
+
+# Monkey-patch the boto3 Bedrock client BEFORE creating any instances.
+patch_bedrock()
+
+MODEL_ID = "anthropic.claude-3-haiku-20240307-v1:0"
+
+# ---------------------------------------------------------------------------
+# Agent entry point
+# ---------------------------------------------------------------------------
+
+
+@watch(agent_id="bedrock-agent")
+def run() -> str:
+    client = boto3.client("bedrock-runtime", region_name=region)
+
+    request_body = json.dumps(
+        {
+            "anthropic_version": "bedrock-2023-05-31",
+            "max_tokens": 256,
+            "messages": [
+                {
+                    "role": "user",
+                    "content": (
+                        "Explain the difference between supervised and "
+                        "unsupervised learning in two sentences."
+                    ),
+                },
+            ],
+        }
+    )
+
+    response = client.invoke_model(
+        modelId=MODEL_ID,
+        contentType="application/json",
+        accept="application/json",
+        body=request_body,
+    )
+
+    response_body = json.loads(response["body"].read())
+    result_text = response_body["content"][0]["text"]
+    return result_text
+
+
+# ---------------------------------------------------------------------------
+# Main
+# ---------------------------------------------------------------------------
+
+if __name__ == "__main__":
+    result = run()
+    print(f"\nAgent response:\n{result}")
+
+    print("\n--- OCW Observation ---")
+    print("Session and LLM spans have been recorded.")
+    print("Run 'ocw status --agent bedrock-agent' to view telemetry.")
+    print("Run 'ocw cost --agent bedrock-agent' to see token costs.")

--- a/examples/single_provider/gemini_agent.py
+++ b/examples/single_provider/gemini_agent.py
@@ -1,0 +1,107 @@
+"""
+Google Gemini summarization agent with OCW observability.
+
+Demonstrates the Gemini provider path: passes a multi-paragraph text to
+gemini-2.0-flash and asks for a concise summary. All LLM calls are captured
+by ocw via the Gemini integration patch.
+
+Requirements:
+    pip install google-generativeai openclawwatch
+
+Environment:
+    GOOGLE_API_KEY or GEMINI_API_KEY  — required (either one works)
+
+Usage:
+    python examples/single_provider/gemini_agent.py
+"""
+from __future__ import annotations
+
+import os
+import sys
+
+# Check for API key before importing the SDK (avoids confusing errors).
+api_key = os.environ.get("GOOGLE_API_KEY") or os.environ.get("GEMINI_API_KEY")
+if not api_key:
+    print("ERROR: GOOGLE_API_KEY or GEMINI_API_KEY environment variable is required.")
+    print("  export GOOGLE_API_KEY=AI...")
+    sys.exit(1)
+
+# Make sure google.generativeai picks up the key from the standard env var.
+os.environ.setdefault("GOOGLE_API_KEY", api_key)
+
+import google.generativeai as genai  # noqa: E402
+
+from ocw.sdk import watch  # noqa: E402
+from ocw.sdk.integrations.gemini import patch_gemini  # noqa: E402
+
+# Monkey-patch the Gemini client BEFORE creating any model instances.
+patch_gemini()
+
+# ---------------------------------------------------------------------------
+# Source text for summarization
+# ---------------------------------------------------------------------------
+
+SOURCE_TEXT = """\
+AI agents represent a significant evolution in how we interact with large language
+models. Rather than issuing single prompts and receiving single responses, agents
+operate in loops: they observe their environment, reason about what to do next,
+take an action (such as calling a tool or querying an API), and then feed the
+result back into the model for further reasoning.
+
+This loop enables capabilities that were previously impossible with simple
+prompt-response interactions. Agents can break complex tasks into subtasks,
+maintain working memory across many steps, recover from errors by re-planning,
+and coordinate with other agents to tackle problems that require diverse
+expertise.
+
+The tooling ecosystem around AI agents has grown rapidly. Frameworks like
+LangChain, LangGraph, CrewAI, and AutoGen provide abstractions for defining
+agents, tools, and orchestration patterns. Meanwhile, observability platforms
+are emerging to help developers understand what their agents are actually doing
+at runtime: which tools are being called, how many tokens are consumed, where
+latency bottlenecks occur, and whether the agent is drifting from expected
+behavior.
+
+Local-first observability is particularly valuable during development. By
+capturing telemetry to a local database instead of a cloud service, developers
+can iterate quickly without worrying about data privacy, network latency, or
+subscription costs. Once the agent is ready for production, the same telemetry
+pipeline can be reconfigured to export to a remote backend.
+
+The OpenTelemetry standard provides a natural foundation for agent observability.
+OTel's span model maps cleanly to agent actions: each LLM call, tool invocation,
+and planning step becomes a span in a trace. Semantic conventions for generative
+AI (such as token counts, model names, and provider identifiers) give structure
+to the data, enabling consistent dashboards and alerts across different providers
+and frameworks.\
+"""
+
+# ---------------------------------------------------------------------------
+# Agent entry point
+# ---------------------------------------------------------------------------
+
+
+@watch(agent_id="gemini-summarizer")
+def run() -> str:
+    model = genai.GenerativeModel("gemini-2.0-flash")
+    prompt = (
+        "Summarize the following text in exactly two sentences. "
+        "Be concise and capture the key ideas.\n\n"
+        f"{SOURCE_TEXT}"
+    )
+    response = model.generate_content(prompt)
+    return response.text
+
+
+# ---------------------------------------------------------------------------
+# Main
+# ---------------------------------------------------------------------------
+
+if __name__ == "__main__":
+    result = run()
+    print(f"\nSummary:\n{result}")
+
+    print("\n--- OCW Observation ---")
+    print("Session and LLM spans have been recorded.")
+    print("Run 'ocw status --agent gemini-summarizer' to view telemetry.")
+    print("Run 'ocw cost --agent gemini-summarizer' to see token costs.")

--- a/examples/single_provider/openai_agent.py
+++ b/examples/single_provider/openai_agent.py
@@ -1,0 +1,178 @@
+"""
+OpenAI tool-use agent with streaming and OCW observability.
+
+Demonstrates the OpenAI function-calling loop with a stub tool, then streams
+the final response token by token. All LLM calls and tool invocations are
+captured by ocw.
+
+Requirements:
+    pip install openai openclawwatch
+
+Environment:
+    OPENAI_API_KEY  — required
+
+Usage:
+    python examples/single_provider/openai_agent.py
+"""
+from __future__ import annotations
+
+import json
+import os
+import sys
+
+import openai
+
+from ocw.sdk import watch
+from ocw.sdk.agent import record_tool_call
+from ocw.sdk.integrations.openai import patch_openai
+
+if not os.environ.get("OPENAI_API_KEY"):
+    print("ERROR: OPENAI_API_KEY environment variable is required.")
+    print("  export OPENAI_API_KEY=sk-...")
+    sys.exit(1)
+
+# Monkey-patch the OpenAI client BEFORE creating any instances.
+patch_openai()
+
+# ---------------------------------------------------------------------------
+# Tool definition (OpenAI function-calling format)
+# ---------------------------------------------------------------------------
+
+TOOLS = [
+    {
+        "type": "function",
+        "function": {
+            "name": "search_web",
+            "description": "Search the web for current information on a topic.",
+            "parameters": {
+                "type": "object",
+                "properties": {
+                    "query": {
+                        "type": "string",
+                        "description": "The search query.",
+                    },
+                },
+                "required": ["query"],
+            },
+        },
+    },
+]
+
+
+# ---------------------------------------------------------------------------
+# Local tool implementation
+# ---------------------------------------------------------------------------
+
+
+def search_web(query: str) -> dict:
+    """Return stub search results for demo purposes."""
+    return {
+        "results": [
+            {
+                "title": f"Top result for: {query}",
+                "snippet": (
+                    "AI agents are autonomous software systems that use LLMs "
+                    "to plan and execute multi-step tasks."
+                ),
+                "url": "https://example.com/ai-agents-overview",
+            },
+            {
+                "title": f"Recent news: {query}",
+                "snippet": (
+                    "The latest frameworks include LangGraph, CrewAI, and "
+                    "OpenAI's Agents SDK for building agentic workflows."
+                ),
+                "url": "https://example.com/agent-frameworks",
+            },
+        ],
+    }
+
+
+TOOL_DISPATCH = {
+    "search_web": search_web,
+}
+
+
+# ---------------------------------------------------------------------------
+# Agent entry point
+# ---------------------------------------------------------------------------
+
+
+@watch(agent_id="openai-tool-agent")
+def run() -> str:
+    client = openai.OpenAI()
+    messages: list[dict] = [
+        {
+            "role": "user",
+            "content": "What are the latest AI agent frameworks available today?",
+        },
+    ]
+
+    # Step 1 — initial request (model may request tool calls)
+    response = client.chat.completions.create(
+        model="gpt-4o-mini",
+        messages=messages,
+        tools=TOOLS,
+    )
+    choice = response.choices[0]
+
+    # Step 2 — handle tool calls if present
+    if choice.finish_reason == "tool_calls" and choice.message.tool_calls:
+        # Append the assistant message with tool calls
+        messages.append(choice.message.model_dump())
+
+        for tool_call in choice.message.tool_calls:
+            func_name = tool_call.function.name
+            func_args = json.loads(tool_call.function.arguments)
+            func = TOOL_DISPATCH.get(func_name)
+
+            if func is None:
+                tool_output = {"error": f"Unknown tool: {func_name}"}
+            else:
+                tool_output = func(**func_args)
+
+            # Record the tool call in ocw
+            record_tool_call(
+                tool_name=func_name,
+                tool_input=func_args,
+                tool_output=tool_output,
+            )
+
+            messages.append(
+                {
+                    "role": "tool",
+                    "tool_call_id": tool_call.id,
+                    "content": json.dumps(tool_output),
+                }
+            )
+
+    # Step 3 — stream the final response
+    print("\nAgent response (streamed):")
+    stream = client.chat.completions.create(
+        model="gpt-4o-mini",
+        messages=messages,
+        stream=True,
+    )
+
+    collected: list[str] = []
+    for chunk in stream:
+        delta = chunk.choices[0].delta if chunk.choices else None
+        if delta and delta.content:
+            print(delta.content, end="", flush=True)
+            collected.append(delta.content)
+    print()  # newline after streaming
+
+    return "".join(collected)
+
+
+# ---------------------------------------------------------------------------
+# Main
+# ---------------------------------------------------------------------------
+
+if __name__ == "__main__":
+    result = run()
+
+    print("\n--- OCW Observation ---")
+    print("Session, LLM, and tool spans have been recorded.")
+    print("Run 'ocw status --agent openai-tool-agent' to view telemetry.")
+    print("Run 'ocw tools --agent openai-tool-agent' to see tool call stats.")

--- a/examples/single_provider/openai_agents_sdk_agent.py
+++ b/examples/single_provider/openai_agents_sdk_agent.py
@@ -1,0 +1,127 @@
+"""
+OpenAI Agents SDK multi-agent example with OCW observability.
+
+Demonstrates a triage/specialist handoff pattern using the OpenAI Agents SDK.
+The triage agent inspects the user query and delegates to a specialist agent
+for a detailed answer.
+
+This integration works differently from other providers: it configures the
+Agents SDK's native OTel support to export traces to `ocw serve` via OTLP.
+You must have `ocw serve` running before executing this script.
+
+Requirements:
+    pip install openai-agents httpx openclawwatch
+
+Environment:
+    OPENAI_API_KEY  — required
+
+Prerequisites:
+    ocw serve must be running:  ocw serve --port 8787
+
+Usage:
+    python examples/single_provider/openai_agents_sdk_agent.py
+"""
+from __future__ import annotations
+
+import asyncio
+import os
+import sys
+
+if not os.environ.get("OPENAI_API_KEY"):
+    print("ERROR: OPENAI_API_KEY environment variable is required.")
+    print("  export OPENAI_API_KEY=sk-...")
+    sys.exit(1)
+
+# Check that ocw serve is reachable before proceeding.
+try:
+    import httpx
+
+    resp = httpx.get("http://127.0.0.1:8787/api/v1/traces", timeout=2)
+    if resp.status_code >= 500:
+        raise ConnectionError(f"ocw serve returned {resp.status_code}")
+except Exception:
+    print("ERROR: Cannot reach ocw serve at http://127.0.0.1:8787")
+    print()
+    print("This example requires a running ocw serve instance because the")
+    print("OpenAI Agents SDK exports traces via OTLP HTTP to the local server.")
+    print()
+    print("Start it in another terminal:")
+    print("  ocw serve --port 8787")
+    sys.exit(1)
+
+from agents import Agent, Runner  # noqa: E402
+
+from ocw.sdk import watch  # noqa: E402
+from ocw.sdk.integrations.openai_agents_sdk import patch_openai_agents  # noqa: E402
+
+# Configure the Agents SDK's native OTel to export to ocw serve.
+# NOTE: patch_openai_agents() does NOT call ensure_initialised() — it sets up
+# OTLP export to ocw serve instead. We still use @watch() for session tracking.
+patch_openai_agents()
+
+# ---------------------------------------------------------------------------
+# Agent definitions
+# ---------------------------------------------------------------------------
+
+coding_specialist = Agent(
+    name="coding_specialist",
+    instructions=(
+        "You are a coding expert. When asked about programming topics, give "
+        "clear, concise explanations with short code examples when helpful. "
+        "Keep answers under 200 words."
+    ),
+    model="gpt-4o-mini",
+)
+
+science_specialist = Agent(
+    name="science_specialist",
+    instructions=(
+        "You are a science expert. When asked about scientific topics, give "
+        "clear, concise explanations suitable for a general audience. "
+        "Keep answers under 200 words."
+    ),
+    model="gpt-4o-mini",
+)
+
+triage_agent = Agent(
+    name="triage_agent",
+    instructions=(
+        "You are a triage agent. Examine the user's question and hand off to "
+        "the most appropriate specialist:\n"
+        "- For programming, software, or coding questions -> coding_specialist\n"
+        "- For science, physics, biology, or chemistry questions -> science_specialist\n"
+        "Do NOT answer the question yourself. Always hand off to a specialist."
+    ),
+    model="gpt-4o-mini",
+    handoffs=[coding_specialist, science_specialist],
+)
+
+# ---------------------------------------------------------------------------
+# Agent entry point
+# ---------------------------------------------------------------------------
+
+
+@watch(agent_id="openai-agents-sdk-demo")
+def run() -> str:
+    query = "How does a Python decorator work under the hood?"
+    print(f"User query: {query}\n")
+
+    result = asyncio.run(
+        Runner.run(triage_agent, input=query)
+    )
+
+    return result.final_output
+
+
+# ---------------------------------------------------------------------------
+# Main
+# ---------------------------------------------------------------------------
+
+if __name__ == "__main__":
+    result = run()
+    print(f"\nAgent response:\n{result}")
+
+    print("\n--- OCW Observation ---")
+    print("Session and agent handoff spans have been recorded.")
+    print("Run 'ocw status --agent openai-agents-sdk-demo' to view telemetry.")
+    print("Run 'ocw traces --agent openai-agents-sdk-demo' to see the trace.")


### PR DESCRIPTION
## Summary

16 runnable examples across 4 tiers:
- single_provider: Anthropic, OpenAI, Gemini, Bedrock, OpenAI Agents SDK
- single_framework: LangChain, LangGraph, CrewAI, AutoGen, LlamaIndex
- multi: provider router, research team, RAG with fallback
- alerts_and_drift: sensitive actions, budget breach, drift detection (no API keys)

Also updates README.md (Examples section), CLAUDE.md (repo layout + rule 13 for PyPI package name), and adds the task spec.

## Checklist

- [ ] Tests pass (`pytest tests/unit/ tests/synthetic/ tests/agents/ tests/integration/`)
- [ ] Lint clean (`ruff check ocw/`)
- [ ] Type check clean (`mypy ocw/`)
- [ ] CLAUDE.md updated (if architecture changed)
- [ ] Test spans use `tests/factories.py` (not raw `NormalizedSpan`)
