### PR TITLE
fix(sdk): apply 401 fail-loud to TjHttpExporter (the path bootstrap actually uses)

### DIFF
--- a/tokenjam/sdk/http_exporter.py
+++ b/tokenjam/sdk/http_exporter.py
@@ -19,10 +19,14 @@ class TjHttpExporter(SpanExporter):
 
     def __init__(self, endpoint: str, ingest_secret: str) -> None:
         self._endpoint = endpoint
+        self._ingest_secret = ingest_secret
         self._headers = {
             "Content-Type": "application/json",
             "Authorization": f"Bearer {ingest_secret}",
         }
+        # Cumulative count of spans dropped on auth failure. Exposed so
+        # `tj doctor` can surface this in a future enhancement (#68 §2).
+        self.dropped_auth_failures = 0
 
     def export(self, spans: Sequence[ReadableSpan]) -> SpanExportResult:
         otlp_spans = [_span_to_otlp(s) for s in spans]
@@ -40,7 +44,31 @@ class TjHttpExporter(SpanExporter):
             )
             if resp.status_code < 300:
                 return SpanExportResult.SUCCESS
-            logger.warning("tj serve returned %d on span export", resp.status_code)
+            if resp.status_code == 401:
+                # 401 won't change on retry. Log loudly at ERROR level with
+                # the secret fingerprint so the user can spot the mismatch
+                # without grepping debug logs (#68 §2). The OTel
+                # BatchSpanProcessor treats FAILURE as drop-after-retries
+                # — by the time we get here the spans are effectively lost.
+                self.dropped_auth_failures += len(spans)
+                secret_fp = (
+                    f"{self._ingest_secret[:8]}..." if self._ingest_secret
+                    else "(no ingest_secret configured)"
+                )
+                logger.error(
+                    "tj serve rejected span export with 401 — your SDK is "
+                    "using ingest_secret=%s but the running daemon expects "
+                    "a different secret. Spans are being DROPPED. Check "
+                    "that .tj/config.toml and ~/.config/tj/config.toml "
+                    "agree (or run `tj stop && tj serve &` after rotating "
+                    "the secret). Dropped %d span(s) so far.",
+                    secret_fp,
+                    self.dropped_auth_failures,
+                )
+            else:
+                logger.warning(
+                    "tj serve returned %d on span export", resp.status_code,
+                )
         except (httpx.ConnectError, httpx.TimeoutException) as exc:
             logger.warning("Failed to export spans to tj serve: %s", exc)
         return SpanExportResult.FAILURE


### PR DESCRIPTION
Quick follow-up to PR #69 — the §2 fix landed in the wrong place.

## What happened

PR #69 fixed §2 on \`tokenjam/sdk/transport.py::HttpTransport\` — adding ERROR-level logging, a dropped-spans counter, and fail-fast (no retry-backoff) on 401. But that class **has no callers in the SDK**. \`bootstrap.py\` wires \`TjHttpExporter\` (the OTel SpanExporter in \`tokenjam/sdk/http_exporter.py\`) for actual span pushes. So the fix targeted dead code; the user-visible 401 footgun was unchanged.

Confirmed by re-running the playbook on \`main\` after #69 merged: every demo still shows the old short \`tj serve returned 401 on span export\` warning at the bottom with no actionable diagnostic.

## Fix

Apply the same pattern to \`TjHttpExporter.export()\`:

- 401 logs at ERROR level with the truncated \`ingest_secret\` fingerprint
- Cumulative \`dropped_auth_failures\` counter
- Message names both config locations + the \`tj stop && tj serve &\` fix verbatim

Non-401 responses keep the original short warning.

## Verified end-to-end

\`\`\`
$ python3 examples/alerts_and_drift/sensitive_actions_demo.py
... agent workflow ...
tj serve rejected span export with 401 — your SDK is using ingest_secret=10711471...
but the running daemon expects a different secret. Spans are being DROPPED. Check
that .tj/config.toml and ~/.config/tj/config.toml agree (or run \`tj stop && tj
serve &\` after rotating the secret). Dropped 7 span(s) so far.
\`\`\`

## Follow-up worth considering

\`tokenjam/sdk/transport.py\` is dead code. The §2 tests (\`test_transport_401.py\`) exercise a class no one calls. Probably worth removing in a separate PR so future debuggers don't waste time on it like I did.

## Test plan

- [x] 575 tests passing (no regressions)
- [x] Manual: re-ran sensitive_actions_demo — new ERROR message fires with fingerprint + dropped count

🤖 Generated with [Claude Code](https://claude.com/claude-code)