### PR TITLE
doctor: detect and repair DuckDB spans column-statistics corruption (#56)

### DIFF
--- a/tests/unit/test_spans_stats_repair.py
+++ b/tests/unit/test_spans_stats_repair.py
@@ -1,0 +1,99 @@
+"""Unit tests for the spans column-statistics corruption check + repair.
+
+The actual DuckDB v1.5.x bug (#56) is hard to reproduce synthetically — it
+arises from a specific bulk-write pattern that corrupts per-row-group min/max
+stats. These tests focus on the contract instead:
+
+  * `check_spans_stats_corruption` returns False on a healthy table.
+  * `check_spans_stats_corruption` returns False when the spans table is
+    empty (nothing to check, so nothing to fix).
+  * `repair_spans_stats` is idempotent and preserves all rows.
+"""
+from __future__ import annotations
+
+import duckdb
+import pytest
+
+from tokenjam.core.db import (
+    check_spans_stats_corruption,
+    repair_spans_stats,
+    run_migrations,
+)
+
+
+@pytest.fixture
+def conn(tmp_path):
+    """Fresh on-disk DuckDB with the standard migrations applied."""
+    path = tmp_path / "test.duckdb"
+    c = duckdb.connect(str(path))
+    run_migrations(c)
+    yield c
+    c.close()
+
+
+def _insert_minimal_span(conn, *, trace_id: str, span_id: str) -> None:
+    """Insert just enough to satisfy NOT NULL constraints; everything else NULL."""
+    import datetime as dt
+    now = dt.datetime.now(dt.timezone.utc)
+    conn.execute(
+        "INSERT INTO spans VALUES "
+        "($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12,$13,$14,$15,$16,$17,$18,$19,$20,$21,$22,$23)",
+        [
+            span_id, trace_id, None, "session-1",
+            "test-agent", "test-span", "internal", "ok",
+            None, now, now, 0,
+            "{}", None, None, None,
+            0, 0, 0, 0.0,
+            None, None, "[]",
+        ],
+    )
+
+
+class TestCheckSpansStatsCorruption:
+    def test_empty_table_returns_false(self, conn):
+        """No rows to check → no corruption → False (don't flag healthy emptiness)."""
+        assert check_spans_stats_corruption(conn) is False
+
+    def test_healthy_table_returns_false(self, conn):
+        for i in range(5):
+            _insert_minimal_span(conn, trace_id=f"trace{i:02d}", span_id=f"span{i:02d}")
+        assert check_spans_stats_corruption(conn) is False
+
+    def test_missing_table_returns_false(self, tmp_path):
+        """If the spans table doesn't exist (pre-migration), don't blow up."""
+        c = duckdb.connect(str(tmp_path / "fresh.duckdb"))
+        try:
+            assert check_spans_stats_corruption(c) is False
+        finally:
+            c.close()
+
+
+class TestRepairSpansStats:
+    def test_preserves_all_rows(self, conn):
+        for i in range(20):
+            _insert_minimal_span(conn, trace_id=f"trace{i:02d}", span_id=f"span{i:02d}")
+        before = conn.execute("SELECT COUNT(*) FROM spans").fetchone()[0]
+        assert before == 20
+        repair_spans_stats(conn)
+        after = conn.execute("SELECT COUNT(*) FROM spans").fetchone()[0]
+        assert after == 20
+
+    def test_preserves_span_data_exactly(self, conn):
+        _insert_minimal_span(conn, trace_id="abc123", span_id="span1")
+        before = conn.execute("SELECT trace_id, span_id, agent_id FROM spans").fetchone()
+        repair_spans_stats(conn)
+        after = conn.execute("SELECT trace_id, span_id, agent_id FROM spans").fetchone()
+        assert before == after
+
+    def test_idempotent_on_empty_table(self, conn):
+        """Running repair on a freshly-migrated empty table must not error."""
+        repair_spans_stats(conn)
+        # Table still exists and is queryable.
+        assert conn.execute("SELECT COUNT(*) FROM spans").fetchone()[0] == 0
+
+    def test_idempotent_when_called_twice(self, conn):
+        for i in range(3):
+            _insert_minimal_span(conn, trace_id=f"trace{i}", span_id=f"span{i}")
+        repair_spans_stats(conn)
+        repair_spans_stats(conn)
+        assert conn.execute("SELECT COUNT(*) FROM spans").fetchone()[0] == 3

--- a/tokenjam/cli/cmd_doctor.py
+++ b/tokenjam/cli/cmd_doctor.py
@@ -11,8 +11,14 @@ from tokenjam.utils.formatting import console
 
 @click.command("doctor")
 @click.option("--json", "output_json", is_flag=True)
+@click.option(
+    "--repair",
+    is_flag=True,
+    help="Attempt to fix issues that have a known repair path (e.g. rebuild the "
+         "spans table when DuckDB column statistics are corrupt — see issue #56).",
+)
 @click.pass_context
-def cmd_doctor(ctx: click.Context, output_json: bool) -> None:
+def cmd_doctor(ctx: click.Context, output_json: bool, repair: bool) -> None:
     """Run health checks on tj configuration and environment."""
     config = ctx.obj["config"]
     checks: list[dict] = []
@@ -41,11 +47,19 @@ def cmd_doctor(ctx: click.Context, output_json: bool) -> None:
     # 8. Webhook domain allowlist
     checks.extend(_check_webhook_allowlist(config))
 
+    # 9. DuckDB spans column-statistics corruption (issue #56)
+    spans_stats_check = _check_spans_stats(ctx.obj["db"])
+    checks.append(spans_stats_check)
+
     if output_json:
         click.echo(json.dumps(checks, default=str))
     else:
         for c in checks:
             _print_check(c)
+
+    # --repair: attempt fixes for any check that exposed a repair_action
+    if repair:
+        _attempt_repairs(checks, ctx.obj["db"], output_json)
 
     has_errors = any(c["level"] == "error" for c in checks)
     has_warnings = any(c["level"] == "warning" for c in checks)
@@ -157,6 +171,76 @@ def _check_webhook_allowlist(config: object) -> list[dict]:
                     "message": f"Webhook domain '{domain}' not in allowed list.",
                 })
     return results
+
+
+def _check_spans_stats(db: object) -> dict:
+    """Detect DuckDB v1.5.x spans column-statistics corruption (issue #56).
+
+    When stats are corrupt, `WHERE trace_id = X` returns 0 rows but the data
+    is still there (visible via `LIKE`). The fix is to rebuild the table.
+
+    Uses the already-open connection on `db` rather than opening a second
+    one — DuckDB rejects mixing read-only and read-write connections to the
+    same file from the same process.
+    """
+    from tokenjam.core.db import check_spans_stats_corruption
+
+    conn = getattr(db, "conn", None)
+    if conn is None:
+        return {"name": "Spans column statistics", "level": "info",
+                "message": "Skipped — non-DuckDB backend."}
+    try:
+        corrupt = check_spans_stats_corruption(conn)
+    except duckdb.Error as e:
+        return {"name": "Spans column statistics", "level": "info",
+                "message": f"Skipped — could not run canary query: {e}"}
+    if corrupt:
+        return {
+            "name": "Spans column statistics",
+            "level": "warning",
+            "message": "DuckDB column statistics on the spans table are corrupt "
+                       "— trace-detail queries (`tj traces <id>`, dashboard "
+                       "trace view) will return no spans. Run `tj doctor "
+                       "--repair` to rebuild the table (data is preserved). "
+                       "See issue #56.",
+            "repair_action": "rebuild_spans",
+        }
+    return {"name": "Spans column statistics", "level": "ok",
+            "message": "Column statistics are consistent."}
+
+
+def _attempt_repairs(checks: list[dict], db: object, output_json: bool) -> None:
+    """Run repair actions for any check that flagged one."""
+    from tokenjam.core.db import repair_spans_stats
+
+    conn = getattr(db, "conn", None)
+    for c in checks:
+        action = c.get("repair_action")
+        if not action:
+            continue
+        if action == "rebuild_spans":
+            if conn is None:
+                if not output_json:
+                    console.print(
+                        "  [yellow]Repair skipped — non-DuckDB backend.[/yellow]"
+                    )
+                continue
+            try:
+                before = conn.execute("SELECT COUNT(*) FROM spans").fetchone()[0]
+                repair_spans_stats(conn)
+                after = conn.execute("SELECT COUNT(*) FROM spans").fetchone()[0]
+            except duckdb.Error as e:
+                if not output_json:
+                    console.print(
+                        f"  [red]Repair failed — {e}. If the database is locked, "
+                        f"stop `tj serve` and retry.[/red]"
+                    )
+                continue
+            if not output_json:
+                console.print(
+                    f"  [green]Spans table rebuilt — {before} rows preserved "
+                    f"(verified: {after}).[/green]"
+                )
 
 
 def _is_local_url(url: str) -> bool:

--- a/tokenjam/cli/cmd_doctor.py
+++ b/tokenjam/cli/cmd_doctor.py
@@ -226,9 +226,11 @@ def _attempt_repairs(checks: list[dict], db: object, output_json: bool) -> None:
                     )
                 continue
             try:
-                before = conn.execute("SELECT COUNT(*) FROM spans").fetchone()[0]
+                before_row = conn.execute("SELECT COUNT(*) FROM spans").fetchone()
                 repair_spans_stats(conn)
-                after = conn.execute("SELECT COUNT(*) FROM spans").fetchone()[0]
+                after_row = conn.execute("SELECT COUNT(*) FROM spans").fetchone()
+                before = before_row[0] if before_row else 0
+                after = after_row[0] if after_row else 0
             except duckdb.Error as e:
                 if not output_json:
                     console.print(

--- a/tokenjam/core/db.py
+++ b/tokenjam/core/db.py
@@ -271,6 +271,69 @@ def _int_or_none(val: object) -> int | None:
 
 
 # ---------------------------------------------------------------------------
+# Column-statistics corruption check & repair (DuckDB v1.5.x bug)
+# ---------------------------------------------------------------------------
+# Under some write patterns, DuckDB's per-row-group min/max statistics for the
+# spans table get out of sync with the actual data. The equality fast-path then
+# skips every row group, so `WHERE trace_id = X` returns 0 rows even when the
+# data is clearly there. `WHERE trace_id LIKE X || '%'` works because it forces
+# a full scan that bypasses the bad stats.
+#
+# Detection: pick a known trace_id (via wildcard-LIKE), then verify that the
+# `=` predicate finds it too. If they disagree the table's stats are corrupt.
+#
+# Repair: copy the table to a fresh one and rename. CHECKPOINT alone does not
+# rebuild stats; only a full table copy does.
+#
+# See issue #56.
+
+
+def check_spans_stats_corruption(conn: duckdb.DuckDBPyConnection) -> bool:
+    """Return True if the spans table's column-equality fast-path is broken.
+
+    Samples up to 3 distinct trace_ids and compares `=` vs `LIKE col || '%'`
+    counts. Any mismatch indicates corrupt column statistics. Returns False
+    on an empty spans table (nothing to check, so nothing to fix).
+    """
+    try:
+        sample = conn.execute(
+            "SELECT DISTINCT trace_id FROM spans LIMIT 3"
+        ).fetchall()
+    except duckdb.Error:
+        return False
+    if not sample:
+        return False
+    for (tid,) in sample:
+        if tid is None:
+            continue
+        try:
+            eq = conn.execute(
+                "SELECT COUNT(*) FROM spans WHERE trace_id = $1", [tid]
+            ).fetchone()[0]
+            like = conn.execute(
+                "SELECT COUNT(*) FROM spans WHERE trace_id LIKE $1 || '%'", [tid]
+            ).fetchone()[0]
+        except duckdb.Error:
+            return False
+        if eq == 0 and like > 0:
+            return True
+    return False
+
+
+def repair_spans_stats(conn: duckdb.DuckDBPyConnection) -> None:
+    """Rebuild the spans table to refresh column statistics.
+
+    Idempotent — safe to call when the table is healthy. Data is preserved.
+    Caller is responsible for ensuring no other process holds a write lock on
+    the database file (DuckDB enforces exclusive write access).
+    """
+    conn.execute("CREATE TABLE _spans_repair AS SELECT * FROM spans")
+    conn.execute("DROP TABLE spans")
+    conn.execute("ALTER TABLE _spans_repair RENAME TO spans")
+    conn.execute("CHECKPOINT")
+
+
+# ---------------------------------------------------------------------------
 # DuckDBBackend
 # ---------------------------------------------------------------------------
 

--- a/tokenjam/core/db.py
+++ b/tokenjam/core/db.py
@@ -307,14 +307,17 @@ def check_spans_stats_corruption(conn: duckdb.DuckDBPyConnection) -> bool:
         if tid is None:
             continue
         try:
-            eq = conn.execute(
+            eq_row = conn.execute(
                 "SELECT COUNT(*) FROM spans WHERE trace_id = $1", [tid]
-            ).fetchone()[0]
-            like = conn.execute(
+            ).fetchone()
+            like_row = conn.execute(
                 "SELECT COUNT(*) FROM spans WHERE trace_id LIKE $1 || '%'", [tid]
-            ).fetchone()[0]
+            ).fetchone()
         except duckdb.Error:
             return False
+        # COUNT(*) always returns one row, but mypy doesn't know that.
+        eq = eq_row[0] if eq_row else 0
+        like = like_row[0] if like_row else 0
         if eq == 0 and like > 0:
             return True
     return False


### PR DESCRIPTION
Closes #56.

## What was broken

DuckDB v1.5.x can leave the \`spans\` table's per-row-group min/max statistics out of sync with the actual data after certain bulk-write patterns. The equality fast-path then trusts the stale stats and skips every row group, so \`WHERE trace_id = X\` returns 0 rows even when the data is clearly there. \`LIKE col || '%'\` works because it forces a full scan that bypasses the bad stats.

**User-visible symptom**: clicking a trace from the dashboard's Traces list hangs on "Loading trace..." indefinitely. The trace-detail endpoint (\`GET /api/v1/traces/{trace_id}\`) runs \`SELECT * FROM spans WHERE trace_id = $1\`, gets 0 rows, and returns \`{spans: [], span_count: 0}\`. \`CHECKPOINT\` does not refresh the stats; only a full table copy does.

## Fix

Two new helpers in \`tokenjam/core/db.py\`:

- **\`check_spans_stats_corruption(conn) -> bool\`** — samples up to 3 distinct \`trace_id\` values and compares \`=\` vs \`LIKE col || '%'\`. Returns True iff any sample row exists via LIKE but is invisible via \`=\`. Safe on empty / missing tables.
- **\`repair_spans_stats(conn) -> None\`** — idempotent rebuild (\`CREATE TABLE _spans_repair AS SELECT * FROM spans → DROP → RENAME → CHECKPOINT\`). Refreshes column statistics; every row preserved.

Wired into \`tj doctor\`:

- **New check #9**: "Spans column statistics". On detected corruption, surfaces a \`warning\` pointing at \`tj doctor --repair\`. On non-DuckDB backends / canary errors, emits an \`info\` line and exits cleanly (does not crash doctor).
- **New flag \`--repair\`**: after running all checks, executes the repair action attached to any check that flagged one. Currently only the spans rebuild. Reports rows preserved before/after.

Both the check and the repair share the existing writable connection on \`ctx.obj["db"]\` rather than opening a second one — DuckDB rejects mixing read-only and read-write connections to the same file from the same process. (This was a real bug I hit while iterating live; first revision opened a second \`read_only=True\` connection and got \`Connection Error: Can't open a connection to same database file with a different configuration\`.)

## Manual verification

\`\`\`
$ tj doctor
  ✓  Config file: Found and valid: .tj/config.toml
  ✓  DuckDB writable: ...
  ✓  Ingest secret: ...
  ✓  Prometheus: ...
  ✓  Schema vs capture: ...
  ✓  Drift detection: ...
  ✓  Webhook security: ...
  ✓  Spans column statistics: Column statistics are consistent.

$ tj doctor --help
...
  --repair  Attempt to fix issues that have a known repair path (e.g. rebuild
            the spans table when DuckDB column statistics are corrupt — see
            issue #56).

$ tj doctor --json | python3 -m json.tool
# emits structured records including the new "Spans column statistics" entry
\`\`\`

When the issue first appeared in my local DB, the workaround I ran manually was the same SQL \`repair_spans_stats\` now wraps — table count went from \`=\`-returning-0 to \`=\`-returning-14 immediately.

## Test plan

- [x] **7 new unit tests** in \`tests/unit/test_spans_stats_repair.py\` covering the contract:
  - \`check_spans_stats_corruption\`: empty table → False, healthy table → False, missing table → False (no crash on pre-migration DBs)
  - \`repair_spans_stats\`: preserves row count, preserves exact data, idempotent on empty table, idempotent across repeated calls
- [x] \`pytest tests/unit/ tests/synthetic/ tests/agents/ tests/integration/\` → **416 passed** (was 409, +7 new)
- [x] \`ruff check tokenjam/\` → clean
- [x] Live \`tj doctor\` and \`tj doctor --repair\` against my (now-healthy) DB — both run cleanly

## What's intentionally NOT in this PR

- **Auto-repair on \`tj serve\` startup** — destructive operation, prefer explicit \`--repair\`.
- **DuckDB version pin bump** — issue may or may not be fixed upstream; doctor-based detection works regardless.
- **Upstream report to DuckDB** — worth doing as a separate follow-up once we can reproduce the corruption synthetically.

🤖 Filed via Claude Code