### PR TITLE
TS SDK: retry logic, ClaudeCodeEvents, agentName/Version, cacheCreateTokens, configurable serviceName, README

### DIFF
--- a/sdk-ts/README.md
+++ b/sdk-ts/README.md
@@ -1,0 +1,178 @@
+# @openclawwatch/sdk
+
+TypeScript SDK for [OpenClawWatch](https://github.com/Metabuilder-Labs/openclawwatch) — local-first, OTel-native observability for AI agents.
+
+Communicates with a running `ocw serve` instance via HTTP. No in-process OTel pipeline — spans are built with `SpanBuilder` and sent by `OcwClient`.
+
+> **Note:** Provider auto-instrumentation (the `patch_anthropic()`, `patch_openai()`, etc. convenience wrappers from the Python SDK) does not exist in this package. Every LLM call and tool call must be manually instrumented using `SpanBuilder`.
+
+## Install
+
+```bash
+npm install @openclawwatch/sdk
+```
+
+Requires Node.js >= 18. Start the OCW server before sending spans:
+
+```bash
+pip install openclawwatch
+ocw serve
+```
+
+## Quick start
+
+```typescript
+import { OcwClient, SpanBuilder, SpanStatus } from "@openclawwatch/sdk";
+
+const client = new OcwClient({
+  ingestSecret: "your-ingest-secret",   // from ocw.toml security.ingest_secret
+  serviceName: "my-agent",              // shown as agent ID in ocw status
+}).start();
+
+// Record an LLM call
+const span = new SpanBuilder("gen_ai.llm.call")
+  .agentId("my-agent")
+  .agentName("My Agent")
+  .provider("anthropic")
+  .model("claude-sonnet-4-6")
+  .inputTokens(512)
+  .outputTokens(128)
+  .cacheReadTokens(256)
+  .cacheCreateTokens(64)
+  .conversationId("conv-abc123")
+  .startTime(new Date().toISOString())
+  .durationMs(1200)
+  .build();
+
+await client.send(span);
+await client.shutdown();
+```
+
+## OcwClient
+
+```typescript
+new OcwClient(options: OcwClientOptions)
+```
+
+| Option | Type | Default | Description |
+|---|---|---|---|
+| `ingestSecret` | `string` | required | Bearer token from `security.ingest_secret` in `ocw.toml` |
+| `baseUrl` | `string` | `http://127.0.0.1:7391` | OCW server base URL |
+| `serviceName` | `string` | `"ocw-ts-sdk"` | Reported as `service.name` in OTLP resource attributes; used as fallback agent ID |
+| `batchSize` | `number` | `50` | Max spans buffered before auto-flush |
+| `flushIntervalMs` | `number` | `5000` | Interval between automatic flushes (ms) |
+| `maxRetries` | `number` | `3` | Retry attempts on network errors and 5xx responses; 4xx errors are not retried |
+
+### Methods
+
+| Method | Description |
+|---|---|
+| `client.start()` | Start the automatic flush timer. Returns `this`. |
+| `client.send(span)` | Buffer a span; auto-flushes when `batchSize` is reached. |
+| `client.flush()` | Immediately send all buffered spans. Returns `IngestResult | null`. |
+| `client.shutdown()` | Flush remaining spans and stop the timer. Call before process exit. |
+
+## SpanBuilder
+
+Fluent builder for constructing spans with GenAI semantic conventions.
+
+```typescript
+new SpanBuilder(name: string)
+```
+
+### Agent identity
+
+| Method | Attribute set |
+|---|---|
+| `.agentId(id)` | `gen_ai.agent.id` + `span.agentId` |
+| `.agentName(name)` | `gen_ai.agent.name` |
+| `.agentVersion(version)` | `gen_ai.agent.version` |
+| `.sessionId(id)` | `gen_ai.session.id` |
+| `.conversationId(id)` | `gen_ai.conversation.id` |
+
+### LLM call attributes
+
+| Method | Attribute set |
+|---|---|
+| `.provider(name)` | `gen_ai.provider.name` |
+| `.model(name)` | `gen_ai.request.model` |
+| `.inputTokens(n)` | `gen_ai.usage.input_tokens` |
+| `.outputTokens(n)` | `gen_ai.usage.output_tokens` |
+| `.cacheReadTokens(n)` | `gen_ai.usage.cache_read_tokens` |
+| `.cacheCreateTokens(n)` | `gen_ai.usage.cache_creation_tokens` |
+
+### Tool call attributes
+
+| Method | Attribute set |
+|---|---|
+| `.toolName(name)` | `gen_ai.tool.name` |
+| `.toolInput(input)` | `gen_ai.tool.input` |
+| `.toolOutput(output)` | `gen_ai.tool.output` |
+
+### Span metadata
+
+| Method | Description |
+|---|---|
+| `.traceId(id)` | Override auto-generated trace ID |
+| `.spanId(id)` | Override auto-generated span ID |
+| `.parentSpanId(id)` | Set parent span for trace hierarchy |
+| `.kind(SpanKind)` | Span kind (default: `CLIENT`) |
+| `.status(SpanStatus, message?)` | Status code (default: `OK`) |
+| `.startTime(iso)` | Start time as ISO 8601 string |
+| `.endTime(iso)` | End time as ISO 8601 string |
+| `.durationMs(ms)` | Duration; used to compute `endTime` if not set |
+| `.attribute(key, value)` | Set any arbitrary attribute |
+| `.build()` | Returns the completed `Span` object |
+
+## Semantic convention constants
+
+```typescript
+import { GenAIAttributes, OcwAttributes, ClaudeCodeEvents } from "@openclawwatch/sdk";
+
+// GenAI attribute name strings
+GenAIAttributes.AGENT_ID           // "gen_ai.agent.id"
+GenAIAttributes.REQUEST_MODEL      // "gen_ai.request.model"
+GenAIAttributes.CACHE_CREATE_TOKENS // "gen_ai.usage.cache_creation_tokens"
+// ...
+
+// OCW-specific attribute name strings
+OcwAttributes.COST_USD             // "ocw.cost_usd"
+OcwAttributes.SANDBOX_EVENT        // "ocw.sandbox.event"
+// ...
+
+// Claude Code OTel log event names and attribute constants
+ClaudeCodeEvents.API_REQUEST       // "claude_code.api_request"
+ClaudeCodeEvents.TOOL_RESULT       // "claude_code.tool_result"
+ClaudeCodeEvents.COST_USD          // "cost_usd"
+ClaudeCodeEvents.INPUT_TOKENS      // "input_tokens"
+// ...
+```
+
+Use `ClaudeCodeEvents` when writing agents that consume Claude Code's own OTel log output (e.g. via the `ocw` MCP server or a log subscriber).
+
+## SpanKind and SpanStatus
+
+```typescript
+import { SpanKind, SpanStatus } from "@openclawwatch/sdk";
+
+SpanKind.CLIENT   // default for LLM calls
+SpanKind.SERVER
+SpanKind.INTERNAL
+SpanKind.PRODUCER
+SpanKind.CONSUMER
+
+SpanStatus.OK     // default
+SpanStatus.ERROR
+SpanStatus.UNSET
+```
+
+## What this SDK does NOT provide
+
+Unlike the Python SDK (`pip install openclawwatch`), this package does **not** include:
+
+- **Session management** (`@watch()` decorator / `AgentSession` context manager) — you must manually build and send `invoke_agent` session spans.
+- **Provider auto-instrumentation** — no `patchAnthropic()`, `patchOpenAI()`, etc. Every LLM call requires an explicit `SpanBuilder`.
+- **Framework patches** — no LangChain JS, OpenAI Agents SDK, or Vercel AI SDK integration.
+- **In-process OTel pipeline** — all telemetry goes over HTTP to `ocw serve`.
+
+See the [Python SDK docs](https://github.com/Metabuilder-Labs/openclawwatch#python-sdk) for the full-featured in-process instrumentation path.

--- a/sdk-ts/package-lock.json
+++ b/sdk-ts/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@openclawwatch/sdk",
-  "version": "0.1.0",
+  "version": "0.1.7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@openclawwatch/sdk",
-      "version": "0.1.0",
+      "version": "0.1.7",
       "license": "MIT",
       "devDependencies": {
         "@types/node": "^25.5.0",

--- a/sdk-ts/src/client.ts
+++ b/sdk-ts/src/client.ts
@@ -15,6 +15,10 @@ export interface OcwClientOptions {
   batchSize?: number;
   /** Flush interval in milliseconds (default: 5000) */
   flushIntervalMs?: number;
+  /** Service name reported in OTLP resource attributes (default: "ocw-ts-sdk") */
+  serviceName?: string;
+  /** Maximum retry attempts on network errors or 5xx responses (default: 3) */
+  maxRetries?: number;
 }
 
 const SPAN_KIND_TO_OTLP: Record<string, number> = {
@@ -87,6 +91,8 @@ export class OcwClient {
   private readonly ingestSecret: string;
   private readonly batchSize: number;
   private readonly flushIntervalMs: number;
+  private readonly serviceName: string;
+  private readonly maxRetries: number;
   private buffer: Span[] = [];
   private timer: ReturnType<typeof setInterval> | null = null;
 
@@ -98,6 +104,8 @@ export class OcwClient {
     this.ingestSecret = options.ingestSecret;
     this.batchSize = options.batchSize ?? 50;
     this.flushIntervalMs = options.flushIntervalMs ?? 5000;
+    this.serviceName = options.serviceName ?? "ocw-ts-sdk";
+    this.maxRetries = options.maxRetries ?? 3;
   }
 
   /**
@@ -158,7 +166,7 @@ export class OcwClient {
             attributes: [
               {
                 key: "service.name",
-                value: { stringValue: "ocw-ts-sdk" },
+                value: { stringValue: this.serviceName },
               },
             ],
           },
@@ -174,25 +182,52 @@ export class OcwClient {
 
   /**
    * POST a span batch to the ingest endpoint.
+   * Retries up to maxRetries times on network errors or 5xx responses using
+   * exponential backoff (base 2s, matching Python HttpTransport behaviour).
+   * 4xx errors are not retried — they indicate auth or validation failures.
    */
   private async post(batch: SpanBatch): Promise<IngestResult> {
     const url = `${this.baseUrl}/api/v1/spans`;
-    const response = await fetch(url, {
-      method: "POST",
-      headers: {
-        "Content-Type": "application/json",
-        Authorization: `Bearer ${this.ingestSecret}`,
-      },
-      body: JSON.stringify(batch),
-    });
+    const body = JSON.stringify(batch);
+    const headers = {
+      "Content-Type": "application/json",
+      Authorization: `Bearer ${this.ingestSecret}`,
+    };
 
-    if (!response.ok) {
+    let lastError: Error | null = null;
+    for (let attempt = 0; attempt <= this.maxRetries; attempt++) {
+      if (attempt > 0) {
+        // Exponential backoff: 2s, 4s, 8s
+        await new Promise(resolve => setTimeout(resolve, 2000 * Math.pow(2, attempt - 1)));
+      }
+
+      let response: Response;
+      try {
+        response = await fetch(url, { method: "POST", headers, body });
+      } catch (err) {
+        // Network-level error — retry
+        lastError = err instanceof Error ? err : new Error(String(err));
+        continue;
+      }
+
+      if (response.ok) {
+        return (await response.json()) as IngestResult;
+      }
+
       const text = await response.text().catch(() => "");
-      throw new Error(
+      const error = new Error(
         `OCW ingest failed: ${response.status} ${response.statusText} — ${text}`
       );
+
+      // 4xx: not retriable (auth/validation failure)
+      if (response.status >= 400 && response.status < 500) {
+        throw error;
+      }
+
+      // 5xx: retriable
+      lastError = error;
     }
 
-    return (await response.json()) as IngestResult;
+    throw lastError ?? new Error("OCW ingest failed after retries");
   }
 }

--- a/sdk-ts/src/index.ts
+++ b/sdk-ts/src/index.ts
@@ -1,4 +1,4 @@
 export { OcwClient, type OcwClientOptions } from "./client.js";
 export { type Span, type SpanBatch, type IngestResult, SpanKind, SpanStatus } from "./types.js";
 export { SpanBuilder } from "./span-builder.js";
-export { GenAIAttributes, OcwAttributes } from "./semconv.js";
+export { GenAIAttributes, OcwAttributes, ClaudeCodeEvents } from "./semconv.js";

--- a/sdk-ts/src/semconv.ts
+++ b/sdk-ts/src/semconv.ts
@@ -36,3 +36,47 @@ export const OcwAttributes = {
   FILESYSTEM_PATH: "ocw.sandbox.filesystem_path",
   SYSCALL_NAME: "ocw.sandbox.syscall_name",
 } as const;
+
+/**
+ * Event names and attribute constants from Claude Code's OTel log exporter.
+ * Mirrors ClaudeCodeEvents in ocw/otel/semconv.py — keep in sync.
+ */
+export const ClaudeCodeEvents = {
+  // Event names (logRecord body values)
+  API_REQUEST: "claude_code.api_request",
+  TOOL_RESULT: "claude_code.tool_result",
+  API_ERROR: "claude_code.api_error",
+  USER_PROMPT: "claude_code.user_prompt",
+  TOOL_DECISION: "claude_code.tool_decision",
+
+  // Standard context attributes present on all events
+  SESSION_ID: "session.id",
+  PROMPT_ID: "prompt.id",
+  EVENT_SEQUENCE: "event.sequence",
+
+  // api_request attributes
+  COST_USD: "cost_usd",
+  DURATION_MS: "duration_ms",
+  SPEED: "speed",
+  INPUT_TOKENS: "input_tokens",
+  OUTPUT_TOKENS: "output_tokens",
+  CACHE_READ_TOKENS: "cache_read_tokens",
+  CACHE_CREATION_TOKENS: "cache_creation_tokens",
+
+  // tool_result attributes
+  TOOL_NAME: "tool_name",
+  SUCCESS: "success",
+  ERROR: "error",
+  TOOL_PARAMETERS: "tool_parameters",
+  TOOL_INPUT: "tool_input",
+  DECISION_TYPE: "decision_type",
+  TOOL_RESULT_SIZE: "tool_result_size_bytes",
+
+  // api_error attributes
+  STATUS_CODE_HTTP: "status_code",
+  ATTEMPT: "attempt",
+
+  // tool_decision attributes
+  DECISION: "decision",
+  DECISION_SOURCE: "source",
+} as const;

--- a/sdk-ts/src/span-builder.ts
+++ b/sdk-ts/src/span-builder.ts
@@ -76,6 +76,16 @@ export class SpanBuilder {
     return this;
   }
 
+  agentName(name: string): this {
+    this.span.attributes[GenAIAttributes.AGENT_NAME] = name;
+    return this;
+  }
+
+  agentVersion(version: string): this {
+    this.span.attributes[GenAIAttributes.AGENT_VERSION] = version;
+    return this;
+  }
+
   sessionId(id: string): this {
     this.span.sessionId = id;
     this.span.attributes["gen_ai.session.id"] = id;
@@ -110,6 +120,11 @@ export class SpanBuilder {
 
   cacheReadTokens(n: number): this {
     this.span.attributes[GenAIAttributes.CACHE_READ_TOKENS] = n;
+    return this;
+  }
+
+  cacheCreateTokens(n: number): this {
+    this.span.attributes[GenAIAttributes.CACHE_CREATE_TOKENS] = n;
     return this;
   }
 


### PR DESCRIPTION
## Summary

Brings the TypeScript SDK (`@openclawwatch/sdk`) to feature parity with the Python SDK across four areas:

- **Retry logic** — `OcwClient.post()` now retries on network errors and 5xx responses using exponential backoff (2s, 4s, 8s), matching Python `HttpTransport` behaviour. 4xx errors (auth/validation failures) are not retried. Configurable via new `maxRetries` option (default: 3).
- **Configurable `serviceName`** — new `OcwClientOptions.serviceName` field (default: `"ocw-ts-sdk"`) maps to `service.name` in OTLP resource attributes, used as fallback agent ID in `ocw status`.
- **`ClaudeCodeEvents` constants** — new export in `semconv.ts` mirroring `ClaudeCodeEvents` in `ocw/otel/semconv.py`: event names and attribute keys for `api_request`, `tool_result`, `api_error`, `user_prompt`, and `tool_decision` log events from Claude Code's OTel exporter.
- **`SpanBuilder` additions** — three new fluent methods: `.agentName()`, `.agentVersion()`, `.cacheCreateTokens()` (all mapping to existing `GenAIAttributes` constants).
- **README** — new `sdk-ts/README.md` covering install, quick start, full `OcwClient` options table, `SpanBuilder` API reference, and `ClaudeCodeEvents` usage.

> **Note:** This branch is built on top of `anshs/changes` (PR #30 — agents API, alert acknowledge, MCP reliability fixes). The non-SDK changes in this diff belong to #30. The SDK-only changes are in commit `140110c`.

## Test plan
- [ ] `cd sdk-ts && npm test` — 21 passed
- [ ] `pytest tests/unit/ tests/synthetic/ tests/agents/ tests/integration/` — 344 passed
- [ ] `OcwClient` with a stopped server retries 3× before throwing
- [ ] `new OcwClient({ serviceName: "my-agent" })` reports correct `service.name` in spans
- [ ] `new SpanBuilder(...).agentName("x").agentVersion("1.0").cacheCreateTokens(64).build()` includes all three attributes

🤖 Generated with [Claude Code](https://claude.com/claude-code)