### PR TITLE
pricing: add Claude Opus 4.8 + 4.7, correct Opus 4.6 rate

### DIFF
--- a/pricing/models.toml
+++ b/pricing/models.toml
@@ -2,11 +2,23 @@
 # Prices in USD per million tokens.
 # Submit a PR when provider prices change.
 
+[anthropic.claude-opus-4-8]
+input_per_mtok = 5.00
+output_per_mtok = 25.00
+cache_read_per_mtok = 0.50
+cache_write_per_mtok = 6.25
+
+[anthropic.claude-opus-4-7]
+input_per_mtok = 5.00
+output_per_mtok = 25.00
+cache_read_per_mtok = 0.50
+cache_write_per_mtok = 6.25
+
 [anthropic.claude-opus-4-6]
-input_per_mtok = 15.00
-output_per_mtok = 75.00
-cache_read_per_mtok = 1.50
-cache_write_per_mtok = 18.75
+input_per_mtok = 5.00
+output_per_mtok = 25.00
+cache_read_per_mtok = 0.50
+cache_write_per_mtok = 6.25
 
 [anthropic.claude-sonnet-4-6]
 input_per_mtok = 3.00

--- a/tests/unit/test_cost.py
+++ b/tests/unit/test_cost.py
@@ -93,9 +93,24 @@ def test_get_rates_returns_model_rates_for_known():
 
 
 def test_calculate_cost_opus_model():
-    # claude-opus-4-6: input=15.00, output=75.00
+    # claude-opus-4-6: input=5.00, output=25.00
     cost = calculate_cost("anthropic", "claude-opus-4-6", 1_000_000, 1_000_000)
-    assert cost == 90.0
+    assert cost == 30.0
+
+
+def test_calculate_cost_opus_4_8_model():
+    # claude-opus-4-8: input=5.00, output=25.00
+    cost = calculate_cost("anthropic", "claude-opus-4-8", 1_000_000, 1_000_000)
+    assert cost == 30.0
+
+
+def test_get_rates_opus_4_8():
+    rates = get_rates("anthropic", "claude-opus-4-8")
+    assert rates is not None
+    assert rates.input_per_mtok == 5.00
+    assert rates.output_per_mtok == 25.00
+    assert rates.cache_read_per_mtok == 0.50
+    assert rates.cache_write_per_mtok == 6.25
 
 
 def test_calculate_cost_openai_model():

--- a/tokenjam/pricing/models.toml
+++ b/tokenjam/pricing/models.toml
@@ -2,11 +2,17 @@
 # Prices in USD per million tokens.
 # Submit a PR when provider prices change.
 
+[anthropic.claude-opus-4-8]
+input_per_mtok = 5.00
+output_per_mtok = 25.00
+cache_read_per_mtok = 0.50
+cache_write_per_mtok = 6.25
+
 [anthropic.claude-opus-4-7]
-input_per_mtok = 15.00
-output_per_mtok = 75.00
-cache_read_per_mtok = 1.50
-cache_write_per_mtok = 18.75
+input_per_mtok = 5.00
+output_per_mtok = 25.00
+cache_read_per_mtok = 0.50
+cache_write_per_mtok = 6.25
 
 [anthropic.claude-opus-4-5]
 input_per_mtok = 15.00
@@ -15,10 +21,10 @@ cache_read_per_mtok = 1.50
 cache_write_per_mtok = 18.75
 
 [anthropic.claude-opus-4-6]
-input_per_mtok = 15.00
-output_per_mtok = 75.00
-cache_read_per_mtok = 1.50
-cache_write_per_mtok = 18.75
+input_per_mtok = 5.00
+output_per_mtok = 25.00
+cache_read_per_mtok = 0.50
+cache_write_per_mtok = 6.25
 
 [anthropic.claude-sonnet-4-6]
 input_per_mtok = 3.00


### PR DESCRIPTION
## Summary

The `pricing/models.toml` Anthropic Opus entry was stale and incomplete:

- `anthropic.claude-opus-4-6` was listed at the **old `$15` / `$75`** per‑MTok Opus tier.
- `claude-opus-4-7` and `claude-opus-4-8` were **missing entirely**.

Opus 4.6, 4.7, and 4.8 all bill at **`$5` input / `$25` output** per MTok, with cache read `$0.50` and cache write `$6.25` (the 5‑minute ephemeral 1.25× multiplier), and ship a 1M context window at standard pricing. Because of the gap, anyone running current Opus models either saw **~3×‑inflated** costs (4.6) or hit the `No pricing data for anthropic/claude-opus-4-8 — using default rates` fallback (4.7/4.8). This also affects users running Claude via Azure AI Foundry, which bills at the same per‑token rates.

## Changes

- Correct `anthropic.claude-opus-4-6` → `5.00 / 25.00 / 0.50 / 6.25`
- Add `anthropic.claude-opus-4-7` (same rates)
- Add `anthropic.claude-opus-4-8` (same rates)
- Update `tests/unit/test_cost.py::test_calculate_cost_opus_model` (`90.0` → `30.0`) and add regression tests for Opus 4.8 cost + rates

Format matches existing entries (per `CONTRIBUTING.md` → *Pricing table contributions*). The `get_rates` date-suffix fallback already handles dated variants like `claude-opus-4-8-20260…`, so no dated rows are needed.

## Test plan

- [x] `pricing/models.toml` parses with `tomllib`; Opus 4.6/4.7/4.8 each compute `$30.00` for 1M input + 1M output
- [x] `pytest tests/unit/test_cost.py` — 15 passed (verified locally, Python 3.13; see verification comment)
- [x] `ruff check tokenjam/` ✅ and `mypy tokenjam/` ✅ (verified locally)

Sources: Anthropic model pricing for Opus 4.6 / 4.7 / 4.8 ($5/$25 per 1M tokens).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
