### PR TITLE
Release 0.2.1

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "tokenjam"
-version = "0.2.0"
+version = "0.2.1"
 description = "TokenJam — local-first OTel-native observability for Autonomous AI agents"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/sdk-ts/package-lock.json
+++ b/sdk-ts/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@tokenjam/sdk",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@tokenjam/sdk",
-      "version": "0.2.0",
+      "version": "0.2.1",
       "license": "MIT",
       "devDependencies": {
         "@types/node": "^25.5.0",

--- a/sdk-ts/package.json
+++ b/sdk-ts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tokenjam/sdk",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "TypeScript SDK for TokenJam — local-first observability for AI agents",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",


### PR DESCRIPTION
## Summary
- Bump `pyproject.toml` and `sdk-ts/package.json` (+ lockfile) to 0.2.1
- Cut from `main` tip (e1b89e4) — includes spans/stats doctor repair (#56), Codex legacy purge, and deferred items from issue #48

## Test plan
- [ ] CI green (lint, mypy, pytest matrix, sdk-ts npm test)
- [ ] After merge: create GitHub release v0.2.1 → triggers `publish-pypi.yml` and `publish-npm.yml`
- [ ] Verify `pip install tokenjam==0.2.1` and `npm view @tokenjam/sdk@0.2.1`

🤖 Generated with [Claude Code](https://claude.com/claude-code)