### PR TITLE
Release 0.2.3

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "tokenjam"
-version = "0.2.2"
+version = "0.2.3"
 description = "TokenJam — local-first OTel-native observability for Autonomous AI agents"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/sdk-ts/package-lock.json
+++ b/sdk-ts/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@tokenjam/sdk",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@tokenjam/sdk",
-      "version": "0.2.2",
+      "version": "0.2.3",
       "license": "MIT",
       "devDependencies": {
         "@types/node": "^25.5.0",

--- a/sdk-ts/package.json
+++ b/sdk-ts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tokenjam/sdk",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "description": "TypeScript SDK for TokenJam — local-first observability for AI agents",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",


### PR DESCRIPTION
## What's new in 0.2.3

### Features

**`tj optimize`** — new command that surfaces cost-saving recommendations from data TokenJam has already captured. Two analyzers run over your existing spans:
- **Model-downgrade candidates** — flags sessions whose structural shape (short input, short output, few tool calls) matches a class of work where a cheaper model in the same provider family is worth reviewing. Surfaces example traces; never claims quality equivalence (the caveat line is in the dataclass default so it can't be removed by accident).
- **Budget projection** — per-provider monthly projection against any `[budget.<provider>]` ceiling you configure. Scopes spend by provider, shows exhaustion date and projected overage, and reports what the run rate would drop to if you acted on the downgrade candidates.

```
tj optimize                                # both analyzers, last 30d
tj optimize --only budget                  # just the projection
tj optimize --budget anthropic --budget-usd 50   # test a different ceiling
tj optimize --json                         # machine-readable
```

Runs alongside a live `tj serve` via a read-only DuckDB fallback. Also exposed as the new `get_optimize_report` MCP tool — your coding agent can ask itself "where could I save money?" mid-session.

**`tj backfill claude-code`** — new command that reads `~/.claude/projects/*.jsonl` and ingests historical sessions into the local DB. Idempotent (deterministic span IDs); safe to re-run. Auto-invoked at the end of `tj onboard --claude-code` so first-time users have history immediately and `tj optimize` returns real numbers on first run.

**`[budget.<provider>]` config sections** — new TOML section for periodic monthly budgets. Distinct from `[defaults.budget]` / `[agents.X.budget]` (which are per-agent alert thresholds). `tj onboard --claude-code` writes a sensible default `[budget.anthropic] usd = 200`.

**MCP server: 14 tools (up from 13).** Added `get_optimize_report`.

### Fixes / improvements

- Pricing lookup tolerates the dated `claude-<family>-<ver>-YYYYMMDD` model-name suffixes Anthropic ships (e.g. `claude-haiku-4-5-20251001`).
- Pricing table: added `claude-opus-4-7` and `claude-opus-4-5`.

### Docs

- README now leads with the `tj optimize` UX (real verbatim output, not fabricated numbers) and embeds five Web UI screenshots.
- CLAUDE.md gains a new rule (#14) codifying the honesty constraint on optimize output and a config section explaining the two distinct budget concepts.
- Manual test runbooks (`tests/manual-pre-release-testing.md`, `tests/manual-new-release-tests.md`) updated with steps for the new commands; duplicated Codex/Claude Code integration blocks trimmed.

### Commits since v0.2.2

- `0cba9c6` Add tj optimize feature: cost analyzers, backfill, [budget.*] config (#62)
- `0b805ac` Manual test docs: cover tj optimize + tj backfill; trim duplicated Codex/CC sections (#63)
- `e6ad89f` README: showcase tj optimize for Claude Code (#63)
- `3ad0307` README: replace fabricated tj optimize output with verbatim rendering (#63)
- `291e7bf` README: add Web UI screenshots (#63)
- `b0c54e7` Bump version to 0.2.3

## Test plan

- [x] `pytest tests/unit tests/synthetic tests/agents tests/integration` — 447/447 pass
- [x] `ruff check tokenjam/` — clean
- [x] `cd sdk-ts && npm test` — 21/21 pass
- [x] Smoke-tested `tj backfill claude-code` + `tj optimize` against real local Claude Code history (139 sessions, $400, 7 projects)
- [ ] After merge: tag `v0.2.3` triggers `publish-pypi.yml` and `publish-npm.yml`
- [ ] After publish: `pip install tokenjam==0.2.3` and `npm view @tokenjam/sdk@0.2.3` resolve

🤖 Generated with [Claude Code](https://claude.com/claude-code)