### PR TITLE
tokenmaxx: rename top tier to TokenGigaChad

### DIFF
--- a/tests/unit/test_cmd_tokenmaxx.py
+++ b/tests/unit/test_cmd_tokenmaxx.py
@@ -28,8 +28,8 @@ def test_classify_walks_tiers_correctly():
         (499.99,  "TokenMaxxer"),
         (500.0,   "TokenChad"),
         (1499.99, "TokenChad"),
-        (1500.0,  "Wallet on Fire"),
-        (50_000,  "Wallet on Fire"),
+        (1500.0,  "TokenGigaChad"),
+        (50_000,  "TokenGigaChad"),
     ]
     for spend, expected in cases:
         assert _classify(spend).label == expected, f"failed at ${spend}"

--- a/tokenjam/cli/cmd_tokenmaxx.py
+++ b/tokenjam/cli/cmd_tokenmaxx.py
@@ -40,7 +40,7 @@ _TIERS: list[Tier] = [
     Tier(50,   "TokenModerator",  "🥱", "Mostly reasonable. Try harder."),
     Tier(200,  "TokenMaxxer",     "💸", "You're paying Anthropic's rent."),
     Tier(500,  "TokenChad",       "🔥", "You're paying their interns' rent too."),
-    Tier(1500, "Wallet on Fire",  "🚨", "Touch grass. Then run `tj optimize`."),
+    Tier(1500, "TokenGigaChad",   "🔥🔥", "Touch grass. Then run `tj optimize`."),
 ]
 
 


### PR DESCRIPTION
Top tier was breaking the ironic chad-escalation pattern. Renamed to follow the ladder (Sipper → Moderator → Maxxer → Chad → GigaChad). Double-fire 🔥🔥 to visually distinguish from regular TokenChad's single 🔥.

Merge this before tagging v0.3.2 so the rename ships in the same release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)