### PR TITLE
Release v0.1.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,22 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/),
 and this project adheres to [Semantic Versioning](https://semver.org/).
 
+## [0.1.5] - 2026-04-08
+
+### Fixed
+- **Pricing file missing from pip wheel** — `pricing/models.toml` was at the repo root, outside the `ocw/` package. Moved to `ocw/pricing/models.toml` so it's included in the wheel. All costs showed `$0.000000` in v0.1.4.
+
+### Improved
+- **Web UI polish** — custom hover tooltips on waterfall bars (cost, duration, model), back arrow on trace detail, agent name heading, tighter layout, hint text on Status and Traces views
+- **Waterfall bar labels** — now show cost alongside duration and model name
+
+### Added
+- Manual release testing checklist (`tests/manual-new-release-tests.md`)
+- Pre-release testing checklist (`tests/manual-pre-release-testing.md`)
+
+### Changed
+- Task specs moved from `.claude/` to `.claude/specs/`
+
 ## [0.1.4] - 2026-04-08
 
 ### Fixed

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "openclawwatch"
-version = "0.1.4"
+version = "0.1.5"
 description = "Local-first OTel-native observability for Autonomous AI agents"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/sdk-ts/package.json
+++ b/sdk-ts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclawwatch/sdk",
-  "version": "0.1.4",
+  "version": "0.1.5",
   "description": "TypeScript SDK for OpenClawWatch — local-first observability for AI agents",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",


### PR DESCRIPTION
## Summary
Patch release fixing the critical pricing bug from v0.1.4 + web UI polish.

### Fixed
- **Pricing file missing from pip wheel** — `pricing/models.toml` was outside the `ocw/` package, so `pip install openclawwatch` resulted in `$0.000000` for all costs. Moved to `ocw/pricing/models.toml`.

### Improved
- Web UI polish: custom hover tooltips on waterfall bars, back arrow on trace detail, agent name heading, tighter layout, hint text on views

### Added
- Manual release and pre-release testing checklists
- Task specs reorganized under `.claude/specs/`

## After merge
Create GitHub release with tag `v0.1.5` to trigger PyPI + npm publish.

🤖 Generated with [Claude Code](https://claude.com/claude-code)