### PR TITLE
Add `tj tokenmaxx` — shareable spend-tier command

### DIFF
--- a/tests/unit/test_cmd_tokenmaxx.py
+++ b/tests/unit/test_cmd_tokenmaxx.py
@@ -1,0 +1,97 @@
+"""Unit tests for `tj tokenmaxx`."""
+from __future__ import annotations
+
+from tokenjam.cli.cmd_tokenmaxx import (
+    Tier,
+    _TIERS,
+    _classify,
+    _config_declared_plan,
+    _plan_label_and_fee,
+)
+from tokenjam.core.config import ProviderBudget, TjConfig
+
+
+# ───────────────────────────── classification ─────────────────────────────
+
+def test_classify_zero_spend_is_sipper():
+    t = _classify(0.0)
+    assert t.label == "TokenSipper"
+
+
+def test_classify_walks_tiers_correctly():
+    # Each threshold should map into the next tier exactly at the boundary.
+    cases = [
+        (49.99,   "TokenSipper"),
+        (50.0,    "TokenModerator"),
+        (199.99,  "TokenModerator"),
+        (200.0,   "TokenMaxxer"),
+        (499.99,  "TokenMaxxer"),
+        (500.0,   "TokenChad"),
+        (1499.99, "TokenChad"),
+        (1500.0,  "Wallet on Fire"),
+        (50_000,  "Wallet on Fire"),
+    ]
+    for spend, expected in cases:
+        assert _classify(spend).label == expected, f"failed at ${spend}"
+
+
+def test_every_tier_has_emoji_and_quip():
+    # The artifact's social-shareability depends on every tier having
+    # readable text — guard against a future blank entry.
+    for tier in _TIERS:
+        assert isinstance(tier, Tier)
+        assert tier.label
+        assert tier.emoji
+        assert tier.quip
+
+
+# ───────────────────────────── config helpers ─────────────────────────────
+
+def test_config_declared_plan_none_when_no_budgets():
+    cfg = TjConfig(version="1")
+    assert _config_declared_plan(cfg) is None
+
+
+def test_config_declared_plan_returns_subscription_tier():
+    cfg = TjConfig(version="1")
+    cfg.budgets["anthropic"] = ProviderBudget(plan="max_5x")
+    assert _config_declared_plan(cfg) == "max_5x"
+
+
+def test_config_declared_plan_prefers_first_sorted_provider():
+    cfg = TjConfig(version="1")
+    cfg.budgets["openai"] = ProviderBudget(plan="plus")
+    cfg.budgets["anthropic"] = ProviderBudget(plan="max_20x")
+    # alphabetical: anthropic < openai
+    assert _config_declared_plan(cfg) == "max_20x"
+
+
+def test_config_declared_plan_skips_providers_without_plan_field():
+    cfg = TjConfig(version="1")
+    cfg.budgets["anthropic"] = ProviderBudget(usd=200.0)  # no plan
+    cfg.budgets["openai"] = ProviderBudget(plan="plus")
+    assert _config_declared_plan(cfg) == "plus"
+
+
+# ───────────────────────────── plan table ─────────────────────────────────
+
+def test_plan_label_and_fee_known_subscription_tiers():
+    assert _plan_label_and_fee("max_5x") == ("Max 5x plan", 100.0)
+    assert _plan_label_and_fee("max_20x") == ("Max 20x plan", 200.0)
+    assert _plan_label_and_fee("pro") == ("Pro plan", 20.0)
+    assert _plan_label_and_fee("plus") == ("ChatGPT Plus", 20.0)
+
+
+def test_plan_label_and_fee_contract_priced_tiers_have_no_fee():
+    label, fee = _plan_label_and_fee("team")
+    assert label == "ChatGPT Team"
+    assert fee is None
+
+
+def test_plan_label_and_fee_returns_none_for_unknown_or_api():
+    # 'api' and 'local' deliberately not in the table — the renderer
+    # doesn't quote a "plan cost multiplier" against pay-per-use plans.
+    assert _plan_label_and_fee("api") is None
+    assert _plan_label_and_fee("local") is None
+    assert _plan_label_and_fee(None) is None
+    assert _plan_label_and_fee("not_a_plan") is None

--- a/tokenjam/cli/cmd_tokenmaxx.py
+++ b/tokenjam/cli/cmd_tokenmaxx.py
@@ -1,0 +1,270 @@
+"""
+`tj tokenmaxx` — single-shot "how hard are you tokenmaxxing?" command.
+
+Designed as a shareable, screenshottable artifact for social posts.
+
+Reads the last 30 days of spend (via the existing cost-summary path, so it
+works under both direct-DB and API-shim modes), classifies it into a tier,
+computes a plan-multiplier when a subscription plan is declared in config,
+and runs the downsize analyzer for the headline savings figure.
+
+Honesty discipline: the tier names are intentionally ironic — escalating
+labels for higher spend — but every tier output is paired with the downsize
+savings figure on the next line, so the command is always actionable, not
+just a flex. Score is the hook; savings is the payoff.
+"""
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+
+import click
+
+from tokenjam.utils.formatting import console, format_cost
+from tokenjam.utils.time_parse import parse_since, utcnow
+
+
+# Tier table — monthly USD spend thresholds → (label, one-liner).
+# Calibrated for individual coding-agent users. Order matters: walked
+# bottom-up, first matching threshold wins.
+@dataclass(frozen=True)
+class Tier:
+    threshold: float
+    label: str
+    emoji: str
+    quip: str
+
+
+_TIERS: list[Tier] = [
+    Tier(0,    "TokenSipper",     "💧", "Are you even using AI?"),
+    Tier(50,   "TokenModerator",  "🥱", "Mostly reasonable. Try harder."),
+    Tier(200,  "TokenMaxxer",     "💸", "You're paying Anthropic's rent."),
+    Tier(500,  "TokenChad",       "🔥", "You're paying their interns' rent too."),
+    Tier(1500, "Wallet on Fire",  "🚨", "Touch grass. Then run `tj optimize`."),
+]
+
+
+def _classify(monthly_spend: float) -> Tier:
+    """Walk tiers high-to-low; first threshold the spend exceeds wins."""
+    for tier in reversed(_TIERS):
+        if monthly_spend >= tier.threshold:
+            return tier
+    return _TIERS[0]
+
+
+@click.command("tokenmaxx")
+@click.option("--since", default="30d", help="Window for analysis (default 30d).")
+@click.option("--json", "output_json", is_flag=True,
+              help="Emit machine-readable JSON.")
+@click.pass_context
+def cmd_tokenmaxx(ctx: click.Context, since: str, output_json: bool) -> None:
+    """How hard are you TokenMaxxing? Find out in one command."""
+    db = ctx.obj.get("db")
+    config = ctx.obj.get("config")
+    if db is None or config is None:
+        raise click.ClickException("tokenmaxx requires a database connection.")
+
+    try:
+        since_dt = parse_since(since)
+    except ValueError as exc:
+        raise click.BadParameter(str(exc), param_hint="'--since'") from exc
+
+    until_dt = utcnow()
+    window_days = max((until_dt - since_dt).days, 1)
+
+    # Pull spend + downsize savings via the same paths optimize uses, so this
+    # works whether the daemon is up (API shim) or not (direct DuckDB).
+    spend_usd, savings_usd, sessions = _fetch(db, config, since_dt, until_dt, since)
+
+    # Normalise to monthly (the tier thresholds are monthly).
+    monthly_spend = spend_usd * (30.0 / window_days)
+
+    # Plan multiplier — only for subscription users with a declared plan.
+    declared_plan = _config_declared_plan(config)
+    plan_info = _plan_label_and_fee(declared_plan)
+    multiplier = None
+    if plan_info and plan_info[1]:
+        multiplier = monthly_spend / plan_info[1]
+
+    tier = _classify(monthly_spend)
+
+    if output_json:
+        click.echo(json.dumps({
+            "window_days": window_days,
+            "sessions": sessions,
+            "spend_usd": round(spend_usd, 2),
+            "monthly_spend_usd": round(monthly_spend, 2),
+            "tier": tier.label,
+            "tier_emoji": tier.emoji,
+            "tier_quip": tier.quip,
+            "plan_tier": declared_plan,
+            "plan_label": plan_info[0] if plan_info else None,
+            "plan_monthly_usd": plan_info[1] if plan_info else None,
+            "plan_multiplier": round(multiplier, 1) if multiplier else None,
+            "downsize_monthly_savings_usd": round(savings_usd, 2),
+        }))
+        return
+
+    _render(
+        tier=tier, spend_usd=spend_usd, monthly_spend=monthly_spend,
+        window_days=window_days, sessions=sessions,
+        plan_info=plan_info, multiplier=multiplier,
+        savings_usd=savings_usd,
+    )
+
+
+# ───────────────────────────── data fetching ──────────────────────────────
+
+def _fetch(db, config, since_dt, until_dt, since_str) -> tuple[float, float, int]:
+    """
+    Returns (spend_usd, monthly_savings_usd, sessions) over the window.
+
+    Two code paths to handle the daemon-up case where db is an ApiBackend
+    without a `.conn` attribute. The optimize report payload already includes
+    the window total + downsize finding, so we can fetch it in one round trip
+    rather than running a second cost query.
+    """
+    from tokenjam.core.optimize import build_report
+
+    conn = getattr(db, "conn", None)
+    if conn is None:
+        # API-shim path
+        from tokenjam.core.api_backend import ApiBackend
+        if not isinstance(db, ApiBackend):
+            raise click.ClickException(
+                "tokenmaxx requires either a direct DuckDB connection or a "
+                "running tj serve at the configured api.{host,port}."
+            )
+        report_dict = db.fetch_optimize_report(
+            since=since_str,
+            findings=["downsize"],
+        )
+        if report_dict.get("error") == "no_data":
+            return 0.0, 0.0, 0
+        window = report_dict.get("window") or {}
+        downgrade = report_dict.get("downgrade") or {}
+        return (
+            float(window.get("total_cost_usd") or 0.0),
+            float(downgrade.get("monthly_savings_usd") or 0.0),
+            int(window.get("sessions") or 0),
+        )
+
+    # Direct-DB path
+    row = conn.execute(
+        "SELECT COUNT(*) FROM spans WHERE model IS NOT NULL"
+    ).fetchone()
+    if not row or not row[0]:
+        return 0.0, 0.0, 0
+
+    report = build_report(
+        db=db, config=config,
+        since=since_dt, until=until_dt,
+        findings=["downsize"],
+    )
+    spend = float(report.window.total_cost_usd or 0.0)
+    sessions = int(report.window.sessions or 0)
+    savings = 0.0
+    if report.downgrade is not None:
+        savings = float(report.downgrade.monthly_savings_usd or 0.0)
+    return spend, savings, sessions
+
+
+# ───────────────────────────── helpers ────────────────────────────────────
+
+def _config_declared_plan(config) -> str | None:
+    """Mirror cmd_optimize._config_declared_plan."""
+    budgets = getattr(config, "budgets", None) or {}
+    for provider in sorted(budgets.keys()):
+        plan = getattr(budgets[provider], "plan", None)
+        if plan:
+            return str(plan)
+    return None
+
+
+def _plan_label_and_fee(plan_tier: str | None) -> tuple[str, float | None] | None:
+    """
+    Mirror cmd_optimize._PLAN_LABEL_AND_FEE without importing it (avoid
+    circular import risk and keep tokenmaxx independently testable).
+    """
+    if plan_tier is None:
+        return None
+    table: dict[str, tuple[str, float | None]] = {
+        "pro":        ("Pro plan",          20.0),
+        "max_5x":     ("Max 5x plan",      100.0),
+        "max_20x":    ("Max 20x plan",     200.0),
+        "plus":       ("ChatGPT Plus",      20.0),
+        "team":       ("ChatGPT Team",       None),
+        "enterprise": ("ChatGPT Enterprise", None),
+    }
+    return table.get(plan_tier)
+
+
+# ───────────────────────────── rendering ──────────────────────────────────
+
+def _render(
+    *, tier: Tier, spend_usd: float, monthly_spend: float,
+    window_days: int, sessions: int,
+    plan_info: tuple[str, float | None] | None,
+    multiplier: float | None,
+    savings_usd: float,
+) -> None:
+    """Big-headline render. Designed to be a clean screenshot artifact."""
+    if sessions == 0:
+        console.print(
+            "\n[yellow]No usage data found.[/yellow]\n"
+            "[dim]Run [bold]tj onboard --claude-code[/bold] to ingest your existing "
+            "Claude Code sessions, or wait for new spans to land.[/dim]\n"
+        )
+        return
+
+    # Banner — the headline shareable line.
+    console.print()
+    console.print(f"  {tier.emoji} [bold]You're a {tier.label}.[/bold]")
+    console.print(f"     [dim italic]\"{tier.quip}\"[/dim italic]")
+    console.print()
+
+    # Spend breakdown — what produced the tier.
+    actual_label = f"last {window_days}d" if window_days < 30 else "last 30d"
+    if window_days == 30:
+        console.print(
+            f"  [bold]{format_cost(spend_usd)}[/bold] in {actual_label} "
+            f"across [bold]{sessions}[/bold] sessions."
+        )
+    else:
+        console.print(
+            f"  [bold]{format_cost(spend_usd)}[/bold] in {actual_label} "
+            f"across [bold]{sessions}[/bold] sessions "
+            f"(≈ [bold]{format_cost(monthly_spend)}/mo[/bold] at this rate)."
+        )
+
+    # Plan multiplier — the punchline.
+    if plan_info and multiplier:
+        plan_label, fee = plan_info
+        console.print(
+            f"  That's [bold]{multiplier:.1f}×[/bold] your "
+            f"[bold]{plan_label}[/bold] cost ({format_cost(fee)}/mo flat)."
+        )
+    elif plan_info:
+        plan_label, _ = plan_info
+        console.print(f"  Plan: [bold]{plan_label}[/bold].")
+
+    console.print()
+
+    # The action — the part that makes this a tool, not a flex.
+    if savings_usd > 0:
+        console.print(
+            f"  💡 [bold]{format_cost(savings_usd)}/mo[/bold] of that looks "
+            f"recoverable. Run [bold]tj optimize[/bold] to see candidates."
+        )
+    else:
+        console.print(
+            "  💡 No obvious savings flagged yet — run [bold]tj optimize[/bold] "
+            "for the full report once you have more data."
+        )
+    console.print()
+
+    # Subtle share prompt.
+    console.print(
+        "  [dim]Share your tier: screenshot the above and post with #tokenmaxx[/dim]"
+    )
+    console.print()

--- a/tokenjam/cli/main.py
+++ b/tokenjam/cli/main.py
@@ -82,6 +82,7 @@ from tokenjam.cli.cmd_uninstall import cmd_uninstall  # noqa: E402
 from tokenjam.cli.cmd_doctor import cmd_doctor  # noqa: E402
 from tokenjam.cli.cmd_budget import cmd_budget  # noqa: E402
 from tokenjam.cli.cmd_optimize import cmd_optimize  # noqa: E402
+from tokenjam.cli.cmd_tokenmaxx import cmd_tokenmaxx  # noqa: E402
 from tokenjam.cli.cmd_backfill import cmd_backfill  # noqa: E402
 from tokenjam.cli.cmd_report import cmd_report  # noqa: E402
 from tokenjam.cli.cmd_policy import cmd_policy  # noqa: E402
@@ -100,6 +101,7 @@ cli.add_command(cmd_uninstall, name="uninstall")
 cli.add_command(cmd_doctor, name="doctor")
 cli.add_command(cmd_budget, name="budget")
 cli.add_command(cmd_optimize, name="optimize")
+cli.add_command(cmd_tokenmaxx, name="tokenmaxx")
 cli.add_command(cmd_backfill, name="backfill")
 cli.add_command(cmd_report, name="report")
 cli.add_command(cmd_policy, name="policy")


### PR DESCRIPTION
## Summary

Single-shot CLI command for the \"how hard are you tokenmaxxing?\" social moment. Reads the last 30 days of spend, classifies into a tier, and surfaces the downsize savings figure on the next line — score is the hook, savings is the payoff.

### Tiers (monthly USD)

| Spend | Tier | One-liner |
|---|---|---|
| < \$50 | 💧 TokenSipper | \"Are you even using AI?\" |
| \$50–\$200 | 🥱 TokenModerator | \"Mostly reasonable. Try harder.\" |
| \$200–\$500 | 💸 TokenMaxxer | \"You're paying Anthropic's rent.\" |
| \$500–\$1500 | 🔥 TokenChad | \"You're paying their interns' rent too.\" |
| \$1500+ | 🚨 Wallet on Fire | \"Touch grass. Then run \`tj optimize\`.\" |

### Plan-aware

When the user has declared a subscription plan in config (\`[budget.<provider>] plan = \"max_5x\"\`), the output adds a multiplier line vs the plan's flat fee:

```
🔥 You're a TokenChad.
   \"You're paying their interns' rent too.\"

$847.32 in last 30d across 24 sessions.
That's 8.5× your Max 5x plan cost ($100.00/mo flat).

💡 $340/mo of that looks recoverable. Run \`tj optimize\` to see candidates.
```

The multiplier is the figure that travels socially (\"8.5× my Max-5x plan\"), not the absolute dollar — calibrated for the screenshot-and-share use case.

### Honesty discipline

Tier names are intentionally escalating (the ironic hook), but the command never exits without an actionable next step. The downsize savings line is always present and prominent.

### Implementation notes

- Reuses \`build_report()\` (direct-DB) and \`ApiBackend.fetch_optimize_report()\` (daemon-up). No new DB queries.
- Window normalised to monthly so \`--since 7d\` and \`--since 30d\` both pin against the monthly tier table.
- API users see absolute spend (no multiplier — pay-per-use); team/enterprise see plan label only (contract-priced fees).
- \`--json\` flag for machine-readable output.

### Test plan
- [x] 10 new unit tests (tier classification, plan lookup, config helpers)
- [x] 585/585 tests pass (was 575 before)
- [x] Live smoke against real DB renders correctly (Wallet on Fire tier 🔥)
- [x] \`--json\` round-trip clean
- [x] No-data path renders friendly hint

🤖 Generated with [Claude Code](https://claude.com/claude-code)