### PR TITLE
Bump version to 0.3.3

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "tokenjam"
-version = "0.3.2"
+version = "0.3.3"
 description = "TokenJam — local-first OTel-native observability for Autonomous AI agents"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/sdk-ts/package.json
+++ b/sdk-ts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tokenjam/sdk",
-  "version": "0.3.2",
+  "version": "0.3.3",
   "description": "TypeScript SDK for TokenJam — local-first observability for AI agents",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",


### PR DESCRIPTION
Version bump to 0.3.3 ahead of GitHub Release.

After merge, create the release with `gh release create v0.3.3` — workflows fire PyPI + npm publishes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)