### PR TITLE
Release v0.1.8

### DIFF
--- a/tests/manual-new-release-tests.md
+++ b/tests/manual-new-release-tests.md
@@ -12,49 +12,71 @@ Run through this sequence after a new release is published to PyPI to verify the
 
 ```bash
 # 1. Clean slate
-ocw stop 2>/dev/null
-kill $(pgrep -f "ocw serve") 2>/dev/null
-rm -rf ~/.ocw
-rm -rf .ocw
+ocw uninstall --yes 2>/dev/null
+rm -rf ~/.ocw ~/.config/ocw .ocw
 
 # 2. Install latest
 pip3 install --upgrade openclawwatch
 ocw --version
 
 # 3. Onboard
+# Note: daemon auto-installs by default (use --no-daemon to skip).
+# Budget prompt appears — enter a value or press enter for default.
 ocw onboard
 
-# 4. Run an example (no server — tests direct DuckDB write)
+# 4. Stop daemon before manual testing (daemon auto-started by onboard)
+ocw stop
+
+# 5. Run an example (no server — tests direct DuckDB write)
 cd ~/openclawwatch
 source .env.local
 python3 examples/single_provider/anthropic_agent.py
 
-# 5. Verify CLI
+# 6. Verify CLI (direct DuckDB, no server)
 ocw status       # should show agent with cost > $0, tokens, completed status
 ocw traces       # should show traces with span waterfall
-ocw cost --since 1h   # should show cost breakdown by model
+ocw cost --since 1h   # should show cost breakdown by model (not $0.000000)
+ocw budget       # should show budget table with configured limits
+ocw alerts       # should show alert history (may be empty)
 
-# 6. Start server (tests web UI + HTTP exporter)
+# 7. Start server (tests web UI + HTTP exporter)
 ocw serve &
 sleep 2
 
-# 7. Run another example (tests SDK HTTP fallback)
+# 8. Run another example (tests SDK HTTP fallback)
 python3 examples/single_provider/litellm_agent.py
 
-# 8. Verify web UI
+# 9. Verify web UI
 open http://127.0.0.1:7391/
-# Check: Status page shows agent cards
+# Check: Status page shows agent cards with cost, tokens
 # Check: Traces page shows span waterfall
+# Check: Cost page shows non-zero USD values
 # Check: Sidebar has SVG logo + opencla.watch styling (deep navy + blue accent)
 
-# 9. Verify both agents show up
-ocw status       # should show both agents (or at least spans from both runs)
+# 10. Verify both agents show up
+ocw status       # should show both agents
 ocw traces       # should show traces from both runs
 ocw cost --since 1h   # model names should be clean (gpt-4o-mini, not openai/gpt-4o-mini)
 
-# 10. Clean up
+# 11. Clean up
 ocw stop
-kill $(pgrep -f "ocw serve") 2>/dev/null
+```
+
+## Claude Code integration (if applicable)
+
+```bash
+# After step 3 above, also test:
+ocw onboard --claude-code
+# Should: not prompt for daemon, write config to ~/.config/ocw/config.toml,
+#         write settings to ~/.claude/settings.json,
+#         register MCP server with Claude Code (if claude CLI is installed)
+
+# Verify settings written
+cat ~/.claude/settings.json | python3 -m json.tool
+# Should contain OTEL_LOGS_EXPORTER, OTEL_EXPORTER_OTLP_ENDPOINT, etc.
+
+# Re-run to test secret resync (should not crash)
+ocw onboard --claude-code --budget 5
 ```
 
 ## What to look for
@@ -62,11 +84,11 @@ kill $(pgrep -f "ocw serve") 2>/dev/null
 | Step | Pass criteria |
 |------|--------------|
 | 2 | Version matches the release being tested |
-| 3 | Config created at `.ocw/config.toml`, ingest secret generated |
-| 4 | Agent runs without errors, no DuckDB lock warnings |
-| 5 | `ocw status` shows non-zero cost and tokens; `ocw traces` shows spans |
-| 6 | Server starts, prints correct metrics URL (`:7391/metrics`) |
-| 7 | Agent runs without "Could not set lock on file" error (HTTP fallback works) |
-| 8 | Web UI loads, shows data, sidebar has SVG logo |
-| 9 | CLI queries work while server is running (API fallback); model names are clean |
-| 10 | `ocw stop` stops the server cleanly |
+| 3 | Config created at `.ocw/config.toml`, ingest secret generated, daemon installed |
+| 5 | Agent runs without errors, no DuckDB lock warnings |
+| 6 | `ocw status` shows non-zero cost and tokens; `ocw cost` shows real USD values (not $0.000000) |
+| 7 | Server starts on `:7391`, prints correct metrics URL |
+| 8 | Agent runs without "Could not set lock on file" error (HTTP fallback works) |
+| 9 | Web UI loads, shows data, sidebar has SVG logo |
+| 10 | CLI queries work while server is running (API fallback); model names are clean |
+| 11 | `ocw stop` stops the server cleanly |

--- a/tests/manual-pre-release-testing.md
+++ b/tests/manual-pre-release-testing.md
@@ -12,10 +12,8 @@ Run through this sequence to test a branch before merging and cutting a release.
 
 ```bash
 # 1. Clean slate
-ocw stop 2>/dev/null
-kill $(pgrep -f "ocw serve") 2>/dev/null
-rm -rf ~/.ocw
-rm -rf .ocw
+ocw uninstall --yes 2>/dev/null
+rm -rf ~/.ocw ~/.config/ocw .ocw
 
 # 2. Check out the branch to test
 cd ~/openclawwatch
@@ -23,37 +21,47 @@ git fetch origin
 git checkout <branch-name>
 
 # 3. Install locally (editable — uses local files, no pip publish needed)
-pip3 install -e .
+pip3 install -e ".[dev,mcp]"
 ocw --version
 
-# 4. Onboard fresh
+# 4. Run automated tests first
+pytest tests/unit/ tests/synthetic/ tests/agents/ tests/integration/
+ruff check ocw/
+
+# 5. Onboard fresh
+# Note: daemon auto-installs by default (use --no-daemon to skip).
 ocw onboard
 
-# 5. Populate test data — simulated (free, no API keys)
+# 6. Stop daemon before manual testing (daemon auto-started by onboard)
+ocw stop
+
+# 7. Populate test data — simulated (free, no API keys)
 python3 examples/alerts_and_drift/sensitive_actions_demo.py
 python3 examples/alerts_and_drift/budget_breach_demo.py
 python3 examples/alerts_and_drift/drift_demo.py
 
-# 6. Populate test data — real API calls
+# 8. Populate test data — real API calls
 source .env.local
 python3 examples/single_provider/anthropic_agent.py
 python3 examples/single_provider/litellm_agent.py
 
-# 7. Verify CLI (direct DuckDB, no server)
-ocw status
-ocw traces
-ocw cost --since 1h
-ocw alerts
-ocw drift
+# 9. Verify CLI (direct DuckDB, no server)
+ocw status        # agents visible with cost > $0, tokens counted
+ocw traces        # spans from all runs
+ocw cost --since 1h   # real USD values, not $0.000000
+ocw alerts        # alerts from sensitive_actions and budget_breach demos
+ocw drift         # baseline built from drift_demo sessions
+ocw budget        # budget table with configured limits
 
-# 8. Start server
+# 10. Start server
+# Note: must stop daemon first (step 6) or this will fail with "Address already in use"
 ocw serve &
 sleep 2
 
-# 9. Run one more example (tests SDK HTTP fallback while server holds DB lock)
+# 11. Run one more example (tests SDK HTTP fallback while server holds DB lock)
 python3 examples/single_provider/anthropic_agent.py
 
-# 10. Verify web UI — Status
+# 12. Verify web UI — Status
 open http://127.0.0.1:7391/
 # [ ] Multiple agent cards visible
 # [ ] Each card shows cost, tokens, tool calls, duration
@@ -62,7 +70,7 @@ open http://127.0.0.1:7391/
 # [ ] Sidebar: Open(white)Claw(blue)Watch(white) with SVG icon
 # [ ] Sidebar footer: API docs + GitHub as proper nav links
 
-# 11. Verify web UI — Traces
+# 13. Verify web UI — Traces
 # [ ] Agent name is first column, no Trace ID column
 # [ ] Type shows friendly names (LLM Call, Tool Call, Agent Run)
 # [ ] Click chevron (→) visible in last column
@@ -73,32 +81,48 @@ open http://127.0.0.1:7391/
 # [ ] Click a span — detail panel shows provider, model, tokens, cost
 # [ ] Friendly span name as heading, raw name in dim text below
 
-# 12. Verify web UI — Cost
+# 14. Verify web UI — Cost
 # [ ] Summary row shows total cost, input tokens, output tokens
 # [ ] Group-by selector works (day / agent / model / tool)
 # [ ] Redundant columns hidden based on group-by selection
-# [ ] Costs show real USD values (not $0.000000 — requires pricing fix)
+# [ ] Costs show real USD values (not $0.000000)
 
-# 13. Verify web UI — Alerts
+# 15. Verify web UI — Alerts
 # [ ] Alerts table populated from sensitive_actions and budget_breach demos
 # [ ] Friendly type names (Sensitive Action, Daily Budget, etc.)
 # [ ] Severity badges with correct colors (critical=red, warning=yellow, info=blue)
 # [ ] ▸/▾ expand toggle on rows, click shows detail JSON
 
-# 14. Verify web UI — Drift
+# 16. Verify web UI — Drift
 # [ ] At least one agent shows baseline data
 # [ ] Metric table shows baseline mean ± stddev, latest value, Z-score
 # [ ] Pass badges are green, drift badges are red
 # [ ] Threshold shown in header (2.0σ)
 
-# 15. Verify CLI works while server is running (API fallback)
+# 17. Verify CLI works while server is running (API fallback)
 ocw status
 ocw traces
 ocw cost --since 1h
 
-# 16. Clean up
+# 18. Clean up
 ocw stop
-kill $(pgrep -f "ocw serve") 2>/dev/null
+```
+
+## Claude Code integration (if applicable)
+
+```bash
+# Test after step 5:
+ocw onboard --claude-code
+# Should: write config to ~/.config/ocw/config.toml (global, not project-local),
+#         write settings to ~/.claude/settings.json,
+#         register MCP server if claude CLI available,
+#         auto-install daemon
+
+# Verify no crash on re-run (secret resync)
+ocw onboard --claude-code --budget 5
+
+# Verify MCP server starts
+ocw mcp --help
 ```
 
 ## Quick test (skip web UI — just verify core)
@@ -106,16 +130,16 @@ kill $(pgrep -f "ocw serve") 2>/dev/null
 For smaller changes that don't touch the UI:
 
 ```bash
-ocw stop 2>/dev/null
-kill $(pgrep -f "ocw serve") 2>/dev/null
-rm -rf ~/.ocw .ocw
+ocw uninstall --yes 2>/dev/null
+rm -rf ~/.ocw ~/.config/ocw .ocw
 cd ~/openclawwatch
 git checkout <branch-name>
-pip3 install -e .
-ocw onboard
+pip3 install -e ".[dev,mcp]"
+ocw onboard --no-daemon
 source .env.local
 python3 examples/single_provider/anthropic_agent.py
 ocw status && ocw traces && ocw cost --since 1h
+# Verify: cost > $0, tokens counted, traces visible
 pytest tests/unit/ tests/synthetic/ tests/agents/ tests/integration/
 ruff check ocw/
 ```
@@ -125,24 +149,21 @@ ruff check ocw/
 | Step | Pass criteria |
 |------|--------------|
 | 3 | Installs without errors, version shows expected value |
-| 4 | Config created, ingest secret generated |
-| 5 | Simulated demos run without errors, no API keys needed |
-| 6 | Real examples run, no DuckDB lock errors |
-| 7 | CLI shows data: cost > $0, tokens counted, traces visible, alerts fired, drift baseline built |
-| 8 | Server starts, prints correct metrics URL (`:7391/metrics`) |
-| 9 | No "Could not set lock on file" error — HTTP fallback works |
-| 10 | Status page: multiple agents, correct data, clickable cards |
-| 11 | Traces: friendly names, waterfall renders, span detail works |
-| 12 | Cost: real USD values, group-by works, no redundant columns |
-| 13 | Alerts: populated from demos, friendly names, expand works |
-| 14 | Drift: baseline shown, Z-scores calculated, pass/drift badges correct |
-| 15 | CLI queries work while server is running (no lock errors) |
+| 4 | All tests pass, no lint errors |
+| 5 | Config created, ingest secret generated, daemon installed |
+| 7 | Simulated demos run without errors, no API keys needed |
+| 8 | Real examples run, no DuckDB lock errors |
+| 9 | CLI shows data: cost > $0, tokens counted, traces visible, alerts fired, drift baseline built |
+| 10 | Server starts on `:7391`, prints correct metrics URL |
+| 11 | No "Could not set lock on file" error — HTTP fallback works |
+| 12-16 | Web UI views render correctly with real data |
+| 17 | CLI queries work while server is running (no lock errors) |
 
 ## Switching back to main after testing
 
 ```bash
-ocw stop 2>/dev/null
-kill $(pgrep -f "ocw serve") 2>/dev/null
+ocw stop
+ocw uninstall --yes 2>/dev/null
 git checkout main
-pip3 install -e .
+pip3 install -e ".[dev,mcp]"
 ```


### PR DESCRIPTION
## Summary

Release v0.1.8 — all changes since v0.1.7.

## Changelog

### Features
- **Agents API endpoint** — `GET /api/v1/agents` with first_seen, last_seen, lifetime_cost_usd
- **Alert acknowledge endpoint** — `PATCH /alerts/{alert_id}/acknowledge` REST endpoint
- **Dashboard auto-polling** — Traces, Cost, Alerts, Drift, and Budget views now refresh every 10s (Status already polled at 5s)
- **TS SDK feature parity** — retry logic, `ClaudeCodeEvents`, `agentName`/`agentVersion`, `cacheCreateTokens`, configurable `serviceName`, updated README
- **MCP auto-registration** — `ocw onboard --claude-code` auto-registers the OCW MCP server via `claude mcp add`; `ocw uninstall` deregisters it

### Bug Fixes
- **Pricing path off by one level** — `PRICING_FILE` resolved to `site-packages/pricing/` instead of `site-packages/ocw/pricing/` when pip-installed, causing all costs to show $0.000000
- **PosixPath not TOML serializable** — `_serialise()` included `config_path` (a Path object); now skips Path instances
- **Claude Code telemetry pipeline** — daemon ran without `--config`, picking up stale project config whose ingest_secret didn't match `~/.claude/settings.json` → every telemetry POST silently 401'd
- **Global config for Claude Code** — `--claude-code` now always writes to `~/.config/ocw/config.toml` (shared across projects) instead of per-project `.ocw/config.toml`
- **Daemon reinstall** — `launchctl unload` before `load` on reinstall so old registration is replaced cleanly
- **Uninstall ordering** — read `projects.json` before deleting `~/.config/ocw/` (was read after, always missed)
- **MCP error handling** — all MCP tool calls wrapped in try/except; field name normalization (`cost_today` → `cost_today_usd`); HTTP mode fixes for agents, sessions, auth headers, and acknowledge proxying
- **CORS** — add PATCH to allowed methods
- **Publish workflow** — install `[mcp]` extra for tests (matches `ci.yml`)

### Cleanup
- Remove redundant `--install-daemon` flag from `ocw onboard` (auto-installs by default; `--no-daemon` remains)
- Add daemon auto-install notice in `--claude-code` path so users know a service is being installed
- Update contributor install instructions with editable + MCP extras
- Rewrite Claude Code integration docs for current install/uninstall flow
- **Update manual test playbooks** — modernize pre-release and post-release checklists for daemon lifecycle, budget commands, MCP verification, and Claude Code onboarding

### Tests
- Add regression tests for pricing path, config serialization roundtrip, and daemon prompt behavior

## Test plan
- [ ] `pytest tests/unit/ tests/synthetic/ tests/agents/ tests/integration/`
- [ ] `ruff check ocw/`
- [ ] Run through `tests/manual-pre-release-testing.md` checklist
- [ ] Verify `ocw onboard --claude-code` on clean install
- [ ] Verify `ocw uninstall --yes` cleans up everything

🤖 Generated with [Claude Code](https://claude.com/claude-code)