### PR TITLE
cost: charge cache-only spans instead of dropping them as no-ops

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,6 +55,9 @@ This release pivots TokenJam toward cost-optimization for autonomous agents. Fou
 - **`tj optimize` plan-tier-aware rendering.** When every session in the window has `plan_tier = 'unknown'`, dollar figures are suppressed and a header note explains why. Mixed / partial-unknown windows render normally with an advisory note.
 - **MCP `get_optimize_report` tool.** Now accepts `findings: list[str]` (was `only: str`). Docstring surfaces for both API-billing and subscription-plan-efficiency phrasings.
 
+### Fixed
+- **Cache-only spans were costed at $0.** A prompt-cache hit (0 new input/output tokens but non-zero cache-read tokens) bills the cache-read rate, but both `calculate_cost` and `CostEngine.process_span` short-circuited on input/output alone, dropping the span as a no-op and under-reporting spend. The early-return guards now fire only when *all* token counts are zero, so cache-read (and cache-write) costs are charged correctly.
+
 ### Internal
 - **Registry-driven optimize analyzers.** `tokenjam/core/optimize.py` split into `tokenjam/core/optimize/` package with `registry.py`, `runner.py`, `types.py`, and `analyzers/` subpackage using `pkgutil` auto-discovery. New analyzers drop a file under `analyzers/` with a `@register("name")` decorator — nothing else needs editing. See `tokenjam/core/optimize/README.md`.
 - **`OptimizeReport.findings` generic dict.** Wave 2 analyzers attach their results here keyed by registration name. Adding a new analyzer no longer requires a typed slot on `OptimizeReport`. The existing typed slots (`downgrade`, `budgets`) stay for backwards compatibility with `cmd_optimize` and the MCP server.

--- a/tests/synthetic/test_cost_tracking.py
+++ b/tests/synthetic/test_cost_tracking.py
@@ -129,6 +129,44 @@ def test_cost_engine_no_op_when_tokens_missing(fake_db: FakeDB, engine: CostEngi
     assert span.cost_usd is None
 
 
+def test_cost_engine_costs_cache_only_span(fake_db: FakeDB, engine: CostEngine) -> None:
+    # A span with no new input/output but cache-read tokens (a cache hit) still
+    # costs the cache-read rate and must be recorded, not dropped as a no-op.
+    # claude-haiku-4-5: cache_read=0.08 per MTok.
+    span = make_llm_span(
+        provider="anthropic", model="claude-haiku-4-5",
+        input_tokens=0, output_tokens=0, cache_tokens=1_000_000,
+    )
+    fake_db.insert_span_stub(span.span_id)
+
+    engine.process_span(span)
+
+    db_cost = fake_db.get_span_cost(span.span_id)
+    assert db_cost == pytest.approx(0.08)
+    assert span.cost_usd == pytest.approx(0.08)
+
+
+def test_cost_engine_cache_only_span_updates_session_total(
+    fake_db: FakeDB, engine: CostEngine,
+) -> None:
+    # The cache-only span's cost must also accumulate into the session total,
+    # not just the span row — dropping it previously under-reported the session.
+    session = make_session()
+    fake_db.insert_session_stub(session.session_id)
+
+    span = make_llm_span(
+        provider="anthropic", model="claude-haiku-4-5",
+        input_tokens=0, output_tokens=0, cache_tokens=1_000_000,
+        session_id=session.session_id,
+    )
+    fake_db.insert_span_stub(span.span_id)
+
+    engine.process_span(span)
+
+    session_cost = fake_db.get_session_cost(session.session_id)
+    assert session_cost == pytest.approx(0.08)
+
+
 def test_cost_engine_no_op_when_provider_missing(fake_db: FakeDB, engine: CostEngine) -> None:
     span = make_llm_span(input_tokens=1000, output_tokens=200)
     span.provider = None

--- a/tests/unit/test_cost.py
+++ b/tests/unit/test_cost.py
@@ -36,9 +36,23 @@ def test_calculate_cost_with_cache_write_tokens():
         cache_read_tokens=0,
         cache_write_tokens=1_000_000,
     )
-    # Zero input/output but cache_write tokens present — still returns 0
-    # because input_tokens == 0 and output_tokens == 0 triggers early return
-    assert cost == 0.0
+    # Zero input/output but cache_write tokens present — the early return only
+    # fires when ALL token counts are zero, so cache_write cost is still charged.
+    # (1_000_000/1M * 1.00) = 1.00
+    assert cost == 1.0
+
+
+def test_calculate_cost_cache_read_only():
+    # claude-haiku-4-5: cache_read=0.08 per MTok. A pure cache hit (no new
+    # input/output) still costs the cache-read rate and must not be dropped.
+    cost = calculate_cost(
+        "anthropic", "claude-haiku-4-5",
+        input_tokens=0,
+        output_tokens=0,
+        cache_read_tokens=1_000_000,
+    )
+    # (1_000_000/1M * 0.08) = 0.08
+    assert cost == 0.08
 
 
 def test_calculate_cost_unknown_model_uses_default(caplog):

--- a/tokenjam/core/cost.py
+++ b/tokenjam/core/cost.py
@@ -25,7 +25,12 @@ def calculate_cost(
     Logs a warning on fallback so developers know to add the model.
     Zero tokens -> zero cost (no warning).
     """
-    if input_tokens == 0 and output_tokens == 0:
+    if (
+        input_tokens == 0
+        and output_tokens == 0
+        and cache_read_tokens == 0
+        and cache_write_tokens == 0
+    ):
         return 0.0
 
     rates = get_rates(provider, model)
@@ -68,10 +73,9 @@ class CostEngine:
             return
         input_tokens = span.input_tokens or 0
         output_tokens = span.output_tokens or 0
-        if input_tokens == 0 and output_tokens == 0:
-            return
-
         cache_read_tokens = span.cache_tokens or 0
+        if input_tokens == 0 and output_tokens == 0 and cache_read_tokens == 0:
+            return
 
         # Record whether the span was already pre-priced before we compute.
         # Pre-priced spans have their session cost handled by _build_or_update_session


### PR DESCRIPTION
## What

A prompt-cache *hit* — a span with 0 new input/output tokens but non-zero cache-read tokens — bills the cache-read rate, so it costs real money. But both `calculate_cost()` and `CostEngine.process_span()` short-circuited on input/output counts alone:

```python
if input_tokens == 0 and output_tokens == 0:
    return 0.0   # ...and in process_span: return
```

So a cache-only span was dropped as a no-op and costed at $0, quietly under-reporting spend. That's a bit of an own-goal for a cost-observability tool — the more effectively you cache, the more cost goes missing.

## Fix

Widen both early-return guards to fire only when *all* token counts are zero. In `process_span` the `cache_read_tokens` read is hoisted above the guard so it can participate in the check. `calculate_cost`'s arithmetic already summed all four token types correctly — only the guard was wrong, so no math changes.

The pure all-zero no-op (genuinely empty spans) is preserved.

## Tests

- `test_calculate_cost_cache_read_only` — pure cache-read span is priced (0.08 for 1M @ claude-haiku-4-5).
- `test_calculate_cost_with_cache_write_tokens` — updated: this previously asserted `0.0` (codifying the bug); now asserts `1.0`, comment corrected.
- `test_cost_engine_costs_cache_only_span` — `process_span` records the span cost.
- `test_cost_engine_cache_only_span_updates_session_total` — and accumulates it into the session total (the under-reporting was at the session level too).

Full suite passes locally (`pytest tests/unit tests/synthetic tests/agents tests/integration`); `ruff check` and `mypy` clean on the changed files. CHANGELOG updated under Unreleased → Fixed.