### PR TITLE
Wire alert/drift/schema engines into ingest pipeline + fix demo UX

### DIFF
--- a/examples/alerts_and_drift/_shared.py
+++ b/examples/alerts_and_drift/_shared.py
@@ -1,0 +1,55 @@
+"""Helper to let alerts/drift demos seed their own per-agent config.
+
+Each demo's alerts (sensitive_actions, budget) live under [agents.<id>] in
+ocw config. Without that block the AlertEngine silently no-ops. This helper
+lets each demo idempotently inject the agent block it needs before bootstrap
+runs, so demos work out of the box on a fresh `ocw onboard`.
+"""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from typing import Any
+
+if sys.version_info >= (3, 11):
+    import tomllib
+else:
+    import tomli as tomllib  # type: ignore[no-redef]
+
+import tomli_w
+
+from ocw.core.config import find_config_file
+
+
+def ensure_demo_agent_config(agent_id: str, agent_block: dict[str, Any]) -> Path:
+    """Idempotently merge `agent_block` into [agents.<agent_id>] in the active ocw config.
+
+    Existing keys are left alone — this only fills in missing config so a tester
+    can override demo settings if they want. Writes to .ocw/config.toml in the
+    cwd if no config exists yet. Returns the path written.
+    """
+    cfg_path = find_config_file()
+    if cfg_path is None:
+        cfg_path = Path(".ocw/config.toml")
+        cfg_path.parent.mkdir(parents=True, exist_ok=True)
+        data: dict[str, Any] = {}
+    else:
+        cfg_path = Path(cfg_path)
+        with cfg_path.open("rb") as f:
+            data = tomllib.load(f)
+
+    agents = data.setdefault("agents", {})
+    existing = agents.setdefault(agent_id, {})
+    _deep_merge_missing(existing, agent_block)
+
+    with cfg_path.open("wb") as f:
+        tomli_w.dump(data, f)
+    return cfg_path
+
+
+def _deep_merge_missing(target: dict[str, Any], source: dict[str, Any]) -> None:
+    for k, v in source.items():
+        if k not in target:
+            target[k] = v
+        elif isinstance(v, dict) and isinstance(target[k], dict):
+            _deep_merge_missing(target[k], v)

--- a/examples/alerts_and_drift/budget_breach_demo.py
+++ b/examples/alerts_and_drift/budget_breach_demo.py
@@ -6,18 +6,13 @@ Shows how ocw tracks costs and fires budget alerts.
 
 No API keys required — uses simulated instrumentation.
 
-# --- Required ocw.toml config ---
-# Add this to your ocw.toml (or ~/.config/ocw/config.toml):
-#
-# [[agents]]
-# id = "budget-demo"
-#
-# [agents.budget]
-# daily_usd = 0.05
-# session_usd = 0.02
-#
-# [[alerts.channels]]
-# type = "stdout"
+The demo seeds its own [agents.budget-demo] block in the active ocw
+config on startup, so it works out of the box on a fresh `ocw onboard`.
+The injected config is equivalent to:
+
+    [agents.budget-demo.budget]
+    daily_usd = 0.05
+    session_usd = 0.02
 """
 from __future__ import annotations
 
@@ -81,6 +76,12 @@ def run_expensive_agent() -> None:
 # ---------------------------------------------------------------------------
 
 if __name__ == "__main__":
+    from examples.alerts_and_drift._shared import ensure_demo_agent_config
+    ensure_demo_agent_config(
+        "budget-demo",
+        {"budget": {"daily_usd": 0.05, "session_usd": 0.02}},
+    )
+
     from ocw.sdk.bootstrap import ensure_initialised
     ensure_initialised()
 

--- a/examples/alerts_and_drift/drift_demo.py
+++ b/examples/alerts_and_drift/drift_demo.py
@@ -9,20 +9,8 @@ Shows how ocw detects statistical drift and fires DRIFT_DETECTED alerts.
 
 No API keys required — uses simulated instrumentation.
 
-# --- Required ocw.toml config ---
-# Add this to your ocw.toml (or ~/.config/ocw/config.toml):
-#
-# [[agents]]
-# id = "drift-demo"
-#
-# [agents.drift]
-# enabled = true
-# baseline_sessions = 10
-# token_threshold = 2.0
-# tool_sequence_diff = 0.4
-#
-# [[alerts.channels]]
-# type = "stdout"
+Drift detection is on by default for any observed agent (see DriftConfig
+defaults), so this demo needs no extra config — it just runs.
 """
 from __future__ import annotations
 

--- a/examples/alerts_and_drift/sensitive_actions_demo.py
+++ b/examples/alerts_and_drift/sensitive_actions_demo.py
@@ -6,26 +6,20 @@ submit_form). Shows how ocw detects and alerts on configured sensitive tools.
 
 No API keys required — uses simulated instrumentation.
 
-# --- Required ocw.toml config ---
-# Add this to your ocw.toml (or ~/.config/ocw/config.toml):
-#
-# [[agents]]
-# id = "sensitive-demo"
-#
-# [[agents.sensitive_actions]]
-# name = "send_email"
-# severity = "warning"
-#
-# [[agents.sensitive_actions]]
-# name = "delete_file"
-# severity = "critical"
-#
-# [[agents.sensitive_actions]]
-# name = "submit_form"
-# severity = "warning"
-#
-# [[alerts.channels]]
-# type = "stdout"
+The demo seeds its own [agents.sensitive-demo] block in the active ocw
+config on startup, so it works out of the box on a fresh `ocw onboard`.
+The injected config is equivalent to:
+
+    [agents.sensitive-demo]
+    [[agents.sensitive-demo.sensitive_actions]]
+    name = "send_email"
+    severity = "warning"
+    [[agents.sensitive-demo.sensitive_actions]]
+    name = "delete_file"
+    severity = "critical"
+    [[agents.sensitive-demo.sensitive_actions]]
+    name = "submit_form"
+    severity = "warning"
 """
 from __future__ import annotations
 
@@ -125,6 +119,18 @@ def run_sensitive_agent() -> None:
 # ---------------------------------------------------------------------------
 
 if __name__ == "__main__":
+    from examples.alerts_and_drift._shared import ensure_demo_agent_config
+    ensure_demo_agent_config(
+        "sensitive-demo",
+        {
+            "sensitive_actions": [
+                {"name": "send_email", "severity": "warning"},
+                {"name": "delete_file", "severity": "critical"},
+                {"name": "submit_form", "severity": "warning"},
+            ],
+        },
+    )
+
     from ocw.sdk.bootstrap import ensure_initialised
     ensure_initialised()
 

--- a/ocw/cli/cmd_serve.py
+++ b/ocw/cli/cmd_serve.py
@@ -20,12 +20,10 @@ def cmd_serve(ctx: click.Context, host: str | None, port: int | None,
 
     import uvicorn
     from ocw.api.app import create_app
-    from ocw.core.ingest import IngestPipeline
-    from ocw.core.cost import CostEngine
+    from ocw.core.ingest import build_default_pipeline
 
     db = ctx.obj["db"]
-    cost_engine = CostEngine(db)
-    pipeline = IngestPipeline(db, config, cost_engine=cost_engine)
+    pipeline = build_default_pipeline(db, config)
     app = create_app(config, db, pipeline)
 
     # Schedule retention cleanup using a separate DB connection per run

--- a/ocw/core/drift.py
+++ b/ocw/core/drift.py
@@ -7,6 +7,7 @@ from __future__ import annotations
 import math
 from typing import TYPE_CHECKING
 
+from ocw.core.config import AgentConfig
 from ocw.core.models import (
     AlertType,
     DriftBaseline,
@@ -219,7 +220,6 @@ class DriftDetector:
         Falls back to default AgentConfig (drift.enabled=True) when agent isn't explicitly
         configured, so drift detection works out of the box for any observed agent.
         """
-        from ocw.core.config import AgentConfig
         agent_config = self.config.agents.get(agent_id) or AgentConfig()
         if not agent_config.drift.enabled:
             return

--- a/ocw/core/drift.py
+++ b/ocw/core/drift.py
@@ -216,9 +216,12 @@ class DriftDetector:
         """
         Called when a session reaches status='completed'.
         Builds baseline if enough sessions exist, or evaluates drift against existing baseline.
+        Falls back to default AgentConfig (drift.enabled=True) when agent isn't explicitly
+        configured, so drift detection works out of the box for any observed agent.
         """
-        agent_config = self.config.agents.get(agent_id)
-        if agent_config is None or not agent_config.drift.enabled:
+        from ocw.core.config import AgentConfig
+        agent_config = self.config.agents.get(agent_id) or AgentConfig()
+        if not agent_config.drift.enabled:
             return
 
         baseline = self.db.get_baseline(agent_id)

--- a/ocw/core/ingest.py
+++ b/ocw/core/ingest.py
@@ -237,3 +237,29 @@ class IngestPipeline:
                 self.schema_validator.validate(span)
             except Exception as exc:
                 logger.warning("SchemaValidator hook failed: %s", exc)
+
+
+def build_default_pipeline(db: "StorageBackend", config: OcwConfig) -> "IngestPipeline":
+    """Construct an IngestPipeline with all standard post-ingest hooks wired up.
+
+    Used by both `ocw serve` and the SDK auto-bootstrap so alerts, drift detection,
+    and schema validation work uniformly regardless of how spans enter the system.
+    """
+    from ocw.core.alerts import AlertEngine
+    from ocw.core.cost import CostEngine
+    from ocw.core.drift import DriftDetector
+    from ocw.core.schema_validator import SchemaValidator
+
+    cost_engine = CostEngine(db)
+    alert_engine = AlertEngine(db=db, config=config)
+    drift_detector = DriftDetector(db=db, alert_engine=alert_engine, config=config)
+    schema_validator = SchemaValidator(db=db, alert_engine=alert_engine, config=config)
+
+    return IngestPipeline(
+        db=db,
+        config=config,
+        cost_engine=cost_engine,
+        alert_engine=alert_engine,
+        drift_detector=drift_detector,
+        schema_validator=schema_validator,
+    )

--- a/ocw/sdk/bootstrap.py
+++ b/ocw/sdk/bootstrap.py
@@ -46,12 +46,10 @@ def ensure_initialised() -> None:
 
             # Direct DuckDB mode
             from ocw.core.db import open_db
-            from ocw.core.ingest import IngestPipeline
-            from ocw.core.cost import CostEngine
+            from ocw.core.ingest import build_default_pipeline
 
             db = open_db(config.storage)
-            cost_engine = CostEngine(db)
-            pipeline = IngestPipeline(db, config, cost_engine=cost_engine)
+            pipeline = build_default_pipeline(db, config)
             _pipeline = pipeline
             _provider = build_tracer_provider(config, pipeline)
             _initialised = True

--- a/tests/manual-new-release-tests.md
+++ b/tests/manual-new-release-tests.md
@@ -115,7 +115,7 @@ ocw onboard --codex
 
 # Verify secret synced between server and Codex config
 SERVER_SECRET=$(grep ingest_secret ~/.config/ocw/config.toml | cut -d'"' -f2)
-CODEX_SECRET=$(grep -oE 'Authorization=Bearer [a-f0-9]+' ~/.codex/config.toml | cut -d' ' -f2)
+CODEX_SECRET=$(grep -oE 'Authorization=Bearer [^ "]+' ~/.codex/config.toml | cut -d' ' -f2)
 [ "$SERVER_SECRET" = "$CODEX_SECRET" ] && echo "ok: secret synced"
 
 # Re-run is a no-op when both [otel] and [mcp_servers.ocw] already present
@@ -125,6 +125,9 @@ ocw onboard --codex
 codex exec "say hello"
 ocw status --agent codex_exec   # should show codex_exec (NOT codex-<project>)
 ocw traces --agent codex_exec
+
+# Stop the background server started in the prereq
+ocw stop
 ```
 
 ## Incident library demos

--- a/tests/manual-pre-release-testing.md
+++ b/tests/manual-pre-release-testing.md
@@ -21,8 +21,10 @@ git fetch origin
 git checkout <branch-name>
 
 # 3. Install locally (editable — uses local files, no pip publish needed)
-pip3 install -e ".[dev,mcp]"
+pip3 install -e ".[dev,mcp]" --force-reinstall
 ocw --version
+# Verify the installed `ocw` actually imports from the repo, not site-packages
+python3 -c "import ocw; print(ocw.__file__)"   # must point inside ~/openclawwatch
 
 # 4. Run automated tests first
 pytest tests/unit/ tests/synthetic/ tests/agents/ tests/integration/
@@ -191,16 +193,24 @@ cat ~/.codex/config.toml
 
 # Verify secret matches the running server
 SERVER_SECRET=$(grep ingest_secret ~/.config/ocw/config.toml | cut -d'"' -f2)
-CODEX_SECRET=$(grep -oE 'Authorization=Bearer [a-f0-9]+' ~/.codex/config.toml | cut -d' ' -f2)
+CODEX_SECRET=$(grep -oE 'Authorization=Bearer [^ "]+' ~/.codex/config.toml | cut -d' ' -f2)
 [ "$SERVER_SECRET" = "$CODEX_SECRET" ] && echo "ok: secret synced" || echo "FAIL: secret mismatch"
 
 # Verify skip-on-rerun (must have BOTH [otel] and [mcp_servers.ocw])
 ocw onboard --codex   # should print "already configured" / no-op
 
+# Stop the foreground `ocw serve` from the prereq before any --force flow,
+# so the daemon reinstall doesn't collide with the running server on port 7391.
+ocw stop
+
 # Verify cross-sync: re-onboarding Claude Code updates Codex config too
 ocw onboard --claude-code --force
 # After: ingest secret in ~/.claude/settings.json, ~/.codex/config.toml,
 #        and ~/.config/ocw/config.toml should all match.
+
+# Restart serve for the remaining checks below
+ocw serve &
+sleep 2
 
 # Drive a Codex session (if codex CLI installed) and verify ingestion
 codex exec "say hello"   # or any short codex command

--- a/tests/unit/test_drift.py
+++ b/tests/unit/test_drift.py
@@ -1,5 +1,10 @@
 """Unit tests for drift detection pure functions."""
-from ocw.core.drift import jaccard_similarity, z_score
+from unittest.mock import MagicMock
+
+from ocw.core.config import OcwConfig
+from ocw.core.drift import DriftDetector, jaccard_similarity, z_score
+from ocw.core.models import SessionRecord
+from ocw.utils.time_parse import utcnow
 
 
 class TestZScore:
@@ -43,3 +48,34 @@ class TestJaccardSimilarity:
         # intersection=2, union=3 => 2/3
         result = jaccard_similarity({"a", "b"}, {"a", "b", "c"})
         assert abs(result - 2 / 3) < 0.001
+
+
+class TestDriftDetectorAgentFallback:
+    """Drift detection should work for agents that aren't explicitly configured."""
+
+    def test_unconfigured_agent_builds_baseline(self):
+        db = MagicMock()
+        db.get_baseline.return_value = None
+        db.get_completed_session_count.return_value = 10
+        db.get_completed_sessions.return_value = [
+            SessionRecord(
+                session_id=f"s{i}", agent_id="ad-hoc-agent",
+                started_at=utcnow(), ended_at=utcnow(), status="completed",
+                input_tokens=100, output_tokens=50, tool_call_count=2,
+            ) for i in range(10)
+        ]
+        alert_engine = MagicMock()
+        # Empty config — no [agents.<id>] block for "ad-hoc-agent"
+        config = OcwConfig(version="1")
+
+        detector = DriftDetector(db=db, alert_engine=alert_engine, config=config)
+        session = SessionRecord(
+            session_id="latest", agent_id="ad-hoc-agent",
+            started_at=utcnow(), ended_at=utcnow(), status="completed",
+            input_tokens=100, output_tokens=50, tool_call_count=2,
+        )
+
+        detector.on_session_end("ad-hoc-agent", session)
+
+        # Baseline should have been built despite no agent config
+        assert db.upsert_baseline.called

--- a/tests/unit/test_drift.py
+++ b/tests/unit/test_drift.py
@@ -3,8 +3,7 @@ from unittest.mock import MagicMock
 
 from ocw.core.config import OcwConfig
 from ocw.core.drift import DriftDetector, jaccard_similarity, z_score
-from ocw.core.models import SessionRecord
-from ocw.utils.time_parse import utcnow
+from tests.factories import make_session
 
 
 class TestZScore:
@@ -58,9 +57,8 @@ class TestDriftDetectorAgentFallback:
         db.get_baseline.return_value = None
         db.get_completed_session_count.return_value = 10
         db.get_completed_sessions.return_value = [
-            SessionRecord(
-                session_id=f"s{i}", agent_id="ad-hoc-agent",
-                started_at=utcnow(), ended_at=utcnow(), status="completed",
+            make_session(
+                agent_id="ad-hoc-agent", session_id=f"s{i}",
                 input_tokens=100, output_tokens=50, tool_call_count=2,
             ) for i in range(10)
         ]
@@ -69,9 +67,8 @@ class TestDriftDetectorAgentFallback:
         config = OcwConfig(version="1")
 
         detector = DriftDetector(db=db, alert_engine=alert_engine, config=config)
-        session = SessionRecord(
-            session_id="latest", agent_id="ad-hoc-agent",
-            started_at=utcnow(), ended_at=utcnow(), status="completed",
+        session = make_session(
+            agent_id="ad-hoc-agent", session_id="latest",
             input_tokens=100, output_tokens=50, tool_call_count=2,
         )
 


### PR DESCRIPTION
## Summary

The headline bug: both \`ocw serve\` and the SDK auto-bootstrap constructed \`IngestPipeline\` with only \`cost_engine\` — \`alert_engine\`, \`drift_detector\`, and \`schema_validator\` were always None, so every post-ingest hook silently no-op'd. Spans were stored and costed correctly, but no alerts ever fired and no drift baseline was ever built in production code paths. Only the incident-library demo (\`ocw/demo/env.py\`) wired things up correctly, which is why \`ocw demo\` scenarios worked but the \`examples/alerts_and_drift/\` demos didn't.

Surfaced while testing PR #42's playbook against current main: ran sensitive_actions / budget_breach / drift demos, got zero alerts and no drift baselines despite 13 completed sessions.

### Fixes

- **Pipeline wiring** (\`ocw/core/ingest.py\`, \`ocw/cli/cmd_serve.py\`, \`ocw/sdk/bootstrap.py\`): new \`build_default_pipeline(db, config)\` factory wires up cost + alerts + drift + schema validator. Both serve and SDK bootstrap use it, so production paths match the demo pipeline.
- **Drift fallback** (\`ocw/core/drift.py\`): unconfigured agents now fall back to default \`AgentConfig()\` (drift.enabled=True), matching the dataclass intent. Drift baseline builds for any agent reaching \`baseline_sessions\` completed sessions.
- **Demo self-config** (\`examples/alerts_and_drift/_shared.py\` + each demo): alert demos require per-agent \`[agents.<id>]\` blocks to fire. Each demo idempotently injects its required config on startup so they work on a fresh \`ocw onboard\`. Demo docstrings now show correct TOML syntax (\`[agents.<id>]\` table-of-tables, not \`[[agents]]\` array-of-tables).

### Greptile P1/P2 from PR #42 review

- Bearer-token regex tightened from \`[a-f0-9]+\` to \`[^ \"]+\` (P1, both playbooks).
- Pre-release Codex section: \`ocw stop\` before \`--force\` daemon reinstall to avoid port 7391 collision (P1).
- New-release Codex section: \`ocw stop\` cleanup at end (P2).

### Playbook addition

- Editable-install verification step (\`python3 -c \"import ocw; print(ocw.__file__)\"\`) so testers can spot a stale PyPI install masking local changes.

## Test plan

- [x] \`pytest tests/unit/ tests/synthetic/ tests/agents/ tests/integration/\` — 399 passed (+1 new fallback test)
- [x] \`ruff check ocw/ examples/\` — clean
- [x] End-to-end: ran all three alert demos against fresh DB, observed 7 alerts (3 sensitive_action, 1 cost_budget_session, 3 drift_detected) and drift baseline built (\`sessions_sampled=10\`)
- [ ] Re-run \`tests/manual-pre-release-testing.md\` end-to-end to confirm step 7 + 7b + 9 now show alerts/drift in CLI and web UI

🤖 Generated with [Claude Code](https://claude.com/claude-code)