### PR TITLE
Point README icon to website-hosted SVG

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 <div align="center">
 
-<img src="https://opencla.watch/icon.svg" alt="TokenJam" width="72" height="72">
+<img src="https://tokenjam.dev/icon.svg" alt="TokenJam" width="72" height="72">
 
 # TokenJam
 


### PR DESCRIPTION
## Summary

Updates the README's logo \`<img src>\` from the old domain (\`https://opencla.watch/icon.svg\`) to the new website domain (\`https://tokenjam.dev/icon.svg\`).

Single source of truth: the website hosts \`icon.svg\`, and this repo references it. Updating the logo on tokenjam.dev flows through to the README automatically.

## ⚠️ Depends on

The website's \`icon.svg\` currently still has the **old** (compass/sunburst) design — the website's \`index.html\` was updated to use an inline SVG of the new TJ jam-jar mark, but the standalone \`icon.svg\` file at the site root wasn't.

A companion PR is needed in [\`Metabuilder-Labs/tokenjam-website\`](https://github.com/Metabuilder-Labs/tokenjam-website) to update \`icon.svg\` to the new mark **before** this README will render correctly. Until that ships, this PR will display the old logo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)