### PR TITLE
Document Codex, Claude Code multi-project, daemon, and incident library

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -128,7 +128,7 @@ Post-ingest hooks run synchronously after each span is written to DB:
 | `ocw demo [scenario]` | `cmd_demo.py` | Run Agent Incident Library scenarios (zero-config, no API keys). `ocw demo` lists all; `ocw demo retry-loop` runs one |
 | `ocw mcp` | `cmd_mcp.py` | Start the stdio MCP server for Claude Code integration |
 | `ocw uninstall` | `cmd_uninstall.py` | Remove all OCW data, config, and daemon |
-| `ocw doctor` | `cmd_doctor.py` | Health checks (config, DB, secrets, webhooks). Exit 0/1/2 |
+| `ocw doctor` | `cmd_doctor.py` | Health checks (config, DB, secrets, webhooks, drift readiness, schema-vs-capture consistency). Exit 0 = ok, 1 = warnings, 2 = errors |
 
 All commands support `--json` for machine-readable output. Commands that query alerts use exit code 1 if active (unacknowledged, unsuppressed) alerts exist.
 
@@ -172,6 +172,42 @@ When a span has a `conversation_id` matching an existing session, it's attribute
 ## Config
 
 Config is TOML, discovered at: `ocw.toml` -> `.ocw/config.toml` -> `~/.config/ocw/config.toml`. Override with `--config` or `OCW_CONFIG` env var. Full config hierarchy is in `ocw/core/config.py` (`OcwConfig` dataclass).
+
+`ocw onboard --claude-code` and `ocw onboard --codex` always write to the **global** config (`~/.config/ocw/config.toml`) regardless of cwd. This is intentional: each coding-agent integration reads one ingest secret from a single global location (`~/.claude/settings.json` or `~/.codex/config.toml`), and per-project configs would rotate that secret on every onboard, breaking auth for previously onboarded projects. Onboarded Claude Code project paths are tracked in `~/.config/ocw/projects.json` for clean uninstall. Codex onboarding is fully project-agnostic — Codex hardcodes `service.name=codex_exec` in its binary, so there is one Codex agent ID for all projects.
+
+## Daemon (launchd / systemd)
+
+`ocw onboard` (and `ocw onboard --claude-code` / `--codex`) installs a background daemon that runs `ocw serve` on login:
+- **macOS**: `~/Library/LaunchAgents/com.openclawwatch.serve.plist` — loaded via `launchctl load`. Logs at `/tmp/ocw-serve.{out,err}`.
+- **Linux**: `~/.config/systemd/user/openclawwatch.service` — enabled via `systemctl --user enable --now openclawwatch`.
+- **Other**: skipped with a notice; user runs `ocw serve` manually.
+
+Reinstall behavior: `--claude-code` and `--codex` onboard check `_daemon_already_running()` (launchctl list / systemctl is-active) and skip reinstall when the daemon is up unless `--force` is passed. This avoids spurious "Background Items Added" prompts on macOS during second-project onboards. The launchd path always `launchctl unload`s before `load` to handle plist updates idempotently. Use `ocw stop` to halt the daemon, `ocw uninstall` to remove unit files.
+
+`ocw serve` writes its resolved config path to `~/.local/share/ocw/server.state` at startup. Onboarding flows (especially `--codex`) read this file first so the ingest secret they write to the agent's config matches the secret in use by the running server, regardless of which project directory onboard is run from.
+
+## MCP Server
+
+`ocw mcp` starts a FastMCP stdio server for Claude Code integration. The connection mode is chosen at startup by `cmd_mcp.py`:
+1. If `ocw serve` is reachable on `config.api.{host,port}`, MCP proxies to it via HTTP (live ingest visible).
+2. Otherwise it tries to spawn `ocw serve` in the background and waits up to 10s for the port.
+3. If neither works, it falls back to a **read-only DuckDB connection** — read tools still work, but newly ingested spans won't appear until restart.
+4. If no config file is found, `init()` is skipped and tools return a no-config sentinel.
+
+To wire into Claude Code locally: `claude mcp add ocw --scope user -- ocw mcp` (the `--claude-code` and `--codex` onboard flows do this automatically when the `claude` CLI is on PATH; `--codex` also writes `[mcp_servers.ocw]` to `~/.codex/config.toml`).
+
+## Codex CLI Integration
+
+`ocw onboard --codex` writes `[otel]` and `[mcp_servers.ocw]` blocks to `~/.codex/config.toml`. Notes:
+- Codex hardcodes `service.name=codex_exec` in its binary and silently ignores `[otel.resource]`, so onboarding does **not** write that block — all Codex traces land under the `codex_exec` agent ID regardless of project. Onboarding is one-time global, not per-project.
+- Codex emits OTLP **logs** (not spans) to `/v1/logs`. `ocw/api/routes/logs.py` converts Codex events (`sse_event`, `user_prompt`, `tool_decision`, `tool_result`, `api_request`) into normalized spans for cost/drift/alerting. Event name is read from `attrs["event.name"]` when the OTLP body is empty (Codex schema quirk); epoch `timeUnixNano=0` falls back to `attrs["event.timestamp"]` ISO-8601. The `/v1/logs` endpoint also silently accepts `resourceSpans`/`resourceMetrics` because Codex's exporter reuses one endpoint for all signal types.
+- Re-running `ocw onboard --codex` is a no-op only when both `[otel]` and `[mcp_servers.ocw]` are present in `~/.codex/config.toml`. Re-onboarding either Codex or Claude Code cross-syncs the ingest secret into the other's config if it's already configured.
+
+## Examples Convention
+
+Each provider integration in `examples/single_provider/` and each framework in `examples/single_framework/` lives in **its own file** — when adding a new SDK integration, mirror this layout (one demo file per integration) so the examples directory stays a 1:1 map of supported integrations. Multi-provider/framework demos go in `examples/multi/`; alert and drift demos that need no API keys go in `examples/alerts_and_drift/`.
+
+The Agent Incident Library at `incidents/` is separate: each scenario is a `scenario.py` + `README.md` pair, invoked via `ocw demo <scenario>`. Scenarios inject synthetic spans through `ocw/demo/env.py` to simulate real failures (retry-loop, surprise-cost, hallucination-drift) without API keys or a live server.
 
 ## Pricing
 

--- a/tests/manual-new-release-tests.md
+++ b/tests/manual-new-release-tests.md
@@ -38,6 +38,7 @@ ocw traces       # should show traces with span waterfall
 ocw cost --since 1h   # should show cost breakdown by model (not $0.000000)
 ocw budget       # should show budget table with configured limits
 ocw alerts       # should show alert history (may be empty)
+ocw doctor       # exit 0 or 1 (warnings ok), no errors
 
 # 7. Start server (tests web UI + HTTP exporter)
 ocw serve &
@@ -77,6 +78,64 @@ cat ~/.claude/settings.json | python3 -m json.tool
 
 # Re-run to test secret resync (should not crash)
 ocw onboard --claude-code --budget 5
+# Output should include: "Daemon: already running (skipped reinstall)"
+# macOS should NOT show a second "Background Items Added" prompt
+
+# Verify projects index exists
+cat ~/.config/ocw/projects.json   # should list current cwd
+
+# Multi-project onboard — daemon should NOT reinstall, secret should NOT rotate
+ORIG_SECRET=$(python3 -c "import json,os; print(json.load(open(os.path.expanduser('~/.claude/settings.json')))['env']['OTEL_EXPORTER_OTLP_HEADERS'])")
+mkdir -p /tmp/ocw-test-project-2 && cd /tmp/ocw-test-project-2
+git init -q
+ocw onboard --claude-code
+NEW_SECRET=$(python3 -c "import json,os; print(json.load(open(os.path.expanduser('~/.claude/settings.json')))['env']['OTEL_EXPORTER_OTLP_HEADERS'])")
+[ "$ORIG_SECRET" = "$NEW_SECRET" ] && echo "ok: secret unchanged" || echo "FAIL: secret rotated"
+cd ~/openclawwatch
+
+# Verify global config fallback: CLI works from a dir with no local config
+cd /tmp && ocw status && cd ~/openclawwatch
+```
+
+## Codex CLI integration (if applicable)
+
+Codex onboarding is **one-time global** (Codex hardcodes `service.name=codex_exec`); all Codex traces land under the `codex_exec` agent ID.
+
+```bash
+# Prereq: ocw serve running — onboard reads ~/.local/share/ocw/server.state
+# to find the running server's config and sync the ingest secret.
+ocw serve &
+sleep 2
+test -f ~/.local/share/ocw/server.state && echo "ok: server.state exists"
+
+ocw onboard --codex
+# Should: write [otel] + [mcp_servers.ocw] to ~/.codex/config.toml,
+#         use ingest secret from running server,
+#         NOT write [otel.resource] block (Codex ignores it).
+
+# Verify secret synced between server and Codex config
+SERVER_SECRET=$(grep ingest_secret ~/.config/ocw/config.toml | cut -d'"' -f2)
+CODEX_SECRET=$(grep -oE 'Authorization=Bearer [a-f0-9]+' ~/.codex/config.toml | cut -d' ' -f2)
+[ "$SERVER_SECRET" = "$CODEX_SECRET" ] && echo "ok: secret synced"
+
+# Re-run is a no-op when both [otel] and [mcp_servers.ocw] already present
+ocw onboard --codex
+
+# If codex CLI is installed, drive a session and verify ingest
+codex exec "say hello"
+ocw status --agent codex_exec   # should show codex_exec (NOT codex-<project>)
+ocw traces --agent codex_exec
+```
+
+## Incident library demos
+
+```bash
+# Zero-config scenarios — no API keys, no live agents needed.
+ocw demo --list
+ocw demo retry-loop
+ocw demo surprise-cost
+ocw demo hallucination-drift
+# Each writes synthetic spans; verify visible in `ocw traces` and `ocw alerts`.
 ```
 
 ## What to look for

--- a/tests/manual-pre-release-testing.md
+++ b/tests/manual-pre-release-testing.md
@@ -40,6 +40,14 @@ python3 examples/alerts_and_drift/sensitive_actions_demo.py
 python3 examples/alerts_and_drift/budget_breach_demo.py
 python3 examples/alerts_and_drift/drift_demo.py
 
+# 7b. Run incident library demos (zero-config, no API keys)
+ocw demo --list
+ocw demo retry-loop
+ocw demo surprise-cost
+ocw demo hallucination-drift
+# [ ] Each runs without errors
+# [ ] Each writes spans to the DB (verify in step 9 with `ocw traces`)
+
 # 8. Populate test data — real API calls
 source .env.local
 python3 examples/single_provider/anthropic_agent.py
@@ -52,6 +60,7 @@ ocw cost --since 1h   # real USD values, not $0.000000
 ocw alerts        # alerts from sensitive_actions and budget_breach demos
 ocw drift         # baseline built from drift_demo sessions
 ocw budget        # budget table with configured limits
+ocw doctor        # exit 0 (or 1 with warnings); no errors. Checks config, DB, secret, drift readiness
 
 # 10. Start server
 # Note: must stop daemon first (step 6) or this will fail with "Address already in use"
@@ -117,12 +126,90 @@ ocw onboard --claude-code
 #         write settings to ~/.claude/settings.json,
 #         register MCP server if claude CLI available,
 #         auto-install daemon
+#         create ~/.config/ocw/projects.json with current cwd
 
-# Verify no crash on re-run (secret resync)
+# Verify global config (not project-local)
+test -f ~/.config/ocw/config.toml && echo "ok: global config"
+test ! -f ./.ocw/config.toml && echo "ok: no project-local config written"
+
+# Verify projects.json tracks the cwd
+cat ~/.config/ocw/projects.json   # should contain current working directory
+
+# Verify no crash on re-run (secret resync, same project)
 ocw onboard --claude-code --budget 5
+# Output should include: "Daemon: already running (skipped reinstall)"
+# macOS should NOT show another "Background Items Added" notification.
+
+# Verify multi-project onboard (the 490ad8e fix)
+mkdir -p /tmp/ocw-test-project-2 && cd /tmp/ocw-test-project-2
+git init -q
+ocw onboard --claude-code
+# [ ] Output shows "Daemon: already running (skipped reinstall)" — daemon NOT reinstalled
+# [ ] No new "Background Items Added" prompt on macOS
+# [ ] ~/.config/ocw/projects.json now lists BOTH project paths
+# [ ] ingest_secret in ~/.claude/settings.json unchanged from first onboard
+#     (so the original project's auth still works)
+cat ~/.config/ocw/projects.json
+cd ~/openclawwatch
+
+# Verify global config fallback: CLI works from a directory with no local config
+cd /tmp && ocw status   # should resolve to global config, not error out
+cd ~/openclawwatch
+
+# Verify --force does reinstall the daemon
+ocw onboard --claude-code --force
+# Output should include: "Daemon: installing..."
 
 # Verify MCP server starts
 ocw mcp --help
+```
+
+## Codex CLI integration (if applicable)
+
+Codex hardcodes `service.name=codex_exec` in its binary, so this is a **one-time global** setup, not per-project. All Codex traces land under the `codex_exec` agent ID regardless of which project directory you onboard from.
+
+```bash
+# Prereq: ocw serve must be running so onboard can read ~/.local/share/ocw/server.state
+ocw serve &
+sleep 2
+
+# Verify the server state file was written by `ocw serve`
+test -f ~/.local/share/ocw/server.state && echo "ok: server.state exists"
+cat ~/.local/share/ocw/server.state   # should contain resolved config path
+
+# Onboard Codex
+ocw onboard --codex
+# Should: write [otel] block + [mcp_servers.ocw] to ~/.codex/config.toml,
+#         use ingest secret from the running server (matched via server.state),
+#         NOT write [otel.resource] (Codex ignores it — would cause stale agent IDs)
+
+# Verify Codex config
+cat ~/.codex/config.toml
+# [ ] Contains [otel] block with otlp_endpoint, otlp_headers (Authorization=Bearer ...)
+# [ ] Contains [mcp_servers.ocw] block
+# [ ] Does NOT contain [otel.resource] block
+
+# Verify secret matches the running server
+SERVER_SECRET=$(grep ingest_secret ~/.config/ocw/config.toml | cut -d'"' -f2)
+CODEX_SECRET=$(grep -oE 'Authorization=Bearer [a-f0-9]+' ~/.codex/config.toml | cut -d' ' -f2)
+[ "$SERVER_SECRET" = "$CODEX_SECRET" ] && echo "ok: secret synced" || echo "FAIL: secret mismatch"
+
+# Verify skip-on-rerun (must have BOTH [otel] and [mcp_servers.ocw])
+ocw onboard --codex   # should print "already configured" / no-op
+
+# Verify cross-sync: re-onboarding Claude Code updates Codex config too
+ocw onboard --claude-code --force
+# After: ingest secret in ~/.claude/settings.json, ~/.codex/config.toml,
+#        and ~/.config/ocw/config.toml should all match.
+
+# Drive a Codex session (if codex CLI installed) and verify ingestion
+codex exec "say hello"   # or any short codex command
+ocw status --agent codex_exec   # should show codex_exec agent with spans/cost
+ocw traces --agent codex_exec
+# [ ] Spans land under agent_id=codex_exec (NOT codex-<project-name>)
+# [ ] /v1/logs endpoint accepted the OTLP log records (no 400 in `ocw serve` output)
+
+ocw stop
 ```
 
 ## Quick test (skip web UI — just verify core)


### PR DESCRIPTION
## Summary
- **CLAUDE.md**: New sections for Daemon (launchd/systemd, `~/.local/share/ocw/server.state`), MCP fallback chain, **Codex CLI Integration** (hardcoded `codex_exec` service name, `/v1/logs` event conversion, cross-sync with Claude Code), and global-config rule for `--claude-code`/`--codex` onboarding. Expanded `ocw doctor` row with full check list + exit-code semantics. Added `incidents/` to examples convention.
- **manual-pre-release-testing.md**: Step 7b for `ocw demo` scenarios, `ocw doctor` in step 9, expanded Claude Code section (multi-project, `projects.json`, secret-stability, `--force` daemon reinstall), new Codex section (server.state, secret sync, `[otel.resource]` omission verification, cross-sync test).
- **manual-new-release-tests.md**: `ocw doctor` smoke check, multi-project secret-stability assertions, new Codex and incident-library sections.

Documents functionality added on `main` since the playbooks were last refreshed (commit `25d4c96`): Codex CLI integration (#40), Agent Incident Library (#41), and the daemon/global-config fix (#36).

## Test plan
- [ ] Run `tests/manual-pre-release-testing.md` end-to-end against this branch and confirm the new Claude Code multi-project + Codex sections pass on a clean machine
- [ ] Confirm `ocw demo --list` and each scenario run from step 7b
- [ ] Spot-check `ocw doctor` exits 0 or 1 (warnings ok), never 2

🤖 Generated with [Claude Code](https://claude.com/claude-code)