### PR TITLE
Fix SDK DuckDB lock, LiteLLM model prefix, sidebar SVG logo

### DIFF
--- a/ocw/sdk/integrations/litellm.py
+++ b/ocw/sdk/integrations/litellm.py
@@ -186,6 +186,8 @@ def _record_usage(response: object, span, model: str) -> None:
     """Extract provider and token usage from a LiteLLM ModelResponse."""
     provider = _parse_provider(model, response)
     span.set_attribute(GenAIAttributes.PROVIDER_NAME, provider)
+    # Update model attribute to strip provider prefix for consistent pricing
+    span.set_attribute(GenAIAttributes.REQUEST_MODEL, _strip_provider_prefix(model))
 
     usage = getattr(response, "usage", None)
     if usage:
@@ -207,6 +209,7 @@ class _SyncStreamWrapper:
         self._span = span
         self._model = model
         self._usage = None
+        self._last_chunk = None
 
     def __iter__(self):
         try:
@@ -214,6 +217,7 @@ class _SyncStreamWrapper:
                 usage = getattr(chunk, "usage", None)
                 if usage:
                     self._usage = usage
+                self._last_chunk = chunk
                 yield chunk
         except Exception as exc:
             self._span.set_status(
@@ -221,6 +225,12 @@ class _SyncStreamWrapper:
             )
             raise
         finally:
+            provider = _parse_provider(self._model, self._last_chunk)
+            self._span.set_attribute(GenAIAttributes.PROVIDER_NAME, provider)
+            self._span.set_attribute(
+                GenAIAttributes.REQUEST_MODEL,
+                _strip_provider_prefix(self._model),
+            )
             if self._usage:
                 prompt_tokens = getattr(
                     self._usage, "prompt_tokens", None,
@@ -251,6 +261,7 @@ class _AsyncStreamWrapper:
         self._span = span
         self._model = model
         self._usage = None
+        self._last_chunk = None
 
     def __aiter__(self):
         return self._iterate()
@@ -261,6 +272,7 @@ class _AsyncStreamWrapper:
                 usage = getattr(chunk, "usage", None)
                 if usage:
                     self._usage = usage
+                self._last_chunk = chunk
                 yield chunk
         except Exception as exc:
             self._span.set_status(
@@ -268,6 +280,12 @@ class _AsyncStreamWrapper:
             )
             raise
         finally:
+            provider = _parse_provider(self._model, self._last_chunk)
+            self._span.set_attribute(GenAIAttributes.PROVIDER_NAME, provider)
+            self._span.set_attribute(
+                GenAIAttributes.REQUEST_MODEL,
+                _strip_provider_prefix(self._model),
+            )
             if self._usage:
                 prompt_tokens = getattr(
                     self._usage, "prompt_tokens", None,

--- a/ocw/ui/index.html
+++ b/ocw/ui/index.html
@@ -55,6 +55,9 @@ code, .mono {
   padding: 0 16px 16px;
   border-bottom: 1px solid var(--border);
   margin-bottom: 8px;
+  display: flex;
+  align-items: center;
+  gap: 8px;
 }
 .sidebar a {
   display: flex;
@@ -354,7 +357,7 @@ tr.clickable:hover td { background: rgba(61,142,255,0.04); }
 <body>
 
 <nav class="sidebar">
-  <div class="sidebar-brand">OpenClawWatch</div>
+  <div class="sidebar-brand"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32" width="24" height="24" style="flex-shrink:0"><circle cx="16" cy="16" r="5" fill="currentColor"/><path d="M16 4v5M16 23v5M4 16h5M23 16h5" stroke="currentColor" stroke-width="2.5" stroke-linecap="round"/><path d="M8.2 8.2l3.5 3.5M20.3 20.3l3.5 3.5M20.3 11.7l3.5-3.5M8.2 23.8l3.5-3.5" stroke="currentColor" stroke-width="2" stroke-linecap="round" opacity="0.6"/></svg> OpenClawWatch</div>
   <a href="#/status" class="nav-link" data-view="status"><span class="icon">&bull;</span> Status</a>
   <a href="#/traces" class="nav-link" data-view="traces"><span class="icon">&diamond;</span> Traces</a>
   <a href="#/cost" class="nav-link" data-view="cost"><span class="icon">$</span> Cost</a>


### PR DESCRIPTION
## Summary
Three bug fixes that were pushed to PR #12's branch after it was already merged.

### 1. SDK DuckDB lock (critical)
SDK bootstrap now detects running `ocw serve` and sends spans via HTTP (`OcwHttpExporter`) instead of opening DuckDB directly. Fixes the "Could not set lock on file" error when agents run alongside `ocw serve`.

### 2. LiteLLM model prefix
Strips `openai/` prefix from model names so pricing lookup finds `gpt-4o-mini` not `openai/gpt-4o-mini`.

### 3. Sidebar SVG logo
Embeds opencla.watch icon inline in web UI sidebar with `currentColor`.

## Test plan
- [x] All 232 tests pass
- [x] `ruff check ocw/` clean
- [ ] Run `ocw serve &` then agent — spans arrive via HTTP
- [ ] `ocw cost` shows `gpt-4o-mini` not `openai/gpt-4o-mini`

🤖 Generated with [Claude Code](https://claude.com/claude-code)