### PR TITLE
Release v0.1.7

### DIFF
--- a/.github/workflows/publish-pypi.yml
+++ b/.github/workflows/publish-pypi.yml
@@ -19,7 +19,7 @@ jobs:
           python-version: "3.12"
 
       - name: Install dependencies
-        run: pip install build ".[dev]"
+        run: pip install build ".[dev,mcp]"
 
       - name: Run tests
         run: pytest tests/unit/ tests/synthetic/ tests/agents/ tests/integration/ -x

--- a/sdk-ts/package.json
+++ b/sdk-ts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclawwatch/sdk",
-  "version": "0.1.6",
+  "version": "0.1.7",
   "description": "TypeScript SDK for OpenClawWatch — local-first observability for AI agents",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",


### PR DESCRIPTION
## Summary

- **MCP server** (`ocw mcp`): 13 stdio tool handlers for Claude Code — status, traces, alerts, budget, cost, drift, tool stats, trace detail, acknowledge, setup, list sessions, open dashboard. Dual-mode: HTTP proxy when `ocw serve` is running, read-only DuckDB fallback.
- **Claude Code integration** (`ocw onboard --claude-code`): one-command OTLP log exporter setup with secret resyncing on re-runs
- **Logs ingestion** (`POST /v1/logs`): converts Claude Code OTLP log events into spans with deterministic trace IDs
- **`ocw drift` CLI**: behavioral drift report with Z-score analysis and Rich table output
- **`ocw budget` CLI + API**: view/set per-agent daily/session cost limits with per-field fallback resolution
- **Architecture doc** (`docs/architecture.md`): comprehensive design reference synthesized from original task specs
- **Fix**: publish workflow now installs `[mcp]` extra so MCP tests pass in CI
- **Fix**: sdk-ts version bumped to 0.1.7 (npm publish was failing on duplicate 0.1.6)

## Test plan

- [x] `pytest tests/unit/ tests/synthetic/ tests/agents/ tests/integration/` — 338 passing
- [ ] Verify publish workflow succeeds with `.[dev,mcp]` install

🤖 Generated with [Claude Code](https://claude.com/claude-code)