### PR TITLE
Fix ocw status API mode, traces TYPE column, and drift UI rendering

### DIFF
--- a/ocw/api/routes/drift.py
+++ b/ocw/api/routes/drift.py
@@ -38,7 +38,9 @@ def _build_agent_drift(db: Any, agent_id: str) -> dict:
             "avg_output_tokens": baseline.avg_output_tokens,
             "stddev_output_tokens": baseline.stddev_output_tokens,
             "avg_session_duration_s": baseline.avg_session_duration_s,
+            "stddev_session_duration": baseline.stddev_session_duration,
             "avg_tool_call_count": baseline.avg_tool_call_count,
+            "stddev_tool_call_count": baseline.stddev_tool_call_count,
         },
         "latest_session": latest,
     }

--- a/ocw/core/api_backend.py
+++ b/ocw/core/api_backend.py
@@ -23,6 +23,7 @@ from ocw.core.models import (
     TraceFilters,
     TraceRecord,
 )
+from ocw.utils.time_parse import utcnow
 
 
 class ApiBackend:
@@ -165,7 +166,7 @@ class ApiBackend:
         return [SessionRecord(
             session_id=a["session_id"],
             agent_id=a.get("agent_id") or agent_id,
-            started_at=datetime.fromisoformat(started_at) if started_at else datetime.utcnow(),
+            started_at=datetime.fromisoformat(started_at) if started_at else utcnow(),
             ended_at=None,
             conversation_id=None,
             status=a.get("status", "completed"),

--- a/ocw/core/api_backend.py
+++ b/ocw/core/api_backend.py
@@ -147,8 +147,35 @@ class ApiBackend:
         return data.get("total_cost_usd", 0.0)
 
     def get_completed_sessions(self, agent_id: str, limit: int) -> list[SessionRecord]:
-        # Not available via API — return empty list, status will degrade gracefully
-        return []
+        # Use /api/v1/status which already returns the latest session per agent
+        # with token counts and tool_call_count populated. Without this,
+        # `ocw status` over a running server shows every agent as "idle" with
+        # zeros even when sessions exist (U3).
+        try:
+            data = self._get("/api/v1/status", {"agent_id": agent_id})
+        except (httpx.HTTPError, ValueError):
+            return []
+        agents = data.get("agents", [])
+        if not agents:
+            return []
+        a = agents[0]
+        if not a.get("session_id"):
+            return []
+        started_at = a.get("started_at")
+        return [SessionRecord(
+            session_id=a["session_id"],
+            agent_id=a.get("agent_id") or agent_id,
+            started_at=datetime.fromisoformat(started_at) if started_at else datetime.utcnow(),
+            ended_at=None,
+            conversation_id=None,
+            status=a.get("status", "completed"),
+            total_cost_usd=a.get("total_cost_usd"),
+            input_tokens=a.get("input_tokens", 0) or 0,
+            output_tokens=a.get("output_tokens", 0) or 0,
+            cache_tokens=0,
+            tool_call_count=a.get("tool_call_count", 0) or 0,
+            error_count=a.get("error_count", 0) or 0,
+        )][:limit]
 
     def get_completed_session_count(self, agent_id: str) -> int:
         return 0

--- a/ocw/core/db.py
+++ b/ocw/core/db.py
@@ -434,10 +434,12 @@ class DuckDBBackend:
             params.append(filters.status)
             idx += 1
         where = " AND ".join(clauses) if clauses else "1=1"
+        # Use FIRST(name ORDER BY start_time) to pick the root span name —
+        # the previous correlated-subquery variant returned NULL for most
+        # rows in DuckDB, leaving the TYPE column blank in `ocw traces` (U2).
         sql = (
             f"SELECT trace_id, MAX(agent_id) AS agent_id, "
-            f"(SELECT name FROM spans s2 WHERE s2.trace_id = spans.trace_id "
-            f" ORDER BY start_time LIMIT 1) AS name, "
+            f"FIRST(name ORDER BY start_time) AS name, "
             f"MIN(start_time) AS start_time, "
             f"SUM(duration_ms) AS duration_ms, "
             f"SUM(cost_usd) AS cost_usd, "

--- a/ocw/ui/index.html
+++ b/ocw/ui/index.html
@@ -984,16 +984,29 @@ function DriftView() {
                 const std = a.baseline[stdKey];
                 const latest = a.latest_session ? a.latest_session[latestKey] : null;
                 let z = null;
-                if (avg != null && std != null && std > 0 && latest != null) {
-                  z = (latest - avg) / std;
+                let zDisplay = '-';
+                if (avg != null && latest != null) {
+                  if (std != null && std > 0) {
+                    z = (latest - avg) / std;
+                    zDisplay = z.toFixed(2);
+                  } else if (std === 0 || std == null) {
+                    // Match drift.py z_score: inf when stddev=0 and value != mean
+                    if (latest !== avg) {
+                      z = Infinity;
+                      zDisplay = 'inf';
+                    } else {
+                      z = 0;
+                      zDisplay = '0.00';
+                    }
+                  }
                 }
-                const pass = z == null || Math.abs(z) < 2;
+                const pass = z == null || (Number.isFinite(z) && Math.abs(z) < 2);
                 return html`
                   <tr>
                     <td>${label}</td>
                     <td class="mono">${avg != null ? avg.toFixed(1) : '-'}${std != null ? ' +/- ' + std.toFixed(1) : ''}</td>
                     <td class="mono">${latest != null ? (typeof latest === 'number' ? latest.toFixed(1) : latest) : '-'}</td>
-                    <td class="mono" style="color:${pass ? 'var(--success)' : 'var(--error)'}">${z != null ? z.toFixed(2) : '-'}</td>
+                    <td class="mono" style="color:${pass ? 'var(--success)' : 'var(--error)'}">${zDisplay}</td>
                     <td><span class="badge ${pass ? 'badge-ok' : 'badge-critical'}">${pass ? 'pass' : 'drift'}</span></td>
                   </tr>
                 `;


### PR DESCRIPTION
## Summary

Three observability bugs surfaced during the manual pre-release test run.

### U1 — Web UI Drift page shows "pass" when CLI shows DRIFTED
The UI Z-score logic short-circuited to "pass" whenever stddev was 0 — which is exactly the case the demo produces (12 baseline sessions with identical token counts produce stddev=0). The CLI handles this via `drift.py:z_score()` returning inf when stddev=0 and value != mean. Mirrored that in the UI: when stddev is 0/null and latest != avg, render "inf" and flag drift; only treat as pass when latest == avg.

The `/api/v1/drift` response also needed `stddev_session_duration` and `stddev_tool_call_count` — the UI referenced them but the route was omitting them, so even with the fixed logic those rows had no stddev to evaluate against.

### U2 — `ocw traces` TYPE column blank for most rows
`DuckDBBackend.get_traces` used a correlated subquery `(SELECT name FROM spans s2 WHERE s2.trace_id = spans.trace_id ORDER BY start_time LIMIT 1)` that DuckDB evaluated non-deterministically when the outer table was un-aliased — returned NULL for most rows. Replaced with `FIRST(name ORDER BY start_time)`. Verified end-to-end against the test DB: 17/17 traces now populate the TYPE column.

### U3 — `cmd_status` returns idle/0 in API mode
`ApiBackend.get_completed_sessions` was a hardcoded `return []` stub with a "degrade gracefully" comment. `cmd_status` reads token/tool counts through that path, so every agent rendered as "idle" with all zeros while ocw serve was running. The `/api/v1/status` endpoint already returns full session info; reuse it to construct the SessionRecord.

## Test plan

- [x] `pytest tests/unit/ tests/synthetic/ tests/agents/ tests/integration/` — 399 passed
- [x] `ruff check ocw/` — clean
- [x] `ocw traces` shows `invoke_agent` for every row in the test DB (was: blank for ~15/17)
- [x] `python3 -c "..."` SQL test confirms `FIRST(name ORDER BY ...)` returns the root span name for all traces
- [ ] After merge: re-run pre-release playbook step 17 (`ocw status` over running server) and confirm session totals are populated, not zeros
- [ ] After merge: open the web UI Drift tab against the demo data and confirm it shows DRIFTED with inf Z-scores, not "pass"

🤖 Generated with [Claude Code](https://claude.com/claude-code)