### PR TITLE
Upgrade Node.js from 20 to 22 in workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,7 +41,7 @@ jobs:
       - name: Set up Node
         uses: actions/setup-node@v4
         with:
-          node-version: "20"
+          node-version: "22"
 
       - name: Install and test TypeScript SDK
         working-directory: sdk-ts

--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -13,7 +13,7 @@ jobs:
 
       - uses: actions/setup-node@v4
         with:
-          node-version: "20"
+          node-version: "22"
           registry-url: https://registry.npmjs.org
 
       - name: Install dependencies


### PR DESCRIPTION
## Summary
- Upgrade Node.js from 20 to 22 in `ci.yml` and `publish-npm.yml`
- Node 20 is deprecated and will be forced to Node 24 on June 2, 2026

## Note
The npm publish failure on v0.1.3 is likely due to a missing `NPM_TOKEN` secret in repo settings, not the Node version. Please add it at Settings > Secrets > Actions if you want npm publishing to work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)