### PR TITLE
Rename optimize analyzers to product names + positional args (v0.3.1)

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ example sessions before changing models.
      Run rate $160.3500/mo — 19% of cycle budget unused.
 ```
 
-Two analyzers reading the same spans you'd otherwise pay LangSmith to host: structural model-downgrade candidate flagging (never claims quality equivalence — surfaces examples to review) and per-provider monthly budget projection. Works with **any** agent already sending TokenJam data, not just Claude Code.
+Two analyzers reading the same spans you'd otherwise pay LangSmith to host: structural downsize candidate flagging (never claims quality equivalence — surfaces examples to review) and per-provider monthly budget projection. Works with **any** agent already sending TokenJam data, not just Claude Code.
 
 Try a tighter budget to see the over-budget renderer:
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -90,7 +90,7 @@ Set limits via CLI (`tj budget --daily 10`), the REST API (`POST /api/v1/budget`
 
 ## Content capture and privacy
 
-By default, `tj` does not capture prompt content, completion content, or tool inputs/outputs — only token counts, model names, tool names, timestamps, and structural metadata. Enable content capture selectively when you need it (for debugging, prompt-bloat analysis, or evaluation):
+By default, `tj` does not capture prompt content, completion content, or tool inputs/outputs — only token counts, model names, tool names, timestamps, and structural metadata. Enable content capture selectively when you need it (for debugging, trim analysis, or evaluation):
 
 ```toml
 [capture]
@@ -108,9 +108,9 @@ The four flags are independent: capture prompts without completions, or tool inp
 
 **What this means for downstream analyzers.**
 
-- `tj optimize --finding cache-efficacy` reads token-count fields and works without content capture.
-- `tj optimize --finding prompt-bloat` reads prompt text and requires `capture.prompts = true`.
-- `tj optimize --finding cache-recommend` reads prompts and requires `capture.prompts = true`.
+- `tj optimize cache` reads token-count fields and works without content capture.
+- `tj optimize trim` reads prompt text and requires `capture.prompts = true`.
+- `tj optimize cache-recommend` reads prompts and requires `capture.prompts = true`.
 
 The analyzers that need content fail with a clear message ("set `capture.prompts = true` in tj.toml and let the daemon collect a fresh window of data") rather than running on partial data.
 

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -27,7 +27,7 @@ TokenJam keeps heavyweight ML dependencies, framework adapters, and the MCP serv
 | Extra | What it pulls in | Why it's optional |
 |---|---|---|
 | `tokenjam[mcp]` | `fastmcp` | Only needed for the Claude Code / Codex MCP server (`tj mcp`). Pulled by `tj onboard --claude-code` automatically when invoked through the documented one-liner. |
-| `tokenjam[bloat]` | `llmlingua>=0.2`, transitively PyTorch + transformers (~2GB) | The Trim analyzer (`tj optimize --finding prompt-bloat`) scores token significance with LLMLingua-2. Most users don't run it; keeping torch out of the base install means `pip install tokenjam` stays small and fast on machines that don't have a GPU/CPU build of torch already. |
+| `tokenjam[bloat]` | `llmlingua>=0.2`, transitively PyTorch + transformers (~2GB) | The Trim analyzer (`tj optimize trim`) scores token significance with LLMLingua-2. Most users don't run it; keeping torch out of the base install means `pip install tokenjam` stays small and fast on machines that don't have a GPU/CPU build of torch already. |
 | `tokenjam[langchain]` | `langchain>=0.2` | Convenience pin for `patch_langchain()`; you can also install langchain yourself. |
 | `tokenjam[crewai]` | `crewai>=0.28` | Convenience pin for `patch_crewai()`. |
 | `tokenjam[autogen]` | `pyautogen>=0.2` | Convenience pin for `patch_autogen()`. |
@@ -44,7 +44,7 @@ pip install "tokenjam[mcp,bloat]"
 
 `tokenjam[bloat]` is the largest extra — LLMLingua-2 transitively pulls in PyTorch and Hugging Face transformers, roughly 2GB on disk. On first run the analyzer downloads a ~110MB BERT-class classifier model under `~/.cache/tokenjam/models/` (override via `TOKENJAM_MODEL_CACHE`); subsequent runs are offline-capable.
 
-If you run `tj optimize --finding prompt-bloat` without the extra installed, the analyzer self-registers and exits with a clear hint pointing at this install command — nothing in the base install crashes from its absence.
+If you run `tj optimize trim` without the extra installed, the analyzer self-registers and exits with a clear hint pointing at this install command — nothing in the base install crashes from its absence.
 
 See [`docs/optimize/trim.md`](optimize/trim.md) for performance numbers, capture requirements, and what the analyzer actually reports.
 

--- a/docs/optimize/cache.md
+++ b/docs/optimize/cache.md
@@ -1,13 +1,13 @@
 # Cache
 
-Product name: **Cache**. Internal/CLI names: `cache-efficacy` and `cache-recommend`. Two related findings under the same product — both surface prompt-caching opportunities; they differ in what they need and what they recommend.
+Product name: **Cache**. Internal/CLI names: `cache` and `cache-recommend`. Two related findings under the same product — both surface prompt-caching opportunities; they differ in what they need and what they recommend.
 
 ```bash
-tj optimize --finding cache-efficacy
-tj optimize --finding cache-recommend
+tj optimize cache
+tj optimize cache-recommend
 ```
 
-## `cache-efficacy` — measure current caching
+## `cache` — measure current caching
 
 Reads aggregate `input_tokens` and `cache_tokens` from spans in the
 window. Computes the share of input bytes served from cache per

--- a/docs/optimize/downsize.md
+++ b/docs/optimize/downsize.md
@@ -1,9 +1,9 @@
 # Downsize
 
-Product name: **Downsize**. Internal/CLI name: `model-downgrade`.
+Product name: **Downsize**. Internal/CLI name: `downsize`.
 
 ```bash
-tj optimize --finding model-downgrade
+tj optimize downsize
 ```
 
 Flags sessions whose structural shape — short input (< 5K tokens), short output (< 500 tokens), few tool calls (≤ 5) — matches a class of work where a cheaper model in the same provider family is worth reviewing.
@@ -37,7 +37,7 @@ JSON output mirrors the same data with top-level `plan` and `pricing_mode` field
 
 ## Confidence
 
-`structural`. The model-downgrade finding identifies a structural pattern in the captured data; it does not validate that the cheaper model would produce equivalent output. The mandatory caveat is the honest framing of that limitation.
+`structural`. The downsize finding identifies a structural pattern in the captured data; it does not validate that the cheaper model would produce equivalent output. The mandatory caveat is the honest framing of that limitation.
 
 ## See also
 

--- a/docs/optimize/script.md
+++ b/docs/optimize/script.md
@@ -1,9 +1,9 @@
 # Script
 
-Product name: **Script**. Internal/CLI name: `workflow-restructure`.
+Product name: **Script**. Internal/CLI name: `script`.
 
 ```bash
-tj optimize --finding workflow-restructure
+tj optimize script
 ```
 
 Flags sessions whose tool-call sequence is structurally identical

--- a/docs/optimize/trim.md
+++ b/docs/optimize/trim.md
@@ -1,9 +1,9 @@
 # Trim
 
-Product name: **Trim**. Internal/CLI name: `prompt-bloat`.
+Product name: **Trim**. Internal/CLI name: `trim`.
 
 ```bash
-tj optimize --finding prompt-bloat
+tj optimize trim
 ```
 
 Scores token-by-token significance in captured prompts using
@@ -26,7 +26,7 @@ pip install "tokenjam[bloat]"
 ```
 
 The base `pip install tokenjam` does NOT pull torch. Trim shows up in
-`tj optimize --finding` choices regardless, but running it without the
+`tj optimize` analyzer choices regardless, but running it without the
 extra prints a clear install hint and exits.
 
 ## Requirements
@@ -56,10 +56,10 @@ marked.
 ## HTML report
 
 ```bash
-tj report --bloat                # all agents, 30d window
-tj report --bloat my-agent       # scope to one agent
-tj report --bloat --since 7d     # custom window
-tj report --bloat --no-open      # write file without opening browser
+tj report --trim                # all agents, 30d window
+tj report --trim my-agent       # scope to one agent
+tj report --trim --since 7d     # custom window
+tj report --trim --no-open      # write file without opening browser
 ```
 
 Output goes to `~/.cache/tokenjam/reports/trim-<timestamp>.html` and

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "tokenjam"
-version = "0.3.0"
+version = "0.3.1"
 description = "TokenJam — local-first OTel-native observability for Autonomous AI agents"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/sdk-ts/package.json
+++ b/sdk-ts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tokenjam/sdk",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "description": "TypeScript SDK for TokenJam — local-first observability for AI agents",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/tests/integration/test_cli.py
+++ b/tests/integration/test_cli.py
@@ -816,7 +816,7 @@ def test_optimize_budget_projection_from_config(runner, db):
         )
         db.insert_span(span)
 
-    result = _invoke(runner, db, cfg, ["optimize", "--finding", "budget-projection"])
+    result = _invoke(runner, db, cfg, ["optimize", "budget-projection"])
     assert result.exit_code == 0
     assert "Budget projection" in result.output
     assert "anthropic" in result.output

--- a/tests/manual-new-release-tests.md
+++ b/tests/manual-new-release-tests.md
@@ -49,11 +49,11 @@ tj doctor             # exit 0 or 1 (warnings ok)
 
 ```bash
 tj optimize                                # all analyzers
-tj optimize --finding model-downgrade      # Downsize
-tj optimize --finding cache-efficacy       # Cache (efficacy)
-tj optimize --finding cache-recommend      # Cache (recommend) — surfaces "enable capture.prompts" if not set
-tj optimize --finding workflow-restructure # Script — likely no candidates on a fresh DB
-tj optimize --finding prompt-bloat         # Trim — should print install hint without [bloat] extra
+tj optimize downsize      # Downsize
+tj optimize cache       # Cache (efficacy)
+tj optimize cache-recommend      # Cache (recommend) — surfaces "enable capture.prompts" if not set
+tj optimize script # Script — likely no candidates on a fresh DB
+tj optimize trim         # Trim — should print install hint without [bloat] extra
 
 # Caveat enforcement on the downgrade finding
 tj optimize --json | python3 -c \
@@ -64,7 +64,7 @@ tj optimize --json | python3 -c \
   "import json,sys;d=json.load(sys.stdin);assert 'plan' in d and 'pricing_mode' in d;print('ok')"
 ```
 
-**Pass criteria:** every `--finding` runs without crashing. Optional analyzers (`cache-recommend`, `prompt-bloat`) surface clear hints when their prereqs aren't met instead of erroring.
+**Pass criteria:** every positional analyzer name runs without crashing. Optional analyzers (`cache-recommend`, `trim`) surface clear hints when their prereqs aren't met instead of erroring.
 
 ## 5. Backfill adapters (smoke against committed fixtures)
 

--- a/tests/manual-pre-release-testing.md
+++ b/tests/manual-pre-release-testing.md
@@ -106,61 +106,61 @@ tj doctor     # exit 0 (or 1 with warnings); no errors
 
 ## 6. Cost-optimization analyzers (the four products)
 
-### 6a. Downsize (`--finding model-downgrade`)
+### 6a. Downsize
 
 ```bash
-tj optimize --finding model-downgrade
+tj optimize downsize
 # [ ] If candidates found: caveat "Candidate-flagging heuristic, not a quality judgment." is present
 # [ ] If no candidates: clean "No candidates flagged" message — not a crash
-tj optimize --finding model-downgrade --json | python3 -c \
+tj optimize downsize --json | python3 -c \
   "import json,sys;r=json.load(sys.stdin);d=r.get('downgrade');assert d is None or 'Candidate-flagging heuristic' in d['caveat'];print('ok: caveat enforced')"
 ```
 
-### 6b. Cache (`--finding cache-efficacy` + `--finding cache-recommend`)
+### 6b. Cache
 
 ```bash
-# cache-efficacy works without content capture
-tj optimize --finding cache-efficacy
+# cache works without content capture
+tj optimize cache
 # [ ] Per (provider, model) rows. Anthropic shows numerically-accurate ratios.
 # [ ] OpenAI / Gemini rows (if present) carry the best-effort caveat.
 # [ ] Rows for Bedrock / LiteLLM / Cohere (if present) show unsupported, not flagged.
 
 # cache-recommend needs capture.prompts. Without it, the analyzer returns a hint.
-tj optimize --finding cache-recommend
+tj optimize cache-recommend
 # [ ] Without capture.prompts: surfaces the "enable capture.prompts" hint, doesn't crash.
 # [ ] With capture.prompts and ≥3 calls sharing a long prefix: surfaces breakpoint candidates.
 ```
 
 To exercise the content-needed branch, set `capture.prompts = true` in `.tj/config.toml`, re-run an example, then re-run `cache-recommend`.
 
-### 6c. Script (`--finding workflow-restructure`)
+### 6c. Script
 
 ```bash
-tj optimize --finding workflow-restructure
+tj optimize script
 # [ ] If ≥20 sessions match a single (tool_name, arg_shape) signature: cluster surfaces with
 #     "review carefully" caveat. With v1's conservative thresholds, most fresh test DBs see no candidates.
 # [ ] No crash; "no clusters found" message is acceptable.
 ```
 
-### 6d. Trim (`--finding prompt-bloat`)
+### 6d. Trim
 
 Trim requires the optional `tokenjam[bloat]` extra (LLMLingua-2 + torch + transformers, ~2GB).
 
 ```bash
 # Without the extra installed: self-registers, errors gracefully with install hint.
-tj optimize --finding prompt-bloat
+tj optimize trim
 # [ ] Output points the user at: pip install "tokenjam[bloat]"
 
 # Install the extra and re-run — only do this if you actually want to test Trim end-to-end
 # (the 2GB download is real). Skip this on quick passes.
 pip3 install -e ".[dev,mcp,bloat]"
 # Enable capture.prompts in .tj/config.toml, re-run examples to populate content, then:
-tj optimize --finding prompt-bloat
+tj optimize trim
 # [ ] First run downloads the ~110MB BERT model under ~/.cache/tokenjam/models/.
 # [ ] Subsequent runs are offline.
 
 # HTML report renderer
-tj report --bloat --no-open
+tj report --trim --no-open
 # [ ] Writes to ~/.cache/tokenjam/reports/trim-<timestamp>.html
 # [ ] HTML contains a caveat block + per-prompt sections
 ```
@@ -400,8 +400,8 @@ python3 examples/single_provider/anthropic_agent.py
 
 tj status && tj traces && tj cost --since 1h
 tj optimize           # all analyzers
-tj optimize --finding model-downgrade
-tj optimize --finding cache-efficacy
+tj optimize downsize
+tj optimize cache
 tj backfill langfuse --source-file tests/fixtures/langfuse_real_response.json
 tj backfill helicone --source-file tests/fixtures/helicone_real_response.json
 tj backfill otlp --source-file tests/fixtures/otlp_sample.json

--- a/tests/unit/test_cache_efficacy.py
+++ b/tests/unit/test_cache_efficacy.py
@@ -1,4 +1,4 @@
-"""Unit tests for the cache-efficacy analyzer."""
+"""Unit tests for the cache analyzer."""
 from __future__ import annotations
 
 from datetime import datetime, timedelta, timezone
@@ -140,10 +140,10 @@ def test_run_integrates_with_build_report(db, config):
     until = datetime(2026, 5, 30, tzinfo=timezone.utc)
     report = build_report(
         db=db, config=config, since=since, until=until,
-        findings=["cache-efficacy"],
+        findings=["cache"],
     )
-    assert "cache-efficacy" in report.findings
-    finding = report.findings["cache-efficacy"]
+    assert "cache" in report.findings
+    finding = report.findings["cache"]
     assert finding.confidence == "structural"
     assert len(finding.rows) == 1
     assert len(finding.flagged) == 1

--- a/tests/unit/test_prompt_bloat.py
+++ b/tests/unit/test_prompt_bloat.py
@@ -1,5 +1,5 @@
 """
-Unit tests for the prompt-bloat (Trim) analyzer.
+Unit tests for the trim (Trim) analyzer.
 
 The LLMLingua-2 model is mocked across these tests so CI doesn't have to
 download ~110MB and run an actual BERT classifier. The mock returns
@@ -83,8 +83,8 @@ def test_disabled_without_capture_prompts(db):
     since = datetime(2026, 5, 1, tzinfo=timezone.utc)
     until = datetime(2026, 5, 30, tzinfo=timezone.utc)
     report = build_report(db=db, config=config, since=since, until=until,
-                          findings=["prompt-bloat"])
-    finding = report.findings["prompt-bloat"]
+                          findings=["trim"])
+    finding = report.findings["trim"]
     assert isinstance(finding, PromptBloatFinding)
     assert finding.enabled is False
     assert "capture" in finding.hint.lower()
@@ -98,8 +98,8 @@ def test_disabled_when_llmlingua_missing(db, monkeypatch):
     since = datetime(2026, 5, 1, tzinfo=timezone.utc)
     until = datetime(2026, 5, 30, tzinfo=timezone.utc)
     report = build_report(db=db, config=config, since=since, until=until,
-                          findings=["prompt-bloat"])
-    finding = report.findings["prompt-bloat"]
+                          findings=["trim"])
+    finding = report.findings["trim"]
     assert finding.enabled is False
     assert "tokenjam[bloat]" in finding.hint
 
@@ -153,8 +153,8 @@ def test_scores_prompts_and_finds_bloat(db, monkeypatch):
     since = datetime(2026, 5, 1, tzinfo=timezone.utc)
     until = datetime(2026, 5, 30, tzinfo=timezone.utc)
     report = build_report(db=db, config=config, since=since, until=until,
-                          findings=["prompt-bloat"])
-    finding = report.findings["prompt-bloat"]
+                          findings=["trim"])
+    finding = report.findings["trim"]
     assert finding.enabled is True
     assert finding.prompts_scored == 3
     # Each scored prompt produces one BloatPrompt entry, up to the 10 cap.
@@ -173,8 +173,8 @@ def test_skips_short_prompts(db, monkeypatch):
     since = datetime(2026, 5, 1, tzinfo=timezone.utc)
     until = datetime(2026, 5, 30, tzinfo=timezone.utc)
     report = build_report(db=db, config=config, since=since, until=until,
-                          findings=["prompt-bloat"])
-    finding = report.findings["prompt-bloat"]
+                          findings=["trim"])
+    finding = report.findings["trim"]
     assert finding.prompts_scored == 0
     assert finding.prompts_skipped == 5
     assert finding.per_prompt == []

--- a/tests/unit/test_workflow_restructure.py
+++ b/tests/unit/test_workflow_restructure.py
@@ -1,4 +1,4 @@
-"""Unit tests for the workflow-restructure analyzer."""
+"""Unit tests for the script analyzer."""
 from __future__ import annotations
 
 from datetime import datetime, timedelta, timezone
@@ -107,8 +107,8 @@ def test_flags_cluster_at_or_above_threshold(db):
     since = datetime(2026, 5, 1, tzinfo=timezone.utc)
     until = datetime(2026, 5, 30, tzinfo=timezone.utc)
     report = build_report(db=db, config=config, since=since, until=until,
-                          findings=["workflow-restructure"])
-    finding = report.findings["workflow-restructure"]
+                          findings=["script"])
+    finding = report.findings["script"]
     assert finding.degraded is False
     assert len(finding.clusters) == 1
     c = finding.clusters[0]
@@ -131,8 +131,8 @@ def test_below_threshold_not_flagged(db):
     since = datetime(2026, 5, 1, tzinfo=timezone.utc)
     until = datetime(2026, 5, 30, tzinfo=timezone.utc)
     report = build_report(db=db, config=config, since=since, until=until,
-                          findings=["workflow-restructure"])
-    assert report.findings["workflow-restructure"].clusters == []
+                          findings=["script"])
+    assert report.findings["script"].clusters == []
 
 
 def test_value_variation_doesnt_split_cluster(db):
@@ -157,8 +157,8 @@ def test_value_variation_doesnt_split_cluster(db):
     since = datetime(2026, 5, 1, tzinfo=timezone.utc)
     until = datetime(2026, 5, 30, tzinfo=timezone.utc)
     report = build_report(db=db, config=config, since=since, until=until,
-                          findings=["workflow-restructure"])
-    finding = report.findings["workflow-restructure"]
+                          findings=["script"])
+    finding = report.findings["script"]
     assert len(finding.clusters) == 1
     assert finding.clusters[0].instances == MIN_CLUSTER_INSTANCES
 
@@ -179,8 +179,8 @@ def test_different_signatures_form_separate_clusters(db):
     since = datetime(2026, 5, 1, tzinfo=timezone.utc)
     until = datetime(2026, 5, 30, tzinfo=timezone.utc)
     report = build_report(db=db, config=config, since=since, until=until,
-                          findings=["workflow-restructure"])
-    assert len(report.findings["workflow-restructure"].clusters) == 2
+                          findings=["script"])
+    assert len(report.findings["script"].clusters) == 2
 
 
 def test_degraded_mode_when_tool_inputs_not_captured(db):
@@ -199,8 +199,8 @@ def test_degraded_mode_when_tool_inputs_not_captured(db):
     since = datetime(2026, 5, 1, tzinfo=timezone.utc)
     until = datetime(2026, 5, 30, tzinfo=timezone.utc)
     report = build_report(db=db, config=config, since=since, until=until,
-                          findings=["workflow-restructure"])
-    finding = report.findings["workflow-restructure"]
+                          findings=["script"])
+    finding = report.findings["script"]
     assert finding.degraded is True
     assert len(finding.clusters) == 1
     # Without arg shape captured, signature carries only tool names.
@@ -213,7 +213,7 @@ def test_no_tool_spans_in_window(db):
     since = datetime(2026, 5, 1, tzinfo=timezone.utc)
     until = datetime(2026, 5, 30, tzinfo=timezone.utc)
     report = build_report(db=db, config=config, since=since, until=until,
-                          findings=["workflow-restructure"])
-    finding = report.findings["workflow-restructure"]
+                          findings=["script"])
+    finding = report.findings["script"]
     assert finding.clusters == []
     assert finding.sessions_examined == 0

--- a/tokenjam/api/routes/optimize.py
+++ b/tokenjam/api/routes/optimize.py
@@ -40,7 +40,7 @@ def get_optimize(
     """
     Run the optimize analyzers server-side and return the serialized report.
 
-    Mirrors the CLI `tj optimize` flags: --since, --agent, --finding (repeatable),
+    Mirrors the CLI `tj optimize` flags: --since, --agent, positional NAME args,
     --budget, --budget-usd. Returns the same dict shape `report_to_dict` produces
     locally, so the CLI can reconstruct an `OptimizeReport` and render it.
     """

--- a/tokenjam/cli/cmd_optimize.py
+++ b/tokenjam/cli/cmd_optimize.py
@@ -92,15 +92,13 @@ def _config_declared_plan(config) -> str | None:
 
 
 @click.command("optimize")
+@click.argument(
+    "findings",
+    nargs=-1,
+    type=click.Choice(sorted(ANALYZER_REGISTRY.keys())),
+)
 @click.option("--agent", default=None, help="Scope to a specific agent_id.")
 @click.option("--since", default="30d", help="Window for analysis (default 30d).")
-@click.option(
-    "--finding",
-    "findings",
-    multiple=True,
-    type=click.Choice(sorted(ANALYZER_REGISTRY.keys())),
-    help="Run only the named analyzer(s). Repeatable. Default: run all.",
-)
 @click.option("--budget", "budget_provider", default=None,
               help="Scope budget projection to a single provider (e.g. anthropic).")
 @click.option("--budget-usd", type=float, default=None,
@@ -454,8 +452,8 @@ def _render_report(
             _render_budget(proj)
             console.print()
 
-    # ----- Wave-2 findings (cache-efficacy, cache-recommend,
-    # workflow-restructure, prompt-bloat) — these attach to report.findings
+    # ----- Wave-2 findings (cache, cache-recommend,
+    # script, trim) — these attach to report.findings
     # rather than typed slots. Dispatch to a per-finding renderer; ignore
     # any unknown finding names (forward-compatible with future analyzers).
     rendered_any_wave2 = False
@@ -468,8 +466,8 @@ def _render_report(
         rendered_any_wave2 = True
 
     # Only show the catch-all when truly nothing rendered. The earlier
-    # condition missed the Wave-2 findings dict, so cache-efficacy /
-    # cache-recommend / workflow-restructure / prompt-bloat were silently
+    # condition missed the Wave-2 findings dict, so cache /
+    # cache-recommend / script / trim were silently
     # falling into "No candidates flagged" (issue #68 §15).
     rendered_any = (
         report.downgrade is not None
@@ -485,7 +483,7 @@ def _render_report(
 
 def _render_downgrade(d: DowngradeFinding, pricing_mode: str = "api") -> None:
     """
-    Render the model-downgrade finding for the given pricing mode.
+    Render the downsize finding for the given pricing mode.
 
     - api:          dollar-denominated savings (current behavior)
     - subscription: token-share framing — "candidate sessions are X% of your
@@ -607,7 +605,7 @@ def _render_budget(p: BudgetProjection) -> None:
     )
     if p.downgrade_run_rate_usd is not None and p.downgrade_run_rate_usd < p.monthly_run_rate_usd:
         console.print(
-            f"     • With model-downgrade pattern: run rate drops to "
+            f"     • With downsize pattern: run rate drops to "
             f"[bold]{format_cost(p.downgrade_run_rate_usd)}/mo[/bold]"
         )
     if p.applies_to_services:
@@ -688,7 +686,7 @@ def _export_snippet(
 
 def _render_cache_efficacy(finding, *, pricing_mode: str = "api") -> None:
     """
-    Render the cache-efficacy finding — current caching-ratio table per
+    Render the cache finding — current caching-ratio table per
     (provider, model). When any rows are flagged, surface them prominently;
     otherwise show the full table dimmed so the user sees the underlying
     data even when no recommendation is warranted.
@@ -791,7 +789,7 @@ def _render_cache_recommend(finding, *, pricing_mode: str = "api") -> None:
 
 def _render_workflow_restructure(finding, *, pricing_mode: str = "api") -> None:
     """
-    Render the workflow-restructure (Script) finding — clusters of sessions
+    Render the script (Script) finding — clusters of sessions
     matching the same (tool_name, arg_shape) signature.
     """
     console.print("  [bold]Workflow restructure:[/bold]")
@@ -850,7 +848,7 @@ def _render_workflow_restructure(finding, *, pricing_mode: str = "api") -> None:
 
 def _render_prompt_bloat(finding, *, pricing_mode: str = "api") -> None:
     """
-    Render the prompt-bloat (Trim) finding — LLMLingua-2 token-significance
+    Render the trim (Trim) finding — LLMLingua-2 token-significance
     summary. When the analyzer is disabled (either capture off or extra
     not installed), surface the hint.
     """
@@ -901,14 +899,14 @@ def _render_prompt_bloat(finding, *, pricing_mode: str = "api") -> None:
         console.print(f"           [dim italic]{sample}[/dim italic]")
     console.print(
         "     [dim]For per-prompt highlights run: "
-        "[bold]tj report --bloat[/bold][/dim]"
+        "[bold]tj report --trim[/bold][/dim]"
     )
 
 
 # Dispatch table — analyzer registration name → renderer.
 _FINDING_RENDERERS = {
-    "cache-efficacy":       _render_cache_efficacy,
+    "cache":       _render_cache_efficacy,
     "cache-recommend":      _render_cache_recommend,
-    "workflow-restructure": _render_workflow_restructure,
-    "prompt-bloat":         _render_prompt_bloat,
+    "script": _render_workflow_restructure,
+    "trim":         _render_prompt_bloat,
 }

--- a/tokenjam/cli/cmd_report.py
+++ b/tokenjam/cli/cmd_report.py
@@ -2,8 +2,8 @@
 `tj report` — generate detailed HTML reports for analyzer findings.
 
 Currently supports:
-  - `tj report --bloat [<agent_id>]`: open an HTML visualization of the
-    prompt-bloat analyzer's findings, with high-significance tokens in
+  - `tj report --trim [<agent_id>]`: open an HTML visualization of the
+    Trim analyzer's findings, with high-significance tokens in
     bold and low-significance regions dimmed.
 
 The HTML is written to a local file and opened in the user's default
@@ -33,30 +33,30 @@ def _report_dir() -> Path:
 
 
 @click.command("report")
-@click.option("--bloat", "bloat_agent", default=None, flag_value="",
-              is_flag=False, help="Generate the prompt-bloat HTML report. "
+@click.option("--trim", "trim_agent", default=None, flag_value="",
+              is_flag=False, help="Generate the Trim HTML report. "
                                    "Optional agent_id scopes the report.")
 @click.option("--since", default="30d", help="Window for the report (default 30d).")
 @click.option("--no-open", "no_open", is_flag=True, default=False,
               help="Write the HTML file without opening it in a browser.")
 @click.pass_context
-def cmd_report(ctx: click.Context, bloat_agent: str | None, since: str,
+def cmd_report(ctx: click.Context, trim_agent: str | None, since: str,
                no_open: bool) -> None:
     """Generate detailed HTML reports for analyzer findings."""
-    if bloat_agent is None:
+    if trim_agent is None:
         raise click.UsageError(
-            "Specify a report type. Currently supported: --bloat [<agent_id>]"
+            "Specify a report type. Currently supported: --trim [<agent_id>]"
         )
-    _render_bloat_report(ctx, bloat_agent or None, since, no_open)
+    _render_trim_report(ctx, trim_agent or None, since, no_open)
 
 
-def _render_bloat_report(
+def _render_trim_report(
     ctx: click.Context,
     agent_id: str | None,
     since: str,
     no_open: bool,
 ) -> None:
-    """Run the prompt-bloat analyzer and write its findings as HTML."""
+    """Run the Trim analyzer and write its findings as HTML."""
     from tokenjam.core.optimize import build_report
     from tokenjam.utils.time_parse import parse_since, utcnow
 
@@ -74,11 +74,11 @@ def _render_bloat_report(
         db=db, config=config,
         since=since_dt, until=utcnow(),
         agent_id=agent_id,
-        findings=["prompt-bloat"],
+        findings=["trim"],
     )
-    finding = report.findings.get("prompt-bloat")
+    finding = report.findings.get("trim")
     if finding is None:
-        raise click.ClickException("Prompt-bloat analyzer didn't produce a finding.")
+        raise click.ClickException("Trim analyzer didn't produce a finding.")
 
     if not finding.enabled:
         # Show the hint inline rather than producing an empty HTML file.
@@ -101,7 +101,7 @@ def _render_bloat_report(
 
 def _render_html(finding, agent_scope: str | None, since: str) -> str:
     """
-    Render the prompt-bloat finding as a standalone HTML page.
+    Render the Trim finding as a standalone HTML page.
 
     Per-prompt detail: the prompt text is split into segments — high-sig
     (bold) vs flagged bloat regions (dimmed + struck through). Each region

--- a/tokenjam/core/export/claude_code.py
+++ b/tokenjam/core/export/claude_code.py
@@ -1,5 +1,5 @@
 """
-Generate Claude Code routing snippets from the model-downgrade analyzer.
+Generate Claude Code routing snippets from the downsize analyzer.
 
 Output shape — a `.claude/settings.json`-shaped fragment under a
 `tokenjam.routing_recommendations` namespace, with honest-framing

--- a/tokenjam/core/optimize/README.md
+++ b/tokenjam/core/optimize/README.md
@@ -17,7 +17,7 @@ def run(ctx: AnalyzerContext) -> None:
 Auto-discovery in `analyzers/__init__.py` imports every `.py` file under that
 directory, so the `@register` side effect fires automatically. No edit to
 `__init__.py` or `cmd_optimize.py` is required — the CLI reads valid
-`--finding` choices from `ANALYZER_REGISTRY.keys()` at click decoration time.
+positional analyzer name choices from `ANALYZER_REGISTRY.keys()` at click decoration time.
 
 ## Ordering
 

--- a/tokenjam/core/optimize/__init__.py
+++ b/tokenjam/core/optimize/__init__.py
@@ -17,7 +17,7 @@ Adding a new analyzer:
      @register("name") taking (ctx: AnalyzerContext) -> None
   2. Add the name to ANALYZER_ORDER in runner.py if it depends on or is
      depended upon by another analyzer
-  3. Nothing else needs editing — cmd_optimize's --finding choices read
+  3. Nothing else needs editing — cmd_optimize's positional choices read
      from ANALYZER_REGISTRY directly
 
 See README.md in this package for details.

--- a/tokenjam/core/optimize/analyzers/budget_projection.py
+++ b/tokenjam/core/optimize/analyzers/budget_projection.py
@@ -125,7 +125,7 @@ def run(ctx: AnalyzerContext) -> None:
     Registry entry point. Appends one BudgetProjection per configured
     provider budget to ctx.report.budgets.
 
-    Reads ctx.report.downgrade (set by model-downgrade analyzer, if it ran)
+    Reads ctx.report.downgrade (set by downsize analyzer, if it ran)
     to provide a downgrade-adjusted run-rate for each provider projection.
     """
     config = ctx.config

--- a/tokenjam/core/optimize/analyzers/cache_efficacy.py
+++ b/tokenjam/core/optimize/analyzers/cache_efficacy.py
@@ -113,13 +113,13 @@ def _compute_rows(conn, since, until, agent_id: str | None) -> list[CacheEfficac
     return result
 
 
-@register("cache-efficacy")
+@register("cache")
 def run(ctx: AnalyzerContext) -> None:
     """Registry entry point. Attaches the finding to ctx.report.findings."""
     rows = _compute_rows(ctx.conn, ctx.since, ctx.until, ctx.agent_id)
     if not rows:
         return
-    ctx.report.findings["cache-efficacy"] = CacheEfficacyFinding(
+    ctx.report.findings["cache"] = CacheEfficacyFinding(
         rows=rows,
         flagged=[r for r in rows if r.flagged],
     )

--- a/tokenjam/core/optimize/analyzers/model_downgrade.py
+++ b/tokenjam/core/optimize/analyzers/model_downgrade.py
@@ -204,7 +204,7 @@ def analyze_model_downgrade(
     )
 
 
-@register("model-downgrade")
+@register("downsize")
 def run(ctx: AnalyzerContext) -> None:
     """Registry entry point. Mutates ctx.report.downgrade."""
     ctx.report.downgrade = analyze_model_downgrade(

--- a/tokenjam/core/optimize/analyzers/prompt_bloat.py
+++ b/tokenjam/core/optimize/analyzers/prompt_bloat.py
@@ -1,5 +1,5 @@
 """
-Trim analyzer (internal: prompt-bloat).
+Trim analyzer (internal: trim).
 
 Scores token-by-token significance in captured prompts using LLMLingua-2
 (BERT-class token classifier, MIT-licensed, runs on CPU). Identifies
@@ -16,7 +16,7 @@ Dependency handling:
     The transitive footprint is ~2GB (PyTorch + transformers), so we
     don't pull it into the base install.
   - The import is deferred to the analysis function body so the analyzer
-    self-registers and shows up in `--finding` choices regardless of
+    self-registers and shows up in positional analyzer name choices regardless of
     whether the extra is installed.
   - Missing extra → analysis returns a finding with a clear message
     pointing the user at the install command.
@@ -229,12 +229,12 @@ def _stringify_prompt(value: Any) -> str:
     return str(value)
 
 
-@register("prompt-bloat")
+@register("trim")
 def run(ctx: AnalyzerContext) -> None:
     """Registry entry point. Attaches a PromptBloatFinding to ctx.report.findings."""
     capture = getattr(ctx.config, "capture", None)
     if capture is None or not getattr(capture, "prompts", False):
-        ctx.report.findings["prompt-bloat"] = PromptBloatFinding(
+        ctx.report.findings["trim"] = PromptBloatFinding(
             enabled=False,
             hint=(
                 "Enable `[capture] prompts = true` in tj.toml and let the "
@@ -249,7 +249,7 @@ def run(ctx: AnalyzerContext) -> None:
     try:
         PromptCompressor = _try_import_llmlingua()
     except ImportError as exc:
-        ctx.report.findings["prompt-bloat"] = PromptBloatFinding(
+        ctx.report.findings["trim"] = PromptBloatFinding(
             enabled=False,
             hint=str(exc),
         )
@@ -273,7 +273,7 @@ def run(ctx: AnalyzerContext) -> None:
     ).fetchall()
 
     if not rows:
-        ctx.report.findings["prompt-bloat"] = PromptBloatFinding(enabled=True)
+        ctx.report.findings["trim"] = PromptBloatFinding(enabled=True)
         return
 
     # Lazy-instantiate the compressor with cached model storage.
@@ -340,7 +340,7 @@ def run(ctx: AnalyzerContext) -> None:
     # Sort by bloat absolute volume — biggest opportunities first.
     per_prompt.sort(key=lambda p: p.bloat_chars, reverse=True)
 
-    ctx.report.findings["prompt-bloat"] = PromptBloatFinding(
+    ctx.report.findings["trim"] = PromptBloatFinding(
         enabled=True,
         prompts_scored=prompts_scored,
         prompts_skipped=prompts_skipped,

--- a/tokenjam/core/optimize/analyzers/workflow_restructure.py
+++ b/tokenjam/core/optimize/analyzers/workflow_restructure.py
@@ -118,7 +118,7 @@ def _extract_tool_input(attrs: Any) -> Any:
     return attrs.get(GenAIAttributes.TOOL_INPUT)
 
 
-@register("workflow-restructure")
+@register("script")
 def run(ctx: AnalyzerContext) -> None:
     """Registry entry point. Attaches a WorkflowRestructureFinding to ctx.report.findings."""
     capture = getattr(ctx.config, "capture", None)
@@ -143,7 +143,7 @@ def run(ctx: AnalyzerContext) -> None:
     ).fetchall()
 
     if not rows:
-        ctx.report.findings["workflow-restructure"] = WorkflowRestructureFinding(
+        ctx.report.findings["script"] = WorkflowRestructureFinding(
             degraded=not has_tool_inputs,
         )
         return
@@ -199,7 +199,7 @@ def run(ctx: AnalyzerContext) -> None:
     # are the biggest savings opportunities.
     interesting.sort(key=lambda c: c.instances, reverse=True)
 
-    ctx.report.findings["workflow-restructure"] = WorkflowRestructureFinding(
+    ctx.report.findings["script"] = WorkflowRestructureFinding(
         clusters=interesting,
         sessions_examined=len(session_signatures),
         degraded=not has_tool_inputs,

--- a/tokenjam/core/optimize/runner.py
+++ b/tokenjam/core/optimize/runner.py
@@ -3,7 +3,7 @@ Optimize orchestrator. Builds OptimizeReport by running selected analyzers
 from the registry in a deterministic order.
 
 Analyzer ordering matters: budget-projection reads ctx.report.downgrade,
-so model-downgrade must run first when both are selected.
+so downsize must run first when both are selected.
 """
 from __future__ import annotations
 
@@ -24,15 +24,15 @@ from tokenjam.core.optimize.types import (
 from tokenjam.core.optimize import analyzers as _analyzers  # noqa: F401
 
 # Deterministic order. Adding a new analyzer? Append to this list. Analyzers
-# requested via --finding are filtered against ANALYZER_REGISTRY but executed
+# requested via positional are filtered against ANALYZER_REGISTRY but executed
 # in the order defined here, so cross-analyzer dependencies stay stable.
 ANALYZER_ORDER: list[str] = [
-    "model-downgrade",
+    "downsize",
     "budget-projection",
-    "cache-efficacy",
+    "cache",
     "cache-recommend",
-    "workflow-restructure",
-    "prompt-bloat",
+    "script",
+    "trim",
 ]
 
 THIN_DATA_DAYS = 7
@@ -365,10 +365,10 @@ def _build_finding_constructors() -> dict:
         )
 
     return {
-        "cache-efficacy": _cache_efficacy,
+        "cache": _cache_efficacy,
         "cache-recommend": _cache_recommend,
-        "workflow-restructure": _workflow_restructure,
-        "prompt-bloat": _prompt_bloat,
+        "script": _workflow_restructure,
+        "trim": _prompt_bloat,
     }
 
 

--- a/tokenjam/core/optimize/types.py
+++ b/tokenjam/core/optimize/types.py
@@ -5,7 +5,7 @@ from dataclasses import dataclass, field
 from datetime import datetime
 from typing import Any
 
-# Mandatory caveat string. Every channel that surfaces the model-downgrade
+# Mandatory caveat string. Every channel that surfaces the downsize
 # finding must include this verbatim; spec rule #2 is non-negotiable.
 MODEL_DOWNGRADE_CAVEAT = (
     "Candidate-flagging heuristic, not a quality judgment. "
@@ -84,10 +84,10 @@ class OptimizeReport:
     budgets:   list[BudgetProjection] = field(default_factory=list)
     notes:     list[str] = field(default_factory=list)
     # Generic findings dict keyed by analyzer registration name. Wave 2
-    # analyzers (cache-efficacy, cache-recommend, prompt-bloat,
-    # workflow-restructure) attach their results here so adding a new
+    # analyzers (cache, cache-recommend, trim,
+    # script) attach their results here so adding a new
     # analyzer doesn't require a typed slot on this dataclass.
-    # Existing analyzers (model-downgrade, budget-projection) keep their
+    # Existing analyzers (downsize, budget-projection) keep their
     # typed slots above for backwards-compat with cmd_optimize and mcp.
     findings:  dict = field(default_factory=dict)
 

--- a/tokenjam/mcp/server.py
+++ b/tokenjam/mcp/server.py
@@ -1097,10 +1097,10 @@ def get_optimize_report(
     looks like, which sessions look like they could have used a cheaper
     model, whether they're using their Claude plan efficiently, or whether
     they're getting their money's worth from a subscription plan. Includes a
-    mandatory caveat field reminding callers that the model-downgrade
+    mandatory caveat field reminding callers that the downsize
     finding is a structural heuristic, not a quality judgment.
 
-    `findings` is a list of analyzer names to run (e.g. ['model-downgrade']
+    `findings` is a list of analyzer names to run (e.g. ['downsize']
     or ['budget-projection']). Omit to run all registered analyzers.
 
     Output includes a `pricing_mode` field derived from the session's


### PR DESCRIPTION
Closes #74.

## Summary
- Drop \`--finding\` flag; accept analyzer names as **positional args**
  - \`tj optimize\` — run all (unchanged)
  - \`tj optimize downsize\` — run one
  - \`tj optimize downsize cache trim\` — run several
- Rename registration strings to match the product names users see in docs / the website / \`docs/optimize/*.md\`:
  | old | new | product page |
  |---|---|---|
  | \`model-downgrade\` | \`downsize\` | downsize.md |
  | \`cache-efficacy\` | \`cache\` | cache.md |
  | \`workflow-restructure\` | \`script\` | script.md |
  | \`prompt-bloat\` | \`trim\` | trim.md |
- Rename \`tj report --bloat\` → \`tj report --trim\`
- Bump version to \`0.3.1\`

\`cache-recommend\` (sub-finding) and \`budget-projection\` (infra concept) keep their names. No back-compat aliases — we have zero external users on 0.3.0.

Honesty discipline preserved: \`MODEL_DOWNGRADE_CAVEAT\` constant stays (internal symbol). All "structural match — review before applying" framing unchanged.

## Test plan
- [x] 575 tests green (unit + synthetic + agents + integration)
- [x] \`tj optimize --help\` lists the new names in the positional argument
- [x] \`tj optimize downsize --since 7d\` runs Downsize only
- [x] \`tj optimize downsize cache\` runs both
- [x] \`tj optimize foo\` errors with a list of valid names (Click's default)
- [x] \`tj report --trim\` works
- [ ] Smoke-test \`tj optimize --export-config claude-code\` snippet (deferred to merger)

🤖 Generated with [Claude Code](https://claude.com/claude-code)