### PR TITLE
Fix Codex onboard, daemon load -w flag, and ocw stop sweep

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -182,9 +182,9 @@ Config is TOML, discovered at: `ocw.toml` -> `.ocw/config.toml` -> `~/.config/oc
 - **Linux**: `~/.config/systemd/user/openclawwatch.service` — enabled via `systemctl --user enable --now openclawwatch`.
 - **Other**: skipped with a notice; user runs `ocw serve` manually.
 
-Reinstall behavior: `--claude-code` and `--codex` onboard check `_daemon_already_running()` (launchctl list / systemctl is-active) and skip reinstall when the daemon is up unless `--force` is passed. This avoids spurious "Background Items Added" prompts on macOS during second-project onboards. The launchd path always `launchctl unload`s before `load` to handle plist updates idempotently. Use `ocw stop` to halt the daemon, `ocw uninstall` to remove unit files.
+Reinstall behavior: `--claude-code` and `--codex` onboard check `_daemon_already_running()` (launchctl list / systemctl is-active) and skip reinstall when the daemon is up unless `--force` is passed. This avoids spurious "Background Items Added" prompts on macOS during second-project onboards. The launchd path always uses `launchctl unload -w` then `launchctl load -w` — the `-w` flag clears any Disabled=true entry from the launchd database (`ocw stop` writes Disabled=true via `launchctl unload -w`), without which a subsequent plain `launchctl load` is a silent no-op. Use `ocw stop` to halt the daemon, `ocw uninstall` to remove unit files. `ocw stop` also sweeps for any orphan foreground `ocw serve` processes (e.g. from a manual `ocw serve &`) so it reliably frees port 7391.
 
-`ocw serve` writes its resolved config path to `~/.local/share/ocw/server.state` at startup. Onboarding flows (especially `--codex`) read this file first so the ingest secret they write to the agent's config matches the secret in use by the running server, regardless of which project directory onboard is run from.
+`ocw serve` writes its resolved config path to `~/.local/share/ocw/server.state` at startup. This is informational — onboarding flows (`--claude-code` and `--codex`) always write to the global config, so server.state is not used for secret-sync.
 
 ## MCP Server
 

--- a/ocw/cli/cmd_onboard.py
+++ b/ocw/cli/cmd_onboard.py
@@ -330,7 +330,7 @@ def _onboard_codex(
 
     from ocw.core.config import (
         AgentConfig, BudgetConfig, OcwConfig, SecurityConfig,
-        find_config_file, load_config, write_config,
+        load_config, write_config,
     )
 
     # Codex hardcodes service.name="codex_exec" in its binary regardless of
@@ -343,25 +343,12 @@ def _onboard_codex(
             type=float, default=0.0, show_default=False,
         )
 
-    # Prefer the running server's config over CWD discovery — otherwise the
-    # secret written to Codex mismatches when onboard runs from a different
-    # project than where `ocw serve` was started.
-    import json as _json
-    _state_path = Path.home() / ".local" / "share" / "ocw" / "server.state"
-    config_path: Path | None = None
-    if _state_path.exists():
-        try:
-            _state = _json.loads(_state_path.read_text())
-            _cp = _state.get("config_path")
-            if _cp and Path(_cp).exists():
-                config_path = Path(_cp)
-        except Exception:
-            pass
-    if config_path is None:
-        existing_path = find_config_file()
-        fallback_path = Path.home() / ".config" / "ocw" / "config.toml"
-        config_path = existing_path if existing_path is not None else fallback_path
-    assert config_path is not None  # fallback_path is always set
+    # `--codex` always writes to the global config, mirroring `--claude-code`.
+    # Codex's own config (~/.codex/config.toml) is global and the agent_id
+    # `codex_exec` is project-agnostic by design (Codex hardcodes service.name
+    # in its binary). Per-project OCW configs would rotate the secret on every
+    # onboard, breaking the running server.
+    config_path = Path.home() / ".config" / "ocw" / "config.toml"
 
     previous_secret: str | None = None
     if config_path.exists():
@@ -415,11 +402,14 @@ def _onboard_codex(
     already_has_otel = "otel" in existing_codex
     already_has_mcp = bool(existing_codex.get("mcp_servers", {}).get("ocw"))
     if already_has_otel and already_has_mcp and not force:
-        console.print(
-            "[yellow]~/.codex/config.toml already has [otel] and [mcp_servers.ocw] sections.[/yellow]"
+        # Use plain print() for messages containing TOML section headers like
+        # [otel] — Rich treats square brackets as markup tags and would strip
+        # them, leaving the message unintelligible ("already has  and ").
+        click.echo(
+            "~/.codex/config.toml already has [otel] and [mcp_servers.ocw] sections."
         )
-        console.print("Use [bold]--force[/bold] to overwrite, or add manually:")
-        console.print()
+        click.echo("Use --force to overwrite, or add manually:")
+        click.echo("")
         _print_codex_otel_block(port, secret, agent_id)
         return
 
@@ -597,12 +587,14 @@ def _codex_otel_toml_block(port: int, secret: str, agent_id: str) -> str:
 
 
 def _print_codex_otel_block(port: int, secret: str, agent_id: str = "codex_exec") -> None:
-    console.print("[dim]Add this to ~/.codex/config.toml:[/dim]")
-    console.print()
+    # Plain print — the TOML block contains [otel] and other section headers
+    # that Rich would interpret as markup tags and strip from the output.
+    click.echo("Add this to ~/.codex/config.toml:")
+    click.echo("")
     block = _codex_otel_toml_block(port, secret, agent_id)
     for line in block.splitlines():
-        console.print(f"[dim]  {line}[/dim]")
-    console.print()
+        click.echo(f"  {line}")
+    click.echo("")
 
 
 def _sync_secret_to_codex(secret: str) -> bool:
@@ -739,11 +731,14 @@ def _install_launchd(config_path: str) -> str | None:
     # Unload any existing registration before loading the updated plist.
     # Ignore errors — the service may not be registered yet on first install.
     subprocess.run(
-        ["launchctl", "unload", str(plist_path)],
+        ["launchctl", "unload", "-w", str(plist_path)],
         capture_output=True, text=True,
     )
+    # `-w` clears the Disabled=true flag that `ocw stop` writes via
+    # `launchctl unload -w`. Without `-w` here, the daemon stays disabled
+    # in launchd's database and load is a no-op even though it returns 0.
     result = subprocess.run(
-        ["launchctl", "load", str(plist_path)],
+        ["launchctl", "load", "-w", str(plist_path)],
         capture_output=True, text=True,
     )
     if result.returncode != 0:

--- a/ocw/cli/cmd_stop.py
+++ b/ocw/cli/cmd_stop.py
@@ -17,6 +17,8 @@ def cmd_stop(ctx: click.Context) -> None:
     plist_path = Path.home() / "Library/LaunchAgents/com.openclawwatch.serve.plist"
     systemd_path = Path.home() / ".config/systemd/user/openclawwatch.service"
 
+    stopped_via: list[str] = []
+
     # Try launchd first (macOS).
     # -w writes a Disabled entry to launchd's database so the daemon does not
     # auto-start on the next login (the plist file stays on disk so the user
@@ -27,9 +29,7 @@ def cmd_stop(ctx: click.Context) -> None:
             capture_output=True, text=True,
         )
         if result.returncode == 0:
-            console.print("[green]ocw serve stopped.[/green] (launchd daemon unloaded)")
-            return
-        # If unload failed, the daemon may not have been loaded — fall through
+            stopped_via.append("launchd daemon unloaded")
 
     # Try systemd (Linux).
     # `disable --now` stops the unit immediately AND removes it from the
@@ -42,18 +42,28 @@ def cmd_stop(ctx: click.Context) -> None:
             capture_output=True, text=True,
         )
         if result.returncode == 0:
-            console.print("[green]ocw serve stopped.[/green] (systemd service stopped)")
-            return
-        # Fall through to pgrep if systemctl is unavailable or the unit isn't loaded
+            stopped_via.append("systemd service stopped")
 
-    # Fallback: find and signal the process directly
-    pid = _find_serve_pid()
-    if pid:
-        os.kill(pid, signal.SIGTERM)
-        console.print(f"[green]ocw serve stopped.[/green] (PID {pid})")
-        return
+    # Always sweep for orphan foreground `ocw serve` processes started via
+    # `ocw serve &` — launchd/systemd unload doesn't affect those, and they
+    # keep holding the port. Loop until pgrep stops finding matches so
+    # multiple stragglers all get reaped.
+    while True:
+        pid = _find_serve_pid()
+        if not pid:
+            break
+        try:
+            os.kill(pid, signal.SIGTERM)
+        except ProcessLookupError:
+            break
+        stopped_via.append(f"PID {pid}")
 
-    console.print("[dim]ocw serve is not running.[/dim]")
+    if stopped_via:
+        console.print(
+            f"[green]ocw serve stopped.[/green] ({', '.join(stopped_via)})"
+        )
+    else:
+        console.print("[dim]ocw serve is not running.[/dim]")
 
 
 def _find_serve_pid() -> int | None:

--- a/ocw/cli/cmd_stop.py
+++ b/ocw/cli/cmd_stop.py
@@ -46,16 +46,19 @@ def cmd_stop(ctx: click.Context) -> None:
 
     # Always sweep for orphan foreground `ocw serve` processes started via
     # `ocw serve &` — launchd/systemd unload doesn't affect those, and they
-    # keep holding the port. Loop until pgrep stops finding matches so
-    # multiple stragglers all get reaped.
-    while True:
+    # keep holding the port. Track signaled PIDs so a slow-shutting process
+    # doesn't get re-signaled (SIGTERM is async; pgrep can return the same
+    # PID before the handler fires, which would otherwise spin forever).
+    signaled: set[int] = set()
+    for _ in range(20):  # hard cap — well above any realistic straggler count
         pid = _find_serve_pid()
-        if not pid:
+        if not pid or pid in signaled:
             break
         try:
             os.kill(pid, signal.SIGTERM)
         except ProcessLookupError:
             break
+        signaled.add(pid)
         stopped_via.append(f"PID {pid}")
 
     if stopped_via:

--- a/tests/unit/test_cmd_stop.py
+++ b/tests/unit/test_cmd_stop.py
@@ -1,0 +1,49 @@
+"""Unit tests for `ocw stop` lifecycle behavior."""
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+from click.testing import CliRunner
+
+from ocw.cli.cmd_stop import cmd_stop
+
+
+class TestStopSweepsForegroundProcesses:
+    """`ocw stop` must reap orphan foreground `ocw serve &` processes after
+    a successful launchctl unload — otherwise port 7391 stays held and
+    "ocw stop didn't actually stop ocw" (C6)."""
+
+    def test_kills_foreground_after_launchd_unload(self, tmp_path, monkeypatch):
+        # Pretend a plist exists so the launchd branch runs.
+        plist = tmp_path / "Library" / "LaunchAgents" / "com.openclawwatch.serve.plist"
+        plist.parent.mkdir(parents=True)
+        plist.write_text("<plist/>")
+        monkeypatch.setattr("ocw.cli.cmd_stop.Path.home", lambda: tmp_path)
+
+        # First call: launchctl unload (returncode=0). Subsequent calls:
+        # _find_serve_pid uses subprocess too — but it's gated behind
+        # _find_serve_pid which we'll patch separately.
+        run_mock = MagicMock(return_value=MagicMock(returncode=0))
+        kill_mock = MagicMock()
+        # _find_serve_pid returns a PID once, then None to break the loop.
+        find_pid_mock = MagicMock(side_effect=[12345, None])
+
+        with patch("ocw.cli.cmd_stop.subprocess.run", run_mock), \
+             patch("ocw.cli.cmd_stop.os.kill", kill_mock), \
+             patch("ocw.cli.cmd_stop._find_serve_pid", find_pid_mock):
+            result = CliRunner().invoke(cmd_stop, [], obj={})
+
+        assert result.exit_code == 0, result.output
+        # The foreground PID must have been signaled.
+        kill_mock.assert_called_once_with(12345, 15)  # SIGTERM = 15
+        # Output mentions both stop methods
+        assert "launchd daemon unloaded" in result.output
+        assert "PID 12345" in result.output
+
+    def test_reports_not_running_when_nothing_to_stop(self, tmp_path, monkeypatch):
+        # No plist, no systemd unit, no foreground process.
+        monkeypatch.setattr("ocw.cli.cmd_stop.Path.home", lambda: tmp_path)
+        with patch("ocw.cli.cmd_stop._find_serve_pid", return_value=None):
+            result = CliRunner().invoke(cmd_stop, [], obj={})
+        assert result.exit_code == 0
+        assert "not running" in result.output

--- a/tests/unit/test_cmd_stop.py
+++ b/tests/unit/test_cmd_stop.py
@@ -40,6 +40,25 @@ class TestStopSweepsForegroundProcesses:
         assert "launchd daemon unloaded" in result.output
         assert "PID 12345" in result.output
 
+    def test_does_not_loop_on_slow_shutdown(self, tmp_path, monkeypatch):
+        """SIGTERM is async — if the target process hasn't exited before the
+        next pgrep, the sweep must NOT re-signal the same PID. Otherwise a
+        slow shutdown handler can make `ocw stop` hang forever."""
+        monkeypatch.setattr("ocw.cli.cmd_stop.Path.home", lambda: tmp_path)
+        kill_mock = MagicMock()
+        # pgrep keeps returning the same PID — simulates a process whose
+        # SIGTERM handler hasn't completed yet.
+        find_pid_mock = MagicMock(side_effect=[12345] * 50)
+
+        with patch("ocw.cli.cmd_stop.os.kill", kill_mock), \
+             patch("ocw.cli.cmd_stop._find_serve_pid", find_pid_mock):
+            result = CliRunner().invoke(cmd_stop, [], obj={})
+
+        assert result.exit_code == 0
+        # SIGTERM sent exactly once even though pgrep saw the PID 50 times.
+        assert kill_mock.call_count == 1
+        kill_mock.assert_called_once_with(12345, 15)
+
     def test_reports_not_running_when_nothing_to_stop(self, tmp_path, monkeypatch):
         # No plist, no systemd unit, no foreground process.
         monkeypatch.setattr("ocw.cli.cmd_stop.Path.home", lambda: tmp_path)

--- a/tests/unit/test_onboard_daemon.py
+++ b/tests/unit/test_onboard_daemon.py
@@ -63,3 +63,26 @@ class TestDaemonAlreadyRunning:
         """Returns False on unsupported platforms."""
         monkeypatch.setattr("ocw.cli.cmd_onboard.platform.system", lambda: "Windows")
         assert _daemon_already_running() is False
+
+
+class TestLaunchdInstallUsesWFlag:
+    """`_install_launchd` must pass -w to both unload and load so it clears
+    the Disabled=true flag that `ocw stop` writes (C1)."""
+
+    def test_load_uses_w_flag(self, tmp_path, monkeypatch):
+        from ocw.cli.cmd_onboard import _install_launchd
+        monkeypatch.setattr("ocw.cli.cmd_onboard.Path.home", lambda: tmp_path)
+        monkeypatch.setattr("ocw.cli.cmd_onboard.shutil.which", lambda _: "/usr/bin/ocw")
+
+        run_mock = MagicMock(return_value=MagicMock(returncode=0))
+        with patch("ocw.cli.cmd_onboard.subprocess.run", run_mock):
+            _install_launchd("/tmp/cfg.toml")
+
+        # Both unload and load must include -w
+        calls = [c.args[0] for c in run_mock.call_args_list]
+        assert any("unload" in c and "-w" in c for c in calls), (
+            f"unload should use -w; calls were {calls}"
+        )
+        assert any("load" in c and "-w" in c for c in calls), (
+            f"load should use -w; calls were {calls}"
+        )


### PR DESCRIPTION
## Summary

Fixes a cluster of onboarding/daemon-lifecycle bugs found during the manual pre-release test run.

### C2/C3 — `ocw onboard --codex` writes to global config now
Was: `--codex` resolved the config path via `server.state` then `find_config_file`, falling back to global. When `ocw serve` ran from a project directory, that resolved to project-local `.ocw/config.toml`, and onboard silently rotated the project-local secret — breaking the running server's auth. Now mirrors `--claude-code` and always writes to `~/.config/ocw/config.toml`. Codex's own config is global and `codex_exec` is project-agnostic, so per-project OCW configs add no value.

### C1 — Daemon skip-reinstall actually fires now
`_install_launchd` did `launchctl unload <plist>` + plain `launchctl load <plist>`. `ocw stop` writes Disabled=true via `launchctl unload -w`, and a plain load does NOT clear that flag — so the daemon stays disabled in launchd's database while `launchctl load` returns 0 from a silently-noop'd call. Result: every re-onboard fell through to "Daemon: installing..." instead of "skipped reinstall" (the UX PR #36 was designed to prevent). Added `-w` to both unload and load.

### C4 — Codex skip-on-rerun message renders correctly
Used `console.print()` for messages containing `[otel]`, which Rich treats as a markup tag and strips. Output was `"already has  and  sections."` Switched to `click.echo()` for plain text.

### C6 — `ocw stop` actually stops everything
Returned immediately after a successful `launchctl unload`, leaving any orphan foreground `ocw serve &` running and holding port 7391. Now loops through `_find_serve_pid()` after the unload to sweep foreground stragglers; reports all stop methods used.

## Test plan

- [x] `pytest tests/unit/ tests/synthetic/ tests/agents/ tests/integration/` — 402 passed (+3 new)
- [x] `ruff check ocw/` — clean
- [x] Manual: `_install_launchd` test asserts both subprocess calls include `-w`
- [x] Manual: `cmd_stop` test asserts the foreground sweep loop runs after launchd unload and signals SIGTERM to discovered PIDs
- [ ] End-to-end re-test the playbook Claude Code + Codex sections after merge:
  - [ ] Second `ocw onboard --claude-code` shows "Daemon: already running (skipped reinstall)"
  - [ ] `ocw onboard --codex` writes to `~/.config/ocw/config.toml`, not project-local
  - [ ] Codex skip-on-rerun message reads `"already has [otel] and [mcp_servers.ocw] sections."`
  - [ ] `ocw stop` after `ocw serve &` actually frees port 7391

🤖 Generated with [Claude Code](https://claude.com/claude-code)