### PR TITLE
Skip daemon reinstall on second project onboard

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -46,6 +46,7 @@ openclawwatch/
 │   ├── core/               Domain logic — NO CLI or HTTP imports allowed here
 │   ├── otel/               OTel SDK wiring + semantic conventions
 │   ├── api/                FastAPI local REST API
+│   ├── mcp/                MCP stdio server (Claude Code integration)
 │   ├── sdk/                Python instrumentation SDK
 │   └── utils/              Formatting, time parsing, ID generation
 ├── examples/               Runnable example agents (see examples/README.md)
@@ -105,6 +106,7 @@ Post-ingest hooks run synchronously after each span is written to DB:
 - **`ocw/api/middleware.py`**: `IngestAuthMiddleware` — protects `POST /api/v1/spans` with Bearer token. Returns `JSONResponse(401)` directly (not `HTTPException`, which doesn't propagate from `BaseHTTPMiddleware.dispatch`).
 - **`ocw/api/deps.py`**: `require_api_key` — FastAPI dependency for optional API key auth on GET endpoints. Only enforced when `api.auth.enabled = true` in config.
 - **`ocw/api/routes/`**: One file per resource — `spans.py` (OTLP JSON ingest), `traces.py`, `cost.py`, `tools.py`, `alerts.py`, `drift.py`, `metrics.py` (Prometheus text format from DB queries).
+- **`ocw/mcp/server.py`**: FastMCP stdio server exposing observability data to Claude Code. Uses either a read-only DuckDB connection or HTTP proxy to `ocw serve`. Initialized via `init()` from `cmd_mcp.py`.
 - **`ocw/cli/main.py`**: Root Click group with global options (`--config`, `--json`, `--no-color`, `--db`, `--agent`, `-v`). Registers all subcommands.
 
 ### CLI Commands
@@ -121,6 +123,9 @@ Post-ingest hooks run synchronously after each span is written to DB:
 | `ocw export` | `cmd_export.py` | Export spans as json (NDJSON), csv, otlp, or openevals format |
 | `ocw serve` | `cmd_serve.py` | Start FastAPI + uvicorn server with retention cleanup cron |
 | `ocw stop` | `cmd_stop.py` | Stop background daemon or ocw serve process |
+| `ocw budget` | `cmd_budget.py` | Get/set daily and session budget limits per agent or globally |
+| `ocw drift` | `cmd_drift.py` | Show drift baselines and Z-scores for recent sessions |
+| `ocw mcp` | `cmd_mcp.py` | Start the stdio MCP server for Claude Code integration |
 | `ocw uninstall` | `cmd_uninstall.py` | Remove all OCW data, config, and daemon |
 | `ocw doctor` | `cmd_doctor.py` | Health checks (config, DB, secrets, webhooks). Exit 0/1/2 |
 

--- a/ocw/cli/cmd_onboard.py
+++ b/ocw/cli/cmd_onboard.py
@@ -284,8 +284,11 @@ def _onboard_claude_code(
 
     want_daemon = not no_daemon
     if want_daemon:
-        console.print("  Daemon:              auto-installing (use --no-daemon to skip)")
-        _install_daemon(str(config_path.resolve()))
+        if not force and _daemon_already_running():
+            console.print("  Daemon:              already running (skipped reinstall)")
+        else:
+            console.print("  Daemon:              installing...")
+            _install_daemon(str(config_path.resolve()))
 
     console.print()
     console.print("[bold green]Claude Code observability configured.[/bold green]")
@@ -328,6 +331,27 @@ def _derive_project_name() -> str:
     except Exception:
         pass
     return Path.cwd().name.lower()
+
+
+def _daemon_already_running() -> bool:
+    """Check if the OCW daemon is already installed and loaded."""
+    system = platform.system()
+    if system == "Darwin":
+        plist = Path.home() / "Library/LaunchAgents/com.openclawwatch.serve.plist"
+        if not plist.exists():
+            return False
+        result = subprocess.run(
+            ["launchctl", "list", "com.openclawwatch.serve"],
+            capture_output=True, text=True,
+        )
+        return result.returncode == 0
+    elif system == "Linux":
+        result = subprocess.run(
+            ["systemctl", "--user", "is-active", "openclawwatch"],
+            capture_output=True, text=True,
+        )
+        return result.stdout.strip() == "active"
+    return False
 
 
 def _install_daemon(config_path: str) -> str | None:
@@ -396,6 +420,10 @@ def _install_launchd(config_path: str) -> str | None:
         console.print("[dim]Or run the server directly:[/dim]")
         console.print("  ocw serve &")
         return None
+    console.print(
+        "  [dim]macOS will show a 'Background Items Added' notification "
+        "-- this is normal.[/dim]"
+    )
     return f"Daemon installed at {plist_path}"
 
 

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -4,10 +4,59 @@ from pathlib import Path
 import pytest
 
 from ocw.core.config import (
-    load_config, _parse, _serialise, OcwConfig, AgentConfig, BudgetConfig,
-    DefaultsConfig, SensitiveAction, SecurityConfig, CaptureConfig, StorageConfig,
-    resolve_effective_budget, validate_budget_value,
+    find_config_file, load_config, _parse, _serialise, OcwConfig, AgentConfig,
+    BudgetConfig, DefaultsConfig, SensitiveAction, SecurityConfig, CaptureConfig,
+    StorageConfig, resolve_effective_budget, validate_budget_value,
 )
+
+
+class TestFindConfigFile:
+    def test_global_fallback_found(self, tmp_path, monkeypatch):
+        """find_config_file() discovers ~/.config/ocw/config.toml when no local config exists."""
+        monkeypatch.chdir(tmp_path)
+        global_config = tmp_path / ".config" / "ocw" / "config.toml"
+        global_config.parent.mkdir(parents=True)
+        global_config.write_bytes(b'version = "1"\n\n[security]\ningest_secret = "global-secret"\n')
+        import ocw.core.config as cfg_mod
+        from ocw.core.config import find_config_file
+        monkeypatch.setattr(cfg_mod, "SEARCH_PATHS", [
+            Path("ocw.toml"),
+            Path(".ocw/config.toml"),
+            global_config,
+        ])
+        result = find_config_file()
+        assert result is not None
+        assert result == global_config
+
+    def test_local_config_takes_priority_over_global(self, tmp_path, monkeypatch):
+        """Local .ocw/config.toml is preferred over the global config."""
+        monkeypatch.chdir(tmp_path)
+        local_config = tmp_path / ".ocw" / "config.toml"
+        local_config.parent.mkdir(parents=True)
+        local_config.write_bytes(b'version = "1"\n\n[security]\ningest_secret = "local"\n')
+        global_config = tmp_path / ".config" / "ocw" / "config.toml"
+        global_config.parent.mkdir(parents=True)
+        global_config.write_bytes(b'version = "1"\n\n[security]\ningest_secret = "global"\n')
+        import ocw.core.config as cfg_mod
+        monkeypatch.setattr(cfg_mod, "SEARCH_PATHS", [
+            Path("ocw.toml"),
+            Path(".ocw/config.toml"),
+            global_config,
+        ])
+        result = find_config_file()
+        assert result is not None
+        # .ocw/config.toml is a relative path so resolve to compare
+        assert result == Path(".ocw/config.toml")
+
+    def test_returns_none_when_no_config_anywhere(self, tmp_path, monkeypatch):
+        monkeypatch.chdir(tmp_path)
+        import ocw.core.config as cfg_mod
+        monkeypatch.setattr(cfg_mod, "SEARCH_PATHS", [
+            Path("ocw.toml"),
+            Path(".ocw/config.toml"),
+            tmp_path / ".config" / "ocw" / "config.toml",
+        ])
+        assert find_config_file() is None
 
 
 class TestLoadConfig:

--- a/tests/unit/test_onboard_daemon.py
+++ b/tests/unit/test_onboard_daemon.py
@@ -1,0 +1,65 @@
+"""Unit tests for daemon detection logic in cmd_onboard."""
+from __future__ import annotations
+
+from unittest.mock import patch, MagicMock
+
+from ocw.cli.cmd_onboard import _daemon_already_running
+
+
+class TestDaemonAlreadyRunning:
+    def test_darwin_plist_exists_and_loaded(self, tmp_path, monkeypatch):
+        """Returns True on macOS when plist exists and launchctl list succeeds."""
+        monkeypatch.setattr("ocw.cli.cmd_onboard.platform.system", lambda: "Darwin")
+        plist = tmp_path / "Library" / "LaunchAgents" / "com.openclawwatch.serve.plist"
+        plist.parent.mkdir(parents=True)
+        plist.write_text("<plist/>")
+        monkeypatch.setattr("ocw.cli.cmd_onboard.Path.home", lambda: tmp_path)
+
+        result_mock = MagicMock(returncode=0)
+        with patch("ocw.cli.cmd_onboard.subprocess.run", return_value=result_mock) as run_mock:
+            assert _daemon_already_running() is True
+            run_mock.assert_called_once_with(
+                ["launchctl", "list", "com.openclawwatch.serve"],
+                capture_output=True, text=True,
+            )
+
+    def test_darwin_plist_missing(self, tmp_path, monkeypatch):
+        """Returns False on macOS when plist does not exist."""
+        monkeypatch.setattr("ocw.cli.cmd_onboard.platform.system", lambda: "Darwin")
+        monkeypatch.setattr("ocw.cli.cmd_onboard.Path.home", lambda: tmp_path)
+        assert _daemon_already_running() is False
+
+    def test_darwin_plist_exists_but_not_loaded(self, tmp_path, monkeypatch):
+        """Returns False on macOS when plist exists but launchctl list fails."""
+        monkeypatch.setattr("ocw.cli.cmd_onboard.platform.system", lambda: "Darwin")
+        plist = tmp_path / "Library" / "LaunchAgents" / "com.openclawwatch.serve.plist"
+        plist.parent.mkdir(parents=True)
+        plist.write_text("<plist/>")
+        monkeypatch.setattr("ocw.cli.cmd_onboard.Path.home", lambda: tmp_path)
+
+        result_mock = MagicMock(returncode=3)
+        with patch("ocw.cli.cmd_onboard.subprocess.run", return_value=result_mock):
+            assert _daemon_already_running() is False
+
+    def test_linux_active(self, monkeypatch):
+        """Returns True on Linux when systemctl reports active."""
+        monkeypatch.setattr("ocw.cli.cmd_onboard.platform.system", lambda: "Linux")
+        result_mock = MagicMock(returncode=0, stdout="active\n")
+        with patch("ocw.cli.cmd_onboard.subprocess.run", return_value=result_mock) as run_mock:
+            assert _daemon_already_running() is True
+            run_mock.assert_called_once_with(
+                ["systemctl", "--user", "is-active", "openclawwatch"],
+                capture_output=True, text=True,
+            )
+
+    def test_linux_inactive(self, monkeypatch):
+        """Returns False on Linux when systemctl reports inactive."""
+        monkeypatch.setattr("ocw.cli.cmd_onboard.platform.system", lambda: "Linux")
+        result_mock = MagicMock(returncode=3, stdout="inactive\n")
+        with patch("ocw.cli.cmd_onboard.subprocess.run", return_value=result_mock):
+            assert _daemon_already_running() is False
+
+    def test_unsupported_platform(self, monkeypatch):
+        """Returns False on unsupported platforms."""
+        monkeypatch.setattr("ocw.cli.cmd_onboard.platform.system", lambda: "Windows")
+        assert _daemon_already_running() is False


### PR DESCRIPTION
## Summary
- **Daemon reinstall fix:** `ocw onboard --claude-code` now checks if the daemon is already running before reinstalling. Second project onboards skip the launchd/systemd reinstall, avoiding the macOS "Background Items Added" notification. `--force` still forces a reinstall.
- **Global config fallback tests:** Added test coverage for `find_config_file()` verifying it discovers `~/.config/ocw/config.toml` when no local config exists (the code already handled this correctly but had no tests).
- **CLAUDE.md updates:** Added missing CLI commands (`budget`, `drift`, `mcp`) and the `ocw/mcp/` package to the repo layout and key modules sections.

## Test plan
- [x] All 358 existing tests pass
- [x] `ruff check` passes on all changed files
- [x] New `TestFindConfigFile` tests verify global fallback, local priority, and no-config-anywhere cases
- [x] New `TestDaemonAlreadyRunning` tests cover macOS (plist exists+loaded, missing, exists+not loaded), Linux (active, inactive), and unsupported platforms

🤖 Generated with [Claude Code](https://claude.com/claude-code)