### PR TITLE
Improve ocw onboard UX

### DIFF
--- a/ocw/cli/cmd_onboard.py
+++ b/ocw/cli/cmd_onboard.py
@@ -8,25 +8,18 @@ from pathlib import Path
 
 import click
 
-from ocw.core.config import (
-    AgentConfig,
-    BudgetConfig,
-    OcwConfig,
-    SecurityConfig,
-    find_config_file,
-    write_config,
-)
+from ocw.core.config import find_config_file
 from ocw.utils.formatting import console
 
 
 @click.command("onboard")
-@click.option("--agent", "agent_id", default=None, help="Agent ID to configure")
-@click.option("--budget", type=float, default=None, help="Daily budget in USD (0 = no limit)")
+@click.option("--budget", type=float, default=None,
+              help="Daily budget in USD per agent (0 = no limit)")
 @click.option("--install-daemon", is_flag=True, default=False)
 @click.option("--no-daemon", is_flag=True, default=False)
 @click.option("--force", is_flag=True, help="Overwrite existing config")
 @click.pass_context
-def cmd_onboard(ctx: click.Context, agent_id: str | None, budget: float | None,
+def cmd_onboard(ctx: click.Context, budget: float | None,
                 install_daemon: bool, no_daemon: bool, force: bool) -> None:
     """Interactive setup wizard for ocw."""
     existing = find_config_file()
@@ -35,11 +28,15 @@ def cmd_onboard(ctx: click.Context, agent_id: str | None, budget: float | None,
         console.print("Use [bold]--force[/bold] to overwrite.")
         return
 
-    if agent_id is None:
-        agent_id = click.prompt("Agent ID", default="my-agent")
+    console.print()
+    console.print("[bold]Setting up OpenClawWatch...[/bold]")
+    console.print()
 
     if budget is None:
-        budget = click.prompt("Daily budget in USD (0 = no limit)", type=float, default=5.0)
+        budget = click.prompt(
+            "Daily budget in USD (applies to all agents, 0 = no limit)",
+            type=float, default=5.0,
+        )
 
     ingest_secret = secrets.token_hex(32)
 
@@ -49,53 +46,115 @@ def cmd_onboard(ctx: click.Context, agent_id: str | None, budget: float | None,
     elif not no_daemon:
         want_daemon = click.confirm("Install background daemon?", default=False)
 
-    agents = {}
-    if budget and budget > 0:
-        agents[agent_id] = AgentConfig(budget=BudgetConfig(daily_usd=budget))
-    else:
-        agents[agent_id] = AgentConfig()
-
-    config = OcwConfig(
-        version="1",
-        agents=agents,
-        security=SecurityConfig(ingest_secret=ingest_secret),
-    )
-
     config_path = Path(".ocw/config.toml")
-    write_config(config, config_path)
+    config_path.parent.mkdir(parents=True, exist_ok=True)
 
+    budget_line = ""
+    if budget and budget > 0:
+        budget_line = f"daily_usd = {budget}"
+
+    config_text = f"""\
+# OpenClawWatch configuration
+# Docs: https://github.com/Metabuilder-Labs/openclawwatch#configuration
+
+[defaults.budget]
+{budget_line}
+
+[security]
+ingest_secret = "{ingest_secret}"
+
+[capture]
+prompts = false
+completions = false
+tool_outputs = false
+
+[storage]
+path = "~/.ocw/telemetry.duckdb"
+retention_days = 90
+
+# Per-agent overrides (optional):
+# [agents.my-agent]
+# description = "My email agent"
+#   [agents.my-agent.budget]
+#   daily_usd = 5.00
+#   session_usd = 1.00
+#   [[agents.my-agent.sensitive_actions]]
+#   name = "send_email"
+#   severity = "critical"
+"""
+    config_path.write_text(config_text)
+
+    daemon_msg = None
     if want_daemon:
-        _install_daemon()
+        daemon_msg = _install_daemon()
+
+    # Output
+    console.print()
+    console.print("[green]\u2713[/green] Config written to [bold].ocw/config.toml[/bold]")
+    console.print(f"[green]\u2713[/green] Ingest secret generated: "
+                  f"[dim]{ingest_secret[:8]}...[/dim]")
+    if budget and budget > 0:
+        console.print(f"[green]\u2713[/green] Default daily budget: "
+                      f"[bold]${budget:.2f}[/bold] per agent")
+    if daemon_msg:
+        console.print(f"[green]\u2713[/green] {daemon_msg}")
 
     console.print()
-    console.print("[bold green]Setup complete.[/bold green]")
-    console.print(f"  Config written to: {config_path}")
-    console.print(f"  Agent ID:          {agent_id}")
-    console.print(f"  Ingest secret:     {ingest_secret[:8]}...")
-    if budget and budget > 0:
-        console.print(f"  Daily budget:      ${budget:.2f}")
+    console.print("[bold]Next steps:[/bold]")
+    console.print()
+    console.print("  1. Instrument your agent:")
+    console.print()
+    console.print("[dim]     from ocw.sdk import watch[/dim]")
+    console.print("[dim]     from ocw.sdk.integrations.anthropic import patch_anthropic[/dim]")
+    console.print()
+    console.print("[dim]     patch_anthropic()[/dim]")
+    console.print()
+    console.print('[dim]     @watch(agent_id="my-agent")[/dim]')
+    console.print("[dim]     def run(task):[/dim]")
+    console.print("[dim]         ...[/dim]")
+    console.print()
+    console.print("  2. Run your agent \u2014 spans are recorded automatically")
+    console.print()
+    console.print("  3. View telemetry:")
+    console.print("[dim]     ocw status          [/dim]# agent overview")
+    console.print("[dim]     ocw traces          [/dim]# span history")
+    console.print("[dim]     ocw serve           [/dim]# web UI at http://127.0.0.1:7391/")
+    console.print()
+
     if not want_daemon:
+        console.print("  Run [bold]ocw serve[/bold] to start the web UI "
+                      "and enable real-time alerts.")
         console.print()
-        console.print("[dim]Run [bold]ocw serve[/bold] manually for real-time alerts "
-                      "on background agents.[/dim]")
+
+    console.print(
+        "  To configure per-agent budgets, sensitive actions, or drift detection:"
+    )
+    console.print(
+        "  Edit [bold].ocw/config.toml[/bold] \u2014 see "
+        "[dim]https://github.com/Metabuilder-Labs/openclawwatch#configuration[/dim]"
+    )
+    console.print()
 
 
-def _install_daemon() -> None:
+def _install_daemon() -> str | None:
+    """Install background daemon. Returns success message or None."""
     system = platform.system()
     try:
         if system == "Darwin":
-            _install_launchd()
+            return _install_launchd()
         elif system == "Linux":
-            _install_systemd()
+            return _install_systemd()
         else:
             console.print(f"[yellow]Background daemon not supported on {system}. "
                           "Run `ocw serve` manually.[/yellow]")
+            return None
     except Exception as e:
         console.print(f"[yellow]Daemon installation failed: {e}[/yellow]")
         console.print("[dim]You can run `ocw serve` manually instead.[/dim]")
+        return None
 
 
-def _install_launchd() -> None:
+def _install_launchd() -> str | None:
     ocw_path = sys.executable.replace("/python", "/ocw").replace("/python3", "/ocw")
     plist_path = Path.home() / "Library/LaunchAgents/com.openclawwatch.serve.plist"
     plist_path.parent.mkdir(parents=True, exist_ok=True)
@@ -134,11 +193,11 @@ def _install_launchd() -> None:
         console.print(f"  launchctl load {plist_path}")
         console.print("[dim]Or run the server directly:[/dim]")
         console.print("  ocw serve &")
-    else:
-        console.print(f"[green]Daemon installed:[/green] {plist_path}")
+        return None
+    return f"Daemon installed at {plist_path}"
 
 
-def _install_systemd() -> None:
+def _install_systemd() -> str | None:
     ocw_path = sys.executable.replace("/python", "/ocw").replace("/python3", "/ocw")
     service_path = Path.home() / ".config/systemd/user/openclawwatch.service"
     service_path.parent.mkdir(parents=True, exist_ok=True)
@@ -158,4 +217,4 @@ WantedBy=default.target"""
         ["systemctl", "--user", "enable", "--now", "openclawwatch"],
         check=True,
     )
-    console.print(f"[green]Daemon installed:[/green] {service_path}")
+    return f"Daemon installed at {service_path}"

--- a/ocw/cli/cmd_status.py
+++ b/ocw/cli/cmd_status.py
@@ -67,10 +67,15 @@ def cmd_status(ctx: click.Context, agent: str | None, output_json: bool) -> None
 
         today_cost = db.get_daily_cost(aid, utcnow().date())
 
-        # Budget from config
+        # Budget from config: per-agent overrides defaults
         config = ctx.obj["config"]
         agent_config = config.agents.get(aid)
-        daily_limit = agent_config.budget.daily_usd if agent_config else None
+        if agent_config and agent_config.budget.daily_usd is not None:
+            daily_limit = agent_config.budget.daily_usd
+        elif hasattr(config, "defaults") and config.defaults.budget.daily_usd is not None:
+            daily_limit = config.defaults.budget.daily_usd
+        else:
+            daily_limit = None
 
         # Active alerts
         alerts = db.get_alerts(AlertFilters(agent_id=aid, unread=True, limit=50))

--- a/ocw/core/alerts.py
+++ b/ocw/core/alerts.py
@@ -273,12 +273,20 @@ class AlertEngine:
     def _check_cost_budgets(self, session: SessionRecord) -> None:
         """Check daily and session cost thresholds against the agent's budget config."""
         agent_cfg = self.config.agents.get(session.agent_id)
-        if not agent_cfg:
+        # Resolve budget: per-agent overrides defaults
+        if agent_cfg:
+            budget = agent_cfg.budget
+        elif hasattr(self.config, "defaults"):
+            budget = self.config.defaults.budget
+        else:
+            return
+        from ocw.core.config import BudgetConfig
+        if budget == BudgetConfig():
             return
 
         # Session budget
-        if agent_cfg.budget.session_usd is not None and session.total_cost_usd is not None:
-            if session.total_cost_usd > agent_cfg.budget.session_usd:
+        if budget.session_usd is not None and session.total_cost_usd is not None:
+            if session.total_cost_usd > budget.session_usd:
                 alert = Alert(
                     alert_id=new_uuid(),
                     fired_at=utcnow(),
@@ -287,8 +295,8 @@ class AlertEngine:
                     title=f"cost_budget_session — {session.agent_id}",
                     detail={
                         "session_cost": session.total_cost_usd,
-                        "budget": agent_cfg.budget.session_usd,
-                        "message": f"Session cost ${session.total_cost_usd:.4f} exceeds budget ${agent_cfg.budget.session_usd:.4f}",
+                        "budget": budget.session_usd,
+                        "message": f"Session cost ${session.total_cost_usd:.4f} exceeds budget ${budget.session_usd:.4f}",
                     },
                     agent_id=session.agent_id,
                     session_id=session.session_id,
@@ -296,10 +304,10 @@ class AlertEngine:
                 self._fire(alert)
 
         # Daily budget
-        if agent_cfg.budget.daily_usd is not None:
+        if budget.daily_usd is not None:
             today = utcnow().date()
             daily_cost = self.db.get_daily_cost(session.agent_id, today)
-            if daily_cost > agent_cfg.budget.daily_usd:
+            if daily_cost > budget.daily_usd:
                 alert = Alert(
                     alert_id=new_uuid(),
                     fired_at=utcnow(),
@@ -308,8 +316,8 @@ class AlertEngine:
                     title=f"cost_budget_daily — {session.agent_id}",
                     detail={
                         "daily_cost": daily_cost,
-                        "budget": agent_cfg.budget.daily_usd,
-                        "message": f"Daily cost ${daily_cost:.4f} exceeds budget ${agent_cfg.budget.daily_usd:.4f}",
+                        "budget": budget.daily_usd,
+                        "message": f"Daily cost ${daily_cost:.4f} exceeds budget ${budget.daily_usd:.4f}",
                     },
                     agent_id=session.agent_id,
                     session_id=session.session_id,

--- a/ocw/core/config.py
+++ b/ocw/core/config.py
@@ -43,6 +43,11 @@ class AgentConfig:
 
 
 @dataclass
+class DefaultsConfig:
+    budget: BudgetConfig = field(default_factory=BudgetConfig)
+
+
+@dataclass
 class StorageConfig:
     path:           str = "~/.ocw/telemetry.duckdb"
     retention_days: int = 90
@@ -135,6 +140,7 @@ class CaptureConfig:
 @dataclass
 class OcwConfig:
     version:  str
+    defaults: DefaultsConfig          = field(default_factory=DefaultsConfig)
     agents:   dict[str, AgentConfig]  = field(default_factory=dict)
     storage:  StorageConfig           = field(default_factory=StorageConfig)
     export:   ExportConfig            = field(default_factory=ExportConfig)
@@ -268,8 +274,13 @@ def _parse(raw: dict) -> OcwConfig:
         tool_outputs=capture_raw.get("tool_outputs", False),
     )
 
+    defaults_raw = raw.get("defaults", {})
+    defaults_budget_raw = defaults_raw.get("budget", {})
+    defaults = DefaultsConfig(budget=BudgetConfig(**defaults_budget_raw))
+
     return OcwConfig(
         version=raw.get("version", "1"),
+        defaults=defaults,
         agents=agents,
         storage=storage,
         export=export,


### PR DESCRIPTION
## Summary
- Remove agent ID prompt — agents are auto-discovered when spans arrive
- Replace per-agent budget with `[defaults.budget]` that applies to all agents
- Per-agent `[agents.X.budget]` overrides the default when configured
- Clean minimal config (no empty sections, commented per-agent example)
- Rich next-steps output with instrumentation code example

## Config changes
New `DefaultsConfig` dataclass with `budget: BudgetConfig`. Budget resolution: per-agent config > `defaults.budget` > none. Updated in `alerts.py` and `cmd_status.py`.

## Generated config
```toml
[defaults.budget]
daily_usd = 10.0

[security]
ingest_secret = "..."

[capture]
prompts = false
completions = false
tool_outputs = false

[storage]
path = "~/.ocw/telemetry.duckdb"
retention_days = 90
```

## Test plan
- [x] All 243 tests pass
- [x] `ruff check ocw/` clean
- [x] `ocw onboard --force` produces clean config and helpful output
- [ ] Agent with `@watch(agent_id="anything")` picks up default budget

🤖 Generated with [Claude Code](https://claude.com/claude-code)