### PR TITLE
Dashboard UI: monochrome theme + light/dark/system toggle

### DIFF
--- a/tokenjam/ui/index.html
+++ b/tokenjam/ui/index.html
@@ -3,34 +3,36 @@
 <head>
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
-<title>Token Juice</title>
+<title>TokenJam</title>
+<link rel="icon" type="image/svg+xml" href="https://tokenjam.dev/icon.svg">
 <link rel="preconnect" href="https://fonts.googleapis.com">
-<link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400;500;600;700&display=swap" rel="stylesheet">
-<link href="https://fonts.googleapis.com/css2?family=Bricolage+Grotesque:wght@600;700;800&display=swap" rel="stylesheet">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link href="https://fonts.googleapis.com/css2?family=Geist:wght@100..900&family=Geist+Mono:wght@100..900&display=swap" rel="stylesheet">
 <style>
 :root {
-  --bg: #070d1a;
-  --surface: #0f1729;
-  --surface2: #1a2840;
-  --border: #1e2d4a;
-  --text: #e2e8f0;
-  --text-dim: #64748b;
+  --bg: #000;
+  --surface: #0a0a0a;
+  --surface2: #111;
+  --border: #1f1f1f;
+  --text: #ededed;
+  --text-dim: #a1a1a1;
+  --text-faint: rgba(237,237,237,0.4);
   --accent: #3d8eff;
-  --warn: #f59e0b;
-  --error: #ef4444;
-  --success: #22c55e;
+  --warn: #f5a623;
+  --error: #ee0000;
+  --success: #0ce490;
   --info: #3d8eff;
 }
 * { margin:0; padding:0; box-sizing:border-box; }
 body {
-  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Helvetica, Arial, sans-serif;
+  font-family: 'Geist', -apple-system, BlinkMacSystemFont, sans-serif;
   background: var(--bg);
   color: var(--text);
   display: flex;
   min-height: 100vh;
 }
 code, .mono {
-  font-family: 'IBM Plex Mono', monospace;
+  font-family: 'Geist Mono', monospace;
 }
 
 /* Sidebar */
@@ -49,7 +51,7 @@ code, .mono {
   z-index: 10;
 }
 .sidebar-brand {
-  font-family: 'Bricolage Grotesque', sans-serif;
+  font-family: 'Geist', sans-serif;
   font-weight: 700;
   font-size: 14px;
   color: var(--text);
@@ -68,7 +70,7 @@ code, .mono {
   padding: 8px 16px;
   color: var(--text-dim);
   text-decoration: none;
-  font-family: 'IBM Plex Mono', monospace;
+  font-family: 'Geist Mono', monospace;
   font-size: 13px;
   transition: background 0.15s, color 0.15s;
 }
@@ -87,7 +89,7 @@ code, .mono {
   padding: 8px 16px;
   color: var(--text-dim);
   text-decoration: none;
-  font-family: 'IBM Plex Mono', monospace;
+  font-family: 'Geist Mono', monospace;
   font-size: 13px;
   transition: background 0.15s, color 0.15s;
 }
@@ -96,7 +98,7 @@ code, .mono {
   padding: 4px 16px 8px;
   font-size: 10px;
   color: var(--text-dim);
-  font-family: 'IBM Plex Mono', monospace;
+  font-family: 'Geist Mono', monospace;
 }
 
 /* Main */
@@ -107,7 +109,7 @@ code, .mono {
   min-width: 0;
 }
 .page-title {
-  font-family: 'Bricolage Grotesque', sans-serif;
+  font-family: 'Geist', sans-serif;
   font-size: 20px;
   font-weight: 700;
   margin-bottom: 20px;
@@ -129,7 +131,7 @@ code, .mono {
   align-items: center;
   gap: 8px;
   margin-bottom: 12px;
-  font-family: 'IBM Plex Mono', monospace;
+  font-family: 'Geist Mono', monospace;
   font-weight: 600;
   font-size: 14px;
 }
@@ -147,7 +149,7 @@ code, .mono {
   justify-content: space-between;
   padding: 3px 0;
   font-size: 13px;
-  font-family: 'IBM Plex Mono', monospace;
+  font-family: 'Geist Mono', monospace;
 }
 .card-row .label { color: var(--text-dim); }
 .card-row .value { color: var(--text); }
@@ -187,12 +189,12 @@ code, .mono {
   transform: translateX(-50%);
   background: var(--surface2);
   color: var(--text);
-  border: 1px solid #2e4a70;
+  border: 1px solid var(--border);
   border-radius: 4px;
   padding: 7px 10px;
   font-size: 11px;
   line-height: 1.5;
-  font-family: 'IBM Plex Mono', monospace;
+  font-family: 'Geist Mono', monospace;
   white-space: normal;
   max-width: 260px;
   z-index: 100;
@@ -206,7 +208,7 @@ code, .mono {
 table {
   width: 100%;
   border-collapse: collapse;
-  font-family: 'IBM Plex Mono', monospace;
+  font-family: 'Geist Mono', monospace;
   font-size: 13px;
 }
 th {
@@ -238,14 +240,14 @@ tr.clickable:hover td.chevron { color: var(--accent); }
   border-radius: 10px;
   font-size: 11px;
   font-weight: 600;
-  font-family: 'IBM Plex Mono', monospace;
+  font-family: 'Geist Mono', monospace;
 }
-.badge-ok, .badge-completed { background: rgba(34,197,94,0.15); color: var(--success); }
-.badge-error { background: rgba(239,68,68,0.15); color: var(--error); }
-.badge-active { background: rgba(34,197,94,0.15); color: var(--success); }
-.badge-stale { background: rgba(245,158,11,0.15); color: var(--warn); }
-.badge-critical { background: rgba(239,68,68,0.15); color: var(--error); }
-.badge-warning { background: rgba(245,158,11,0.15); color: var(--warn); }
+.badge-ok, .badge-completed { background: rgba(12,228,144,0.15); color: var(--success); }
+.badge-error { background: rgba(238,0,0,0.15); color: var(--error); }
+.badge-active { background: rgba(12,228,144,0.15); color: var(--success); }
+.badge-stale { background: rgba(245,166,35,0.15); color: var(--warn); }
+.badge-critical { background: rgba(238,0,0,0.15); color: var(--error); }
+.badge-warning { background: rgba(245,166,35,0.15); color: var(--warn); }
 .badge-info { background: rgba(61,142,255,0.15); color: var(--info); }
 
 /* Filters */
@@ -262,7 +264,7 @@ tr.clickable:hover td.chevron { color: var(--accent); }
   color: var(--text);
   padding: 6px 10px;
   border-radius: 6px;
-  font-family: 'IBM Plex Mono', monospace;
+  font-family: 'Geist Mono', monospace;
   font-size: 12px;
 }
 .filters select:focus, .filters input:focus { outline: none; border-color: var(--accent); }
@@ -273,7 +275,7 @@ tr.clickable:hover td.chevron { color: var(--accent); }
   padding: 6px 12px;
   border-radius: 6px;
   cursor: pointer;
-  font-family: 'IBM Plex Mono', monospace;
+  font-family: 'Geist Mono', monospace;
   font-size: 12px;
 }
 .btn:hover { border-color: var(--accent); color: var(--accent); }
@@ -296,7 +298,7 @@ tr.clickable:hover td.chevron { color: var(--accent); }
 .wf-row.selected .wf-label { color: var(--accent); }
 .wf-label {
   flex-shrink: 0;
-  font-family: 'IBM Plex Mono', monospace;
+  font-family: 'Geist Mono', monospace;
   font-size: 12px;
   color: var(--text-dim);
   overflow: hidden;
@@ -312,11 +314,11 @@ tr.clickable:hover td.chevron { color: var(--accent); }
   top: calc(100% + 6px);
   left: 0;
   right: auto;
-  background: #1a2236;
+  background: var(--surface2);
   border: 1px solid var(--border);
   border-radius: 6px;
   padding: 8px 10px;
-  font-family: 'IBM Plex Mono', monospace;
+  font-family: 'Geist Mono', monospace;
   font-size: 11px;
   color: var(--text);
   white-space: pre;
@@ -335,15 +337,15 @@ tr.clickable:hover td.chevron { color: var(--accent); }
   display: flex;
   align-items: center;
   padding: 0 6px;
-  font-family: 'IBM Plex Mono', monospace;
+  font-family: 'Geist Mono', monospace;
   font-size: 10px;
   color: #fff;
   overflow: hidden;
   white-space: nowrap;
 }
-.wf-bar.agent { background: var(--success); color: #070d1a; }
+.wf-bar.agent { background: var(--success); color: var(--bg); }
 .wf-bar.llm { background: var(--accent); }
-.wf-bar.tool { background: var(--warn); color: #070d1a; }
+.wf-bar.tool { background: var(--warn); color: var(--bg); }
 .wf-bar.other { background: var(--text-dim); }
 
 /* Span detail */
@@ -353,7 +355,7 @@ tr.clickable:hover td.chevron { color: var(--accent); }
   border-radius: 8px;
   padding: 16px;
   margin-top: 16px;
-  font-family: 'IBM Plex Mono', monospace;
+  font-family: 'Geist Mono', monospace;
   font-size: 12px;
 }
 .span-detail h3 {
@@ -384,14 +386,14 @@ tr.clickable:hover td.chevron { color: var(--accent); }
   min-width: 140px;
 }
 .summary-label {
-  font-family: 'IBM Plex Mono', monospace;
+  font-family: 'Geist Mono', monospace;
   font-size: 11px;
   color: var(--text-dim);
   text-transform: uppercase;
   margin-bottom: 4px;
 }
 .summary-value {
-  font-family: 'IBM Plex Mono', monospace;
+  font-family: 'Geist Mono', monospace;
   font-size: 20px;
   font-weight: 600;
 }
@@ -405,7 +407,7 @@ tr.clickable:hover td.chevron { color: var(--accent); }
   margin-bottom: 16px;
 }
 .drift-section h3 {
-  font-family: 'Bricolage Grotesque', sans-serif;
+  font-family: 'Geist', sans-serif;
   font-size: 15px;
   font-weight: 700;
   margin-bottom: 12px;
@@ -430,7 +432,7 @@ tr.clickable:hover td.chevron { color: var(--accent); }
 .expand-toggle.open { transform: rotate(90deg); }
 
 /* Waterfall hint */
-.wf-hint { font-size: 11px; color: var(--text-dim); margin-top: 8px; font-family: 'IBM Plex Mono', monospace; }
+.wf-hint { font-size: 11px; color: var(--text-dim); margin-top: 8px; font-family: 'Geist Mono', monospace; }
 
 /* Alert detail expand */
 .alert-detail {
@@ -439,7 +441,7 @@ tr.clickable:hover td.chevron { color: var(--accent); }
   border-radius: 6px;
   padding: 12px;
   margin: 8px 12px;
-  font-family: 'IBM Plex Mono', monospace;
+  font-family: 'Geist Mono', monospace;
   font-size: 11px;
   white-space: pre-wrap;
   word-break: break-all;
@@ -450,7 +452,7 @@ tr.clickable:hover td.chevron { color: var(--accent); }
 <body>
 
 <nav class="sidebar">
-  <div class="sidebar-brand"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32" width="24" height="24" style="flex-shrink:0"><circle cx="16" cy="16" r="5" fill="var(--accent)"/><path d="M16 4v5M16 23v5M4 16h5M23 16h5" stroke="var(--accent)" stroke-width="2.5" stroke-linecap="round"/><path d="M8.2 8.2l3.5 3.5M20.3 20.3l3.5 3.5M20.3 11.7l3.5-3.5M8.2 23.8l3.5-3.5" stroke="var(--accent)" stroke-width="2" stroke-linecap="round" opacity="0.6"/></svg><span>Open<span class="brand-claw">Claw</span>Watch</span></div>
+  <div class="sidebar-brand"><svg xmlns="http://www.w3.org/2000/svg" viewBox="54 32 132 132" width="22" height="22" style="flex-shrink:0" fill="none" stroke="var(--accent)" stroke-width="8" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><rect x="74" y="44" width="92" height="20" rx="6" ry="6"/><path d="M 104 72 L 74 72 L 74 152 L 104 152"/><path d="M 136 72 L 166 72 L 166 152 L 136 152"/></svg><span>Token<span class="brand-claw">Jam</span></span></div>
   <a href="#/status" class="nav-link" data-view="status"><span class="icon">&bull;</span> Status</a>
   <a href="#/traces" class="nav-link" data-view="traces"><span class="icon">&diamond;</span> Traces</a>
   <a href="#/cost" class="nav-link" data-view="cost"><span class="icon">$</span> Cost</a>
@@ -459,7 +461,7 @@ tr.clickable:hover td.chevron { color: var(--accent); }
   <a href="#/budget" class="nav-link" data-view="budget"><span class="icon">$</span> Budget</a>
   <div class="sidebar-footer">
     <a href="/docs" target="_blank" class="footer-link"><span class="icon">&#x2737;</span> API docs</a>
-    <a href="https://github.com/Metabuilder-Labs/tokenjuice" target="_blank" class="footer-link"><span class="icon">&#x2197;</span> GitHub</a>
+    <a href="https://github.com/Metabuilder-Labs/tokenjam" target="_blank" class="footer-link"><span class="icon">&#x2197;</span> GitHub</a>
     <div class="version">v0.1.4</div>
   </div>
 </nav>
@@ -593,11 +595,11 @@ function StatusView() {
   useEffect(() => { load(); const t = setInterval(load, 5000); return () => clearInterval(t); }, [load]);
 
   if (!data) return html`<div class="empty">Loading...</div>`;
-  if (!data.agents.length) return html`<div class="empty">No agents found. Run an agent with ${'`@watch()`'} to start recording.<code>pip install tokenjuice && tj onboard</code></div>`;
+  if (!data.agents.length) return html`<div class="empty">No agents found. Run an agent with ${'`@watch()`'} to start recording.<code>pip install tokenjam && tj onboard</code></div>`;
 
   return html`
     <div class="page-title">Status</div>
-    <div style="font-size:12px;color:var(--text-dim);margin:-14px 0 16px;font-family:'IBM Plex Mono',monospace">Click on an agent tile for details</div>
+    <div style="font-size:12px;color:var(--text-dim);margin:-14px 0 16px;font-family:'Geist Mono',monospace">Click on an agent tile for details</div>
     <div class="cards">
       ${data.agents.map(a => html`
         <div class="card clickable" onClick=${() => { location.hash = '#/traces'; }}>
@@ -657,7 +659,7 @@ function TracesListView() {
 
   return html`
     <div class="page-title">Traces</div>
-    <div style="font-size:12px;color:var(--text-dim);margin:-14px 0 16px;font-family:'IBM Plex Mono',monospace">Click on a trace row for details</div>
+    <div style="font-size:12px;color:var(--text-dim);margin:-14px 0 16px;font-family:'Geist Mono',monospace">Click on a trace row for details</div>
     <div class="filters">
       <select value=${since} onChange=${e => setSince(e.target.value)}>
         <option value="1h">Last 1h</option>
@@ -758,7 +760,7 @@ function TraceDetailView({ traceId }) {
   return html`
     <button class="btn btn-back" onClick=${() => location.hash = '#/traces'}>\u2190 Back to traces</button>
     <div class="page-title">Trace details for ${agentName}</div>
-    <div style="font-size:12px;color:var(--text-dim);margin:-14px 0 16px;font-family:'IBM Plex Mono',monospace">Click a span for details</div>
+    <div style="font-size:12px;color:var(--text-dim);margin:-14px 0 16px;font-family:'Geist Mono',monospace">Click a span for details</div>
     <div class="waterfall">
       ${rows.map(({ span: s, depth }) => {
         const st = new Date(s.start_time).getTime() - traceStart;
@@ -798,7 +800,7 @@ function TraceDetailView({ traceId }) {
     ${sel ? html`
       <div class="span-detail">
         <h3>${friendlySpanName(sel.name)}</h3>
-        <div style="color:var(--text-dim);font-size:11px;margin:-8px 0 12px;font-family:'IBM Plex Mono',monospace">${sel.name}</div>
+        <div style="color:var(--text-dim);font-size:11px;margin:-8px 0 12px;font-family:'Geist Mono',monospace">${sel.name}</div>
         <div class="detail-grid">
           <span class="dk">Duration</span><span class="dv">${fmtDur(sel.duration_ms)}</span>
           <span class="dk">Status</span><span class="dv">${sel.status_code}</span>
@@ -973,7 +975,7 @@ function DriftView() {
       <div class="drift-section">
         <h3>${a.agent_id}</h3>
         ${!a.baseline ? html`<div style="color:var(--text-dim);font-size:13px">No baseline yet.</div>` : html`
-          <div style="font-size:12px;color:var(--text-dim);margin-bottom:12px;font-family:'IBM Plex Mono',monospace">
+          <div style="font-size:12px;color:var(--text-dim);margin-bottom:12px;font-family:'Geist Mono',monospace">
             Baseline: ${a.baseline.sessions_sampled} sessions sampled${a.baseline.computed_at ? ', computed ' + fmtAgo(a.baseline.computed_at) : ''}
           </div>
           <table>

--- a/tokenjam/ui/index.html
+++ b/tokenjam/ui/index.html
@@ -10,18 +10,39 @@
 <link href="https://fonts.googleapis.com/css2?family=Geist:wght@100..900&family=Geist+Mono:wght@100..900&display=swap" rel="stylesheet">
 <style>
 :root {
+  /* Dark theme (default) — Vercel-style monochrome, matches tokenjam.dev */
   --bg: #000;
   --surface: #0a0a0a;
   --surface2: #111;
+  --surface3: #1a1a1a;
   --border: #1f1f1f;
   --text: #ededed;
   --text-dim: #a1a1a1;
   --text-faint: rgba(237,237,237,0.4);
-  --accent: #3d8eff;
+  --accent: #ededed;            /* monochrome intensity (active/hover/focus) */
+  --accent-rgb: 255,255,255;     /* for rgba() tints */
+  --brand: #3d8eff;              /* brand blue — logo + LLM category fill only */
   --warn: #f5a623;
   --error: #ee0000;
   --success: #0ce490;
   --info: #3d8eff;
+}
+[data-theme="light"] {
+  --bg: #fff;
+  --surface: #fafafa;
+  --surface2: #f4f4f4;
+  --surface3: #eaeaea;
+  --border: #eaeaea;
+  --text: #000;
+  --text-dim: #666;
+  --text-faint: rgba(0,0,0,0.4);
+  --accent: #000;
+  --accent-rgb: 0,0,0;
+  --brand: #3d8eff;
+  --warn: #c47e0c;
+  --error: #cc0000;
+  --success: #0a8050;
+  --info: #0070f3;
 }
 * { margin:0; padding:0; box-sizing:border-box; }
 body {
@@ -62,7 +83,7 @@ code, .mono {
   align-items: center;
   gap: 8px;
 }
-.sidebar-brand .brand-claw { color: var(--accent); }
+.sidebar-brand .brand-mark { display: inline-flex; flex-shrink: 0; }
 .sidebar a {
   display: flex;
   align-items: center;
@@ -74,8 +95,8 @@ code, .mono {
   font-size: 13px;
   transition: background 0.15s, color 0.15s;
 }
-.sidebar a:hover { background: rgba(255,255,255,0.04); color: var(--text); }
-.sidebar a.active { color: var(--accent); background: rgba(61,142,255,0.08); }
+.sidebar a:hover { background: rgba(var(--accent-rgb),0.04); color: var(--text); }
+.sidebar a.active { color: var(--accent); background: rgba(var(--accent-rgb),0.08); }
 .sidebar a .icon { width: 16px; text-align: center; font-size: 14px; }
 .sidebar-footer {
   margin-top: auto;
@@ -93,12 +114,32 @@ code, .mono {
   font-size: 13px;
   transition: background 0.15s, color 0.15s;
 }
-.sidebar-footer a.footer-link:hover { background: rgba(255,255,255,0.04); color: var(--text); }
+.sidebar-footer a.footer-link:hover { background: rgba(var(--accent-rgb),0.04); color: var(--text); }
 .sidebar-footer .version {
   padding: 4px 16px 8px;
   font-size: 10px;
   color: var(--text-dim);
   font-family: 'Geist Mono', monospace;
+}
+.theme-toggle {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 8px 16px;
+  width: 100%;
+  background: transparent;
+  border: none;
+  text-align: left;
+  color: var(--text-dim);
+  font-family: 'Geist Mono', monospace;
+  font-size: 13px;
+  cursor: pointer;
+  transition: background 0.15s, color 0.15s;
+}
+.theme-toggle:hover { background: rgba(var(--accent-rgb),0.04); color: var(--text); }
+.theme-toggle .icon {
+  width: 16px; text-align: center; font-size: 14px;
+  display: inline-flex; align-items: center; justify-content: center;
 }
 
 /* Main */
@@ -227,9 +268,9 @@ td {
   border-bottom: 1px solid var(--border);
   white-space: nowrap;
 }
-tr:hover td { background: rgba(255,255,255,0.02); }
+tr:hover td { background: rgba(var(--accent-rgb),0.02); }
 tr.clickable { cursor: pointer; }
-tr.clickable:hover td { background: rgba(61,142,255,0.06); }
+tr.clickable:hover td { background: rgba(var(--accent-rgb),0.06); }
 td.chevron { color: var(--text-dim); font-size: 14px; text-align: center; width: 24px; }
 tr.clickable:hover td.chevron { color: var(--accent); }
 
@@ -291,10 +332,10 @@ tr.clickable:hover td.chevron { color: var(--accent); }
   border-radius: 4px;
   transition: background 0.1s;
 }
-.wf-row:hover { background: rgba(255,255,255,0.04); }
+.wf-row:hover { background: rgba(var(--accent-rgb),0.04); }
 .wf-row:hover .wf-label { color: var(--text); }
 .wf-row:hover .wf-bar { box-shadow: 0 0 8px rgba(61,142,255,0.25); }
-.wf-row.selected { background: rgba(61,142,255,0.08); border-left: 2px solid var(--accent); }
+.wf-row.selected { background: rgba(var(--accent-rgb),0.08); border-left: 2px solid var(--accent); }
 .wf-row.selected .wf-label { color: var(--accent); }
 .wf-label {
   flex-shrink: 0;
@@ -344,7 +385,7 @@ tr.clickable:hover td.chevron { color: var(--accent); }
   white-space: nowrap;
 }
 .wf-bar.agent { background: var(--success); color: var(--bg); }
-.wf-bar.llm { background: var(--accent); }
+.wf-bar.llm { background: var(--brand); }
 .wf-bar.tool { background: var(--warn); color: var(--bg); }
 .wf-bar.other { background: var(--text-dim); }
 
@@ -448,11 +489,20 @@ tr.clickable:hover td.chevron { color: var(--accent); }
   color: var(--text-dim);
 }
 </style>
+<script>
+  // Apply theme before paint to prevent flash of incorrect theme
+  (function () {
+    var pref = localStorage.getItem('tj-theme') || 'system';
+    var mql = window.matchMedia('(prefers-color-scheme: light)');
+    var isLight = pref === 'light' || (pref === 'system' && mql.matches);
+    document.documentElement.setAttribute('data-theme', isLight ? 'light' : 'dark');
+  })();
+</script>
 </head>
 <body>
 
 <nav class="sidebar">
-  <div class="sidebar-brand"><svg xmlns="http://www.w3.org/2000/svg" viewBox="54 32 132 132" width="22" height="22" style="flex-shrink:0" fill="none" stroke="var(--accent)" stroke-width="8" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><rect x="74" y="44" width="92" height="20" rx="6" ry="6"/><path d="M 104 72 L 74 72 L 74 152 L 104 152"/><path d="M 136 72 L 166 72 L 166 152 L 136 152"/></svg><span>Token<span class="brand-claw">Jam</span></span></div>
+  <div class="sidebar-brand"><svg class="brand-mark" xmlns="http://www.w3.org/2000/svg" viewBox="54 32 132 132" width="26" height="26" fill="none" stroke="currentColor" stroke-width="6" stroke-linecap="round" stroke-linejoin="round" aria-label="TokenJam"><rect x="74" y="44" width="92" height="20" rx="6" ry="6"/><path d="M 104 72 L 74 72 L 74 152 L 104 152"/><path d="M 136 72 L 166 72 L 166 152 L 136 152"/><g fill="currentColor" stroke="none" fill-rule="evenodd"><path transform="translate(85.68,104)" d="M21.19,-14.32 L16.75,-0.00 L13.63,-0.00 L10.74,-10.58 L7.85,-0.00 L4.73,-0.00 L0.26,-14.32 L3.27,-14.32 L6.26,-2.81 L9.31,-14.32 L12.40,-14.32 L15.32,-2.86 L18.28,-14.32 L21.19,-14.32 Z"/><path transform="translate(106.83,107)" d="M0.54,-7.50 L0.54,-8.75 L3.04,-8.75 L3.04,-0.00 L1.66,-0.00 L1.66,-7.50 L0.54,-7.50 Z M4.74,-7.50 L4.74,-8.75 L7.24,-8.75 L7.24,-0.00 L5.86,-0.00 L5.86,-7.50 L4.74,-7.50 Z"/><path transform="translate(123.97,104)" d="M21.19,-14.32 L16.75,-0.00 L13.63,-0.00 L10.74,-10.58 L7.85,-0.00 L4.73,-0.00 L0.26,-14.32 L3.27,-14.32 L6.26,-2.81 L9.31,-14.32 L12.40,-14.32 L15.32,-2.86 L18.28,-14.32 L21.19,-14.32 Z"/><path transform="translate(145.12,107)" d="M0.54,-7.50 L0.54,-8.75 L3.04,-8.75 L3.04,-0.00 L1.66,-0.00 L1.66,-7.50 L0.54,-7.50 Z M5.68,-1.86 Q6.83,-2.86 7.49,-3.50 Q8.16,-4.14 8.60,-4.84 Q9.05,-5.53 9.05,-6.23 Q9.05,-6.95 8.71,-7.36 Q8.36,-7.76 7.63,-7.76 Q6.92,-7.76 6.53,-7.31 Q6.14,-6.86 6.12,-6.11 L4.80,-6.11 Q4.84,-7.48 5.62,-8.20 Q6.41,-8.93 7.62,-8.93 Q8.93,-8.93 9.67,-8.21 Q10.40,-7.49 10.40,-6.29 Q10.40,-5.42 9.97,-4.63 Q9.53,-3.83 8.92,-3.20 Q8.32,-2.57 7.38,-1.74 L6.84,-1.26 L10.64,-1.26 L10.64,-0.12 L4.81,-0.12 L4.81,-1.12 L5.68,-1.86 Z"/><path transform="translate(84.35,128)" d="M21.19,-14.32 L16.75,-0.00 L13.63,-0.00 L10.74,-10.58 L7.85,-0.00 L4.73,-0.00 L0.26,-14.32 L3.27,-14.32 L6.26,-2.81 L9.31,-14.32 L12.40,-14.32 L15.32,-2.86 L18.28,-14.32 L21.19,-14.32 Z"/><path transform="translate(105.44,131)" d="M1.48,-1.86 Q2.63,-2.86 3.29,-3.50 Q3.96,-4.14 4.40,-4.84 Q4.85,-5.53 4.85,-6.23 Q4.85,-6.95 4.51,-7.36 Q4.16,-7.76 3.43,-7.76 Q2.72,-7.76 2.33,-7.31 Q1.94,-6.86 1.92,-6.11 L0.60,-6.11 Q0.64,-7.48 1.42,-8.20 Q2.21,-8.93 3.42,-8.93 Q4.73,-8.93 5.47,-8.21 Q6.20,-7.49 6.20,-6.29 Q6.20,-5.42 5.77,-4.63 Q5.33,-3.83 4.72,-3.20 Q4.12,-2.57 3.18,-1.74 L2.64,-1.26 L6.44,-1.26 L6.44,-0.12 L0.61,-0.12 L0.61,-1.12 L1.48,-1.86 Z M7.46,-7.50 L7.46,-8.75 L9.96,-8.75 L9.96,-0.00 L8.58,-0.00 L8.58,-7.50 L7.46,-7.50 Z"/><path transform="translate(122.64,128)" d="M21.19,-14.32 L16.75,-0.00 L13.63,-0.00 L10.74,-10.58 L7.85,-0.00 L4.73,-0.00 L0.26,-14.32 L3.27,-14.32 L6.26,-2.81 L9.31,-14.32 L12.40,-14.32 L15.32,-2.86 L18.28,-14.32 L21.19,-14.32 Z"/><path transform="translate(143.73,131)" d="M1.48,-1.86 Q2.63,-2.86 3.29,-3.50 Q3.96,-4.14 4.40,-4.84 Q4.85,-5.53 4.85,-6.23 Q4.85,-6.95 4.51,-7.36 Q4.16,-7.76 3.43,-7.76 Q2.72,-7.76 2.33,-7.31 Q1.94,-6.86 1.92,-6.11 L0.60,-6.11 Q0.64,-7.48 1.42,-8.20 Q2.21,-8.93 3.42,-8.93 Q4.73,-8.93 5.47,-8.21 Q6.20,-7.49 6.20,-6.29 Q6.20,-5.42 5.77,-4.63 Q5.33,-3.83 4.72,-3.20 Q4.12,-2.57 3.18,-1.74 L2.64,-1.26 L6.44,-1.26 L6.44,-0.12 L0.61,-0.12 L0.61,-1.12 L1.48,-1.86 Z M8.40,-1.86 Q9.55,-2.86 10.22,-3.50 Q10.88,-4.14 11.33,-4.84 Q11.77,-5.53 11.77,-6.23 Q11.77,-6.95 11.43,-7.36 Q11.09,-7.76 10.36,-7.76 Q9.65,-7.76 9.26,-7.31 Q8.87,-6.86 8.84,-6.11 L7.52,-6.11 Q7.56,-7.48 8.35,-8.20 Q9.13,-8.93 10.34,-8.93 Q11.65,-8.93 12.39,-8.21 Q13.13,-7.49 13.13,-6.29 Q13.13,-5.42 12.69,-4.63 Q12.25,-3.83 11.65,-3.20 Q11.04,-2.57 10.10,-1.74 L9.56,-1.26 L13.37,-1.26 L13.37,-0.12 L7.54,-0.12 L7.54,-1.12 L8.40,-1.86 Z"/></g></svg><span>TokenJam</span></div>
   <a href="#/status" class="nav-link" data-view="status"><span class="icon">&bull;</span> Status</a>
   <a href="#/traces" class="nav-link" data-view="traces"><span class="icon">&diamond;</span> Traces</a>
   <a href="#/cost" class="nav-link" data-view="cost"><span class="icon">$</span> Cost</a>
@@ -462,6 +512,7 @@ tr.clickable:hover td.chevron { color: var(--accent); }
   <div class="sidebar-footer">
     <a href="/docs" target="_blank" class="footer-link"><span class="icon">&#x2737;</span> API docs</a>
     <a href="https://github.com/Metabuilder-Labs/tokenjam" target="_blank" class="footer-link"><span class="icon">&#x2197;</span> GitHub</a>
+    <button class="theme-toggle" id="theme-toggle" aria-label="Toggle theme"><span class="icon" id="theme-icon">&#x2299;</span> <span id="theme-label">System</span></button>
     <div class="version">v0.1.4</div>
   </div>
 </nav>
@@ -1210,6 +1261,33 @@ function App() {
 }
 
 render(html`<${App} />`, document.getElementById('app'));
+</script>
+<script>
+  // Theme toggle: cycles dark → light → system
+  (function () {
+    var KEY = 'tj-theme';
+    var ICONS = { dark: '☾', light: '☀', system: '⊙' };  // ☾ ☀ ⊙
+    var LABELS = { dark: 'Dark', light: 'Light', system: 'System' };
+    var btn = document.getElementById('theme-toggle');
+    var iconEl = document.getElementById('theme-icon');
+    var labelEl = document.getElementById('theme-label');
+    var mql = window.matchMedia('(prefers-color-scheme: light)');
+    function apply(pref) {
+      var isLight = pref === 'light' || (pref === 'system' && mql.matches);
+      document.documentElement.setAttribute('data-theme', isLight ? 'light' : 'dark');
+      if (iconEl) iconEl.textContent = ICONS[pref];
+      if (labelEl) labelEl.textContent = LABELS[pref];
+      if (btn) btn.title = 'Theme: ' + pref + ' (click to cycle)';
+    }
+    var pref = localStorage.getItem(KEY) || 'system';
+    apply(pref);
+    if (btn) btn.addEventListener('click', function () {
+      pref = pref === 'system' ? 'light' : pref === 'light' ? 'dark' : 'system';
+      localStorage.setItem(KEY, pref);
+      apply(pref);
+    });
+    mql.addEventListener('change', function () { if (pref === 'system') apply(pref); });
+  })();
 </script>
 </body>
 </html>


### PR DESCRIPTION
## Summary

Aligns the local observability dashboard at \`tokenjam/ui/index.html\` with the [tokenjam.dev](https://tokenjam.dev) design system, and adds a Light/Dark/System theme toggle.

## Changes

**Logo & wordmark**
- Replaced the old compass SVG + "OpenClawWatch" text with the new TJ jar-mark — full inline SVG (rect + walls + 8 inner glyphs) using \`currentColor\` so it inherits text color (white in dark, black in light, matching the website).
- "TokenJam" wordmark is single-color (no blue "Jam" highlight — website is monochrome too).
- \`<title>\` and favicon updated.

**Color system** (matches website CSS vars)

| | Dark | Light |
|---|---|---|
| \`--bg\` | \`#000\` | \`#fff\` |
| \`--surface\` | \`#0a0a0a\` | \`#fafafa\` |
| \`--surface2\` | \`#111\` | \`#f4f4f4\` |
| \`--border\` | \`#1f1f1f\` | \`#eaeaea\` |
| \`--text\` | \`#ededed\` | \`#000\` |
| \`--text-dim\` | \`#a1a1a1\` | \`#666\` |
| \`--accent\` | \`#ededed\` | \`#000\` |
| \`--accent-rgb\` | \`255,255,255\` | \`0,0,0\` |
| \`--brand\` | \`#3d8eff\` (logo + LLM bar fill only) | same |
| \`--success\` | \`#0ce490\` | \`#0a8050\` |
| \`--warn\` | \`#f5a623\` | \`#c47e0c\` |
| \`--error\` | \`#ee0000\` | \`#cc0000\` |

\`--accent\` was previously \`#3d8eff\` (blue); it's now the monochrome intensity color so active states / focus / hover are white-on-faint-white in dark mode and black-on-faint-black in light mode. Tinted backgrounds use \`rgba(var(--accent-rgb), X)\` so they re-tint correctly per theme.

**Typography**
- Body: system → Geist
- Mono: IBM Plex Mono → Geist Mono
- Display: Bricolage Grotesque → Geist
- Single Google Fonts request via the variable-axis URL.

**Theme toggle**
- Button in sidebar footer cycles \`System ⊙\` → \`Light ☀\` → \`Dark ☾\`.
- Persisted in \`localStorage['tj-theme']\`. \`System\` mode reads \`prefers-color-scheme\` and live-updates if the OS theme switches.
- Anti-flash inline script in \`<head>\` applies the theme before paint.

**What's not changed**: layout, components, routing, all data-fetching JS. This is brand alignment + theming only.

## Test plan

- [x] \`pytest tests/unit/ tests/synthetic/ tests/agents/ tests/integration/\` → 403 passed (no Python regressions)
- [x] \`tj serve\` and load http://127.0.0.1:7391/ — visually confirmed by author: dashboard renders correctly in dark mode, logo/wordmark match brand, theme toggle cycles through all three states
- [ ] Verify in light mode (toggle to Light) — text contrast, status colors, selected/hover states

🤖 Generated with [Claude Code](https://claude.com/claude-code)