### PR TITLE
MCP reliability fixes, Add agents API, and full uninstall cleanup, alert acknowledge endpoint

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -49,3 +49,4 @@ ocw.toml
 
 # Superpowers skill output (internal planning artifacts, not for OSS)
 docs/superpowers/
+.gstack/

--- a/README.md
+++ b/README.md
@@ -160,35 +160,40 @@ No signup, no cloud — runs entirely on your machine.
 
 ## Claude Code integration
 
-Monitor every Claude Code session — costs, tool calls, API requests, errors — with a single command:
-
-```bash
-ocw onboard --claude-code          # configures telemetry, sets daily budget
-ocw serve &                        # start the server
-# restart Claude Code, then:
-ocw status --agent claude-code-*   # see cost, tokens, active alerts
-```
-
-`ocw onboard --claude-code` automatically:
-- Writes OTLP exporter config to `~/.claude/settings.json` (global) and `.claude/settings.json` (project)
-- Sets up Docker harness-compatible env vars in `~/.zshrc`
-- Creates a per-agent budget in `.ocw/config.toml`
-- Optionally installs a background daemon (launchd/systemd) to keep `ocw serve` alive
-
-Claude Code emits OTLP log events which `ocw serve` converts into spans — every API request, tool result, tool decision, and error becomes a first-class span with cost tracking, alert evaluation, and drift detection.
-
-Works in both interactive and autonomous (headless) mode. Drift detection is especially useful for autonomous runs where Claude Code executes recurring tasks — token anomalies and tool sequence changes are caught automatically.
-
-### MCP server
-
-`ocw` ships an MCP server that gives Claude Code direct access to your observability data — no `ocw serve` required. Install it once globally:
+Monitor every Claude Code session — costs, tool calls, API requests, errors — with two commands:
 
 ```bash
 pip install "openclawwatch[mcp]"
-claude mcp add --scope user ocw -- ocw mcp
+ocw onboard --claude-code
+# Restart Claude Code, then:
+ocw status --agent claude-code-<project>
 ```
 
-Restart Claude Code. You now have 13 tools available in every session:
+`ocw onboard --claude-code` does everything in one shot:
+- Creates a shared config at `~/.config/ocw/config.toml` (one config for all your projects)
+- Writes OTLP exporter vars to `~/.claude/settings.json` so Claude Code sends telemetry automatically
+- Tags this project's sessions by writing `OTEL_RESOURCE_ATTRIBUTES=service.name=claude-code-<project>` to `.claude/settings.json`
+- Registers the MCP server globally (`claude mcp add --scope user ocw -- ocw mcp`)
+- Installs a background daemon (launchd on macOS, systemd on Linux) to keep `ocw serve` alive across restarts
+- Adds Docker harness-compatible OTLP env vars to `~/.zshrc`
+
+**Claude Code must be restarted** after running `ocw onboard --claude-code` for the new `settings.json` env vars to take effect.
+
+**Adding a second (or third) project** — run once per project directory, no reinstall needed:
+
+```bash
+cd /path/to/other-project
+ocw onboard --claude-code   # adds agent to shared config, tags this project
+# Restart Claude Code
+```
+
+Each project gets its own agent ID (`claude-code-<repo-name>`), all sharing one running server and one ingest secret. Running `ocw onboard --claude-code` in a new project never rotates the secret or breaks other projects.
+
+Claude Code emits OTLP log events which `ocw serve` converts into spans — every API request, tool result, tool decision, and error becomes a first-class span with cost tracking, alert evaluation, and drift detection. Works in both interactive and autonomous (headless) mode.
+
+### MCP server
+
+The MCP server is included in the `[mcp]` extra and registered automatically by `ocw onboard --claude-code`. It gives Claude Code direct access to your observability data inside the session itself. After restarting Claude Code you have 13 tools available in every session:
 
 | Tool | What it does |
 |---|---|
@@ -213,6 +218,25 @@ The MCP server opens the DuckDB file read-only — no lock conflicts with `ocw s
 > "Set up OCW for this project"
 
 Claude calls `setup_project`, which writes `.claude/settings.json` with `OTEL_RESOURCE_ATTRIBUTES=service.name=<project>` so spans from that project are tagged with the right agent ID.
+
+### Uninstalling
+
+```bash
+# Remove all OCW data, config, daemon, MCP registration, and env vars from every onboarded project:
+ocw uninstall --yes
+
+# Then remove the package itself (ocw uninstall intentionally skips this):
+pip uninstall openclawwatch -y
+```
+
+`ocw uninstall` cleans up everything set by `ocw onboard --claude-code`:
+- Stops and removes the background daemon (launchd/systemd)
+- Deregisters the MCP server from Claude Code
+- Deletes `~/.ocw/` (telemetry database)
+- Deletes `~/.config/ocw/` (global config and projects index)
+- Removes OTLP env vars from `~/.claude/settings.json`
+- Removes `OTEL_RESOURCE_ATTRIBUTES` from `.claude/settings.json` in every onboarded project
+- Removes the harness env block from `~/.zshrc`
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -505,12 +505,22 @@ See [`examples/README.md`](examples/README.md) for the full list with required e
 ```bash
 git clone https://github.com/Metabuilder-Labs/openclawwatch
 cd openclawwatch
-pip install -e ".[dev]"
+pip install -e ".[dev,mcp]"   # editable install with dev tools + MCP support
 
 pytest tests/unit/ tests/synthetic/ tests/agents/ tests/integration/
 ruff check ocw/
 mypy ocw/
 ```
+
+To test the Claude Code integration locally after cloning:
+
+```bash
+pip install -e ".[dev,mcp]"
+ocw onboard --claude-code
+# Restart Claude Code
+```
+
+The editable install means changes to `ocw/` take effect immediately — no reinstall needed. Use `pip install -e ".[dev]"` if you don't need the MCP server.
 
 292 tests. 2.5 seconds. All green.
 

--- a/ocw/api/app.py
+++ b/ocw/api/app.py
@@ -41,7 +41,7 @@ def create_app(
     app.add_middleware(
         CORSMiddleware,
         allow_origin_regex=r"^https?://(localhost|127\.0\.0\.1)(:\d+)?$",
-        allow_methods=["GET", "POST"],
+        allow_methods=["GET", "POST", "PATCH"],
         allow_headers=["Authorization", "Content-Type"],
     )
 
@@ -64,6 +64,7 @@ def create_app(
     from ocw.api.routes.status import router as status_router
     from ocw.api.routes.otlp import router as otlp_router
     from ocw.api.routes.budget import router as budget_router
+    from ocw.api.routes.agents import router as agents_router
 
     app.include_router(spans_router, prefix="/api/v1")
     app.include_router(traces_router, prefix="/api/v1")
@@ -73,6 +74,7 @@ def create_app(
     app.include_router(drift_router, prefix="/api/v1")
     app.include_router(status_router, prefix="/api/v1")
     app.include_router(budget_router, prefix="/api/v1")
+    app.include_router(agents_router, prefix="/api/v1")
     app.include_router(metrics_router)  # /metrics — no prefix
     app.include_router(otlp_router)  # /v1/traces, /v1/metrics, /v1/logs — no prefix
 

--- a/ocw/api/routes/agents.py
+++ b/ocw/api/routes/agents.py
@@ -1,0 +1,33 @@
+"""GET /api/v1/agents — agent registry."""
+from __future__ import annotations
+
+from fastapi import APIRouter, Depends, Request
+
+from ocw.api.deps import require_api_key
+
+router = APIRouter(dependencies=[Depends(require_api_key)])
+
+
+@router.get("/agents")
+async def list_agents(request: Request) -> dict:
+    db = request.app.state.db
+    if not hasattr(db, "conn") or db.conn is None:
+        return {"agents": []}
+    rows = db.conn.execute(
+        "SELECT a.agent_id, a.first_seen, a.last_seen, "
+        "COALESCE(SUM(s.cost_usd), 0.0) AS lifetime_cost "
+        "FROM agents a LEFT JOIN spans s ON a.agent_id = s.agent_id "
+        "GROUP BY a.agent_id, a.first_seen, a.last_seen "
+        "ORDER BY a.last_seen DESC NULLS LAST"
+    ).fetchall()
+    return {
+        "agents": [
+            {
+                "agent_id": r[0],
+                "first_seen": r[1].isoformat() if r[1] else None,
+                "last_seen": r[2].isoformat() if r[2] else None,
+                "lifetime_cost_usd": float(r[3]),
+            }
+            for r in rows
+        ]
+    }

--- a/ocw/api/routes/alerts.py
+++ b/ocw/api/routes/alerts.py
@@ -10,6 +10,7 @@ from ocw.utils.time_parse import parse_since
 router = APIRouter(dependencies=[Depends(require_api_key)])
 
 
+
 @router.get("/alerts")
 async def get_alerts(
     request: Request,
@@ -55,3 +56,22 @@ async def get_alerts(
         ],
         "count": len(alerts),
     }
+
+
+@router.patch("/alerts/{alert_id}/acknowledge")
+async def acknowledge_alert(alert_id: str, request: Request) -> dict:
+    db = request.app.state.db
+    conn = getattr(db, "conn", None)
+    if conn is None:
+        from fastapi import HTTPException
+        raise HTTPException(status_code=503, detail="Write operations unavailable in read-only mode")
+    result = conn.execute(
+        "SELECT alert_id FROM alerts WHERE alert_id = $1", [alert_id]
+    ).fetchone()
+    if result is None:
+        from fastapi import HTTPException
+        raise HTTPException(status_code=404, detail=f"Alert {alert_id} not found")
+    conn.execute(
+        "UPDATE alerts SET acknowledged = true WHERE alert_id = $1", [alert_id]
+    )
+    return {"acknowledged": True, "alert_id": alert_id}

--- a/ocw/api/routes/otlp.py
+++ b/ocw/api/routes/otlp.py
@@ -2,7 +2,8 @@
 
 POST /v1/traces — forwards to the same OTLP JSON ingest logic as /api/v1/spans.
 POST /v1/metrics — stub (200 OK, silently discards).
-POST /v1/logs — stub (200 OK, silently discards).
+POST /v1/logs — primary ingest path for Claude Code telemetry; converts OTLP log
+    events to NormalizedSpan objects via parse_log_records() in logs.py.
 
 These exist so that OTel exporters configured with a bare endpoint
 (e.g. ``http://127.0.0.1:7391``) work out of the box — OpenClaw's

--- a/ocw/api/routes/status.py
+++ b/ocw/api/routes/status.py
@@ -73,6 +73,8 @@ async def get_status(
             "error_count": session.error_count if session else 0,
             "active_alerts": len(active_alerts),
             "duration_seconds": session.duration_seconds if session else None,
+            "started_at": session.started_at.isoformat() if session and session.started_at else None,
+            "total_cost_usd": float(session.total_cost_usd) if session and session.total_cost_usd is not None else 0.0,
         }
         agents_data.append(agent_data)
 

--- a/ocw/cli/cmd_onboard.py
+++ b/ocw/cli/cmd_onboard.py
@@ -190,6 +190,13 @@ def _onboard_claude_code(
         write_config(config, config_path)
         console.print(f"  ocw config written to: {config_path}")
 
+    # --- Register MCP server with Claude Code ---
+    if shutil.which("claude"):
+        subprocess.run(
+            ["claude", "mcp", "add", "ocw", "--scope", "user", "--", "ocw", "mcp"],
+            capture_output=True,
+        )
+
     # --- Global settings (~/.claude/settings.json) ---
     claude_dir = Path.home() / ".claude"
     claude_dir.mkdir(parents=True, exist_ok=True)
@@ -243,7 +250,8 @@ def _onboard_claude_code(
     marker = "# ocw harness observability"
     zshrc_text = zshrc.read_text()
     if marker not in zshrc_text:
-        zshrc.open("a").write(f"""
+        with zshrc.open("a") as f:
+            f.write(f"""
 {marker}
 export CLAUDE_CODE_ENABLE_TELEMETRY=1
 export OTEL_LOGS_EXPORTER=otlp

--- a/ocw/cli/cmd_onboard.py
+++ b/ocw/cli/cmd_onboard.py
@@ -43,8 +43,8 @@ def cmd_onboard(ctx: click.Context, claude_code: bool, budget: float | None,
 
     if budget is None:
         budget = click.prompt(
-            "Daily budget in USD per agent (0 = no limit, default 5)",
-            type=float, default=5.0, show_default=False,
+            "Daily budget in USD per agent (0 = no limit, default 0)",
+            type=float, default=0.0, show_default=False,
         )
 
     ingest_secret = secrets.token_hex(32)
@@ -91,7 +91,7 @@ retention_days = 90
 
     daemon_msg = None
     if want_daemon:
-        daemon_msg = _install_daemon()
+        daemon_msg = _install_daemon(str(config_path.resolve()))
 
     # Output
     console.print()
@@ -152,23 +152,28 @@ def _onboard_claude_code(
         AgentConfig, BudgetConfig, OcwConfig, SecurityConfig, load_config, write_config,
     )
 
+    # --claude-code always uses the global config so that all projects share one
+    # ingest secret and one running daemon. Per-project configs cause the secret in
+    # ~/.claude/settings.json to rotate on every project onboard, breaking auth for
+    # every other project.
+    global_config_path = Path.home() / ".config" / "ocw" / "config.toml"
+
     project_name = _derive_project_name()
     agent_id = f"claude-code-{project_name}"
-    existing = find_config_file()
 
     if budget is None:
         budget = click.prompt(
-            "Daily budget in USD (0 = no limit, default 5)",
-            type=float, default=5.0, show_default=False,
+            "Daily budget in USD (0 = no limit, default 0)",
+            type=float, default=0.0, show_default=False,
         )
 
-    if existing and not force:
-        config = load_config(str(existing))
+    if global_config_path.exists() and not force:
+        config = load_config(str(global_config_path))
         if agent_id not in config.agents:
             config.agents[agent_id] = AgentConfig()
         if budget and budget > 0:
             config.agents[agent_id].budget.daily_usd = budget
-        config_path = Path(existing)
+        config_path = global_config_path
         write_config(config, config_path)
         console.print(f"  ocw config updated: {config_path}")
     else:
@@ -180,7 +185,8 @@ def _onboard_claude_code(
             agents=agents,
             security=SecurityConfig(ingest_secret=ingest_secret),
         )
-        config_path = Path(".ocw/config.toml")
+        config_path = global_config_path
+        config_path.parent.mkdir(parents=True, exist_ok=True)
         write_config(config, config_path)
         console.print(f"  ocw config written to: {config_path}")
 
@@ -203,15 +209,16 @@ def _onboard_claude_code(
         except (json_mod.JSONDecodeError, OSError):
             global_settings = {}
 
-    # Write global OTLP config — endpoint keys only on first run, secret always synced
+    # Write global OTLP config — always overwrite endpoint vars so reinstall stays in sync.
+    # Custom headers (non-OCW) are preserved; only OCW-generated "Authorization=Bearer"
+    # headers are replaced when the secret rotates.
     port = config.api.port
     secret = config.security.ingest_secret
     global_env: dict = global_settings.get("env", {})
-    if "OTEL_EXPORTER_OTLP_ENDPOINT" not in global_env:
-        global_env["CLAUDE_CODE_ENABLE_TELEMETRY"] = "1"
-        global_env["OTEL_LOGS_EXPORTER"] = "otlp"
-        global_env["OTEL_EXPORTER_OTLP_PROTOCOL"] = "http/json"
-        global_env["OTEL_EXPORTER_OTLP_ENDPOINT"] = f"http://127.0.0.1:{port}"
+    global_env["CLAUDE_CODE_ENABLE_TELEMETRY"] = "1"
+    global_env["OTEL_LOGS_EXPORTER"] = "otlp"
+    global_env["OTEL_EXPORTER_OTLP_PROTOCOL"] = "http/json"
+    global_env["OTEL_EXPORTER_OTLP_ENDPOINT"] = f"http://127.0.0.1:{port}"
     existing_header = global_env.get("OTEL_EXPORTER_OTLP_HEADERS", "")
     if secret and (not existing_header or "Authorization=Bearer" in existing_header):
         global_env["OTEL_EXPORTER_OTLP_HEADERS"] = f"Authorization=Bearer {secret}"
@@ -235,6 +242,17 @@ def _onboard_claude_code(
     project_settings["env"] = project_env
     project_settings_path.write_text(json_mod.dumps(project_settings, indent=2) + "\n")
 
+    # --- Track onboarded project paths for clean uninstall ---
+    projects_index = config_path.parent / "projects.json"
+    try:
+        known: list[str] = json_mod.loads(projects_index.read_text()) if projects_index.exists() else []
+    except (json_mod.JSONDecodeError, OSError):
+        known = []
+    cwd_str = str(Path.cwd())
+    if cwd_str not in known:
+        known.append(cwd_str)
+        projects_index.write_text(json_mod.dumps(known, indent=2) + "\n")
+
     # --- Shell env (~/.zshrc) ---
     # Writes host.docker.internal endpoint so harness sessions (Docker) pick up
     # the vars automatically via compose.yml passthrough — no manual setup needed.
@@ -243,21 +261,31 @@ def _onboard_claude_code(
     zshrc.touch(exist_ok=True)
     marker = "# ocw harness observability"
     zshrc_text = zshrc.read_text()
+    new_block = (
+        f"\n{marker}\n"
+        f"export CLAUDE_CODE_ENABLE_TELEMETRY=1\n"
+        f"export OTEL_LOGS_EXPORTER=otlp\n"
+        f"export OTEL_EXPORTER_OTLP_PROTOCOL=http/json\n"
+        f"export OTEL_EXPORTER_OTLP_ENDPOINT=http://host.docker.internal:{port}\n"
+        f'export OTEL_EXPORTER_OTLP_HEADERS="Authorization=Bearer {secret}"\n'
+    )
     if marker not in zshrc_text:
         with zshrc.open("a") as f:
-            f.write(f"""
-{marker}
-export CLAUDE_CODE_ENABLE_TELEMETRY=1
-export OTEL_LOGS_EXPORTER=otlp
-export OTEL_EXPORTER_OTLP_PROTOCOL=http/json
-export OTEL_EXPORTER_OTLP_ENDPOINT=http://host.docker.internal:{port}
-export OTEL_EXPORTER_OTLP_HEADERS="Authorization=Bearer {secret}"
-""")
+            f.write(new_block)
+    else:
+        # Marker already present — replace the entire block to keep the secret in sync.
+        import re as _re
+        updated = _re.sub(
+            r"# ocw harness observability\n(?:export [^\n]+\n)*",
+            new_block.lstrip("\n"),
+            zshrc_text,
+        )
+        zshrc.write_text(updated)
 
     want_daemon = not no_daemon
     if want_daemon:
         console.print("  Daemon:              auto-installing (use --no-daemon to skip)")
-        _install_daemon()
+        _install_daemon(str(config_path.resolve()))
 
     console.print()
     console.print("[bold green]Claude Code observability configured.[/bold green]")
@@ -302,14 +330,14 @@ def _derive_project_name() -> str:
     return Path.cwd().name.lower()
 
 
-def _install_daemon() -> str | None:
+def _install_daemon(config_path: str) -> str | None:
     """Install background daemon. Returns success message or None."""
     system = platform.system()
     try:
         if system == "Darwin":
-            return _install_launchd()
+            return _install_launchd(config_path)
         elif system == "Linux":
-            return _install_systemd()
+            return _install_systemd(config_path)
         else:
             console.print(f"[yellow]Background daemon not supported on {system}. "
                           "Run `ocw serve` manually.[/yellow]")
@@ -320,7 +348,7 @@ def _install_daemon() -> str | None:
         return None
 
 
-def _install_launchd() -> str | None:
+def _install_launchd(config_path: str) -> str | None:
     ocw_path = shutil.which("ocw") or sys.executable.replace("/python", "/ocw").replace("/python3", "/ocw")
     plist_path = Path.home() / "Library/LaunchAgents/com.openclawwatch.serve.plist"
     plist_path.parent.mkdir(parents=True, exist_ok=True)
@@ -335,6 +363,8 @@ def _install_launchd() -> str | None:
     <key>ProgramArguments</key>
     <array>
         <string>{ocw_path}</string>
+        <string>--config</string>
+        <string>{config_path}</string>
         <string>serve</string>
     </array>
     <key>RunAtLoad</key>
@@ -348,6 +378,12 @@ def _install_launchd() -> str | None:
 </dict>
 </plist>"""
     plist_path.write_text(plist_content)
+    # Unload any existing registration before loading the updated plist.
+    # Ignore errors — the service may not be registered yet on first install.
+    subprocess.run(
+        ["launchctl", "unload", str(plist_path)],
+        capture_output=True, text=True,
+    )
     result = subprocess.run(
         ["launchctl", "load", str(plist_path)],
         capture_output=True, text=True,
@@ -363,7 +399,7 @@ def _install_launchd() -> str | None:
     return f"Daemon installed at {plist_path}"
 
 
-def _install_systemd() -> str | None:
+def _install_systemd(config_path: str) -> str | None:
     ocw_path = shutil.which("ocw") or sys.executable.replace("/python", "/ocw").replace("/python3", "/ocw")
     service_path = Path.home() / ".config/systemd/user/openclawwatch.service"
     service_path.parent.mkdir(parents=True, exist_ok=True)
@@ -373,7 +409,7 @@ Description=OpenClawWatch observability server
 After=network.target
 
 [Service]
-ExecStart={ocw_path} serve
+ExecStart={ocw_path} --config {config_path} serve
 Restart=on-failure
 
 [Install]

--- a/ocw/cli/cmd_onboard.py
+++ b/ocw/cli/cmd_onboard.py
@@ -19,17 +19,15 @@ from ocw.utils.formatting import console
               help="Configure Claude Code telemetry to flow into ocw")
 @click.option("--budget", type=float, default=None,
               help="Daily budget in USD per agent (0 = no limit)")
-@click.option("--install-daemon", "install_daemon", is_flag=True, default=False,
-              help="Install background daemon without prompting")
 @click.option("--no-daemon", is_flag=True, default=False,
               help="Skip background daemon installation")
 @click.option("--force", is_flag=True, help="Overwrite existing config")
 @click.pass_context
 def cmd_onboard(ctx: click.Context, claude_code: bool, budget: float | None,
-                install_daemon: bool, no_daemon: bool, force: bool) -> None:
+                no_daemon: bool, force: bool) -> None:
     """Interactive setup wizard for ocw."""
     if claude_code:
-        _onboard_claude_code(ctx, budget, install_daemon, no_daemon, force)
+        _onboard_claude_code(ctx, budget, no_daemon, force)
         return
     existing = find_config_file()
     if existing and not force:
@@ -49,11 +47,9 @@ def cmd_onboard(ctx: click.Context, claude_code: bool, budget: float | None,
 
     ingest_secret = secrets.token_hex(32)
 
-    want_daemon = install_daemon or (
-        not no_daemon and click.confirm(
-            "Install background daemon (keeps ocw serve alive across reboots)?",
-            default=False,
-        )
+    want_daemon = not no_daemon and click.confirm(
+        "Install background daemon (keeps ocw serve alive across reboots)?",
+        default=False,
     )
 
     config_path = Path(".ocw/config.toml")
@@ -149,7 +145,6 @@ retention_days = 90
 def _onboard_claude_code(
     ctx: click.Context,
     budget: float | None,
-    install_daemon: bool,
     no_daemon: bool,
     force: bool,
 ) -> None:
@@ -252,11 +247,9 @@ export OTEL_EXPORTER_OTLP_ENDPOINT=http://host.docker.internal:{port}
 export OTEL_EXPORTER_OTLP_HEADERS="Authorization=Bearer {secret}"
 """)
 
-    want_daemon = install_daemon or (
-        not no_daemon and click.confirm(
-            "Install background daemon (keeps ocw serve alive across reboots)?",
-            default=False,
-        )
+    want_daemon = not no_daemon and click.confirm(
+        "Install background daemon (keeps ocw serve alive across reboots)?",
+        default=False,
     )
     if want_daemon:
         _install_daemon()

--- a/ocw/cli/cmd_uninstall.py
+++ b/ocw/cli/cmd_uninstall.py
@@ -57,26 +57,42 @@ def cmd_uninstall(ctx: click.Context, yes: bool) -> None:
         systemd_path.unlink()
         console.print(f"  Removed {systemd_path}")
 
-    # 5. Delete ~/.ocw/
+    # 5. Delete ~/.ocw/ (telemetry DB)
     ocw_dir = Path.home() / ".ocw"
     if ocw_dir.exists():
         shutil.rmtree(ocw_dir)
         console.print(f"  Removed {ocw_dir}")
 
-    # 6. Delete local .ocw/ if present
+    # 6. Read projects index BEFORE deleting the global config dir.
+    global_config_dir = Path.home() / ".config" / "ocw"
+    project_paths: list[Path] = []
+    projects_index = global_config_dir / "projects.json"
+    try:
+        if projects_index.exists():
+            paths = json.loads(projects_index.read_text())
+            project_paths = [Path(p) for p in paths if isinstance(p, str)]
+    except Exception:
+        pass
+
+    # 7. Delete global config ~/.config/ocw/
+    if global_config_dir.exists():
+        shutil.rmtree(global_config_dir)
+        console.print(f"  Removed {global_config_dir}")
+
+    # 8. Delete local .ocw/ if present
     local_ocw = Path(".ocw")
     if local_ocw.exists():
         shutil.rmtree(local_ocw)
         console.print(f"  Removed {local_ocw}")
 
-    # 7. Delete temp files
+    # 9. Delete temp files
     for tmp_file in ["/tmp/ocw-serve.out", "/tmp/ocw-serve.err"]:
         p = Path(tmp_file)
         if p.exists():
             p.unlink()
             console.print(f"  Removed {tmp_file}")
 
-    # 8. Remove OCW env vars from ~/.claude/settings.json (Gap #7)
+    # 10. Remove OCW env vars from ~/.claude/settings.json
     _GLOBAL_OCW_KEYS = {
         "CLAUDE_CODE_ENABLE_TELEMETRY",
         "OTEL_LOGS_EXPORTER",
@@ -99,28 +115,37 @@ def cmd_uninstall(ctx: click.Context, yes: bool) -> None:
         except Exception as exc:
             console.print(f"  [yellow]Could not clean {global_settings_path}: {exc}[/yellow]")
 
-    # 9. Remove OTEL_RESOURCE_ATTRIBUTES from project .claude/settings.json (Gap #7)
-    project_settings_path = Path.cwd() / ".claude" / "settings.json"
-    if project_settings_path.exists():
+    # 11. Remove OTEL_RESOURCE_ATTRIBUTES from all onboarded project .claude/settings.json files.
+    # project_paths was read from projects.json before the global config dir was deleted above.
+    # Always include CWD so running uninstall from a project dir works even without the index
+    cwd = Path.cwd()
+    if cwd not in project_paths:
+        project_paths.append(cwd)
+
+    for proj in project_paths:
+        proj_settings = proj / ".claude" / "settings.json"
+        if not proj_settings.exists():
+            continue
         try:
-            ps = json.loads(project_settings_path.read_text())
+            ps = json.loads(proj_settings.read_text())
             env = ps.get("env", {})
             if "OTEL_RESOURCE_ATTRIBUTES" in env:
                 del env["OTEL_RESOURCE_ATTRIBUTES"]
                 ps["env"] = env
-                project_settings_path.write_text(json.dumps(ps, indent=2) + "\n")
-                console.print(f"  Removed OTEL_RESOURCE_ATTRIBUTES from {project_settings_path}")
+                proj_settings.write_text(json.dumps(ps, indent=2) + "\n")
+                console.print(f"  Removed OTEL_RESOURCE_ATTRIBUTES from {proj_settings}")
         except Exception as exc:
-            console.print(f"  [yellow]Could not clean {project_settings_path}: {exc}[/yellow]")
+            console.print(f"  [yellow]Could not clean {proj_settings}: {exc}[/yellow]")
 
-    # 10. Remove # ocw harness observability block from ~/.zshrc (Gap #7)
+    # 11. Remove # ocw harness observability block from ~/.zshrc
     zshrc = Path.home() / ".zshrc"
     if zshrc.exists():
         try:
             text = zshrc.read_text()
+            # Match the marker line plus all following export lines (any count)
             cleaned = re.sub(
-                r"\n# ocw harness observability\nexport [^\n]+\nexport [^\n]+\nexport [^\n]+\nexport [^\n]+\nexport [^\n]+\n",
-                "\n",
+                r"# ocw harness observability\n(?:export [^\n]+\n)*",
+                "",
                 text,
             )
             if cleaned != text:

--- a/ocw/cli/cmd_uninstall.py
+++ b/ocw/cli/cmd_uninstall.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import json
+import re
 import shutil
 import subprocess
 from pathlib import Path
@@ -27,7 +29,15 @@ def cmd_uninstall(ctx: click.Context, yes: bool) -> None:
     from ocw.cli.cmd_stop import cmd_stop
     ctx.invoke(cmd_stop)
 
-    # 2. Unload and delete launchd plist
+    # 2. Deregister MCP server from Claude Code (Gap #13)
+    if shutil.which("claude"):
+        subprocess.run(
+            ["claude", "mcp", "remove", "ocw", "--scope", "user"],
+            capture_output=True, text=True,
+        )
+        console.print("  Removed ocw MCP server from Claude Code.")
+
+    # 3. Unload and delete launchd plist
     plist_path = Path.home() / "Library/LaunchAgents/com.openclawwatch.serve.plist"
     if plist_path.exists():
         subprocess.run(
@@ -37,7 +47,7 @@ def cmd_uninstall(ctx: click.Context, yes: bool) -> None:
         plist_path.unlink()
         console.print(f"  Removed {plist_path}")
 
-    # 3. Delete systemd service if present
+    # 4. Delete systemd service if present
     systemd_path = Path.home() / ".config/systemd/user/openclawwatch.service"
     if systemd_path.exists():
         subprocess.run(
@@ -47,24 +57,77 @@ def cmd_uninstall(ctx: click.Context, yes: bool) -> None:
         systemd_path.unlink()
         console.print(f"  Removed {systemd_path}")
 
-    # 4. Delete ~/.ocw/
+    # 5. Delete ~/.ocw/
     ocw_dir = Path.home() / ".ocw"
     if ocw_dir.exists():
         shutil.rmtree(ocw_dir)
         console.print(f"  Removed {ocw_dir}")
 
-    # 5. Delete local .ocw/ if present
+    # 6. Delete local .ocw/ if present
     local_ocw = Path(".ocw")
     if local_ocw.exists():
         shutil.rmtree(local_ocw)
         console.print(f"  Removed {local_ocw}")
 
-    # 6. Delete temp files
+    # 7. Delete temp files
     for tmp_file in ["/tmp/ocw-serve.out", "/tmp/ocw-serve.err"]:
         p = Path(tmp_file)
         if p.exists():
             p.unlink()
             console.print(f"  Removed {tmp_file}")
+
+    # 8. Remove OCW env vars from ~/.claude/settings.json (Gap #7)
+    _GLOBAL_OCW_KEYS = {
+        "CLAUDE_CODE_ENABLE_TELEMETRY",
+        "OTEL_LOGS_EXPORTER",
+        "OTEL_EXPORTER_OTLP_PROTOCOL",
+        "OTEL_EXPORTER_OTLP_ENDPOINT",
+        "OTEL_EXPORTER_OTLP_HEADERS",
+    }
+    global_settings_path = Path.home() / ".claude" / "settings.json"
+    if global_settings_path.exists():
+        try:
+            gs = json.loads(global_settings_path.read_text())
+            env = gs.get("env", {})
+            removed = [k for k in _GLOBAL_OCW_KEYS if k in env]
+            for k in removed:
+                del env[k]
+            if removed:
+                gs["env"] = env
+                global_settings_path.write_text(json.dumps(gs, indent=2) + "\n")
+                console.print(f"  Cleaned {len(removed)} OCW env vars from {global_settings_path}")
+        except Exception as exc:
+            console.print(f"  [yellow]Could not clean {global_settings_path}: {exc}[/yellow]")
+
+    # 9. Remove OTEL_RESOURCE_ATTRIBUTES from project .claude/settings.json (Gap #7)
+    project_settings_path = Path.cwd() / ".claude" / "settings.json"
+    if project_settings_path.exists():
+        try:
+            ps = json.loads(project_settings_path.read_text())
+            env = ps.get("env", {})
+            if "OTEL_RESOURCE_ATTRIBUTES" in env:
+                del env["OTEL_RESOURCE_ATTRIBUTES"]
+                ps["env"] = env
+                project_settings_path.write_text(json.dumps(ps, indent=2) + "\n")
+                console.print(f"  Removed OTEL_RESOURCE_ATTRIBUTES from {project_settings_path}")
+        except Exception as exc:
+            console.print(f"  [yellow]Could not clean {project_settings_path}: {exc}[/yellow]")
+
+    # 10. Remove # ocw harness observability block from ~/.zshrc (Gap #7)
+    zshrc = Path.home() / ".zshrc"
+    if zshrc.exists():
+        try:
+            text = zshrc.read_text()
+            cleaned = re.sub(
+                r"\n# ocw harness observability\nexport [^\n]+\nexport [^\n]+\nexport [^\n]+\nexport [^\n]+\nexport [^\n]+\n",
+                "\n",
+                text,
+            )
+            if cleaned != text:
+                zshrc.write_text(cleaned)
+                console.print(f"  Removed OCW env block from {zshrc}")
+        except Exception as exc:
+            console.print(f"  [yellow]Could not clean {zshrc}: {exc}[/yellow]")
 
     console.print()
     console.print("[green]OpenClawWatch data and config removed.[/green]")

--- a/ocw/mcp/server.py
+++ b/ocw/mcp/server.py
@@ -40,7 +40,10 @@ def _http_get(path: str, params: dict | None = None) -> dict:
         filtered = {k: str(v) for k, v in params.items() if v is not None}
         if filtered:
             url += "?" + urllib.parse.urlencode(filtered)
-    with urllib.request.urlopen(url, timeout=5) as resp:
+    req = urllib.request.Request(url)
+    if _config and _config.api.auth.enabled:
+        req.add_header("Authorization", f"Bearer {_config.api.auth.api_key}")
+    with urllib.request.urlopen(req, timeout=5) as resp:
         return json.loads(resp.read())
 
 
@@ -52,111 +55,126 @@ class _HttpDB:
         return None
 
     def get_cost_summary(self, filters):
-        from types import SimpleNamespace
-        params = {}
-        if filters.agent_id:
-            params["agent_id"] = filters.agent_id
-        if filters.since:
-            params["since"] = filters.since.isoformat()
-        if filters.group_by:
-            params["group_by"] = filters.group_by
-        data = _http_get("/api/v1/cost", params)
-        return [
-            SimpleNamespace(
-                group=r.get("group"),
-                agent_id=r.get("agent_id"),
-                model=r.get("model"),
-                input_tokens=r.get("input_tokens", 0),
-                output_tokens=r.get("output_tokens", 0),
-                cost_usd=r.get("cost_usd", 0.0),
-            )
-            for r in data.get("rows", [])
-        ]
+        try:
+            from types import SimpleNamespace
+            params = {}
+            if filters.agent_id:
+                params["agent_id"] = filters.agent_id
+            if filters.since:
+                params["since"] = filters.since.isoformat()
+            if filters.group_by:
+                params["group_by"] = filters.group_by
+            data = _http_get("/api/v1/cost", params)
+            return [
+                SimpleNamespace(
+                    group=r.get("group"),
+                    agent_id=r.get("agent_id"),
+                    model=r.get("model"),
+                    input_tokens=r.get("input_tokens", 0),
+                    output_tokens=r.get("output_tokens", 0),
+                    cost_usd=r.get("cost_usd", 0.0),
+                )
+                for r in data.get("rows", [])
+            ]
+        except Exception:
+            return []
 
     def get_alerts(self, filters):
-        from datetime import datetime
-        from types import SimpleNamespace
-        params = {}
-        if filters.agent_id:
-            params["agent_id"] = filters.agent_id
-        if filters.severity:
-            params["severity"] = filters.severity.value
-        if filters.unread:
-            params["unread"] = "true"
-        data = _http_get("/api/v1/alerts", params)
-        results = []
-        for a in data.get("alerts", []):
-            results.append(SimpleNamespace(
-                alert_id=a["alert_id"],
-                fired_at=datetime.fromisoformat(a["fired_at"]),
-                type=SimpleNamespace(value=a["type"]),
-                severity=SimpleNamespace(value=a["severity"]),
-                title=a["title"],
-                agent_id=a["agent_id"],
-                acknowledged=a["acknowledged"],
-                suppressed=a["suppressed"],
-            ))
-        return results
+        try:
+            from datetime import datetime
+            from types import SimpleNamespace
+            params = {}
+            if filters.agent_id:
+                params["agent_id"] = filters.agent_id
+            if filters.severity:
+                params["severity"] = filters.severity.value
+            if filters.unread:
+                params["unread"] = "true"
+            data = _http_get("/api/v1/alerts", params)
+            results = []
+            for a in data.get("alerts", []):
+                results.append(SimpleNamespace(
+                    alert_id=a["alert_id"],
+                    fired_at=datetime.fromisoformat(a["fired_at"]),
+                    type=SimpleNamespace(value=a["type"]),
+                    severity=SimpleNamespace(value=a["severity"]),
+                    title=a["title"],
+                    agent_id=a["agent_id"],
+                    acknowledged=a["acknowledged"],
+                    suppressed=a["suppressed"],
+                ))
+            return results
+        except Exception:
+            return []
 
     def get_traces(self, filters):
-        from datetime import datetime
-        from types import SimpleNamespace
-        params = {}
-        if filters.agent_id:
-            params["agent_id"] = filters.agent_id
-        if filters.since:
-            params["since"] = filters.since.isoformat()
-        if filters.limit:
-            params["limit"] = filters.limit
-        data = _http_get("/api/v1/traces", params)
-        results = []
-        for t in data.get("traces", []):
-            results.append(SimpleNamespace(
-                trace_id=t["trace_id"],
-                agent_id=t.get("agent_id"),
-                name=t.get("name"),
-                start_time=datetime.fromisoformat(t["start_time"]) if t.get("start_time") else None,
-                duration_ms=t.get("duration_ms"),
-                cost_usd=t.get("cost_usd"),
-                status_code=t.get("status_code"),
-                span_count=t.get("span_count", 0),
-            ))
-        return results
+        try:
+            from datetime import datetime
+            from types import SimpleNamespace
+            params = {}
+            if filters.agent_id:
+                params["agent_id"] = filters.agent_id
+            if filters.since:
+                params["since"] = filters.since.isoformat()
+            if filters.limit:
+                params["limit"] = filters.limit
+            data = _http_get("/api/v1/traces", params)
+            results = []
+            for t in data.get("traces", []):
+                results.append(SimpleNamespace(
+                    trace_id=t["trace_id"],
+                    agent_id=t.get("agent_id"),
+                    name=t.get("name"),
+                    start_time=datetime.fromisoformat(t["start_time"]) if t.get("start_time") else None,
+                    duration_ms=t.get("duration_ms"),
+                    cost_usd=t.get("cost_usd"),
+                    status_code=t.get("status_code"),
+                    span_count=t.get("span_count", 0),
+                ))
+            return results
+        except Exception:
+            return []
 
     def get_trace_spans(self, trace_id: str):
-        from datetime import datetime
-        from types import SimpleNamespace
-        data = _http_get(f"/api/v1/traces/{trace_id}")
-        results = []
-        for s in data.get("spans", []):
-            results.append(SimpleNamespace(
-                span_id=s["span_id"],
-                parent_span_id=s.get("parent_span_id"),
-                name=s.get("name"),
-                kind=SimpleNamespace(value=s.get("kind", "")),
-                status_code=SimpleNamespace(value=s.get("status_code", "")),
-                start_time=datetime.fromisoformat(s["start_time"]) if s.get("start_time") else None,
-                end_time=datetime.fromisoformat(s["end_time"]) if s.get("end_time") else None,
-                duration_ms=s.get("duration_ms"),
-                provider=s.get("provider"),
-                model=s.get("model"),
-                tool_name=s.get("tool_name"),
-                input_tokens=s.get("input_tokens"),
-                output_tokens=s.get("output_tokens"),
-                cost_usd=s.get("cost_usd"),
-            ))
-        return results
+        try:
+            from datetime import datetime
+            from types import SimpleNamespace
+            data = _http_get(f"/api/v1/traces/{trace_id}")
+            results = []
+            for s in data.get("spans", []):
+                results.append(SimpleNamespace(
+                    span_id=s["span_id"],
+                    parent_span_id=s.get("parent_span_id"),
+                    name=s.get("name"),
+                    kind=SimpleNamespace(value=s.get("kind", "")),
+                    status_code=SimpleNamespace(value=s.get("status_code", "")),
+                    start_time=datetime.fromisoformat(s["start_time"]) if s.get("start_time") else None,
+                    end_time=datetime.fromisoformat(s["end_time"]) if s.get("end_time") else None,
+                    duration_ms=s.get("duration_ms"),
+                    provider=s.get("provider"),
+                    model=s.get("model"),
+                    tool_name=s.get("tool_name"),
+                    input_tokens=s.get("input_tokens"),
+                    output_tokens=s.get("output_tokens"),
+                    cost_usd=s.get("cost_usd"),
+                ))
+            return results
+        except Exception:
+            return []
 
     def get_tool_calls(self, agent_id, since, tool_name):
-        params = {}
-        if agent_id:
-            params["agent_id"] = agent_id
-        if since:
-            params["since"] = since.isoformat()
-        if tool_name:
-            params["tool_name"] = tool_name
-        data = _http_get("/api/v1/tools", params)
-        return data.get("tools", [])
+        try:
+            params = {}
+            if agent_id:
+                params["agent_id"] = agent_id
+            if since:
+                params["since"] = since.isoformat()
+            if tool_name:
+                params["tool_name"] = tool_name
+            data = _http_get("/api/v1/tools", params)
+            return data.get("tools", [])
+        except Exception:
+            return []
 
     def get_baseline(self, agent_id: str):
         from datetime import datetime
@@ -194,7 +212,7 @@ class _HttpDB:
                 input_tokens=a.get("input_tokens", 0),
                 output_tokens=a.get("output_tokens", 0),
                 tool_call_count=a.get("tool_call_count", 0),
-                duration_seconds=None,
+                duration_seconds=a.get("duration_seconds"),
             ))
         return results
 
@@ -254,7 +272,9 @@ def _tool_get_status(conn, config, agent_id: str | None = None) -> dict:
             agents = data.get("agents", [])
             matching = [a for a in agents if a.get("agent_id") == agent_id]
             if matching:
-                return matching[0]
+                raw = dict(matching[0])
+                raw["cost_today_usd"] = raw.pop("cost_today", raw.get("cost_today_usd", 0.0))
+                return raw
             return {
                 "agent_id": agent_id,
                 "session_id": None,
@@ -266,7 +286,12 @@ def _tool_get_status(conn, config, agent_id: str | None = None) -> dict:
                 "cost_today_usd": 0.0,
                 "active_alerts": 0,
             }
-        return data
+        agents = []
+        for a in data.get("agents", []):
+            a = dict(a)
+            a["cost_today_usd"] = a.pop("cost_today", a.get("cost_today_usd", 0.0))
+            agents.append(a)
+        return {"agents": agents}
 
     from ocw.utils.time_parse import utcnow
 
@@ -371,6 +396,7 @@ def _tool_get_budget_headroom(conn, config, agent_id: str) -> dict:
         if agents:
             a = agents[0]
             today_cost = float(a.get("cost_today", 0.0))
+            session_cost = float(a.get("total_cost_usd", 0.0))
         return {
             "agent_id": agent_id,
             "daily_limit_usd": daily_limit,
@@ -414,14 +440,14 @@ def _tool_list_agents(conn) -> dict:
     if conn is None:
         if _serve_url is None:
             return _no_config()
-        data = _http_get("/api/v1/status")
+        data = _http_get("/api/v1/agents")
         return {
             "agents": [
                 {
                     "agent_id": a["agent_id"],
-                    "first_seen": None,
-                    "last_seen": None,
-                    "lifetime_cost_usd": float(a.get("cost_today", 0.0)),
+                    "first_seen": a.get("first_seen"),
+                    "last_seen": a.get("last_seen"),
+                    "lifetime_cost_usd": float(a.get("lifetime_cost_usd", 0.0)),
                 }
                 for a in data.get("agents", [])
             ]
@@ -457,8 +483,8 @@ def _tool_list_active_sessions(conn) -> dict:
             {
                 "session_id": a.get("session_id"),
                 "agent_id": a["agent_id"],
-                "started_at": None,
-                "total_cost_usd": float(a.get("cost_today", 0.0)),
+                "started_at": a.get("started_at"),
+                "total_cost_usd": float(a.get("total_cost_usd", 0.0)),
                 "input_tokens": a.get("input_tokens", 0),
                 "output_tokens": a.get("output_tokens", 0),
                 "tool_call_count": a.get("tool_call_count", 0),
@@ -724,11 +750,11 @@ def _tool_setup_project(
         try:
             gs = json.loads(global_settings.read_text())
             if "OTEL_EXPORTER_OTLP_ENDPOINT" not in gs.get("env", {}):
-                warning = "Global OTLP endpoint not configured. Run 'ocw onboard --claude-code' to finish setup."
+                warning = "Global OTLP endpoint not configured. Run 'ocw onboard --claude-code' to finish setup, then run 'claude mcp add ocw --scope user -- ocw mcp' to register the MCP server."
         except Exception:
             warning = "Could not read ~/.claude/settings.json."
     else:
-        warning = "~/.claude/settings.json not found. Run 'ocw onboard --claude-code' to configure the global OTLP endpoint."
+        warning = "~/.claude/settings.json not found. Run 'ocw onboard --claude-code' to configure the global OTLP endpoint and register the MCP server."
 
     result = {
         "agent_id": agent_id,
@@ -767,7 +793,8 @@ def _tool_open_dashboard(config) -> dict:
 
     # Spawn ocw serve detached from this process.
     # start_new_session is Unix-only; use DETACHED_PROCESS on Windows instead.
-    ocw_bin = sys.argv[0] if sys.argv[0].endswith("ocw") else "ocw"
+    import shutil as _shutil
+    ocw_bin = _shutil.which("ocw") or sys.argv[0]
     import sys as _sys
     popen_kwargs: dict = {
         "stdout": subprocess.DEVNULL,
@@ -779,7 +806,7 @@ def _tool_open_dashboard(config) -> dict:
         popen_kwargs["start_new_session"] = True
     try:
         subprocess.Popen([ocw_bin, "serve"], **popen_kwargs)
-    except FileNotFoundError:
+    except (FileNotFoundError, OSError):
         return {"error": f"Could not find '{ocw_bin}' on PATH. Run 'ocw serve' manually."}
 
     # Wait up to 5 seconds for the port to open
@@ -812,7 +839,10 @@ def get_status(agent_id: str | None = None) -> dict:
     agent status, what's running, token usage, cost today, or active alerts. Omit agent_id
     to get a summary of every known agent.
     """
-    return _tool_get_status(_ro_conn, _config, agent_id)
+    try:
+        return _tool_get_status(_ro_conn, _config, agent_id)
+    except Exception as e:
+        return {"error": str(e)}
 
 
 @mcp.tool()
@@ -822,7 +852,10 @@ def get_budget_headroom(agent_id: str) -> dict:
     Use this when the user asks how much budget is left, whether they're close to a limit,
     or wants to check spend against their configured daily_usd or session_usd cap.
     """
-    return _tool_get_budget_headroom(_ro_conn, _config, agent_id)
+    try:
+        return _tool_get_budget_headroom(_ro_conn, _config, agent_id)
+    except Exception as e:
+        return {"error": str(e)}
 
 
 @mcp.tool()
@@ -834,7 +867,10 @@ def list_agents() -> dict:
     """
     if _ro_conn is None and _serve_url is None:
         return _no_config()
-    return _tool_list_agents(_ro_conn)
+    try:
+        return _tool_list_agents(_ro_conn)
+    except Exception as e:
+        return {"error": str(e)}
 
 
 @mcp.tool()
@@ -847,7 +883,10 @@ def list_active_sessions() -> dict:
     """
     if _ro_conn is None and _serve_url is None:
         return _no_config()
-    return _tool_list_active_sessions(_ro_conn)
+    try:
+        return _tool_list_active_sessions(_ro_conn)
+    except Exception as e:
+        return {"error": str(e)}
 
 
 @mcp.tool()
@@ -864,7 +903,10 @@ def get_cost_summary(
     """
     if _ro_db is None:
         return _no_config()
-    return _tool_get_cost_summary(_ro_db, agent_id, since, group_by)
+    try:
+        return _tool_get_cost_summary(_ro_db, agent_id, since, group_by)
+    except Exception as e:
+        return {"error": str(e)}
 
 
 @mcp.tool()
@@ -881,7 +923,10 @@ def list_alerts(
     """
     if _ro_db is None:
         return _no_config()
-    return _tool_list_alerts(_ro_db, agent_id, severity, unread)
+    try:
+        return _tool_list_alerts(_ro_db, agent_id, severity, unread)
+    except Exception as e:
+        return {"error": str(e)}
 
 
 @mcp.tool()
@@ -897,7 +942,10 @@ def list_traces(
     """
     if _ro_db is None:
         return _no_config()
-    return _tool_list_traces(_ro_db, agent_id, since, limit)
+    try:
+        return _tool_list_traces(_ro_db, agent_id, since, limit)
+    except Exception as e:
+        return {"error": str(e)}
 
 
 @mcp.tool()
@@ -909,7 +957,10 @@ def get_trace(trace_id: str) -> dict:
     """
     if _ro_db is None:
         return _no_config()
-    return _tool_get_trace(_ro_db, trace_id)
+    try:
+        return _tool_get_trace(_ro_db, trace_id)
+    except Exception as e:
+        return {"error": str(e)}
 
 
 @mcp.tool()
@@ -924,7 +975,10 @@ def get_tool_stats(
     """
     if _ro_db is None:
         return _no_config()
-    return _tool_get_tool_stats(_ro_db, agent_id, since)
+    try:
+        return _tool_get_tool_stats(_ro_db, agent_id, since)
+    except Exception as e:
+        return {"error": str(e)}
 
 
 @mcp.tool()
@@ -937,7 +991,10 @@ def get_drift_report(agent_id: str | None = None) -> dict:
     """
     if _ro_db is None:
         return _no_config()
-    return _tool_get_drift_report(_ro_db, agent_id)
+    try:
+        return _tool_get_drift_report(_ro_db, agent_id)
+    except Exception as e:
+        return {"error": str(e)}
 
 
 @mcp.tool()
@@ -949,11 +1006,23 @@ def acknowledge_alert(alert_id: str) -> dict:
     """
     if _config is None:
         return _no_config()
-    from pathlib import Path
-    import duckdb as _duckdb
-    db_path = str(Path(_config.storage.path).expanduser())
-    with _duckdb.connect(db_path) as write_conn:
-        return _tool_acknowledge_alert(write_conn, alert_id)
+    try:
+        if _serve_url is not None:
+            import json as _json
+            import urllib.request as _urlreq
+            url = f"{_serve_url}/api/v1/alerts/{alert_id}/acknowledge"
+            req = _urlreq.Request(url, method="PATCH", data=b"")
+            if _config.api.auth.enabled:
+                req.add_header("Authorization", f"Bearer {_config.api.auth.api_key}")
+            with _urlreq.urlopen(req, timeout=5) as resp:
+                return _json.loads(resp.read())
+        from pathlib import Path
+        import duckdb as _duckdb
+        db_path = str(Path(_config.storage.path).expanduser())
+        with _duckdb.connect(db_path) as write_conn:
+            return _tool_acknowledge_alert(write_conn, alert_id)
+    except Exception as e:
+        return {"error": str(e)}
 
 
 @mcp.tool()
@@ -964,14 +1033,17 @@ def setup_project(agent_id: str | None = None, project_path: str | None = None) 
     when the user wants to start monitoring a new project, or asks how to set up OCW for
     this repo. Infers agent_id from the git remote if not provided.
     """
-    from ocw.core.config import find_config_file
-    cp = find_config_file()
-    return _tool_setup_project(
-        config=_config,
-        config_path=str(cp) if cp else None,
-        agent_id=agent_id,
-        project_path=project_path,
-    )
+    try:
+        from ocw.core.config import find_config_file
+        cp = find_config_file()
+        return _tool_setup_project(
+            config=_config,
+            config_path=str(cp) if cp else None,
+            agent_id=agent_id,
+            project_path=project_path,
+        )
+    except Exception as e:
+        return {"error": str(e)}
 
 
 @mcp.tool()
@@ -982,4 +1054,7 @@ def open_dashboard() -> dict:
     whenever the user asks to open the dashboard, view the UI, or browse observability data
     visually. Returns the URL to open. Safe to call repeatedly — detects if already running.
     """
-    return _tool_open_dashboard(_config)
+    try:
+        return _tool_open_dashboard(_config)
+    except Exception as e:
+        return {"error": str(e)}

--- a/ocw/ui/index.html
+++ b/ocw/ui/index.html
@@ -649,7 +649,7 @@ function TracesListView() {
     setAgentStatus(map);
   }, [since, statusF]);
 
-  useEffect(() => { load(); }, [load]);
+  useEffect(() => { load(); const t = setInterval(load, 10000); return () => clearInterval(t); }, [load]);
 
   return html`
     <div class="page-title">Traces</div>
@@ -833,7 +833,7 @@ function CostView() {
     setTotal(d.total_cost_usd || 0);
   }, [since, groupBy]);
 
-  useEffect(() => { load(); }, [load]);
+  useEffect(() => { load(); const t = setInterval(load, 10000); return () => clearInterval(t); }, [load]);
 
   const totalIn = rows.reduce((s, r) => s + (r.input_tokens || 0), 0);
   const totalOut = rows.reduce((s, r) => s + (r.output_tokens || 0), 0);
@@ -905,7 +905,7 @@ function AlertsView() {
     setAlerts(d.alerts || []);
   }, [severity]);
 
-  useEffect(() => { load(); }, [load]);
+  useEffect(() => { load(); const t = setInterval(load, 10000); return () => clearInterval(t); }, [load]);
 
   return html`
     <div class="page-title">Alerts</div>
@@ -947,6 +947,8 @@ function DriftView() {
 
   useEffect(() => {
     api('/drift').then(d => setData(d));
+    const t = setInterval(() => api('/drift').then(d => setData(d)), 10000);
+    return () => clearInterval(t);
   }, []);
 
   if (!data) return html`<div class="empty">Loading...</div>`;
@@ -1068,7 +1070,7 @@ function BudgetView() {
     setAlerts([...daily, ...session].sort((a, b) => b.fired_at.localeCompare(a.fired_at)));
   }).catch(e => setError(e.message));
 
-  useEffect(() => { load(); }, []);
+  useEffect(() => { load(); const t = setInterval(load, 10000); return () => clearInterval(t); }, []);
 
   const handleSave = async (scope, dailyStr, sessionStr) => {
     // Empty field means "no limit" — send 0 so the server runs validate_budget_value(0) → None.

--- a/tests/integration/test_cli.py
+++ b/tests/integration/test_cli.py
@@ -442,8 +442,10 @@ def test_onboard_claude_code_resyncs_secret_on_rerun(runner, tmp_path):
         }
     }) + "\n")
 
-    fake_config_path = tmp_path / ".ocw" / "config.toml"
+    # Global config path — --claude-code always uses ~/.config/ocw/config.toml
+    fake_config_path = fake_home / ".config" / "ocw" / "config.toml"
     fake_config_path.parent.mkdir(parents=True)
+    fake_config_path.touch()  # must exist so the "existing and not force" branch runs
 
     from ocw.core.config import AgentConfig, OcwConfig, SecurityConfig
     fake_config = OcwConfig(
@@ -452,8 +454,7 @@ def test_onboard_claude_code_resyncs_secret_on_rerun(runner, tmp_path):
         security=SecurityConfig(ingest_secret=new_secret),
     )
 
-    with patch("ocw.cli.cmd_onboard.find_config_file", return_value=str(fake_config_path)), \
-         patch("ocw.core.config.load_config", return_value=fake_config), \
+    with patch("ocw.core.config.load_config", return_value=fake_config), \
          patch("ocw.core.config.write_config"), \
          patch("ocw.cli.cmd_onboard.Path.home", return_value=fake_home), \
          patch("ocw.cli.cmd_onboard.click.confirm", return_value=False):
@@ -487,8 +488,10 @@ def test_onboard_claude_code_preserves_custom_otlp_headers(runner, tmp_path):
         }
     }) + "\n")
 
-    fake_config_path = tmp_path / ".ocw" / "config.toml"
+    # Global config path — --claude-code always uses ~/.config/ocw/config.toml
+    fake_config_path = fake_home / ".config" / "ocw" / "config.toml"
     fake_config_path.parent.mkdir(parents=True)
+    fake_config_path.touch()  # must exist so the "existing and not force" branch runs
 
     from ocw.core.config import AgentConfig, OcwConfig, SecurityConfig
     fake_config = OcwConfig(
@@ -497,8 +500,7 @@ def test_onboard_claude_code_preserves_custom_otlp_headers(runner, tmp_path):
         security=SecurityConfig(ingest_secret="newsecret" * 4),
     )
 
-    with patch("ocw.cli.cmd_onboard.find_config_file", return_value=str(fake_config_path)), \
-         patch("ocw.core.config.load_config", return_value=fake_config), \
+    with patch("ocw.core.config.load_config", return_value=fake_config), \
          patch("ocw.core.config.write_config"), \
          patch("ocw.cli.cmd_onboard.Path.home", return_value=fake_home), \
          patch("ocw.cli.cmd_onboard.click.confirm", return_value=False):

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -13,6 +13,14 @@ from ocw.core.config import (
 class TestLoadConfig:
     def test_returns_defaults_when_no_file(self, tmp_path, monkeypatch):
         monkeypatch.chdir(tmp_path)
+        # SEARCH_PATHS is a module-level constant built at import time; patch it
+        # directly so the real ~/.config/ocw/config.toml is never found.
+        import ocw.core.config as cfg_mod
+        monkeypatch.setattr(cfg_mod, "SEARCH_PATHS", [
+            Path("ocw.toml"),
+            Path(".ocw/config.toml"),
+            tmp_path / ".config" / "ocw" / "config.toml",
+        ])
         config = load_config()
         assert config.version == "1"
         assert config.storage.path == "~/.ocw/telemetry.duckdb"

--- a/tests/unit/test_mcp_server.py
+++ b/tests/unit/test_mcp_server.py
@@ -480,6 +480,10 @@ def test_get_status_http_mode():
         with patch("ocw.mcp.server._http_get", return_value=fake_response):
             result = _tool_get_status(None, config, "alpha")
         assert result["status"] == "active"
+        # cost_today from API must be renamed to cost_today_usd in the single-agent path
+        assert "cost_today_usd" in result
+        assert abs(result["cost_today_usd"] - 1.23) < 0.01
+        assert "cost_today" not in result
     finally:
         _set_serve_url(None)
 
@@ -573,9 +577,35 @@ def test_list_active_sessions_http_mode():
 
 # --- test_acknowledge_alert_http_mode ---
 
-def test_acknowledge_alert_http_mode():
+def test_acknowledge_alert_inner_conn_none_returns_error():
+    """_tool_acknowledge_alert with conn=None returns a descriptive error (not a crash)."""
     result = _tool_acknowledge_alert(None, "some-id")
     assert "error" in result
+
+
+def test_acknowledge_alert_http_mode_proxies_patch():
+    """acknowledge_alert MCP wrapper proxies to PATCH endpoint when _serve_url is set."""
+    from unittest.mock import MagicMock
+    config = _make_config("alpha")
+    _set_serve_url("http://127.0.0.1:7391")
+    _srv._config = config
+    try:
+        mock_resp = MagicMock()
+        mock_resp.__enter__ = lambda s: s
+        mock_resp.__exit__ = MagicMock(return_value=False)
+        mock_resp.read.return_value = b'{"acknowledged": true, "alert_id": "alert-1"}'
+
+        with patch("urllib.request.urlopen", return_value=mock_resp) as mock_urlopen:
+            result = _srv.acknowledge_alert("alert-1")
+
+        call_args = mock_urlopen.call_args
+        req = call_args[0][0]
+        assert "alerts/alert-1/acknowledge" in req.full_url
+        assert req.get_method() == "PATCH"
+        assert result["acknowledged"] is True
+    finally:
+        _set_serve_url(None)
+        _srv._config = None
 
 
 # --- test_get_budget_headroom_http_mode ---

--- a/tests/unit/test_openclaw_ingest.py
+++ b/tests/unit/test_openclaw_ingest.py
@@ -313,3 +313,43 @@ class TestOpenClawAttributeMapping:
         assert usage_spans[0].input_tokens == 1000
         assert usage_spans[0].output_tokens == 300
         assert usage_spans[0].provider == "anthropic"
+
+
+# ---------------------------------------------------------------------------
+# GET /api/v1/agents
+# ---------------------------------------------------------------------------
+
+class TestAgentsEndpoint:
+
+    @pytest.mark.asyncio
+    async def test_list_agents_returns_registered_agents(self, client, db):
+        from ocw.core.models import AgentRecord
+        from ocw.utils.time_parse import utcnow
+
+        t = utcnow()
+        db.upsert_agent(AgentRecord(agent_id="agent-a", first_seen=t, last_seen=t))
+        db.upsert_agent(AgentRecord(agent_id="agent-b", first_seen=t, last_seen=t))
+
+        from tests.factories import make_llm_span
+        db.insert_span(make_llm_span(agent_id="agent-a", cost_usd=1.50))
+        db.insert_span(make_llm_span(agent_id="agent-a", cost_usd=0.50))
+
+        resp = await client.get("/api/v1/agents")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert "agents" in data
+
+        by_id = {a["agent_id"]: a for a in data["agents"]}
+        assert "agent-a" in by_id
+        assert "agent-b" in by_id
+
+        a = by_id["agent-a"]
+        assert abs(a["lifetime_cost_usd"] - 2.0) < 0.01
+        assert a["first_seen"] is not None
+        assert a["last_seen"] is not None
+
+    @pytest.mark.asyncio
+    async def test_list_agents_empty(self, client):
+        resp = await client.get("/api/v1/agents")
+        assert resp.status_code == 200
+        assert resp.json() == {"agents": []}


### PR DESCRIPTION
## Summary

### Claude Code telemetry pipeline fixes

The core issue: `ocw serve` ran without `--config`, so launchd started it from `/` and picked up a stale project config with a different `ingest_secret` than `~/.claude/settings.json`. Every telemetry POST silently 401'd and was dropped.

**`ocw onboard --claude-code` now:**
- Always writes to `~/.config/ocw/config.toml` (global config) instead of per-project `.ocw/config.toml`. All projects share one secret and one daemon — onboarding a second project no longer rotates the secret and breaks every other project
- Bakes `--config <absolute-path>` into the launchd plist and systemd unit so the correct config is always loaded regardless of working directory
- Runs `launchctl unload` before `launchctl load` on reinstall so the old registration is replaced cleanly
- Always overwrites all OTLP env vars in `~/.claude/settings.json` — fixes the reinstall case where `CLAUDE_CODE_ENABLE_TELEMETRY` was silently skipped when the endpoint key already existed
- Replaces the `~/.zshrc` block in-place on re-run (keeps the secret in sync, not append-only)
- Writes onboarded project paths to `~/.config/ocw/projects.json` so uninstall knows where to clean

**`ocw uninstall` now:**
- Reads `projects.json` *before* deleting `~/.config/ocw/` (was read after deletion — always missed every project)
- Deletes `~/.config/ocw/` (global config) on uninstall
- Removes `OTEL_RESOURCE_ATTRIBUTES` from all tracked project `.claude/settings.json` files, not just CWD
- Fixed zshrc cleanup regex to match any number of `export` lines (was hardcoded to 5)

**Other fixes:**
- `ocw/api/routes/otlp.py` module docstring corrected: `/v1/logs` is not a stub
- Budget prompt default changed from `$5` to `$0` (no limit)

### Previously in this PR
- **`GET /api/v1/agents`** — agent registry endpoint with `first_seen`, `last_seen`, `lifetime_cost_usd`
- **`PATCH /alerts/{alert_id}/acknowledge`** — REST endpoint to acknowledge alerts
- **`ocw onboard --claude-code`** auto-registers the OCW MCP server via `claude mcp add`
- MCP reliability fixes: error handling, HTTP auth, field name normalisation, endpoint corrections
- `status` route adds `started_at` and `total_cost_usd` to agent records

## Test plan
- [x] `pytest tests/unit/ tests/integration/` — 266 tests pass
- [x] Full install → verify → uninstall → verify cycle run manually: all 6 cleanup checks pass (global config, OTLP vars, both project `OTEL_RESOURCE_ATTRIBUTES`, plist, zshrc block)
- [x] Multi-project: onboard in openclawwatch + splito → same secret in both, single server serves both → both agents visible on dashboard
- [x] Reinstall: uninstall removes all traces; re-onboard creates fresh global config; server auth works immediately

🤖 Generated with [Claude Code](https://claude.com/claude-code)