### PR TITLE
pricing: support a user override file (TJ_PRICING_FILE / ~/.config/tj/pricing.toml)

### DIFF
--- a/tests/unit/test_pricing_override.py
+++ b/tests/unit/test_pricing_override.py
@@ -1,0 +1,114 @@
+"""Unit tests for the user pricing override file in tokenjam.core.pricing.
+
+Covers the TJ_PRICING_FILE env var, the default ~/.config/tj/pricing.toml
+path, merge semantics over the packaged table, and graceful fallback when
+the override is missing or malformed.
+"""
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+
+import pytest
+
+from tokenjam.core import pricing
+
+
+@pytest.fixture(autouse=True)
+def _isolate_pricing(monkeypatch, tmp_path):
+    """Clear the lru_cache around every test and point HOME at an empty dir
+    so a real ~/.config/tj/pricing.toml on the dev machine can't leak in."""
+    monkeypatch.delenv(pricing.USER_PRICING_ENV, raising=False)
+    monkeypatch.setenv("HOME", str(tmp_path))          # POSIX
+    monkeypatch.setenv("USERPROFILE", str(tmp_path))   # Windows Path.home()
+    pricing.load_pricing_table.cache_clear()
+    yield
+    pricing.load_pricing_table.cache_clear()
+
+
+def _write(path: Path, body: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(body, encoding="utf-8")
+
+
+def test_no_override_uses_packaged_rates():
+    rates = pricing.get_rates("anthropic", "claude-haiku-4-5")
+    assert rates is not None
+    assert rates.input_per_mtok == 0.80
+
+
+def test_env_override_adds_new_model(tmp_path, monkeypatch):
+    f = tmp_path / "pricing.toml"
+    _write(f, "[myprovider.custom-1]\ninput_per_mtok = 1.0\noutput_per_mtok = 2.0\n")
+    monkeypatch.setenv(pricing.USER_PRICING_ENV, str(f))
+    pricing.load_pricing_table.cache_clear()
+
+    rates = pricing.get_rates("myprovider", "custom-1")
+    assert rates is not None
+    assert rates.input_per_mtok == 1.0
+    assert rates.output_per_mtok == 2.0
+
+
+def test_env_override_overrides_packaged_rate(tmp_path, monkeypatch):
+    f = tmp_path / "pricing.toml"
+    _write(
+        f,
+        "[anthropic.claude-haiku-4-5]\n"
+        "input_per_mtok = 99.0\noutput_per_mtok = 100.0\n",
+    )
+    monkeypatch.setenv(pricing.USER_PRICING_ENV, str(f))
+    pricing.load_pricing_table.cache_clear()
+
+    rates = pricing.get_rates("anthropic", "claude-haiku-4-5")
+    assert rates is not None
+    assert rates.input_per_mtok == 99.0
+    assert rates.output_per_mtok == 100.0
+
+
+def test_env_override_leaves_unrelated_models_intact(tmp_path, monkeypatch):
+    f = tmp_path / "pricing.toml"
+    _write(f, "[anthropic.claude-haiku-4-5]\ninput_per_mtok = 99.0\noutput_per_mtok = 100.0\n")
+    monkeypatch.setenv(pricing.USER_PRICING_ENV, str(f))
+    pricing.load_pricing_table.cache_clear()
+
+    # A model not mentioned in the override keeps its packaged rate.
+    rates = pricing.get_rates("openai", "gpt-4o")
+    assert rates is not None
+    assert rates.input_per_mtok == 2.50
+
+
+def test_default_user_path_is_used_when_present(tmp_path, monkeypatch):
+    cfg = tmp_path / ".config" / "tj" / "pricing.toml"
+    _write(cfg, "[anthropic.claude-haiku-4-5]\ninput_per_mtok = 0.01\noutput_per_mtok = 0.02\n")
+    pricing.load_pricing_table.cache_clear()
+
+    rates = pricing.get_rates("anthropic", "claude-haiku-4-5")
+    assert rates is not None
+    assert rates.input_per_mtok == 0.01
+
+
+def test_missing_env_file_warns_and_falls_back(tmp_path, monkeypatch, caplog):
+    monkeypatch.setenv(pricing.USER_PRICING_ENV, str(tmp_path / "nope.toml"))
+    pricing.load_pricing_table.cache_clear()
+
+    with caplog.at_level(logging.WARNING, logger="tokenjam.core.pricing"):
+        rates = pricing.get_rates("anthropic", "claude-haiku-4-5")
+
+    # Packaged rates still load.
+    assert rates is not None
+    assert rates.input_per_mtok == 0.80
+    assert "not found" in caplog.text.lower()
+
+
+def test_malformed_override_warns_and_falls_back(tmp_path, monkeypatch, caplog):
+    f = tmp_path / "pricing.toml"
+    _write(f, "this is not = valid = toml [[[")
+    monkeypatch.setenv(pricing.USER_PRICING_ENV, str(f))
+    pricing.load_pricing_table.cache_clear()
+
+    with caplog.at_level(logging.WARNING, logger="tokenjam.core.pricing"):
+        rates = pricing.get_rates("anthropic", "claude-haiku-4-5")
+
+    assert rates is not None
+    assert rates.input_per_mtok == 0.80
+    assert "could not read" in caplog.text.lower()

--- a/tokenjam/core/pricing.py
+++ b/tokenjam/core/pricing.py
@@ -1,4 +1,6 @@
 from __future__ import annotations
+import logging
+import os
 import sys
 from dataclasses import dataclass
 from functools import lru_cache
@@ -10,7 +12,18 @@ else:
     import tomli as tomllib  # type: ignore[no-redef]
 
 
+log = logging.getLogger(__name__)
+
 PRICING_FILE = Path(__file__).parent.parent / "pricing" / "models.toml"
+
+# Optional user-maintained override file. Lets users add or correct rates
+# without editing the packaged models.toml (which a pip upgrade overwrites).
+# Resolution order, highest priority first:
+#   1. The path in the TJ_PRICING_FILE env var, if set.
+#   2. ~/.config/tj/pricing.toml, if it exists.
+# Entries in the override are merged over the packaged table per
+# provider/model, so it can both override existing rates and add new models.
+USER_PRICING_ENV = "TJ_PRICING_FILE"
 
 # Default rate used when a model is not in the pricing table.
 # 0.50 per MTok input, 2.00 per MTok output — conservative mid-range estimate.
@@ -26,14 +39,9 @@ class ModelRates:
     cache_write_per_mtok: float = 0.0
 
 
-@lru_cache(maxsize=1)
-def load_pricing_table() -> dict[str, dict[str, ModelRates]]:
-    """
-    Load pricing/models.toml and return a nested dict:
-      { provider: { model_name: ModelRates } }
-    Cached after first load — restart process to pick up changes.
-    """
-    with open(PRICING_FILE, "rb") as f:
+def _parse_pricing_file(path: Path) -> dict[str, dict[str, ModelRates]]:
+    """Parse a pricing TOML file into { provider: { model: ModelRates } }."""
+    with open(path, "rb") as f:
         raw = tomllib.load(f)
     result: dict[str, dict[str, ModelRates]] = {}
     for provider, models in raw.items():
@@ -45,6 +53,61 @@ def load_pricing_table() -> dict[str, dict[str, ModelRates]]:
                 cache_read_per_mtok=rates.get("cache_read_per_mtok", 0.0),
                 cache_write_per_mtok=rates.get("cache_write_per_mtok", 0.0),
             )
+    return result
+
+
+def _user_pricing_file() -> Path | None:
+    """Resolve the optional user override file, or None if not configured.
+
+    TJ_PRICING_FILE (if set) wins and is returned even when the file is
+    missing, so a typo'd path surfaces as a warning rather than being
+    silently ignored. Otherwise the default ~/.config/tj/pricing.toml is
+    returned only when it exists. Path.home() is resolved here (not at
+    import) so the lookup honors the current environment.
+    """
+    override = os.environ.get(USER_PRICING_ENV)
+    if override:
+        return Path(override).expanduser()
+    default = Path.home() / ".config" / "tj" / "pricing.toml"
+    return default if default.exists() else None
+
+
+@lru_cache(maxsize=1)
+def load_pricing_table() -> dict[str, dict[str, ModelRates]]:
+    """
+    Load the packaged pricing/models.toml, then merge an optional user
+    override file over it, and return a nested dict:
+      { provider: { model_name: ModelRates } }
+
+    The override (see USER_PRICING_ENV / ~/.config/tj/pricing.toml) is
+    applied per provider/model, so it can correct a packaged rate or add a
+    model the package doesn't ship. Cached after first load — restart the
+    process (or call load_pricing_table.cache_clear()) to pick up changes.
+    """
+    result = _parse_pricing_file(PRICING_FILE)
+
+    user_file = _user_pricing_file()
+    if user_file is not None:
+        try:
+            overrides = _parse_pricing_file(user_file)
+        except FileNotFoundError:
+            log.warning(
+                "Pricing override file %s=%s not found; using packaged rates only.",
+                USER_PRICING_ENV,
+                user_file,
+            )
+            overrides = {}
+        except (OSError, tomllib.TOMLDecodeError) as exc:
+            log.warning(
+                "Could not read pricing override file %s (%s); "
+                "using packaged rates only.",
+                user_file,
+                exc,
+            )
+            overrides = {}
+        for provider, models in overrides.items():
+            result.setdefault(provider, {}).update(models)
+
     return result
 
 


### PR DESCRIPTION
## Summary

Today `pricing/models.toml` is the only source of rates, and it ships **inside the installed package**. So when a model is missing or a rate is stale, the only fix for an end user is to edit the file under `site-packages/tokenjam/pricing/models.toml` — which `pip install --upgrade tokenjam` then silently overwrites. Contributing the fix upstream (PR #78 does exactly that for the Opus line) is the right long-term answer, but users still need a local, upgrade-safe escape hatch in the meantime.

This adds an optional **user override file** that is merged over the packaged table, resolved highest-priority-first:

1. the path in the **`TJ_PRICING_FILE`** env var, if set
2. **`~/.config/tj/pricing.toml`**, if it exists

The merge is per `provider`/`model`, so an override can both **correct** a packaged rate and **add** a model the package doesn't ship. Same TOML schema as `models.toml`.

```toml
# ~/.config/tj/pricing.toml
[anthropic.claude-opus-4-8]
input_per_mtok = 5.00
output_per_mtok = 25.00
cache_read_per_mtok = 0.50
cache_write_per_mtok = 6.25
```

## Behavior / safety

- A missing `TJ_PRICING_FILE` path or a malformed override **logs a warning and falls back** to packaged rates — it never breaks cost calculation.
- `Path.home()` is resolved at call time (not import) so the lookup honors the current environment.
- Pure stdlib; lives in `tokenjam/core/` (no CLI/HTTP imports per `AGENTS.md`); keeps the existing `load_pricing_table()` signature and `lru_cache`. The `get_rates` date-suffix fallback is unaffected.

## Test plan

- [x] Standalone harness exercising all paths passes: no-override → packaged; env override add/override/untouched; default `~/.config/tj/pricing.toml`; missing-env → warn+fallback; malformed → warn+fallback
- [x] `tokenjam/core/pricing.py` and the new test compile (`py_compile`)
- [x] `pytest tests/unit/test_pricing_override.py` — 7 passed (verified locally, Python 3.13; see verification comment)
- [x] `ruff check tokenjam/` ✅ / `mypy tokenjam/` ✅ (verified locally)

Adds `tests/unit/test_pricing_override.py`. Independent of #78 (different files), so the two can merge in either order.

Note: this is a small change to `core/` rather than a framework integration, so per `CONTRIBUTING.md` I went straight to a PR — happy to convert to an issue-first discussion if you'd prefer to align on the approach (env var name, default path) first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
