### PR TITLE
Fix pricing path, config serialization, and daemon prompt

### DIFF
--- a/ocw/cli/cmd_onboard.py
+++ b/ocw/cli/cmd_onboard.py
@@ -20,7 +20,7 @@ from ocw.utils.formatting import console
 @click.option("--budget", type=float, default=None,
               help="Daily budget in USD per agent (0 = no limit)")
 @click.option("--install-daemon", "install_daemon", is_flag=True, default=False,
-              help="Install background daemon without prompting")
+              help="(no-op: daemon is installed by default; use --no-daemon to skip)")
 @click.option("--no-daemon", is_flag=True, default=False,
               help="Skip background daemon installation")
 @click.option("--force", is_flag=True, help="Overwrite existing config")
@@ -249,6 +249,7 @@ export OTEL_EXPORTER_OTLP_HEADERS="Authorization=Bearer {secret}"
 
     want_daemon = not no_daemon
     if want_daemon:
+        console.print("  Daemon:              auto-installing (use --no-daemon to skip)")
         _install_daemon()
 
     console.print()

--- a/ocw/cli/cmd_onboard.py
+++ b/ocw/cli/cmd_onboard.py
@@ -49,12 +49,7 @@ def cmd_onboard(ctx: click.Context, claude_code: bool, budget: float | None,
 
     ingest_secret = secrets.token_hex(32)
 
-    want_daemon = install_daemon or (
-        not no_daemon and click.confirm(
-            "Install background daemon (keeps ocw serve alive across reboots)?",
-            default=False,
-        )
-    )
+    want_daemon = not no_daemon
 
     config_path = Path(".ocw/config.toml")
     config_path.parent.mkdir(parents=True, exist_ok=True)
@@ -252,12 +247,7 @@ export OTEL_EXPORTER_OTLP_ENDPOINT=http://host.docker.internal:{port}
 export OTEL_EXPORTER_OTLP_HEADERS="Authorization=Bearer {secret}"
 """)
 
-    want_daemon = install_daemon or (
-        not no_daemon and click.confirm(
-            "Install background daemon (keeps ocw serve alive across reboots)?",
-            default=False,
-        )
-    )
+    want_daemon = not no_daemon
     if want_daemon:
         _install_daemon()
 

--- a/ocw/core/config.py
+++ b/ocw/core/config.py
@@ -311,7 +311,7 @@ def _serialise(config: OcwConfig) -> dict:
                 ]
             elif hasattr(val, "__dataclass_fields__"):
                 result[f.name] = _dc_to_dict(val)
-            elif val is not None:
+            elif val is not None and not isinstance(val, Path):
                 result[f.name] = val
         return result
 

--- a/ocw/core/pricing.py
+++ b/ocw/core/pricing.py
@@ -10,7 +10,7 @@ else:
     import tomli as tomllib  # type: ignore[no-redef]
 
 
-PRICING_FILE = Path(__file__).parent.parent.parent / "pricing" / "models.toml"
+PRICING_FILE = Path(__file__).parent.parent / "pricing" / "models.toml"
 
 # Default rate used when a model is not in the pricing table.
 # 0.50 per MTok input, 2.00 per MTok output — conservative mid-range estimate.

--- a/tests/integration/test_cli.py
+++ b/tests/integration/test_cli.py
@@ -510,6 +510,29 @@ def test_onboard_claude_code_preserves_custom_otlp_headers(runner, tmp_path):
     assert data["env"]["OTEL_EXPORTER_OTLP_HEADERS"] == custom_header
 
 
+def test_onboard_does_not_prompt_for_daemon(runner, tmp_path):
+    """Regression: ocw onboard should auto-install the daemon without
+    prompting. The prompt was removed in v0.1.6 but reappeared.
+    See v0.1.7 fix."""
+    with patch("ocw.cli.cmd_onboard.find_config_file", return_value=None), \
+         patch("ocw.cli.cmd_onboard._install_daemon", return_value="Daemon installed") as mock_daemon:
+        result = runner.invoke(cli, ["onboard", "--budget", "5.0"], input="")
+    assert result.exit_code == 0
+    # Daemon should be auto-installed (not prompted)
+    mock_daemon.assert_called_once()
+    # Should NOT contain the interactive prompt text
+    assert "Install background daemon" not in result.output
+
+
+def test_onboard_no_daemon_skips_install(runner, tmp_path):
+    """--no-daemon flag should skip daemon installation entirely."""
+    with patch("ocw.cli.cmd_onboard.find_config_file", return_value=None), \
+         patch("ocw.cli.cmd_onboard._install_daemon") as mock_daemon:
+        result = runner.invoke(cli, ["onboard", "--budget", "5.0", "--no-daemon"])
+    assert result.exit_code == 0
+    mock_daemon.assert_not_called()
+
+
 def test_budget_show_displays_defaults(runner, db, config):
     """ocw budget with no flags shows current budgets."""
     result = _invoke(runner, db, config, ["budget"])

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -142,6 +142,36 @@ class TestSerialise:
         assert restored.security.ingest_secret == "secret123"
         assert restored.capture.prompts is True
 
+    def test_serialise_excludes_config_path(self):
+        """Regression: config_path is a Path object which is not TOML
+        serializable. _serialise() must exclude it. See v0.1.7 fix."""
+        config = OcwConfig(
+            version="1",
+            security=SecurityConfig(ingest_secret="s"),
+            config_path=Path("/some/path/ocw.toml"),
+        )
+        serialised = _serialise(config)
+        assert "config_path" not in serialised
+
+    def test_write_config_after_load_roundtrip(self, tmp_path):
+        """Regression: load_config sets config_path (a Path). Writing that
+        config back must not crash with 'PosixPath is not TOML serializable'.
+        See v0.1.7 fix."""
+        from ocw.core.config import write_config
+
+        toml_content = b'version = "1"\n\n[security]\ningest_secret = "abc"\n'
+        config_file = tmp_path / "ocw.toml"
+        config_file.write_bytes(toml_content)
+
+        config = load_config(str(config_file))
+        assert config.config_path is not None
+
+        out_path = tmp_path / "out.toml"
+        write_config(config, out_path)
+        assert out_path.exists()
+        reloaded = load_config(str(out_path))
+        assert reloaded.security.ingest_secret == "abc"
+
 
 class TestResolveEffectiveBudget:
     def test_agent_with_both_fields_uses_agent_values(self):

--- a/tests/unit/test_cost.py
+++ b/tests/unit/test_cost.py
@@ -103,3 +103,14 @@ def test_calculate_cost_openai_model():
     cost = calculate_cost("openai", "gpt-4o", 500_000, 100_000)
     # (500k/1M * 2.50) + (100k/1M * 10.00) = 1.25 + 1.00 = 2.25
     assert cost == 2.25
+
+
+def test_pricing_file_exists_at_expected_path():
+    """Regression: PRICING_FILE must resolve to ocw/pricing/models.toml,
+    not a path outside the package. A broken path causes $0.00 costs
+    when installed via pip (non-editable). See v0.1.7 fix."""
+    from ocw.core.pricing import PRICING_FILE
+    assert PRICING_FILE.exists(), f"Pricing file not found at {PRICING_FILE}"
+    assert "ocw" in PRICING_FILE.parts, (
+        f"PRICING_FILE should be inside the ocw package, got {PRICING_FILE}"
+    )


### PR DESCRIPTION
## Summary

These bugs were found when testing release 0.1.7

- **Fix cost showing $0.000000** — `PRICING_FILE` path was 3 levels up from `ocw/core/pricing.py` instead of 2, resolving to `site-packages/pricing/models.toml` (missing) instead of `site-packages/ocw/pricing/models.toml`. All pip-installed cost calculations failed silently.
- **Fix `ocw onboard --claude-code` crash** — `_serialise()` included `config_path` (a `PosixPath`) in the TOML output dict, causing `TypeError: Object of type 'PosixPath' is not TOML serializable`
- **Remove daemon install prompt** — both `ocw onboard` and `--claude-code` still prompted for daemon install despite v0.1.6 intending auto-install. Now auto-installs by default (skip with `--no-daemon`).
- **Updated Test Coverage**: 5 new regression tests to catch these types of issues before release in the future

## Test plan

- [x] `pytest tests/unit/ tests/synthetic/ tests/agents/ tests/integration/` — 341 passed
- [ ] `pip install openclawwatch && ocw onboard` — no daemon prompt, daemon auto-installs
- [ ] `ocw onboard --claude-code` — no crash, config written successfully
- [ ] Run example agent → `ocw cost` shows non-zero costs

🤖 Generated with [Claude Code](https://claude.com/claude-code)