### PR TITLE
fix(v0.3.0): close all 11 pre-release findings + 2 API follow-ups (closes #68)

### DIFF
--- a/examples/alerts_and_drift/_shared.py
+++ b/examples/alerts_and_drift/_shared.py
@@ -7,6 +7,8 @@ runs, so demos work out of the box on a fresh `tj onboard`.
 """
 from __future__ import annotations
 
+import os
+import socket
 import sys
 from pathlib import Path
 from typing import Any
@@ -18,33 +20,81 @@ else:
 
 import tomli_w
 
-from tokenjam.core.config import find_config_file
+from tokenjam.core.config import SEARCH_PATHS, find_config_file
 
 
-def ensure_demo_agent_config(agent_id: str, agent_block: dict[str, Any]) -> Path:
-    """Idempotently merge `agent_block` into [agents.<agent_id>] in the active tj config.
+def ensure_demo_agent_config(
+    agent_id: str, agent_block: dict[str, Any]
+) -> list[Path]:
+    """Idempotently merge `agent_block` into [agents.<agent_id>] in every
+    tj config file that currently exists on disk.
 
-    Existing keys are left alone — this only fills in missing config so a tester
-    can override demo settings if they want. Writes to .tj/config.toml in the
-    cwd if no config exists yet. Returns the path written.
+    The original helper wrote to `find_config_file()` only — which returns
+    the first match in the search-path order (project-local before global).
+    That broke a real footgun (#68 §6 → §5): a tester who'd run
+    `tj onboard --claude-code` had a global config AND a project-local
+    config, the daemon was launched with the global one, but the helper
+    only updated the project-local file. Demo agents stayed invisible
+    to the running daemon and no alerts fired.
+
+    Now: write to every config file in SEARCH_PATHS that exists. Idempotent
+    merge — existing keys stay, only missing ones get added. Returns the
+    list of paths actually touched.
+
+    If no config file exists anywhere, creates .tj/config.toml in cwd as
+    a fallback (same as the old behaviour).
     """
-    cfg_path = find_config_file()
-    if cfg_path is None:
-        cfg_path = Path(".tj/config.toml")
-        cfg_path.parent.mkdir(parents=True, exist_ok=True)
-        data: dict[str, Any] = {}
-    else:
-        cfg_path = Path(cfg_path)
-        with cfg_path.open("rb") as f:
-            data = tomllib.load(f)
+    touched: list[Path] = []
+    for candidate in SEARCH_PATHS:
+        p = Path(candidate)
+        if not p.exists():
+            continue
+        _merge_into(p, agent_id, agent_block)
+        try:
+            touched.append(p.resolve())
+        except OSError:
+            touched.append(p)
+    if not touched:
+        fallback = Path(".tj/config.toml")
+        fallback.parent.mkdir(parents=True, exist_ok=True)
+        _merge_into(fallback, agent_id, agent_block, allow_create=True)
+        touched.append(fallback.resolve())
+    return touched
 
-    agents = data.setdefault("agents", {})
-    existing = agents.setdefault(agent_id, {})
-    _deep_merge_missing(existing, agent_block)
 
-    with cfg_path.open("wb") as f:
-        tomli_w.dump(data, f)
-    return cfg_path
+def warn_if_daemon_running() -> bool:
+    """Print a heads-up if a tj serve daemon is listening on the default port.
+
+    Demos write config changes that the AlertEngine needs to load. If the
+    daemon is up, it loaded config at startup and won't auto-reload on
+    file changes — alerts for the freshly-added demo agent will silently
+    fail to fire (issue #68 §6).
+
+    Returns True if a daemon appears to be running; the caller can choose
+    whether to abort, prompt the user, or just continue.
+    """
+    port = int(os.environ.get("TJ_PORT", "7391"))
+    s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    s.settimeout(0.2)
+    try:
+        running = s.connect_ex(("127.0.0.1", port)) == 0
+    except OSError:
+        running = False
+    finally:
+        s.close()
+    if running:
+        print(
+            "\n[demo] A tj serve daemon appears to be running on port "
+            f"{port}. The daemon's AlertEngine loaded its config at "
+            "startup and does NOT hot-reload — alerts for this demo's "
+            "agent will only fire if the daemon is restarted to pick "
+            "up the freshly-added config:\n"
+            "\n    tj stop && tj serve &\n"
+            "\nOr stop the daemon entirely (`tj stop`) so the SDK writes "
+            "directly to DuckDB and fires alerts in-process.\n",
+            file=sys.stderr,
+        )
+    return running
 
 
 def _deep_merge_missing(target: dict[str, Any], source: dict[str, Any]) -> None:
@@ -53,3 +103,24 @@ def _deep_merge_missing(target: dict[str, Any], source: dict[str, Any]) -> None:
             target[k] = v
         elif isinstance(v, dict) and isinstance(target[k], dict):
             _deep_merge_missing(target[k], v)
+
+
+def _merge_into(
+    cfg_path: Path,
+    agent_id: str,
+    agent_block: dict[str, Any],
+    *,
+    allow_create: bool = False,
+) -> None:
+    if cfg_path.exists():
+        with cfg_path.open("rb") as f:
+            data = tomllib.load(f)
+    elif allow_create:
+        data = {}
+    else:
+        return
+    agents = data.setdefault("agents", {})
+    existing = agents.setdefault(agent_id, {})
+    _deep_merge_missing(existing, agent_block)
+    with cfg_path.open("wb") as f:
+        tomli_w.dump(data, f)

--- a/examples/alerts_and_drift/budget_breach_demo.py
+++ b/examples/alerts_and_drift/budget_breach_demo.py
@@ -76,11 +76,16 @@ def run_expensive_agent() -> None:
 # ---------------------------------------------------------------------------
 
 if __name__ == "__main__":
-    from examples.alerts_and_drift._shared import ensure_demo_agent_config
+    from examples.alerts_and_drift._shared import (
+        ensure_demo_agent_config,
+        warn_if_daemon_running,
+    )
     ensure_demo_agent_config(
         "budget-demo",
         {"budget": {"daily_usd": 0.05, "session_usd": 0.02}},
     )
+    # Surface the "daemon already running" footgun before bootstrap (#68 §6).
+    warn_if_daemon_running()
 
     from tokenjam.sdk.bootstrap import ensure_initialised
     ensure_initialised()

--- a/examples/alerts_and_drift/drift_demo.py
+++ b/examples/alerts_and_drift/drift_demo.py
@@ -94,6 +94,14 @@ def run_anomalous_session() -> None:
 # ---------------------------------------------------------------------------
 
 if __name__ == "__main__":
+    # drift_demo doesn't need ensure_demo_agent_config because drift
+    # detection is on by default (DriftConfig.enabled = True). But it
+    # still needs to warn the user about a running daemon — without a
+    # restart, the daemon's DriftDetector won't reload thresholds set
+    # in tj.toml at runtime (#68 §6).
+    from examples.alerts_and_drift._shared import warn_if_daemon_running
+    warn_if_daemon_running()
+
     from tokenjam.sdk.bootstrap import ensure_initialised
     ensure_initialised()
 

--- a/examples/alerts_and_drift/sensitive_actions_demo.py
+++ b/examples/alerts_and_drift/sensitive_actions_demo.py
@@ -119,7 +119,10 @@ def run_sensitive_agent() -> None:
 # ---------------------------------------------------------------------------
 
 if __name__ == "__main__":
-    from examples.alerts_and_drift._shared import ensure_demo_agent_config
+    from examples.alerts_and_drift._shared import (
+        ensure_demo_agent_config,
+        warn_if_daemon_running,
+    )
     ensure_demo_agent_config(
         "sensitive-demo",
         {
@@ -130,6 +133,10 @@ if __name__ == "__main__":
             ],
         },
     )
+    # If the daemon's already up, the freshly-merged config won't reach
+    # its AlertEngine without a restart. Surface that loudly so users
+    # don't see "No active alerts" and get confused (#68 §6).
+    warn_if_daemon_running()
 
     from tokenjam.sdk.bootstrap import ensure_initialised
     ensure_initialised()

--- a/tests/manual-new-release-tests.md
+++ b/tests/manual-new-release-tests.md
@@ -132,12 +132,12 @@ tj stop
 ## Claude Code integration (smoke)
 
 ```bash
-tj onboard --claude-code --plan max_20x
+tj onboard --claude-code --plan max_5x   # substitute your actual plan
 cat ~/.claude/settings.json | python3 -m json.tool | grep -E "OTEL_LOGS_EXPORTER|OTEL_EXPORTER_OTLP_ENDPOINT"
 cat ~/.config/tj/projects.json   # current cwd present
 
 # Re-run is a quiet no-op
-tj onboard --claude-code --plan max_20x
+tj onboard --claude-code --plan max_5x   # substitute your actual plan
 
 # Backfill ran automatically during onboard — verify history is present
 tj cost --since 30d --agent claude-code-tokenjam || true

--- a/tests/manual-pre-release-testing.md
+++ b/tests/manual-pre-release-testing.md
@@ -7,6 +7,7 @@ Run through this sequence to test a branch before merging and cutting a release.
 - `ANTHROPIC_API_KEY` and `OPENAI_API_KEY` set (used by example agents)
 - Both in `~/tokenjam/.env.local`, sourced before running
 - A clean shell (`tj uninstall --yes && rm -rf ~/.tj ~/.config/tj .tj` if anything from a prior test lingers)
+- **No lingering daemon from a prior install.** Run `tj stop` early — if a previous `tj onboard` installed the launchd / systemd unit, the daemon may still be live with stale config. Verify with `launchctl list | grep tokenjam` (macOS) or `systemctl --user is-active tokenjam` (Linux).
 
 ## 1. Install and verify the build
 
@@ -35,25 +36,41 @@ pytest tests/unit/ tests/synthetic/ tests/agents/ tests/integration/
 ruff check tokenjam/
 ```
 
-**Pass criteria:** all tests green, ruff at or below the documented baseline (49 errors as of v0.3.x — none of them new).
+**Pass criteria:** all tests green, ruff clean (no errors). If ruff reports anything, only proceed if the errors are pre-existing on `main` — confirm by running `ruff check` on `main` first.
 
-## 3. Onboard with plan-tier prompts
+## 3. Onboard
 
 ```bash
 tj onboard --no-daemon   # daemon auto-starts otherwise; stop afterward
 ```
 
-Verify the onboard flow now prompts for **plan tier** (api / pro / max_5x / max_20x for Anthropic; api / plus / team / enterprise for OpenAI when applicable). Pick `api` for this test run so dollar-denominated rendering kicks in across the rest of the script.
+The bare `tj onboard` doesn't prompt for plan tier (plan tier is per-provider — it's set by the integration-specific flows). It only asks for a daily-budget number.
+
+Plan-tier prompting happens in `--claude-code` and `--codex`:
 
 ```bash
-# Confirm the plan landed in config.
-grep -A2 "^\[budget.anthropic\]" .tj/config.toml || grep -A2 "^\[budget.anthropic\]" ~/.config/tj/config.toml
-# [ ] shows plan = "api" (or whichever you picked)
+# Use whichever plan you actually have on the test machine.
+# The examples below use max_5x; substitute max_20x / pro / plus / etc.
+# as appropriate. The format of the expected output is what matters,
+# not the specific plan label.
+tj onboard --claude-code --plan max_5x --no-daemon
+# [ ] prompts for plan tier if --plan not provided
+# [ ] writes plan = "max_5x" under [budget.anthropic] in ~/.config/tj/config.toml
+
+# Confirm the plan landed.
+grep -A3 "^\[budget.anthropic\]" ~/.config/tj/config.toml
+# [ ] plan = "max_5x" (or whichever you picked)
 # [ ] does NOT auto-write usd = 200 (that default is gone in v0.3.x)
 
-# Test --reconfigure re-prompts against an existing config.
-tj onboard --reconfigure --plan max_20x   # non-interactive override
-# [ ] succeeds; plan field updated in config
+# --reconfigure on the integration paths actually re-prompts.
+tj onboard --claude-code --reconfigure --plan api
+# [ ] config updated; plan field flipped
+
+# Bare `tj onboard --reconfigure` is an error now (#68 §1) — points at
+# the integration-specific flows. Verify the explicit error renders.
+tj onboard --reconfigure --plan max_5x; echo "expected exit 1, got $?"
+# [ ] prints "--reconfigure has no effect without --claude-code or --codex"
+# [ ] exit code 1
 ```
 
 ## 4. Populate test data
@@ -164,13 +181,18 @@ tj optimize --json | python3 -c \
 Reconfigure to a subscription plan and re-run `tj optimize` — output should reframe.
 
 ```bash
-tj onboard --reconfigure --plan max_20x
+# Use the plan you actually have on this machine. Expected output shape:
+#   pro     → "Pro plan, $20/mo flat"
+#   max_5x  → "Max 5x plan, $100/mo flat"
+#   max_20x → "Max 20x plan, $200/mo flat"
+#   plus    → "ChatGPT Plus, $20/mo flat"
+tj onboard --claude-code --reconfigure --plan max_5x
 tj optimize
-# [ ] Header reads "(Max 20x plan, $200/mo flat)" + "Implied API value: $X — about Y× your plan cost"
+# [ ] Header reads "(<Plan label>, $<fee>/mo flat)" + "Implied API value: $X — about Y× your plan cost"
 # [ ] NO line that uses the word "spend" against a dollar figure
 # [ ] Downgrade body (if any) uses token-share framing, not "$X/mo savings"
 
-tj onboard --reconfigure --plan api
+tj onboard --claude-code --reconfigure --plan api
 tj optimize
 # [ ] Back to "$X spend (last 30d)..." header and dollar-denominated downgrade savings
 
@@ -306,7 +328,7 @@ tj stop
 ## Claude Code integration (if the change touches onboard / settings.json / daemon)
 
 ```bash
-tj onboard --claude-code --plan max_20x   # non-interactive
+tj onboard --claude-code --plan max_5x   # non-interactive
 # [ ] writes ~/.config/tj/config.toml (global, not project-local)
 # [ ] writes ~/.claude/settings.json with OTEL_EXPORTER_OTLP_ENDPOINT and Bearer header
 # [ ] registers MCP server if `claude` CLI on PATH
@@ -314,11 +336,11 @@ tj onboard --claude-code --plan max_20x   # non-interactive
 # [ ] adds cwd to ~/.config/tj/projects.json
 
 # Re-run is a quiet no-op (no duplicate "Background Items Added" notification on macOS)
-tj onboard --claude-code --plan max_20x
+tj onboard --claude-code --plan max_5x
 
 # Multi-project: secret must NOT rotate on second project
 mkdir -p /tmp/tj-test-project-2 && cd /tmp/tj-test-project-2 && git init -q
-tj onboard --claude-code --plan max_20x
+tj onboard --claude-code --plan max_5x
 # [ ] "Daemon: already running (skipped reinstall)"
 # [ ] ~/.config/tj/projects.json lists BOTH paths
 # [ ] ingest_secret in ~/.claude/settings.json unchanged from the first onboard
@@ -326,7 +348,7 @@ test ! -f .tj/config.toml && echo "ok: --claude-code did not create project-loca
 cd ~/tokenjam
 
 # --force does reinstall the daemon
-tj onboard --claude-code --plan max_20x --force
+tj onboard --claude-code --plan max_5x --force
 # [ ] "Daemon: installing..."
 
 tj mcp --help   # MCP server CLI exists

--- a/tests/unit/test_config_secret_divergence.py
+++ b/tests/unit/test_config_secret_divergence.py
@@ -1,0 +1,103 @@
+"""
+Test the diverged-secret warning at config-load time (#68 §5).
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from tokenjam.core.config import (
+    SEARCH_PATHS,
+    _reset_secret_divergence_warning,
+    load_config,
+)
+
+
+@pytest.fixture(autouse=True)
+def _reset_warning_state():
+    """Reset the once-per-process warning guard before every test."""
+    _reset_secret_divergence_warning()
+
+
+def _write_config(path: Path, *, secret: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(
+        'version = "1"\n'
+        '[security]\n'
+        f'ingest_secret = "{secret}"\n'
+    )
+
+
+def test_warns_when_project_and_global_diverge(tmp_path, monkeypatch, capsys):
+    """Project-local + global with different secrets → stderr warning."""
+    project_local = tmp_path / "project" / ".tj" / "config.toml"
+    global_cfg = tmp_path / "home" / ".config" / "tj" / "config.toml"
+    _write_config(project_local, secret="A" * 64)
+    _write_config(global_cfg, secret="B" * 64)
+
+    # Point the discovery + the helper at our temp paths.
+    monkeypatch.setattr(
+        "tokenjam.core.config.SEARCH_PATHS",
+        [project_local, global_cfg],
+    )
+
+    cfg = load_config(str(project_local))
+    captured = capsys.readouterr()
+
+    assert cfg.security.ingest_secret == "A" * 64
+    assert "warning: ingest_secret differs" in captured.err
+    assert ".tj/config.toml" in captured.err or str(project_local) in captured.err
+
+
+def test_no_warning_when_only_one_config_exists(tmp_path, monkeypatch, capsys):
+    """No global config → nothing to compare against → no warning."""
+    project_local = tmp_path / ".tj" / "config.toml"
+    _write_config(project_local, secret="A" * 64)
+
+    monkeypatch.setattr(
+        "tokenjam.core.config.SEARCH_PATHS",
+        [project_local, Path("/nonexistent/global/config.toml")],
+    )
+
+    load_config(str(project_local))
+    captured = capsys.readouterr()
+
+    assert "warning: ingest_secret" not in captured.err
+
+
+def test_no_warning_when_secrets_match(tmp_path, monkeypatch, capsys):
+    """Same secret in both configs → no divergence → no warning."""
+    project_local = tmp_path / "project" / ".tj" / "config.toml"
+    global_cfg = tmp_path / "home" / ".config" / "tj" / "config.toml"
+    _write_config(project_local, secret="SAME" + "x" * 60)
+    _write_config(global_cfg, secret="SAME" + "x" * 60)
+
+    monkeypatch.setattr(
+        "tokenjam.core.config.SEARCH_PATHS",
+        [project_local, global_cfg],
+    )
+
+    load_config(str(project_local))
+    captured = capsys.readouterr()
+    assert "warning: ingest_secret" not in captured.err
+
+
+def test_warning_fires_at_most_once_per_process(tmp_path, monkeypatch, capsys):
+    """Repeated load_config calls in one process emit the warning once."""
+    project_local = tmp_path / "project" / ".tj" / "config.toml"
+    global_cfg = tmp_path / "home" / ".config" / "tj" / "config.toml"
+    _write_config(project_local, secret="A" * 64)
+    _write_config(global_cfg, secret="B" * 64)
+
+    monkeypatch.setattr(
+        "tokenjam.core.config.SEARCH_PATHS",
+        [project_local, global_cfg],
+    )
+
+    load_config(str(project_local))
+    load_config(str(project_local))
+    load_config(str(project_local))
+
+    captured = capsys.readouterr()
+    assert captured.err.count("warning: ingest_secret differs") == 1

--- a/tests/unit/test_transport_401.py
+++ b/tests/unit/test_transport_401.py
@@ -1,0 +1,123 @@
+"""
+Test the SDK HttpTransport's 401 fail-fast behavior (#68 §2).
+
+Before this fix, a 401 from tj serve was silently retried 3× with
+exponential backoff (~6s of stalling per send), then the spans got
+buffered. Users hitting a config-secret mismatch saw their spans
+disappear and only a single line of warning output.
+
+After the fix:
+- 401 is detected, logged at ERROR level (loud), and the spans drop
+  immediately (no buffering — they'd never succeed).
+- dropped_auth_failures counter increments so `tj doctor` can later
+  surface cumulative loss to the user.
+- No 6s stall — fail fast.
+"""
+from __future__ import annotations
+
+from unittest.mock import patch, MagicMock
+
+import pytest
+
+from tokenjam.core.config import ApiConfig, SecurityConfig, TjConfig
+from tokenjam.sdk.transport import HttpTransport
+
+
+@pytest.fixture
+def transport() -> HttpTransport:
+    config = TjConfig(
+        version="1",
+        api=ApiConfig(host="127.0.0.1", port=7391),
+        security=SecurityConfig(ingest_secret="local-secret-aabbcc1122"),
+    )
+    return HttpTransport(config)
+
+
+def test_401_fails_fast_and_clears_buffer(transport):
+    """A 401 response should drop the spans immediately, no retry."""
+    spans = [{"span_id": "s1"}, {"span_id": "s2"}]
+
+    mock_resp = MagicMock()
+    mock_resp.status_code = 401
+
+    with patch("tokenjam.sdk.transport.httpx.post", return_value=mock_resp) as mock_post, \
+         patch("tokenjam.sdk.transport.time.sleep") as mock_sleep:
+        result = transport.send(spans)
+
+    assert result is False
+    # Critical: only one POST attempt (no retry). Pre-fix would have been 3.
+    assert mock_post.call_count == 1, (
+        "401 should not be retried — it won't change on retry"
+    )
+    # Critical: no exponential backoff sleep.
+    assert mock_sleep.call_count == 0, (
+        "401 should fail fast without waiting through backoff"
+    )
+    # Spans are dropped (cleared), not buffered for next attempt.
+    assert transport._buffer == []
+    # Counter incremented.
+    assert transport.dropped_auth_failures == 2
+
+
+def test_401_counter_accumulates_across_calls(transport):
+    """Successive 401s accumulate the dropped count."""
+    mock_resp = MagicMock()
+    mock_resp.status_code = 401
+
+    with patch("tokenjam.sdk.transport.httpx.post", return_value=mock_resp), \
+         patch("tokenjam.sdk.transport.time.sleep"):
+        transport.send([{"span_id": "a"}])
+        transport.send([{"span_id": "b"}, {"span_id": "c"}])
+        transport.send([{"span_id": "d"}])
+
+    assert transport.dropped_auth_failures == 4
+
+
+def test_non_401_errors_still_retry_and_buffer(transport):
+    """Non-401 4xx/5xx still get the original retry-and-buffer treatment."""
+    mock_resp = MagicMock()
+    mock_resp.status_code = 503
+
+    with patch("tokenjam.sdk.transport.httpx.post", return_value=mock_resp) as mock_post, \
+         patch("tokenjam.sdk.transport.time.sleep"):
+        result = transport.send([{"span_id": "x"}])
+
+    assert result is False
+    # Full 3 attempts (backoff between).
+    assert mock_post.call_count == 3
+    # Spans stay buffered (not dropped) — could succeed if server recovers.
+    assert transport._buffer == [{"span_id": "x"}]
+    # Auth-failure counter NOT incremented for non-401 errors.
+    assert transport.dropped_auth_failures == 0
+
+
+def test_success_path_unchanged(transport):
+    """Happy path: 2xx clears buffer and returns True."""
+    mock_resp = MagicMock()
+    mock_resp.status_code = 200
+
+    with patch("tokenjam.sdk.transport.httpx.post", return_value=mock_resp) as mock_post, \
+         patch("tokenjam.sdk.transport.time.sleep"):
+        result = transport.send([{"span_id": "ok"}])
+
+    assert result is True
+    assert mock_post.call_count == 1
+    assert transport._buffer == []
+    assert transport.dropped_auth_failures == 0
+
+
+def test_401_logs_secret_fingerprint(transport, caplog):
+    """The error message should include a truncated secret fingerprint."""
+    import logging
+    mock_resp = MagicMock()
+    mock_resp.status_code = 401
+
+    with patch("tokenjam.sdk.transport.httpx.post", return_value=mock_resp), \
+         patch("tokenjam.sdk.transport.time.sleep"), \
+         caplog.at_level(logging.ERROR, logger="tokenjam.sdk.transport"):
+        transport.send([{"span_id": "z"}])
+
+    assert any(
+        "local-se..." in r.message and "401" in r.message
+        for r in caplog.records
+    ), "error log should mention the truncated SDK secret + 401"

--- a/tokenjam/api/app.py
+++ b/tokenjam/api/app.py
@@ -73,6 +73,7 @@ def create_app(
     from tokenjam.api.routes.budget import router as budget_router
     from tokenjam.api.routes.agents import router as agents_router
     from tokenjam.api.routes.optimize import router as optimize_router
+    from tokenjam.api.routes.cost_compare import router as cost_compare_router
 
     app.include_router(spans_router, prefix="/api/v1")
     app.include_router(traces_router, prefix="/api/v1")
@@ -84,6 +85,7 @@ def create_app(
     app.include_router(budget_router, prefix="/api/v1")
     app.include_router(agents_router, prefix="/api/v1")
     app.include_router(optimize_router, prefix="/api/v1")
+    app.include_router(cost_compare_router, prefix="/api/v1")
     app.include_router(metrics_router)  # /metrics — no prefix
     app.include_router(otlp_router)  # /v1/traces, /v1/metrics, /v1/logs — no prefix
 

--- a/tokenjam/api/app.py
+++ b/tokenjam/api/app.py
@@ -72,6 +72,7 @@ def create_app(
     from tokenjam.api.routes.otlp import router as otlp_router
     from tokenjam.api.routes.budget import router as budget_router
     from tokenjam.api.routes.agents import router as agents_router
+    from tokenjam.api.routes.optimize import router as optimize_router
 
     app.include_router(spans_router, prefix="/api/v1")
     app.include_router(traces_router, prefix="/api/v1")
@@ -82,6 +83,7 @@ def create_app(
     app.include_router(status_router, prefix="/api/v1")
     app.include_router(budget_router, prefix="/api/v1")
     app.include_router(agents_router, prefix="/api/v1")
+    app.include_router(optimize_router, prefix="/api/v1")
     app.include_router(metrics_router)  # /metrics — no prefix
     app.include_router(otlp_router)  # /v1/traces, /v1/metrics, /v1/logs — no prefix
 

--- a/tokenjam/api/routes/cost_compare.py
+++ b/tokenjam/api/routes/cost_compare.py
@@ -1,0 +1,75 @@
+"""
+GET /api/v1/cost/compare — server-side period comparison.
+
+Restores `tj cost --compare` and `tj optimize --compare` under
+daemon-up mode. Like /api/v1/optimize (#68 §12), this exists because
+compute_cost_diff queries db.conn directly and DuckDB blocks
+non-daemon attaches.
+"""
+from __future__ import annotations
+
+from typing import Any
+
+from fastapi import APIRouter, Depends, HTTPException, Query, Request
+
+from tokenjam.api.deps import require_api_key
+from tokenjam.core.cost import compute_cost_diff
+from tokenjam.utils.time_parse import parse_since, utcnow
+
+router = APIRouter()
+
+
+@router.get("/cost/compare", dependencies=[Depends(require_api_key)])
+def get_cost_compare(
+    request: Request,
+    since: str = Query("7d", description="Current window lookback."),
+    compare: str = Query(..., description="previous / last-week / last-month / last-7d / last-30d / YYYY-MM-DD:YYYY-MM-DD"),
+    agent_id: str | None = Query(None, alias="agent_id"),
+    top_n: int = Query(5, description="Top per-agent / per-model shifts."),
+) -> dict[str, Any]:
+    """
+    Return the structured CostDiff payload that cmd_cost / cmd_optimize
+    render. Schema mirrors `_diff_to_dict` in cmd_cost.
+    """
+    db = request.app.state.db
+    if db is None:
+        raise HTTPException(status_code=503, detail="Server db not initialised.")
+
+    try:
+        since_dt = parse_since(since)
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail=f"Invalid --since: {exc}") from exc
+
+    until_dt = utcnow()
+
+    try:
+        diff = compute_cost_diff(
+            db, since_dt, until_dt, compare,
+            agent_id=agent_id, top_n=top_n,
+        )
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
+    except RuntimeError as exc:
+        raise HTTPException(status_code=500, detail=str(exc)) from exc
+
+    def _wt(w):
+        return {
+            "since": w.since.isoformat(),
+            "until": w.until.isoformat(),
+            "sessions": w.sessions,
+            "input_tokens": w.input_tokens,
+            "output_tokens": w.output_tokens,
+            "cache_tokens": w.cache_tokens,
+            "total_tokens": w.total_tokens,
+            "total_cost_usd": w.total_cost_usd,
+        }
+    return {
+        "current": _wt(diff.current),
+        "previous": _wt(diff.previous),
+        "cost_delta_usd": diff.cost_delta_usd,
+        "cost_delta_pct": diff.cost_delta_pct,
+        "tokens_delta": diff.tokens_delta,
+        "tokens_delta_pct": diff.tokens_delta_pct,
+        "by_agent": diff.by_agent,
+        "by_model": diff.by_model,
+    }

--- a/tokenjam/api/routes/optimize.py
+++ b/tokenjam/api/routes/optimize.py
@@ -1,0 +1,76 @@
+"""
+GET /api/v1/optimize — server-side `tj optimize` execution.
+
+Exists because `cmd_optimize` runs analyzers via direct `db.conn.execute(SQL)`
+queries that DuckDB blocks when another process (tj serve) holds the write
+lock. Routing optimize through the API lets the CLI work in the recommended
+operating mode (daemon auto-started by tj onboard) — see issue #68 §12.
+
+The endpoint runs `build_report` server-side using `app.state.db` (the same
+connection that handles ingest) and returns the JSON-serialized report. The
+CLI's `cmd_optimize` deserializes the response back into an `OptimizeReport`
+via `report_from_dict` and feeds the rendering path as if it had built the
+report locally — no second code path for rendering.
+"""
+from __future__ import annotations
+
+from typing import Any
+
+from fastapi import APIRouter, Depends, HTTPException, Query, Request
+
+from tokenjam.api.deps import require_api_key
+from tokenjam.core.optimize import build_report, report_to_dict
+from tokenjam.utils.time_parse import parse_since, utcnow
+
+router = APIRouter()
+
+
+@router.get("/optimize", dependencies=[Depends(require_api_key)])
+def get_optimize(
+    request: Request,
+    since: str = Query("30d", description="Lookback window (e.g. 30d, 7d, 24h)."),
+    agent_id: str | None = Query(None, alias="agent_id"),
+    finding: list[str] | None = Query(
+        None,
+        description="Optional list of analyzer names to run. Omit to run all.",
+    ),
+    budget_provider: str | None = Query(None),
+    budget_usd: float | None = Query(None),
+) -> dict[str, Any]:
+    """
+    Run the optimize analyzers server-side and return the serialized report.
+
+    Mirrors the CLI `tj optimize` flags: --since, --agent, --finding (repeatable),
+    --budget, --budget-usd. Returns the same dict shape `report_to_dict` produces
+    locally, so the CLI can reconstruct an `OptimizeReport` and render it.
+    """
+    db = request.app.state.db
+    config = request.app.state.config
+    if db is None or config is None:
+        raise HTTPException(
+            status_code=503,
+            detail="Server not fully initialised (db or config missing).",
+        )
+
+    try:
+        since_dt = parse_since(since)
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail=f"Invalid --since: {exc}") from exc
+
+    try:
+        report = build_report(
+            db=db,
+            config=config,
+            since=since_dt,
+            until=utcnow(),
+            agent_id=agent_id,
+            findings=list(finding) if finding else None,
+            budget_provider_filter=budget_provider,
+            budget_usd_override=budget_usd,
+        )
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
+    except RuntimeError as exc:
+        raise HTTPException(status_code=500, detail=str(exc)) from exc
+
+    return report_to_dict(report)

--- a/tokenjam/api/routes/optimize.py
+++ b/tokenjam/api/routes/optimize.py
@@ -57,12 +57,13 @@ def get_optimize(
     except ValueError as exc:
         raise HTTPException(status_code=400, detail=f"Invalid --since: {exc}") from exc
 
+    until_dt = utcnow()
     try:
         report = build_report(
             db=db,
             config=config,
             since=since_dt,
-            until=utcnow(),
+            until=until_dt,
             agent_id=agent_id,
             findings=list(finding) if finding else None,
             budget_provider_filter=budget_provider,
@@ -73,4 +74,31 @@ def get_optimize(
     except RuntimeError as exc:
         raise HTTPException(status_code=500, detail=str(exc)) from exc
 
-    return report_to_dict(report)
+    payload = report_to_dict(report)
+
+    # Plan-tier mix lets the CLI render subscription / local / unknown
+    # framings correctly under daemon mode. Without this the CLI defaults
+    # to "api" pricing_mode regardless of the user's actual plan (#68 §12
+    # follow-up). Best-effort: depends on db.conn (DuckDBBackend); skip
+    # silently if the daemon's storage layer doesn't expose a connection.
+    conn = getattr(db, "conn", None)
+    if conn is not None:
+        try:
+            clauses = ["started_at >= $1", "started_at < $2"]
+            params: list = [since_dt, until_dt]
+            if agent_id:
+                clauses.append(f"agent_id = ${len(params) + 1}")
+                params.append(agent_id)
+            where = " AND ".join(clauses)
+            rows = conn.execute(
+                f"SELECT COALESCE(plan_tier, 'unknown'), COUNT(*) FROM sessions "
+                f"WHERE {where} GROUP BY 1",
+                params,
+            ).fetchall()
+            payload["plan_tier_mix"] = {str(r[0]): int(r[1]) for r in rows}
+        except Exception:
+            payload["plan_tier_mix"] = {}
+    else:
+        payload["plan_tier_mix"] = {}
+
+    return payload

--- a/tokenjam/cli/cmd_budget.py
+++ b/tokenjam/cli/cmd_budget.py
@@ -94,13 +94,28 @@ def _show_budgets(config, db) -> None:
         _fmt(config.defaults.budget.session_usd),
     )
 
-    # Merge agent IDs from config + DB-observed agents
+    # Merge agent IDs from config + DB-observed agents. Two paths:
+    # - Direct DB: pull distinct agent_ids from sessions table.
+    # - API shim (daemon up, no db.conn): derive from recent traces.
+    #   Without this fallback, `tj budget` silently misses every agent
+    #   that hasn't been declared in tj.toml when the daemon is running
+    #   (#68 §11). Mirrors the pattern already used by cmd_status.
     agent_ids = set(config.agents)
-    if db is not None and hasattr(db, "conn"):
-        rows = db.conn.execute(
-            "SELECT DISTINCT agent_id FROM sessions ORDER BY agent_id"
-        ).fetchall()
-        agent_ids |= {r[0] for r in rows}
+    if db is not None:
+        if hasattr(db, "conn"):
+            rows = db.conn.execute(
+                "SELECT DISTINCT agent_id FROM sessions ORDER BY agent_id"
+            ).fetchall()
+            agent_ids |= {r[0] for r in rows if r[0]}
+        else:
+            try:
+                from tokenjam.core.models import TraceFilters
+                traces = db.get_traces(TraceFilters(limit=200))
+                agent_ids |= {t.agent_id for t in traces if t.agent_id}
+            except Exception:
+                # API call failed (server down, transient error) —
+                # render what we have from config rather than crash.
+                pass
 
     for agent_id in sorted(agent_ids):
         agent_cfg = config.agents.get(agent_id)

--- a/tokenjam/cli/cmd_cost.py
+++ b/tokenjam/cli/cmd_cost.py
@@ -30,20 +30,37 @@ def cmd_cost(ctx: click.Context, agent: str | None, since: str,
     # before the regular grouped report and exits — the two outputs are
     # different shapes and combining them would be cluttered.
     if compare:
-        if not hasattr(db, "conn"):
-            raise click.ClickException(
-                "--compare requires a direct DuckDB connection. Stop tj serve first."
-            )
-        until_dt = utcnow()
-        try:
-            diff = compute_cost_diff(db, since_dt, until_dt, compare, agent_id=agent)
-        except ValueError as exc:
-            raise click.BadParameter(str(exc), param_hint="'--compare'") from exc
-        if output_json:
-            click.echo(json.dumps(_diff_to_dict(diff), default=str))
-        else:
-            _render_diff(diff)
-        return
+        if hasattr(db, "conn"):
+            until_dt = utcnow()
+            try:
+                diff = compute_cost_diff(db, since_dt, until_dt, compare, agent_id=agent)
+            except ValueError as exc:
+                raise click.BadParameter(str(exc), param_hint="'--compare'") from exc
+            if output_json:
+                click.echo(json.dumps(_diff_to_dict(diff), default=str))
+            else:
+                _render_diff(diff)
+            return
+        # API-shim path: fetch the diff from tj serve. The endpoint
+        # mirrors compute_cost_diff's output schema, so we can pass
+        # the dict to _render_diff_from_dict (or just emit it as JSON).
+        if hasattr(db, "fetch_cost_compare"):
+            try:
+                diff_dict = db.fetch_cost_compare(
+                    since=since, compare=compare, agent_id=agent,
+                )
+            except Exception as exc:
+                raise click.ClickException(
+                    f"Failed to fetch comparison from tj serve: {exc}"
+                ) from exc
+            if output_json:
+                click.echo(json.dumps(diff_dict, default=str))
+            else:
+                _render_diff_dict(diff_dict)
+            return
+        raise click.ClickException(
+            "--compare requires a direct DuckDB connection or a running tj serve."
+        )
 
     filters = CostFilters(
         agent_id=agent,
@@ -213,3 +230,88 @@ def _diff_to_dict(diff) -> dict:
         "by_agent": diff.by_agent,
         "by_model": diff.by_model,
     }
+
+
+def _render_diff_dict(d: dict) -> None:
+    """
+    Render the cost-diff dict format returned by `/api/v1/cost/compare`.
+
+    Same visual structure as `_render_diff` but operates on the JSON shape
+    directly so cmd_cost doesn't have to round-trip through CostDiff
+    dataclasses when fetched from the API (#68 §12 follow-up).
+    """
+    from datetime import datetime
+    cur = d.get("current") or {}
+    prev = d.get("previous") or {}
+
+    def _pd(s: str | None):
+        if not s:
+            return None
+        try:
+            return datetime.fromisoformat(s.replace("Z", "+00:00"))
+        except Exception:
+            return None
+
+    cur_since = _pd(cur.get("since"))
+    cur_until = _pd(cur.get("until"))
+    prev_since = _pd(prev.get("since"))
+    prev_until = _pd(prev.get("until"))
+    cur_days = max((cur_until - cur_since).days, 1) if (cur_since and cur_until) else 1
+    prev_days = max((prev_until - prev_since).days, 1) if (prev_since and prev_until) else 1
+
+    console.print(
+        f"\n[bold]Current  "
+        f"({cur_since.date() if cur_since else '?'} → "
+        f"{cur_until.date() if cur_until else '?'}, {cur_days}d):[/bold]  "
+        f"{cur.get('sessions', 0)} sessions, "
+        f"{format_tokens(int(cur.get('total_tokens', 0)))} tokens, "
+        f"{format_cost(float(cur.get('total_cost_usd', 0)))}"
+    )
+    console.print(
+        f"[bold]Previous "
+        f"({prev_since.date() if prev_since else '?'} → "
+        f"{prev_until.date() if prev_until else '?'}, {prev_days}d):[/bold] "
+        f"{prev.get('sessions', 0)} sessions, "
+        f"{format_tokens(int(prev.get('total_tokens', 0)))} tokens, "
+        f"{format_cost(float(prev.get('total_cost_usd', 0)))}"
+    )
+    console.print()
+
+    cost_delta = float(d.get("cost_delta_usd", 0))
+    tokens_delta = int(d.get("tokens_delta", 0))
+    cost_pct = d.get("cost_delta_pct")
+    tokens_pct = d.get("tokens_delta_pct")
+    console.print(
+        f"  Cost delta:   {_arrow(cost_delta)} "
+        f"[bold]{format_cost(abs(cost_delta))}[/bold] "
+        f"{_pct_str(cost_pct)}"
+    )
+    console.print(
+        f"  Token delta:  {_arrow(tokens_delta)} "
+        f"[bold]{format_tokens(abs(tokens_delta))}[/bold] "
+        f"{_pct_str(tokens_pct)}"
+    )
+
+    by_agent = d.get("by_agent") or []
+    by_model = d.get("by_model") or []
+    if by_agent:
+        console.print("\n  [bold]Top shifts by agent:[/bold]")
+        for entry in by_agent:
+            delta = float(entry.get("delta", 0))
+            console.print(
+                f"    {_arrow(delta)} {str(entry.get('group', '')):<24} "
+                f"{format_cost(float(entry.get('previous_cost', 0)))} → "
+                f"{format_cost(float(entry.get('current_cost', 0)))}  "
+                f"[dim]({'+' if delta >= 0 else ''}{format_cost(delta)})[/dim]"
+            )
+    if by_model:
+        console.print("\n  [bold]Top shifts by model:[/bold]")
+        for entry in by_model:
+            delta = float(entry.get("delta", 0))
+            console.print(
+                f"    {_arrow(delta)} {str(entry.get('group', '')):<32} "
+                f"{format_cost(float(entry.get('previous_cost', 0)))} → "
+                f"{format_cost(float(entry.get('current_cost', 0)))}  "
+                f"[dim]({'+' if delta >= 0 else ''}{format_cost(delta)})[/dim]"
+            )
+    console.print()

--- a/tokenjam/cli/cmd_doctor.py
+++ b/tokenjam/cli/cmd_doctor.py
@@ -86,6 +86,12 @@ def _check_config() -> dict:
 
 
 def _check_db(config: object) -> dict:
+    """
+    Verify the DuckDB file is writable. The daemon legitimately holds
+    the write lock when running — that's the recommended operating mode
+    after `tj onboard`. Detect a lock-conflict error and downgrade to
+    informational rather than flagging it as ✗ (#68 §4).
+    """
     try:
         from pathlib import Path
         db_path = Path(config.storage.path).expanduser()
@@ -94,6 +100,21 @@ def _check_db(config: object) -> dict:
         return {"name": "DuckDB writable", "level": "ok",
                 "message": f"Database accessible: {db_path}"}
     except Exception as e:
+        # DuckDB raises "Could not set lock on file ... Conflicting lock
+        # is held in ... PID N" when another process (the daemon, in the
+        # common case) has the DB open in write mode. That's the expected
+        # operating state — surface as info, not error.
+        err_msg = str(e).lower()
+        if "conflicting lock" in err_msg or "could not set lock" in err_msg:
+            return {
+                "name": "DuckDB writable",
+                "level": "info",
+                "message": (
+                    "Skipped — DB write lock held by another process "
+                    "(typically tj serve). This is the expected operating "
+                    "state when the daemon is running."
+                ),
+            }
         return {"name": "DuckDB writable", "level": "error",
                 "message": f"Cannot open database: {e}"}
 

--- a/tokenjam/cli/cmd_drift.py
+++ b/tokenjam/cli/cmd_drift.py
@@ -20,7 +20,12 @@ def cmd_drift(ctx: click.Context, agent: str | None, output_json: bool) -> None:
     config = ctx.obj["config"]
     agent_filter = agent or ctx.obj.get("agent")
 
-    # Discover agents with baselines
+    # Discover agents with baselines. Two paths:
+    # - Direct DB (no daemon, or daemon stopped): SELECT from drift_baselines.
+    # - API shim (daemon up, db.conn is None): hit /api/v1/drift via the
+    #   ApiBackend. Without this fallback `tj drift` reported "No drift
+    #   baselines found" even when drift_detected had clearly fired —
+    #   confusing users (#68 §3).
     if agent_filter:
         agent_ids = [agent_filter]
     elif hasattr(db, "conn"):
@@ -28,6 +33,9 @@ def cmd_drift(ctx: click.Context, agent: str | None, output_json: bool) -> None:
             "SELECT DISTINCT agent_id FROM drift_baselines ORDER BY agent_id"
         ).fetchall()
         agent_ids = [r[0] for r in rows]
+    elif hasattr(db, "list_baseline_agents"):
+        # ApiBackend method
+        agent_ids = db.list_baseline_agents()
     else:
         agent_ids = []
 

--- a/tokenjam/cli/cmd_onboard.py
+++ b/tokenjam/cli/cmd_onboard.py
@@ -49,6 +49,28 @@ def cmd_onboard(ctx: click.Context, claude_code: bool, codex: bool, budget: floa
         return
     existing = find_config_file()
     if existing and not force:
+        # --reconfigure is only meaningful with --claude-code / --codex.
+        # The bare onboard path writes a generic config and doesn't manage
+        # plan tier — that's per-provider, written into [budget.<provider>]
+        # sections by the integration-specific onboarders. Silently
+        # no-op'ing here would frustrate users who pass --reconfigure --plan
+        # expecting their plan field to update (#68 §1).
+        if reconfigure:
+            console.print(
+                "[red]--reconfigure has no effect without --claude-code or "
+                "--codex.[/red]"
+            )
+            console.print(
+                "\nThe bare onboard path writes a generic config and doesn't "
+                "manage plan tier — that's per-provider, set by the "
+                "integration-specific flows.\n"
+            )
+            console.print(
+                "Try [bold]tj onboard --claude-code --reconfigure[/bold] or "
+                "[bold]tj onboard --codex --reconfigure[/bold] instead."
+            )
+            ctx.exit(1)
+            return
         console.print(f"[bold]Config already exists:[/bold] {existing}")
         console.print("Use [bold]--force[/bold] to overwrite.")
         return

--- a/tokenjam/cli/cmd_optimize.py
+++ b/tokenjam/cli/cmd_optimize.py
@@ -168,13 +168,10 @@ def cmd_optimize(
             return
 
         report = report_from_dict(report_dict)
-        # Plan-tier mix isn't on the report payload yet; the API path renders
-        # without per-session plan_tier breakdown. Empty dict → _dominant_plan
-        # returns "api" (the historical default). The honesty-discipline
-        # behaviors that rely on plan_mix (the unknown-tier note, subscription
-        # reframing) are best-effort here; a richer API payload is a future
-        # enhancement (see #68 §12 follow-up).
-        plan_mix = {}
+        # Plan-tier mix is included in the /api/v1/optimize payload as of
+        # #68 §12 follow-up #29, so the CLI can render subscription /
+        # local / unknown framings correctly under daemon mode.
+        plan_mix = report_dict.get("plan_tier_mix") or {}
     else:
         row = conn.execute(
             "SELECT COUNT(*) FROM spans WHERE model IS NOT NULL"
@@ -226,17 +223,26 @@ def cmd_optimize(
     # surfaces a window-cost diff at the top so the user can see trend
     # before reading the recommendations.
     cost_diff = None
+    cost_diff_dict = None  # populated under API-shim mode
     if compare:
         if conn is None:
-            # API-shim path doesn't yet expose period comparison; would need
-            # a /api/v1/cost/compare route (#68 §12 follow-up). Surface
-            # explicitly rather than crash deep inside compute_cost_diff.
-            console.print(
-                "[yellow]Note:[/yellow] [dim]--compare is not yet supported "
-                "while [bold]tj serve[/bold] is running. Stop the daemon "
-                "([bold]tj stop[/bold]) and re-run, or omit --compare. "
-                "Continuing without comparison.[/dim]\n"
-            )
+            # API-shim path: fetch from /api/v1/cost/compare. Result is a
+            # dict (not a CostDiff dataclass) so we render it via
+            # _render_diff_dict instead of _render_diff.
+            if hasattr(db, "fetch_cost_compare"):
+                try:
+                    cost_diff_dict = db.fetch_cost_compare(
+                        since=since, compare=compare, agent_id=agent,
+                    )
+                except Exception as exc:
+                    raise click.ClickException(
+                        f"Failed to fetch --compare from tj serve: {exc}"
+                    ) from exc
+            else:
+                console.print(
+                    "[yellow]Note:[/yellow] [dim]--compare is not supported "
+                    "via this backend. Continuing without comparison.[/dim]\n"
+                )
         else:
             from tokenjam.core.cost import compute_cost_diff
             try:
@@ -252,6 +258,8 @@ def cmd_optimize(
         if cost_diff is not None:
             from tokenjam.cli.cmd_cost import _diff_to_dict
             payload["compare"] = _diff_to_dict(cost_diff)
+        elif cost_diff_dict is not None:
+            payload["compare"] = cost_diff_dict
         # For subscription/local users, the dollar fields on the downgrade
         # finding mislead — surface the token-share fields instead. Don't
         # remove actual_cost_usd / alternative_cost_usd; those are useful
@@ -273,6 +281,10 @@ def cmd_optimize(
         from tokenjam.cli.cmd_cost import _render_diff
         console.print("\n[bold]Window comparison[/bold]")
         _render_diff(cost_diff)
+    elif cost_diff_dict is not None:
+        from tokenjam.cli.cmd_cost import _render_diff_dict
+        console.print("\n[bold]Window comparison[/bold]")
+        _render_diff_dict(cost_diff_dict)
 
 
 def _plan_tier_mix(conn, since, until, agent_id: str | None) -> dict[str, int]:

--- a/tokenjam/cli/cmd_optimize.py
+++ b/tokenjam/cli/cmd_optimize.py
@@ -13,6 +13,7 @@ from tokenjam.core.optimize import (
     DowngradeFinding,
     OptimizeReport,
     build_report,
+    report_from_dict,
     report_to_dict,
 )
 from tokenjam.otel.semconv import SUBSCRIPTION_PLAN_TIERS
@@ -119,60 +120,93 @@ def cmd_optimize(
 
     until_dt = utcnow()
 
-    # If tj serve is running it holds the write-lock, and main.py hands us an
-    # API-proxy backend that has no .conn. Open the DB ourselves read-only so
-    # optimize works alongside a running server.
+    # Two paths depending on whether the daemon holds the DB lock.
+    #
+    # Local DB available (no daemon, or we got handed a real DuckDBBackend) →
+    # build the report locally using db.conn directly. Fastest, no HTTP.
+    #
+    # Daemon up (main.py handed us an ApiBackend because DuckDB refused to
+    # open) → fetch the report from /api/v1/optimize. Previously this path
+    # tried to open the DB read-only, but DuckDB blocks read-only attaches
+    # while another process holds the write lock — `tj optimize` failed with
+    # "Could not set lock on file" any time the daemon was up. See issue
+    # #68 §12.
     conn = getattr(db, "conn", None)
+    report: OptimizeReport
+    plan_mix: dict[str, int]
     if conn is None:
-        import duckdb
-        from pathlib import Path as _Path
-        db_path = str(_Path(config.storage.path).expanduser())
+        # API-shim path
+        from tokenjam.core.api_backend import ApiBackend
+        if not isinstance(db, ApiBackend):
+            raise click.ClickException(
+                "optimize requires either a direct DuckDB connection or a "
+                "running tj serve at the configured api.{host,port}."
+            )
         try:
-            ro_conn = duckdb.connect(db_path, read_only=True)
+            report_dict = db.fetch_optimize_report(
+                since=since,
+                agent_id=agent,
+                findings=list(findings) if findings else None,
+                budget_provider=budget_provider,
+                budget_usd=budget_usd,
+            )
         except Exception as exc:
             raise click.ClickException(
-                f"Could not open {db_path} read-only: {exc}"
+                f"Failed to fetch optimize report from tj serve: {exc}"
             ) from exc
 
-        class _RoShim:
-            def __init__(self, c):
-                self.conn = c
-        db = _RoShim(ro_conn)
-        conn = ro_conn
-    row = conn.execute(
-        "SELECT COUNT(*) FROM spans WHERE model IS NOT NULL"
-    ).fetchone()
-    if not row or not row[0]:
-        if output_json:
-            click.echo(json.dumps({
-                "error": "no_data",
-                "message": "No span data available — let TokenJam run for a few "
-                           "days, or `tj backfill claude-code` if you use Claude Code.",
-            }))
-        else:
-            console.print(
-                "[yellow]No usage data found.[/yellow] "
-                "[dim]Let TokenJam run for a few days, or — if you use "
-                "Claude Code — try [bold]tj backfill claude-code[/bold] to "
-                "ingest historical sessions.[/dim]"
-            )
-        return
+        if report_dict.get("error") == "no_data":
+            if output_json:
+                click.echo(json.dumps(report_dict))
+            else:
+                console.print(
+                    "[yellow]No usage data found.[/yellow] "
+                    "[dim]Let TokenJam run for a few days, or — if you use "
+                    "Claude Code — try [bold]tj backfill claude-code[/bold] to "
+                    "ingest historical sessions.[/dim]"
+                )
+            return
 
-    report = build_report(
-        db=db,
-        config=config,
-        since=since_dt,
-        until=until_dt,
-        agent_id=agent,
-        findings=list(findings) if findings else None,
-        budget_provider_filter=budget_provider,
-        budget_usd_override=budget_usd,
-    )
+        report = report_from_dict(report_dict)
+        # Plan-tier mix isn't on the report payload yet; the API path renders
+        # without per-session plan_tier breakdown. Empty dict → _dominant_plan
+        # returns "api" (the historical default). The honesty-discipline
+        # behaviors that rely on plan_mix (the unknown-tier note, subscription
+        # reframing) are best-effort here; a richer API payload is a future
+        # enhancement (see #68 §12 follow-up).
+        plan_mix = {}
+    else:
+        row = conn.execute(
+            "SELECT COUNT(*) FROM spans WHERE model IS NOT NULL"
+        ).fetchone()
+        if not row or not row[0]:
+            if output_json:
+                click.echo(json.dumps({
+                    "error": "no_data",
+                    "message": "No span data available — let TokenJam run for a few "
+                               "days, or `tj backfill claude-code` if you use Claude Code.",
+                }))
+            else:
+                console.print(
+                    "[yellow]No usage data found.[/yellow] "
+                    "[dim]Let TokenJam run for a few days, or — if you use "
+                    "Claude Code — try [bold]tj backfill claude-code[/bold] to "
+                    "ingest historical sessions.[/dim]"
+                )
+            return
 
-    # Query plan-tier mix in this window. Used for both the unknown-tier note
-    # (0.4b) and dominant-plan rendering (when Task 1.1 ships the full
-    # subscription reframing this stays useful as the signal).
-    plan_mix = _plan_tier_mix(conn, since_dt, until_dt, agent)
+        report = build_report(
+            db=db,
+            config=config,
+            since=since_dt,
+            until=until_dt,
+            agent_id=agent,
+            findings=list(findings) if findings else None,
+            budget_provider_filter=budget_provider,
+            budget_usd_override=budget_usd,
+        )
+
+        plan_mix = _plan_tier_mix(conn, since_dt, until_dt, agent)
 
     dominant = _dominant_plan(plan_mix)
     pricing_mode = _pricing_mode_for(dominant)
@@ -193,11 +227,22 @@ def cmd_optimize(
     # before reading the recommendations.
     cost_diff = None
     if compare:
-        from tokenjam.core.cost import compute_cost_diff
-        try:
-            cost_diff = compute_cost_diff(db, since_dt, until_dt, compare, agent_id=agent)
-        except ValueError as exc:
-            raise click.BadParameter(str(exc), param_hint="'--compare'") from exc
+        if conn is None:
+            # API-shim path doesn't yet expose period comparison; would need
+            # a /api/v1/cost/compare route (#68 §12 follow-up). Surface
+            # explicitly rather than crash deep inside compute_cost_diff.
+            console.print(
+                "[yellow]Note:[/yellow] [dim]--compare is not yet supported "
+                "while [bold]tj serve[/bold] is running. Stop the daemon "
+                "([bold]tj stop[/bold]) and re-run, or omit --compare. "
+                "Continuing without comparison.[/dim]\n"
+            )
+        else:
+            from tokenjam.core.cost import compute_cost_diff
+            try:
+                cost_diff = compute_cost_diff(db, since_dt, until_dt, compare, agent_id=agent)
+            except ValueError as exc:
+                raise click.BadParameter(str(exc), param_hint="'--compare'") from exc
 
     if output_json:
         payload = report_to_dict(report)

--- a/tokenjam/cli/cmd_optimize.py
+++ b/tokenjam/cli/cmd_optimize.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 import json
 
 import click
+from rich.markup import escape as _rich_escape
 
 from tokenjam.core.optimize import (
     ANALYZER_REGISTRY,
@@ -344,10 +345,29 @@ def _render_report(
             _render_budget(proj)
             console.print()
 
-    if (
-        report.downgrade is None
-        and not (pricing_mode == "api" and report.budgets)
-    ):
+    # ----- Wave-2 findings (cache-efficacy, cache-recommend,
+    # workflow-restructure, prompt-bloat) — these attach to report.findings
+    # rather than typed slots. Dispatch to a per-finding renderer; ignore
+    # any unknown finding names (forward-compatible with future analyzers).
+    rendered_any_wave2 = False
+    for name, finding in (report.findings or {}).items():
+        renderer = _FINDING_RENDERERS.get(name)
+        if renderer is None:
+            continue
+        renderer(finding, pricing_mode=pricing_mode)
+        console.print()
+        rendered_any_wave2 = True
+
+    # Only show the catch-all when truly nothing rendered. The earlier
+    # condition missed the Wave-2 findings dict, so cache-efficacy /
+    # cache-recommend / workflow-restructure / prompt-bloat were silently
+    # falling into "No candidates flagged" (issue #68 §15).
+    rendered_any = (
+        report.downgrade is not None
+        or (pricing_mode == "api" and bool(report.budgets))
+        or rendered_any_wave2
+    )
+    if not rendered_any:
         console.print(
             "[dim]No candidates flagged in this window. Either spend is small or "
             "all sessions already use a cost-effective model.[/dim]"
@@ -418,13 +438,26 @@ def _render_downgrade(d: DowngradeFinding, pricing_mode: str = "api") -> None:
     if d.examples:
         console.print()
         console.print("     [dim]Examples:[/dim]")
+        # The per-example cost figure has the same honesty problem as the
+        # top-level savings line: in non-api modes we either don't know whether
+        # the number is real spend (unknown), or we know it isn't (subscription
+        # users on flat fees, local users with zero marginal cost). Drop the
+        # column rather than leak the dollar value into a context where we've
+        # explicitly suppressed it above. (issue #68 §14)
         for ex in d.examples:
             dur = f"{ex.duration_seconds:.1f}s" if ex.duration_seconds else "—"
-            console.print(
-                f"       [dim]{ex.trace_id[:8]}..[/dim]  "
-                f"{ex.tool_calls} tool calls   {dur}   "
-                f"{format_cost(ex.cost_usd)}  ({ex.model})"
-            )
+            if pricing_mode == "api":
+                console.print(
+                    f"       [dim]{ex.trace_id[:8]}..[/dim]  "
+                    f"{ex.tool_calls} tool calls   {dur}   "
+                    f"{format_cost(ex.cost_usd)}  ({ex.model})"
+                )
+            else:
+                console.print(
+                    f"       [dim]{ex.trace_id[:8]}..[/dim]  "
+                    f"{ex.tool_calls} tool calls   {dur}   "
+                    f"({ex.model})"
+                )
     console.print()
     console.print(
         f"     [yellow]![/yellow] [italic]{MODEL_DOWNGRADE_CAVEAT}[/italic]"
@@ -530,3 +563,243 @@ def _export_snippet(
             "\n[dim]TokenJam does not enforce these rules. The snippet is "
             "a recommendation, not an active routing config.[/dim]"
         )
+
+
+# ---------------------------------------------------------------------------
+# Wave-2 finding renderers
+# ---------------------------------------------------------------------------
+# These render the findings attached to OptimizeReport.findings (the generic
+# dict keyed by analyzer name). _FINDING_RENDERERS at the bottom maps each
+# analyzer's registration name to the function that renders its finding.
+#
+# Each renderer takes (finding, pricing_mode=str) and prints to the global
+# `console`. Adding a new analyzer: add a renderer here and an entry in the
+# dispatch table. cmd_optimize._render_report iterates report.findings and
+# calls into here.
+
+def _render_cache_efficacy(finding, *, pricing_mode: str = "api") -> None:
+    """
+    Render the cache-efficacy finding — current caching-ratio table per
+    (provider, model). When any rows are flagged, surface them prominently;
+    otherwise show the full table dimmed so the user sees the underlying
+    data even when no recommendation is warranted.
+    """
+    console.print("  [bold]Cache efficacy:[/bold]")
+    if not finding.rows:
+        console.print(
+            "     [dim]No LLM spans with provider/model in this window.[/dim]"
+        )
+        return
+
+    flagged = list(finding.flagged) if finding.flagged else []
+    if flagged:
+        console.print(
+            f"     • [bold]{len(flagged)}[/bold] (provider, model) "
+            f"row{'s' if len(flagged) != 1 else ''} flagged below the "
+            f"30% efficacy threshold at ≥100K input tokens:"
+        )
+        for r in flagged:
+            console.print(
+                f"       [bold]{r.provider}/{r.model}[/bold]  "
+                f"{r.efficacy*100:.0f}% efficacy  "
+                f"({format_tokens(r.input_tokens)} input / "
+                f"{format_tokens(r.cache_tokens)} cache)"
+            )
+        console.print()
+
+    console.print("     [dim]All (provider, model) usage in window:[/dim]")
+    for r in finding.rows:
+        caveat = ""
+        if r.support == "best_effort":
+            caveat = " [dim](best-effort)[/dim]"
+        elif r.support == "unsupported":
+            caveat = " [dim](unsupported)[/dim]"
+        flag_marker = "[yellow]![/yellow] " if r.flagged else "  "
+        console.print(
+            f"     {flag_marker}{r.provider}/{r.model}  "
+            f"[dim]efficacy[/dim] {r.efficacy*100:.0f}%  "
+            f"[dim]input[/dim] {format_tokens(r.input_tokens)}  "
+            f"[dim]cache[/dim] {format_tokens(r.cache_tokens)}"
+            f"{caveat}"
+        )
+
+
+def _render_cache_recommend(finding, *, pricing_mode: str = "api") -> None:
+    """
+    Render the cache-recommend finding — Anthropic-only v1 breakpoint
+    candidates. When the analyzer is disabled (capture.prompts off), surface
+    the hint instead of an empty table.
+    """
+    console.print("  [bold]Cache recommend:[/bold]")
+    if not finding.enabled:
+        # Hint includes the install / config instruction from the analyzer.
+        # _rich_escape because the hint contains TOML section names like
+        # `[capture]` which Rich would otherwise interpret as a style tag
+        # and silently strip from the output.
+        if finding.hint:
+            console.print(f"     [dim]{_rich_escape(finding.hint)}[/dim]")
+        else:
+            console.print(
+                "     [dim]Disabled. Set [bold]capture.prompts = true[/bold] "
+                "in tj.toml to run this analyzer.[/dim]"
+            )
+        return
+
+    if not finding.candidates:
+        msg = "     [dim]No stable prefixes shared across ≥3 Anthropic calls"
+        if finding.skipped_provider_count:
+            msg += (
+                f". Skipped {finding.skipped_provider_count} non-Anthropic "
+                f"span(s) — multi-provider support is a future feature."
+            )
+        msg += ".[/dim]"
+        console.print(msg)
+        return
+
+    console.print(
+        f"     • [bold]{len(finding.candidates)}[/bold] prefix candidate"
+        f"{'s' if len(finding.candidates) != 1 else ''} for "
+        f"[bold]cache_control[/bold] placement:"
+    )
+    for c in finding.candidates:
+        sample = c.sample_chars.replace("\n", " ")[:80]
+        if len(c.sample_chars) > 80:
+            sample = sample[:77] + "..."
+        console.print(
+            f"       [dim]{c.prefix_hash[:8]}..[/dim]  "
+            f"{c.occurrences}× shared  "
+            f"~{format_tokens(c.estimated_cacheable_tokens)} cacheable/call  "
+            f"[dim]({format_tokens(int(c.avg_input_tokens))} avg input)[/dim]"
+        )
+        console.print(f"           [dim italic]{sample}[/dim italic]")
+
+    if finding.skipped_provider_count:
+        console.print(
+            f"     [dim]Note: {finding.skipped_provider_count} non-Anthropic "
+            f"span(s) skipped — multi-provider support is a future feature.[/dim]"
+        )
+
+
+def _render_workflow_restructure(finding, *, pricing_mode: str = "api") -> None:
+    """
+    Render the workflow-restructure (Script) finding — clusters of sessions
+    matching the same (tool_name, arg_shape) signature.
+    """
+    console.print("  [bold]Workflow restructure:[/bold]")
+    if not finding.clusters:
+        if finding.sessions_examined == 0:
+            console.print(
+                "     [dim]No tool spans in this window.[/dim]"
+            )
+        else:
+            console.print(
+                f"     [dim]Examined {finding.sessions_examined} session"
+                f"{'s' if finding.sessions_examined != 1 else ''}; "
+                f"no clusters above threshold (≥20 identical signatures, "
+                f"zero branching).[/dim]"
+            )
+        if finding.degraded:
+            console.print(
+                "     [dim]Clustering ran in tool-names-only mode "
+                "(capture.tool_inputs = false). Enable to "
+                "cluster by argument shape too.[/dim]"
+            )
+        return
+
+    note = ""
+    if finding.degraded:
+        note = " [dim](tool-names-only — enable capture.tool_inputs for "\
+               "finer clustering)[/dim]"
+    console.print(
+        f"     • [bold]{len(finding.clusters)}[/bold] deterministic-pattern "
+        f"cluster{'s' if len(finding.clusters) != 1 else ''} found{note}"
+    )
+    for c in finding.clusters:
+        # Build a compact signature preview
+        sig_preview = " → ".join(
+            f"{step['tool']}({','.join(step.get('args', [])) or '-'})"
+            for step in c.signature
+        )
+        if len(sig_preview) > 100:
+            sig_preview = sig_preview[:97] + "..."
+        dur = (
+            f"{c.avg_duration_seconds:.1f}s avg"
+            if c.avg_duration_seconds else "—"
+        )
+        console.print(
+            f"       [bold]{c.instances}×[/bold] {sig_preview}  "
+            f"[dim]({dur})[/dim]"
+        )
+        if pricing_mode == "api" and c.avg_cost_usd > 0:
+            console.print(
+                f"          [dim]avg session cost {format_cost(c.avg_cost_usd)}; "
+                f"replacing with a deterministic script would eliminate it.[/dim]"
+            )
+    if finding.caveat:
+        console.print(f"     [yellow]![/yellow] [italic]{finding.caveat}[/italic]")
+
+
+def _render_prompt_bloat(finding, *, pricing_mode: str = "api") -> None:
+    """
+    Render the prompt-bloat (Trim) finding — LLMLingua-2 token-significance
+    summary. When the analyzer is disabled (either capture off or extra
+    not installed), surface the hint.
+    """
+    console.print("  [bold]Prompt bloat:[/bold]")
+    if not finding.enabled:
+        if finding.hint:
+            # Escape Rich markup — hints can contain TOML section names
+            # (`[capture]`) or bracketed install hints (`tokenjam[bloat]`).
+            console.print(f"     [dim]{_rich_escape(finding.hint)}[/dim]")
+        else:
+            console.print(
+                "     [dim]Disabled. See "
+                "[bold]docs/optimize/trim.md[/bold] for install + capture "
+                "requirements.[/dim]"
+            )
+        return
+
+    if not finding.per_prompt:
+        console.print(
+            f"     [dim]Scanned {finding.prompts_scored} prompt"
+            f"{'s' if finding.prompts_scored != 1 else ''}; "
+            f"skipped {finding.prompts_skipped}. No bloat regions above "
+            f"the minimum-length threshold.[/dim]"
+        )
+        return
+
+    pct = (
+        finding.total_bloat_chars / finding.total_chars * 100.0
+        if finding.total_chars > 0 else 0.0
+    )
+    console.print(
+        f"     • Scored [bold]{finding.prompts_scored}[/bold] prompt"
+        f"{'s' if finding.prompts_scored != 1 else ''}: "
+        f"[bold]{pct:.1f}%[/bold] of chars in flagged regions "
+        f"([bold]{finding.total_bloat_chars}[/bold] / "
+        f"{finding.total_chars})"
+    )
+    console.print("     • Top prompts by bloat volume:")
+    for p in finding.per_prompt[:5]:
+        sample = p.sample_chars.replace("\n", " ")[:80]
+        if len(p.sample_chars) > 80:
+            sample = sample[:77] + "..."
+        console.print(
+            f"       [dim]{p.agent_id}[/dim]  "
+            f"[bold]{p.bloat_chars}[/bold] bloat / {p.prompt_chars} chars  "
+            f"[dim]~{p.estimated_token_reduction} tokens trimmable[/dim]"
+        )
+        console.print(f"           [dim italic]{sample}[/dim italic]")
+    console.print(
+        "     [dim]For per-prompt highlights run: "
+        "[bold]tj report --bloat[/bold][/dim]"
+    )
+
+
+# Dispatch table — analyzer registration name → renderer.
+_FINDING_RENDERERS = {
+    "cache-efficacy":       _render_cache_efficacy,
+    "cache-recommend":      _render_cache_recommend,
+    "workflow-restructure": _render_workflow_restructure,
+    "prompt-bloat":         _render_prompt_bloat,
+}

--- a/tokenjam/core/api_backend.py
+++ b/tokenjam/core/api_backend.py
@@ -6,6 +6,7 @@ queries through the REST API.
 from __future__ import annotations
 
 from datetime import date, datetime
+from typing import Any
 
 import httpx
 
@@ -186,6 +187,37 @@ class ApiBackend:
 
     def get_recent_spans(self, session_id: str, limit: int) -> list[NormalizedSpan]:
         return []
+
+    def fetch_optimize_report(
+        self,
+        *,
+        since: str = "30d",
+        agent_id: str | None = None,
+        findings: list[str] | None = None,
+        budget_provider: str | None = None,
+        budget_usd: float | None = None,
+    ) -> dict:
+        """
+        Fetch a serialized optimize report from `tj serve`.
+
+        Used by cmd_optimize when the local DuckDB connection is unavailable
+        (daemon holds the write lock). Returns the dict that `report_to_dict`
+        produced server-side; the CLI passes it through `report_from_dict`
+        before rendering.
+
+        See issue #68 §12 for the rationale.
+        """
+        params: dict[str, Any] = {"since": since}
+        if agent_id:
+            params["agent_id"] = agent_id
+        if findings:
+            # FastAPI accepts repeated query params for list values.
+            params["finding"] = findings
+        if budget_provider:
+            params["budget_provider"] = budget_provider
+        if budget_usd is not None:
+            params["budget_usd"] = budget_usd
+        return self._get("/api/v1/optimize", params)
 
     def close(self) -> None:
         self.client.close()

--- a/tokenjam/core/api_backend.py
+++ b/tokenjam/core/api_backend.py
@@ -238,6 +238,28 @@ class ApiBackend:
             if a.get("agent_id")
         ]
 
+    def fetch_cost_compare(
+        self,
+        *,
+        since: str = "7d",
+        compare: str = "previous",
+        agent_id: str | None = None,
+        top_n: int = 5,
+    ) -> dict:
+        """
+        Fetch a window-vs-window cost diff from tj serve. Mirrors
+        compute_cost_diff's output schema; used by cmd_cost and cmd_optimize
+        when the daemon holds the DB lock (#68 §12 follow-up).
+        """
+        params: dict[str, Any] = {
+            "since": since,
+            "compare": compare,
+            "top_n": top_n,
+        }
+        if agent_id:
+            params["agent_id"] = agent_id
+        return self._get("/api/v1/cost/compare", params)
+
     def fetch_optimize_report(
         self,
         *,

--- a/tokenjam/core/api_backend.py
+++ b/tokenjam/core/api_backend.py
@@ -188,6 +188,56 @@ class ApiBackend:
     def get_recent_spans(self, session_id: str, limit: int) -> list[NormalizedSpan]:
         return []
 
+    def get_baseline(self, agent_id: str):
+        """
+        Fetch a drift baseline for a single agent via /api/v1/drift?agent_id=X.
+
+        Returns DriftBaseline or None. Mirrors the StorageBackend method so
+        cmd_drift can call it transparently in API-shim mode (#68 §3).
+        """
+        from tokenjam.core.models import DriftBaseline
+        try:
+            data = self._get("/api/v1/drift", {"agent_id": agent_id})
+        except httpx.HTTPStatusError as exc:
+            if exc.response.status_code == 404:
+                return None
+            raise
+        b = data.get("baseline")
+        if not b:
+            return None
+        return DriftBaseline(
+            agent_id=agent_id,
+            sessions_sampled=int(b.get("sessions_sampled", 0)),
+            computed_at=(
+                datetime.fromisoformat(b["computed_at"])
+                if b.get("computed_at") else datetime.now()
+            ),
+            avg_input_tokens=b.get("avg_input_tokens"),
+            stddev_input_tokens=b.get("stddev_input_tokens"),
+            avg_output_tokens=b.get("avg_output_tokens"),
+            stddev_output_tokens=b.get("stddev_output_tokens"),
+            avg_session_duration_s=b.get("avg_session_duration_s"),
+            stddev_session_duration=b.get("stddev_session_duration"),
+            avg_tool_call_count=b.get("avg_tool_call_count"),
+            stddev_tool_call_count=b.get("stddev_tool_call_count"),
+        )
+
+    def list_baseline_agents(self) -> list[str]:
+        """
+        Enumerate agent IDs that have a drift baseline. Hits /api/v1/drift
+        (no agent_id) which returns {"agents": [...]} for every baseline.
+
+        Used by cmd_drift to discover agents under API-shim mode (#68 §3).
+        """
+        try:
+            data = self._get("/api/v1/drift")
+        except Exception:
+            return []
+        return [
+            a["agent_id"] for a in data.get("agents", [])
+            if a.get("agent_id")
+        ]
+
     def fetch_optimize_report(
         self,
         *,

--- a/tokenjam/core/config.py
+++ b/tokenjam/core/config.py
@@ -188,6 +188,68 @@ SEARCH_PATHS = [
 ]
 
 
+def _warn_if_secrets_diverge(active_path: Path, active_raw: dict) -> None:
+    """
+    Emit a stderr warning if a shadowed config exists with a different
+    ingest_secret. Tracks the common footgun (#68 §5): project-local
+    .tj/config.toml has secret A; global ~/.config/tj/config.toml has
+    secret B; the SDK uses A; the daemon (started with global config)
+    uses B; span pushes 401 silently.
+
+    Fires at most once per process via the module-level guard so this
+    doesn't spam multi-call test environments.
+    """
+    global _SECRET_DIVERGENCE_WARNED
+    if _SECRET_DIVERGENCE_WARNED:
+        return
+    active_secret = (active_raw.get("security") or {}).get("ingest_secret")
+    if not active_secret:
+        return
+    try:
+        active_resolved = active_path.resolve()
+    except OSError:
+        return
+    for candidate in SEARCH_PATHS:
+        try:
+            cand_resolved = candidate.resolve()
+        except OSError:
+            continue
+        if cand_resolved == active_resolved:
+            continue
+        if not candidate.exists():
+            continue
+        try:
+            with open(candidate, "rb") as f:
+                other_raw = tomllib.load(f)
+        except (OSError, tomllib.TOMLDecodeError):
+            continue
+        other_secret = (other_raw.get("security") or {}).get("ingest_secret")
+        if not other_secret or other_secret == active_secret:
+            continue
+        # Diverged. Warn once.
+        print(
+            f"warning: ingest_secret differs between {active_path} "
+            f"and {candidate}. The SDK will use the secret from "
+            f"{active_path} but a daemon launched from a different cwd "
+            f"may use the other one — span pushes will 401 silently. "
+            f"Align them (copy one secret into the other config) or "
+            f"delete the unused config.",
+            file=sys.stderr,
+        )
+        _SECRET_DIVERGENCE_WARNED = True
+        return
+
+
+# Module-level guard. Reset for tests via the helper exposed below.
+_SECRET_DIVERGENCE_WARNED = False
+
+
+def _reset_secret_divergence_warning() -> None:
+    """Test helper — reset the once-per-process warning guard."""
+    global _SECRET_DIVERGENCE_WARNED
+    _SECRET_DIVERGENCE_WARNED = False
+
+
 def find_config_file(override: str | None = None) -> Path | None:
     if override:
         p = Path(override)
@@ -213,6 +275,13 @@ def load_config(path: str | None = None) -> TjConfig:
 
     with open(config_path, "rb") as f:   # "rb" is REQUIRED
         raw = tomllib.load(f)
+
+    # Diverged-secret detection (#68 §5). When a project-local config
+    # shadows a global one with a different ingest_secret, the SDK and
+    # daemon end up with different secrets and span pushes silently 401.
+    # Warn at config-load time so the user gets a chance to align them
+    # before debugging mysterious 401s.
+    _warn_if_secrets_diverge(config_path, raw)
 
     cfg = _parse(raw)
     cfg.config_path = config_path.resolve()

--- a/tokenjam/core/optimize/__init__.py
+++ b/tokenjam/core/optimize/__init__.py
@@ -29,6 +29,7 @@ from tokenjam.core.optimize.registry import ANALYZER_REGISTRY, register
 from tokenjam.core.optimize.runner import (
     ANALYZER_ORDER,
     build_report,
+    report_from_dict,
     report_to_dict,
     summarize_window,
 )
@@ -69,6 +70,7 @@ __all__ = [
     "build_report",
     "project_budget",
     "register",
+    "report_from_dict",
     "report_to_dict",
     "summarize_window",
 ]

--- a/tokenjam/core/optimize/runner.py
+++ b/tokenjam/core/optimize/runner.py
@@ -167,3 +167,222 @@ def report_to_dict(report: OptimizeReport) -> dict:
             return {k: _serialise(v) for k, v in o.items()}
         return o
     return _serialise(report)
+
+
+def _parse_dt(value: Any) -> datetime | None:
+    """Parse an ISO-8601 string back into datetime; tolerate None / already-dt."""
+    if value is None or value == "":
+        return None
+    if isinstance(value, datetime):
+        return value
+    if isinstance(value, str):
+        s = value.replace("Z", "+00:00") if value.endswith("Z") else value
+        try:
+            return datetime.fromisoformat(s)
+        except ValueError:
+            return None
+    return None
+
+
+def report_from_dict(d: dict) -> OptimizeReport:
+    """
+    Reconstruct an OptimizeReport from the dict produced by `report_to_dict`.
+
+    Symmetric with `report_to_dict`. Used by the CLI when fetching an
+    optimize report from a running `tj serve` via /api/v1/optimize — the
+    daemon serialises the report and the CLI deserialises here so the same
+    rendering path works for both local and HTTP-fetched reports
+    (issue #68 §12).
+
+    Wave-2 analyzer findings live under `d["findings"]` keyed by analyzer
+    name; each registered analyzer module's `from_dict` helper is invoked
+    via the registry. Unknown finding names are dropped silently — this
+    keeps the CLI forward-compatible if the daemon advertises a finding
+    the local install doesn't know how to render yet.
+    """
+    from tokenjam.core.optimize.types import (
+        BudgetProjection,
+        DowngradeExample,
+        DowngradeFinding,
+        WindowSummary,
+    )
+
+    w = d.get("window") or {}
+    window = WindowSummary(
+        since=_parse_dt(w.get("since")) or datetime.now(tz=timezone.utc),
+        until=_parse_dt(w.get("until")) or datetime.now(tz=timezone.utc),
+        days=float(w.get("days", 0.0)),
+        sessions=int(w.get("sessions", 0)),
+        spans=int(w.get("spans", 0)),
+        total_tokens=int(w.get("total_tokens", 0)),
+        total_cost_usd=float(w.get("total_cost_usd", 0.0)),
+        thin_data=bool(w.get("thin_data", False)),
+    )
+
+    downgrade = None
+    if d.get("downgrade"):
+        dd = dict(d["downgrade"])
+        examples = [
+            DowngradeExample(
+                trace_id=str(ex.get("trace_id", "")),
+                session_id=ex.get("session_id"),
+                model=str(ex.get("model", "")),
+                tool_calls=int(ex.get("tool_calls", 0)),
+                duration_seconds=ex.get("duration_seconds"),
+                cost_usd=float(ex.get("cost_usd", 0.0)),
+            )
+            for ex in (dd.get("examples") or [])
+        ]
+        downgrade = DowngradeFinding(
+            candidate_sessions=int(dd.get("candidate_sessions", 0)),
+            total_sessions=int(dd.get("total_sessions", 0)),
+            actual_cost_usd=float(dd.get("actual_cost_usd", 0.0)),
+            alternative_cost_usd=float(dd.get("alternative_cost_usd", 0.0)),
+            monthly_savings_usd=float(dd.get("monthly_savings_usd", 0.0)),
+            percent_of_sessions=float(dd.get("percent_of_sessions", 0.0)),
+            examples=examples,
+            suggestions=dict(dd.get("suggestions") or {}),
+            caveat=str(dd.get("caveat", "")),
+            candidate_tokens=int(dd.get("candidate_tokens", 0)),
+            window_total_tokens=int(dd.get("window_total_tokens", 0)),
+            percent_of_tokens=float(dd.get("percent_of_tokens", 0.0)),
+            monthly_tokens_in_candidates=int(dd.get("monthly_tokens_in_candidates", 0)),
+        )
+
+    budgets = []
+    for b in d.get("budgets") or []:
+        bb = dict(b)
+        budgets.append(BudgetProjection(
+            provider=str(bb.get("provider", "")),
+            budget_usd=float(bb.get("budget_usd", 0.0)),
+            cycle_start_day=int(bb.get("cycle_start_day", 1)),
+            cycle_start=_parse_dt(bb.get("cycle_start")) or datetime.now(tz=timezone.utc),
+            cycle_end=_parse_dt(bb.get("cycle_end")) or datetime.now(tz=timezone.utc),
+            days_into_cycle=float(bb.get("days_into_cycle", 0.0)),
+            days_remaining=float(bb.get("days_remaining", 0.0)),
+            window_spend_usd=float(bb.get("window_spend_usd", 0.0)),
+            daily_run_rate_usd=float(bb.get("daily_run_rate_usd", 0.0)),
+            monthly_run_rate_usd=float(bb.get("monthly_run_rate_usd", 0.0)),
+            projected_cycle_total=float(bb.get("projected_cycle_total", 0.0)),
+            projected_overage_usd=float(bb.get("projected_overage_usd", 0.0)),
+            exhaustion_date=_parse_dt(bb.get("exhaustion_date")),
+            days_until_exhaustion=bb.get("days_until_exhaustion"),
+            over_budget=bool(bb.get("over_budget", False)),
+            applies_to_services=list(bb.get("applies_to_services") or []),
+            downgrade_run_rate_usd=bb.get("downgrade_run_rate_usd"),
+        ))
+
+    findings = {}
+    for name, payload in (d.get("findings") or {}).items():
+        constructor = _finding_constructor_for(name)
+        if constructor is None:
+            # Forward-compatible: ignore unknown findings rather than crash.
+            continue
+        try:
+            findings[name] = constructor(payload)
+        except Exception:
+            # Don't let one malformed finding break the whole report.
+            continue
+
+    return OptimizeReport(
+        window=window,
+        downgrade=downgrade,
+        budgets=budgets,
+        notes=list(d.get("notes") or []),
+        findings=findings,
+    )
+
+
+# Dispatch table: finding-registration-name -> (dict) -> dataclass constructor.
+# Filled lazily so importing runner.py doesn't require every analyzer module
+# to be imported (analyzers self-register via auto-discovery; the order
+# matters during package init).
+def _build_finding_constructors() -> dict:
+    from tokenjam.core.optimize.analyzers.cache_efficacy import (
+        CacheEfficacyFinding,
+        CacheEfficacyRow,
+    )
+    from tokenjam.core.optimize.analyzers.cache_recommend import (
+        CachePrefixCandidate,
+        CacheRecommendFinding,
+    )
+    from tokenjam.core.optimize.analyzers.prompt_bloat import (
+        BloatPrompt,
+        BloatRegion,
+        PromptBloatFinding,
+    )
+    from tokenjam.core.optimize.analyzers.workflow_restructure import (
+        WorkflowCluster,
+        WorkflowRestructureFinding,
+    )
+
+    def _cache_efficacy(d: dict) -> CacheEfficacyFinding:
+        rows = [CacheEfficacyRow(**r) for r in d.get("rows") or []]
+        flagged = [CacheEfficacyRow(**r) for r in d.get("flagged") or []]
+        return CacheEfficacyFinding(
+            rows=rows, flagged=flagged,
+            confidence=d.get("confidence", "structural"),
+        )
+
+    def _cache_recommend(d: dict) -> CacheRecommendFinding:
+        candidates = [
+            CachePrefixCandidate(**c) for c in d.get("candidates") or []
+        ]
+        return CacheRecommendFinding(
+            enabled=bool(d.get("enabled", False)),
+            candidates=candidates,
+            skipped_provider_count=int(d.get("skipped_provider_count", 0)),
+            confidence=d.get("confidence", "structural"),
+            hint=d.get("hint"),
+        )
+
+    def _workflow_restructure(d: dict) -> WorkflowRestructureFinding:
+        clusters = [WorkflowCluster(**c) for c in d.get("clusters") or []]
+        return WorkflowRestructureFinding(
+            clusters=clusters,
+            sessions_examined=int(d.get("sessions_examined", 0)),
+            degraded=bool(d.get("degraded", False)),
+            confidence=d.get("confidence", "structural"),
+            caveat=d.get("caveat", ""),
+        )
+
+    def _prompt_bloat(d: dict) -> PromptBloatFinding:
+        per_prompt = []
+        for p in d.get("per_prompt") or []:
+            regions = [BloatRegion(**r) for r in p.get("regions") or []]
+            pp = dict(p)
+            pp["regions"] = regions
+            per_prompt.append(BloatPrompt(**pp))
+        return PromptBloatFinding(
+            enabled=bool(d.get("enabled", False)),
+            prompts_scored=int(d.get("prompts_scored", 0)),
+            prompts_skipped=int(d.get("prompts_skipped", 0)),
+            total_bloat_chars=int(d.get("total_bloat_chars", 0)),
+            total_chars=int(d.get("total_chars", 0)),
+            per_prompt=per_prompt,
+            confidence=d.get("confidence", "structural"),
+            hint=d.get("hint"),
+        )
+
+    return {
+        "cache-efficacy": _cache_efficacy,
+        "cache-recommend": _cache_recommend,
+        "workflow-restructure": _workflow_restructure,
+        "prompt-bloat": _prompt_bloat,
+    }
+
+
+_FINDING_CONSTRUCTORS: dict = {}
+
+
+def _ensure_constructors_loaded() -> dict:
+    """Lazy-load the finding constructors on first use."""
+    global _FINDING_CONSTRUCTORS
+    if not _FINDING_CONSTRUCTORS:
+        _FINDING_CONSTRUCTORS = _build_finding_constructors()
+    return _FINDING_CONSTRUCTORS
+
+
+# Wire the lazy loader into report_from_dict above.
+def _finding_constructor_for(name: str):
+    return _ensure_constructors_loaded().get(name)

--- a/tokenjam/sdk/transport.py
+++ b/tokenjam/sdk/transport.py
@@ -27,6 +27,8 @@ class HttpTransport:
 
     Buffers up to 1000 spans if tj serve is not reachable.
     Retries with exponential backoff (max 3 attempts, 2s base delay).
+    On 401 (secret mismatch) fails fast — retrying won't change the
+    answer — and surfaces a clear diagnostic so the user notices.
     Drops buffered spans on process exit with a log warning.
     """
 
@@ -36,11 +38,15 @@ class HttpTransport:
         )
         self.secret = config.security.ingest_secret
         self._buffer: list[dict] = []
+        # Counter of spans dropped on 401. Exposed so `tj doctor` can
+        # surface it later (#68 §2 follow-up: doctor integration).
+        self.dropped_auth_failures = 0
 
     def send(self, spans: list[dict]) -> bool:
         """
         POST spans to tj serve.
-        Returns True on success, False on failure (spans are buffered).
+        Returns True on success, False on failure (spans are buffered,
+        except on 401 — see below).
         """
         # Add new spans to buffer
         self._buffer.extend(spans)
@@ -65,6 +71,33 @@ class HttpTransport:
                 if resp.status_code < 300:
                     self._buffer.clear()
                     return True
+                if resp.status_code == 401:
+                    # Auth failure won't change on retry. Don't burn the
+                    # backoff window (would be 6s of waiting per send call
+                    # while the user's agent stalls). Fail fast, log loudly
+                    # so the silent-data-loss footgun (#68 §2) is visible,
+                    # and clear the buffer — these spans will never succeed
+                    # with this secret. The configured secret is included
+                    # in the message (truncated) to make the mismatch
+                    # debuggable.
+                    secret_fingerprint = (
+                        f"{self.secret[:8]}..." if self.secret
+                        else "(no ingest_secret configured)"
+                    )
+                    logger.error(
+                        "tj serve rejected span export with 401 — your SDK "
+                        "is using ingest_secret=%s but the running daemon "
+                        "expects a different secret. Spans are being "
+                        "dropped (not buffered). Check that .tj/config.toml "
+                        "and ~/.config/tj/config.toml agree, or restart "
+                        "tj serve after rotating the secret. Dropped %d "
+                        "span(s) so far.",
+                        secret_fingerprint,
+                        len(payload) + self.dropped_auth_failures,
+                    )
+                    self.dropped_auth_failures += len(payload)
+                    self._buffer.clear()
+                    return False
                 logger.warning(
                     "tj serve returned %d on attempt %d",
                     resp.status_code, attempt + 1,


### PR DESCRIPTION
Closes #68. Closes all 11 numbered findings from the pre-release walkthrough plus the two API-mode follow-ups we noted while fixing §12. Originally opened against only the two launch-blockers (§12 + §15) — scope expanded after triage so the v0.3.0 release tag goes out with a clean slate.

## Commits (oldest → newest)

| Commit | Bug | Scope |
|---|---|---|
| `92b0811` | §14, §15, §16 | Wave-2 renderer dispatch; per-example dollar leak under unknown-tier; Rich-markup escape in hints |
| `3f146e3` | §12 | `/api/v1/optimize` route + `report_from_dict` deserializer; `tj optimize` no longer crashes alongside daemon |
| `cced338` | §1 | Explicit error on bare `tj onboard --reconfigure` (it's a no-op without `--claude-code` / `--codex`) |
| `cd1f78f` | §4 | `tj doctor` downgrades DB-writable from `✗` to `i` when the daemon holds the lock |
| `9bc8562` | §11 | `tj budget` enumerates recently-active agents via `get_traces()` under API-shim mode |
| `0770966` | §3 | `tj drift` surfaces baselines via new `ApiBackend.list_baseline_agents()` + `get_baseline()` |
| `12f0c36` | §2, §5 | SDK fails fast + drops spans on 401 (not silent buffering); `load_config` warns on diverged secrets across project-local and global configs |
| `e78608d` | #69 §28, §29 | New `/api/v1/cost/compare` route restores `--compare` under daemon mode; `plan_tier_mix` now included in optimize API payload |
| `5d938fe` | §6 | `ensure_demo_agent_config` writes to every config file in SEARCH_PATHS (not just the first match); demos now call `warn_if_daemon_running()` with the actionable restart hint |
| `2c4653e` | §7, §8, §9, §10 | Playbook polish: bare onboard doesn't prompt for plan tier (route through integrations); add "stop pre-existing daemon" to prerequisites; plan-tier examples are plan-agnostic; ruff baseline note updated to "clean" |

## What this enables

**`tj optimize` works in the recommended operating mode.** That's the strategy-pivot product. The combination of `92b0811` (Wave-2 renderer) and `3f146e3` (API route) means every `--finding` runs and renders correctly whether the daemon is up or down. Verified end-to-end on the live system.

**`tj doctor` cleanly reports a healthy system.** With `cd1f78f`, doctor under daemon mode is now all ✓ / i, no false ✗. Exit 0.

**`tj drift` surfaces baselines.** §3 was confusing during the walkthrough — drift_detected fired but `tj drift` reported "no baselines found" because the CLI went through the API path that didn't enumerate. Fixed at `0770966`.

**No more silent data loss.** §2 was the worst footgun in the codebase: SDK got 401s, dropped spans, logged a single warning line. Now: ERROR-level loud message with the truncated secret fingerprint, no retry (won't change), counter for cumulative loss. Plus `12f0c36` adds a config-load-time warning when project-local and global secrets diverge — the upstream cause of most 401s.

**`tj budget` and `tj cost --compare` work everywhere.** Both used to silently degrade under daemon mode. Now full functionality regardless of daemon state.

**Demos actually fire alerts.** §6's silent-no-fire was caused by the same secret-divergence class of bug plus the daemon's no-hot-reload behavior. Helper now writes to every config; demos warn if daemon is up.

## What I changed in the playbook

- Step 3 routes plan-tier verification through `tj onboard --claude-code` (the bare path doesn't prompt — `tj onboard` is provider-agnostic).
- Prerequisites now include "stop any lingering daemon" with the launchctl / systemctl one-liners.
- Plan-tier examples switched to `max_5x` (closer to the typical tester's actual plan), with a format table so the tester picks their own.
- Ruff baseline updated from "49 errors" to "clean" — and the practical fallback "if anything reports, confirm it's pre-existing on `main`".

## Test plan

- [x] **575 tests passing** locally (`pytest tests/unit tests/synthetic tests/agents tests/integration`)
- [x] **mypy strict clean** across 103+ source files
- [x] **ruff clean** (no new warnings introduced by this PR)
- [x] **End-to-end verification on the user's live system** — every Wave-2 analyzer renders, `tj cost --compare` works under daemon, `tj drift` shows baselines under daemon, `tj doctor` exits 0 under daemon
- [x] **9 new unit tests** (5 for the SDK 401 fail-fast + counter behavior, 4 for the config-divergence warning)
- [ ] **Re-run the playbook end-to-end** after merge to validate the v0.3.0 tag — that's the next step (issue #68 is closed pending merge)

🤖 Generated with [Claude Code](https://claude.com/claude-code)