### PR TITLE
docs: sweep remaining pip install → pipx install (#86 follow-up)

### DIFF
--- a/docs/claude-code-integration.md
+++ b/docs/claude-code-integration.md
@@ -3,7 +3,7 @@
 Monitor every Claude Code session — costs, tool calls, API requests, errors — with two commands:
 
 ```bash
-pip install "tokenjam[mcp]"
+pipx install 'tokenjam[mcp]'
 tj onboard --claude-code
 # Restart Claude Code, then:
 tj status --agent claude-code-<project>

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -14,7 +14,16 @@ This is the recommended install path on **all platforms**. `pipx` automatically 
 - It works on Debian 12+ / Ubuntu 24+ (same PEP 668 enforcement).
 - It doesn't pollute your system Python or any project's venv.
 
-Don't have `pipx`? Install it with `brew install pipx` (macOS), `apt install pipx` (Debian/Ubuntu), or `python3 -m pip install --user pipx` (anywhere else). Then ensure pipx's bin dir is on your `PATH` with `pipx ensurepath`.
+Don't have `pipx`? Install it with one of:
+
+| Platform | Command |
+|---|---|
+| macOS | `brew install pipx` |
+| Debian / Ubuntu | `apt install pipx` |
+| Windows | `py -m pip install --user pipx` |
+| Anywhere else | `python3 -m pip install --user pipx` |
+
+Then ensure pipx's bin dir is on your `PATH` with `pipx ensurepath`.
 
 ### Alternative: pip in a venv
 

--- a/docs/optimize/trim.md
+++ b/docs/optimize/trim.md
@@ -22,7 +22,7 @@ LLMLingua-2 pulls in PyTorch and transformers (~2GB). Kept out of the
 base install:
 
 ```bash
-pip install "tokenjam[bloat]"
+pipx install 'tokenjam[bloat]'
 ```
 
 The base `pip install tokenjam` does NOT pull torch. Trim shows up in

--- a/docs/python-sdk.md
+++ b/docs/python-sdk.md
@@ -5,7 +5,7 @@ For any Python agent — Anthropic, OpenAI, Gemini, Bedrock, LangChain, CrewAI, 
 ## Install
 
 ```bash
-pip install tokenjam
+pipx install tokenjam
 tj onboard    # creates config, generates ingest secret
 tj doctor     # verify your setup
 ```

--- a/examples/openclaw/README.md
+++ b/examples/openclaw/README.md
@@ -5,7 +5,7 @@ This is a config-only integration — no Python code needed. OpenClaw's built-in
 ## Step 1: Start TokenJam
 
 ```bash
-pip install tokenjam
+pipx install tokenjam
 tj onboard
 tj serve &
 ```

--- a/incidents/hallucination-drift/README.md
+++ b/incidents/hallucination-drift/README.md
@@ -1,6 +1,6 @@
 # My agent worked yesterday. Today it's possessed.
 
-**Run it:** `pip install tokenjam && tj demo hallucination-drift`
+**Run it:** `pipx install tokenjam && tj demo hallucination-drift`
 
 ---
 
@@ -60,7 +60,7 @@ The demo uses `baseline_sessions = 5` for speed. In production, 10–50 sessions
 ## Try it yourself
 
 ```bash
-pip install tokenjam
+pipx install tokenjam
 tj demo hallucination-drift
 ```
 
@@ -75,4 +75,4 @@ To track drift on your real agent, wire up the TokenJam SDK, enable drift in `tj
 
 ---
 
-[TokenJam](https://github.com/Metabuilder-Labs/TokenJam) is a local-first, zero-signup observability CLI for AI agents. No cloud. No account. Just `pip install tokenjam` and start seeing what your agent actually does.
+[TokenJam](https://github.com/Metabuilder-Labs/TokenJam) is a local-first, zero-signup observability CLI for AI agents. No cloud. No account. Just `pipx install tokenjam` and start seeing what your agent actually does.

--- a/incidents/retry-loop/README.md
+++ b/incidents/retry-loop/README.md
@@ -1,6 +1,6 @@
 # Your agent isn't flaky. You're blind.
 
-**Run it:** `pip install tokenjam && tj demo retry-loop`
+**Run it:** `pipx install tokenjam && tj demo retry-loop`
 
 ---
 
@@ -57,7 +57,7 @@ The loop was visible from span #4. Your logs didn't surface it until a user comp
 ## Try it yourself
 
 ```bash
-pip install tokenjam
+pipx install tokenjam
 tj demo retry-loop
 ```
 
@@ -72,4 +72,4 @@ To catch this in your real agent, wire up the TokenJam SDK (`@watch()` + `patch_
 
 ---
 
-[TokenJam](https://github.com/Metabuilder-Labs/TokenJam) is a local-first, zero-signup observability CLI for AI agents. No cloud. No account. Just `pip install tokenjam` and start seeing what your agent actually does.
+[TokenJam](https://github.com/Metabuilder-Labs/TokenJam) is a local-first, zero-signup observability CLI for AI agents. No cloud. No account. Just `pipx install tokenjam` and start seeing what your agent actually does.

--- a/incidents/surprise-cost/README.md
+++ b/incidents/surprise-cost/README.md
@@ -1,6 +1,6 @@
 # Why did my agent just spend $47 on a hello world?
 
-**Run it:** `pip install tokenjam && tj demo surprise-cost`
+**Run it:** `pipx install tokenjam && tj demo surprise-cost`
 
 ---
 
@@ -75,7 +75,7 @@ TokenJam fires `cost_budget_session` and `cost_budget_daily` alerts when limits 
 ## Try it yourself
 
 ```bash
-pip install tokenjam
+pipx install tokenjam
 tj demo surprise-cost
 ```
 
@@ -90,4 +90,4 @@ To track real spend, instrument your agent with the tokenjam SDK and run `tj ser
 
 ---
 
-[TokenJam](https://github.com/Metabuilder-Labs/TokenJam) is a local-first, zero-signup observability CLI for AI agents. No cloud. No account. Just `pip install tokenjam` and start seeing what your agent actually does.
+[TokenJam](https://github.com/Metabuilder-Labs/TokenJam) is a local-first, zero-signup observability CLI for AI agents. No cloud. No account. Just `pipx install tokenjam` and start seeing what your agent actually does.


### PR DESCRIPTION
Companion to PR #88 / closes #86.

The first pipx pass updated README.md, the top of docs/installation.md, and the website install cards. This sweeps the **secondary surfaces** a non-Python developer is likely to hit and adds Windows to the pipx-install fallback table.

## Updated (8 files)

- `docs/python-sdk.md`
- `docs/claude-code-integration.md`
- `docs/optimize/trim.md`
- `examples/openclaw/README.md`
- `incidents/retry-loop/README.md` (3 refs)
- `incidents/hallucination-drift/README.md` (3 refs)
- `incidents/surprise-cost/README.md` (3 refs)
- `docs/installation.md` — added Windows row to pipx-install fallback table

## Intentionally NOT updated

- `docs/installation.md` *"Alternative: pip in a venv"* section — explicit alt path we want documented
- Prose mentions in `installation.md` and `trim.md` discussing **package size** (`pip install tokenjam` used as a noun phrase) — editing would awkwardly imply pipx and pip install different packages
- `incidents/*/BLOG.md` — already-published walkthrough narratives; editing risks breaking prose flow

## Cross-platform table now reads

| Platform | Command |
|---|---|
| macOS | `brew install pipx` |
| Debian / Ubuntu | `apt install pipx` |
| Windows | `py -m pip install --user pipx` |
| Anywhere else | `python3 -m pip install --user pipx` |

## Test plan
- [x] 12/12 offline-UI tests still pass (no code touched)
- [x] Manual grep — only intentional `pip install tokenjam` references remain

🤖 Generated with [Claude Code](https://claude.com/claude-code)