### PR TITLE
Release 0.1.9: server.state fix, playbook fixes, version bump

### DIFF
--- a/ocw/cli/cmd_serve.py
+++ b/ocw/cli/cmd_serve.py
@@ -53,17 +53,23 @@ def cmd_serve(ctx: click.Context, host: str | None, port: int | None,
         scheduler.shutdown(wait=False)
 
     # Write the resolved config path so other subcommands (e.g. onboard --codex)
-    # can find the secret this server is using regardless of CWD.
+    # can find the secret this server is using regardless of CWD. Defer the
+    # write to a FastAPI startup event so it only fires after uvicorn binds
+    # the port — otherwise a failed-to-bind serve clobbers the state file
+    # of the running daemon (D2).
     import json as _json
     _state_path = Path.home() / ".local" / "share" / "ocw" / "server.state"
-    _state_path.parent.mkdir(parents=True, exist_ok=True)
-    _state_path.write_text(
-        _json.dumps({
-            "config_path": str(config.config_path) if config.config_path else None,
-            "port": bind_port,
-            "pid": __import__("os").getpid(),
-        })
-    )
+
+    @app.on_event("startup")
+    async def _write_server_state() -> None:
+        _state_path.parent.mkdir(parents=True, exist_ok=True)
+        _state_path.write_text(
+            _json.dumps({
+                "config_path": str(config.config_path) if config.config_path else None,
+                "port": bind_port,
+                "pid": __import__("os").getpid(),
+            })
+        )
 
     console.print(f"[bold]ocw serve[/bold] starting on http://{bind_host}:{bind_port}")
     console.print(f"  API docs:    http://{bind_host}:{bind_port}/docs")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "openclawwatch"
-version = "0.1.8"
+version = "0.1.9"
 description = "Local-first OTel-native observability for Autonomous AI agents"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/sdk-ts/package-lock.json
+++ b/sdk-ts/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@openclawwatch/sdk",
-  "version": "0.1.7",
+  "version": "0.1.9",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@openclawwatch/sdk",
-      "version": "0.1.7",
+      "version": "0.1.9",
       "license": "MIT",
       "devDependencies": {
         "@types/node": "^25.5.0",

--- a/sdk-ts/package.json
+++ b/sdk-ts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclawwatch/sdk",
-  "version": "0.1.8",
+  "version": "0.1.9",
   "description": "TypeScript SDK for OpenClawWatch — local-first observability for AI agents",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/tests/manual-new-release-tests.md
+++ b/tests/manual-new-release-tests.md
@@ -113,9 +113,11 @@ ocw onboard --codex
 #         use ingest secret from running server,
 #         NOT write [otel.resource] block (Codex ignores it).
 
-# Verify secret synced between server and Codex config
-SERVER_SECRET=$(grep ingest_secret ~/.config/ocw/config.toml | cut -d'"' -f2)
-CODEX_SECRET=$(grep -oE 'Authorization=Bearer [^ "]+' ~/.codex/config.toml | cut -d' ' -f2)
+# Verify secret synced between server and Codex config.
+# ~/.codex/config.toml uses TOML format `Authorization = "Bearer <secret>"`,
+# so the grep must allow the spaces around `=` and the surrounding quotes.
+SERVER_SECRET=$(grep ingest_secret ~/.config/ocw/config.toml | sed 's/.*= "//' | tr -d '"')
+CODEX_SECRET=$(grep -oE 'Bearer [^"]+' ~/.codex/config.toml | sed 's/Bearer //')
 [ "$SERVER_SECRET" = "$CODEX_SECRET" ] && echo "ok: secret synced"
 
 # Re-run is a no-op when both [otel] and [mcp_servers.ocw] already present

--- a/tests/manual-pre-release-testing.md
+++ b/tests/manual-pre-release-testing.md
@@ -134,9 +134,12 @@ ocw onboard --claude-code
 #         auto-install daemon
 #         create ~/.config/ocw/projects.json with current cwd
 
-# Verify global config (not project-local)
+# Verify global config exists.
+# Note: a project-local `.ocw/config.toml` likely already exists from step 5's
+# `ocw onboard` — `--claude-code` does NOT delete or overwrite it; it only
+# writes to the global config. The "no project-local" check belongs in the
+# multi-project block below where cwd is genuinely fresh.
 test -f ~/.config/ocw/config.toml && echo "ok: global config"
-test ! -f ./.ocw/config.toml && echo "ok: no project-local config written"
 
 # Verify projects.json tracks the cwd
 cat ~/.config/ocw/projects.json   # should contain current working directory
@@ -156,6 +159,9 @@ ocw onboard --claude-code
 # [ ] ingest_secret in ~/.claude/settings.json unchanged from first onboard
 #     (so the original project's auth still works)
 cat ~/.config/ocw/projects.json
+# Confirm --claude-code did NOT create a project-local config in this fresh
+# directory (this dir has no preexisting .ocw/, so the check is meaningful here).
+test ! -f .ocw/config.toml && echo "ok: --claude-code did not create project-local config"
 cd ~/openclawwatch
 
 # Verify global config fallback: CLI works from a directory with no local config
@@ -195,9 +201,12 @@ cat ~/.codex/config.toml
 # [ ] Contains [mcp_servers.ocw] block
 # [ ] Does NOT contain [otel.resource] block
 
-# Verify secret matches the running server
-SERVER_SECRET=$(grep ingest_secret ~/.config/ocw/config.toml | cut -d'"' -f2)
-CODEX_SECRET=$(grep -oE 'Authorization=Bearer [^ "]+' ~/.codex/config.toml | cut -d' ' -f2)
+# Verify secret matches the running server.
+# Note: ~/.codex/config.toml uses TOML format `Authorization = "Bearer <secret>"`
+# (with spaces around `=` and surrounding quotes), so the grep must allow for
+# that — a literal `Authorization=Bearer ` pattern silently misses every match.
+SERVER_SECRET=$(grep ingest_secret ~/.config/ocw/config.toml | sed 's/.*= "//' | tr -d '"')
+CODEX_SECRET=$(grep -oE 'Bearer [^"]+' ~/.codex/config.toml | sed 's/Bearer //')
 [ "$SERVER_SECRET" = "$CODEX_SECRET" ] && echo "ok: secret synced" || echo "FAIL: secret mismatch"
 
 # Verify skip-on-rerun (must have BOTH [otel] and [mcp_servers.ocw])


### PR DESCRIPTION
## Summary

Final pre-release cleanup before tagging 0.1.9.

### D2 — server.state race
\`cmd_serve.py\` was writing \`~/.local/share/ocw/server.state\` synchronously before uvicorn's bind. When you tried to start a manual \`ocw serve &\` while the launchd daemon was already serving port 7391, the foreground process would write its own (stale) state — pointing at whatever config it was launched with — and *then* fail to bind. The launchd daemon's state file was overwritten silently. Move the write into a FastAPI \`@app.on_event(\"startup\")\` handler, which uvicorn fires only after a successful bind.

### D1 — Playbook secret-sync regex
\`grep -oE 'Authorization=Bearer ...' \` doesn't match the actual TOML format \`Authorization = \"Bearer <secret>\"\` (spaces around \`=\`, surrounding quotes). The check produced a false \`FAIL: secret mismatch\` on a working system. Switched to \`grep -oE 'Bearer [^\"]+'\` and same-style fix for SERVER_SECRET. Applied to both playbooks.

### Playbook path-check rearrangement
In the Claude Code section, \`test ! -f ./.ocw/config.toml\` ran from \`~/openclawwatch\`, which already has a project-local config from step 5's \`ocw onboard\`. The check silently failed (\`&& echo\` never fired). Moved the meaningful "no project-local" assertion into the multi-project block where cwd is genuinely fresh, and added a clarifying comment that \`--claude-code\` doesn't touch preexisting project-local configs.

### Version bump
- \`pyproject.toml\`: 0.1.8 → 0.1.9
- \`sdk-ts/package.json\`: 0.1.8 → 0.1.9 (+ package-lock.json regenerated)

## Test plan

- [x] \`pytest tests/unit/ tests/synthetic/ tests/agents/ tests/integration/\` — 403 passed
- [x] \`ruff check ocw/\` — clean
- [x] \`cd sdk-ts && npm test\` — 21 passed
- [x] Manual end-to-end playbook run earlier today confirmed all U/C bugs fixed; this PR is the cleanup pass before tagging
- [ ] After merge: tag \`v0.1.9\` and create the GitHub release. The publish-pypi.yml and publish-npm.yml workflows trigger on release-published events.

🤖 Generated with [Claude Code](https://claude.com/claude-code)