### PR TITLE
ingest: persist + thread cache_write_tokens through DB + adapters (#93, #94)

### DIFF
--- a/tests/integration/test_db.py
+++ b/tests/integration/test_db.py
@@ -42,8 +42,8 @@ def _insert_agent(db, agent_id="test-agent"):
 def test_migrations_run_on_empty_db():
     backend = InMemoryBackend()
     rows = backend.conn.execute("SELECT version FROM schema_migrations").fetchall()
-    assert len(rows) == 4
-    assert {r[0] for r in rows} == {1, 2, 3, 4}
+    assert len(rows) == 5
+    assert {r[0] for r in rows} == {1, 2, 3, 4, 5}
     backend.close()
 
 
@@ -52,7 +52,7 @@ def test_migrations_are_idempotent():
     # Running migrations again should not raise
     run_migrations(backend.conn)
     rows = backend.conn.execute("SELECT version FROM schema_migrations").fetchall()
-    assert len(rows) == 4
+    assert len(rows) == 5
     backend.close()
 
 

--- a/tests/unit/test_ingest_helicone.py
+++ b/tests/unit/test_ingest_helicone.py
@@ -192,3 +192,71 @@ def test_ingest_rejects_both_sources(db):
 def test_ingest_rejects_neither_source(db):
     with pytest.raises(ValueError, match="exactly one"):
         ingest_helicone(db)
+
+
+# -- Cache token threading (issue #93) --
+
+def test_record_to_span_threads_cache_write_tokens():
+    """Anthropic-via-Helicone surfaces `cache_creation_input_tokens` on the
+    response object. The adapter now threads that into
+    `NormalizedSpan.cache_write_tokens` so cache-write cost is charged on
+    the Helicone backfill path the same way the live OTLP path charges it."""
+    record = {
+        "request": {
+            "id": "req-cw",
+            "created_at": "2026-04-01T10:00:00Z",
+            "model": "claude-haiku-4-5",
+            "provider": "ANTHROPIC",
+            "prompt_tokens": 100,
+        },
+        "response": {
+            "completion_tokens": 20,
+            "cache_read_input_tokens": 800,
+            "cache_creation_input_tokens": 1500,
+            "status": 200,
+        },
+        "cost_usd": 0.001,
+    }
+    span = _record_to_span(record)
+    assert span is not None
+    assert span.cache_tokens == 800
+    assert span.cache_write_tokens == 1500
+
+
+def test_record_to_span_cache_write_on_record_fallback():
+    """Older Helicone shape: cache token counts live on the top-level record
+    instead of nested under `response`. The adapter falls back to the
+    record-level key, same pattern as for cache_read."""
+    record = {
+        "request": {
+            "id": "req-cw-fallback",
+            "created_at": "2026-04-01T10:00:00Z",
+            "model": "claude-haiku-4-5",
+            "provider": "ANTHROPIC",
+            "prompt_tokens": 100,
+        },
+        "cache_read_input_tokens": 800,
+        "cache_creation_input_tokens": 1500,
+    }
+    span = _record_to_span(record)
+    assert span is not None
+    assert span.cache_tokens == 800
+    assert span.cache_write_tokens == 1500
+
+
+def test_record_to_span_cache_write_absent_leaves_field_none():
+    """When neither the response nor the record carries cache-creation,
+    the field stays None — distinguishes 'no data' from 'genuinely 0'."""
+    record = {
+        "request": {
+            "id": "req-no-cw",
+            "created_at": "2026-04-01T10:00:00Z",
+            "model": "claude-haiku-4-5",
+            "provider": "ANTHROPIC",
+            "prompt_tokens": 100,
+        },
+        "response": {"completion_tokens": 20},
+    }
+    span = _record_to_span(record)
+    assert span is not None
+    assert span.cache_write_tokens is None

--- a/tests/unit/test_ingest_langfuse.py
+++ b/tests/unit/test_ingest_langfuse.py
@@ -165,3 +165,70 @@ def test_ingest_rejects_neither_source(db):
     """Passing neither raises."""
     with pytest.raises(ValueError, match="exactly one"):
         ingest_langfuse(db)
+
+
+# -- Cache token threading (issue #93) --
+
+def test_observation_to_span_threads_cache_write_tokens():
+    """Cache-creation tokens (modern `usageDetails.input_cache_creation` key)
+    flow through to `NormalizedSpan.cache_write_tokens`. Without this, the
+    higher-rate cache-write cost was never charged on the Langfuse backfill
+    path."""
+    obs = {
+        "id": "obs-cw",
+        "traceId": "trace-cw",
+        "type": "GENERATION",
+        "startTime": "2026-04-01T10:00:00Z",
+        "endTime": "2026-04-01T10:00:01Z",
+        "model": "claude-haiku-4-5",
+        "usageDetails": {
+            "input": 100,
+            "output": 20,
+            "input_cache_read": 800,
+            "input_cache_creation": 1500,
+        },
+        "calculatedTotalCost": 0.001,
+    }
+    span = _observation_to_span(obs)
+    assert span is not None
+    assert span.input_tokens == 100
+    assert span.cache_tokens == 800
+    assert span.cache_write_tokens == 1500
+
+
+def test_observation_to_span_threads_cache_write_camelcase_key():
+    """The legacy camelCase variant (`cacheCreationInputTokens`) is also
+    recognised, mirroring the cacheReadInputTokens fallback."""
+    obs = {
+        "id": "obs-cw2",
+        "traceId": "trace-cw2",
+        "type": "GENERATION",
+        "startTime": "2026-04-01T10:00:00Z",
+        "endTime": "2026-04-01T10:00:01Z",
+        "model": "claude-haiku-4-5",
+        "usageDetails": {
+            "cacheReadInputTokens": 800,
+            "cacheCreationInputTokens": 1500,
+        },
+    }
+    span = _observation_to_span(obs)
+    assert span is not None
+    assert span.cache_tokens == 800
+    assert span.cache_write_tokens == 1500
+
+
+def test_observation_to_span_cache_write_absent_leaves_field_none():
+    """When the source doesn't carry cache-creation, the field stays None —
+    not silently zero, so downstream can tell 'no data' from 'genuinely 0'."""
+    obs = {
+        "id": "obs-no-cw",
+        "traceId": "trace-no-cw",
+        "type": "GENERATION",
+        "startTime": "2026-04-01T10:00:00Z",
+        "endTime": "2026-04-01T10:00:01Z",
+        "model": "claude-haiku-4-5",
+        "usageDetails": {"input": 100, "output": 20},
+    }
+    span = _observation_to_span(obs)
+    assert span is not None
+    assert span.cache_write_tokens is None

--- a/tests/unit/test_logs_converter.py
+++ b/tests/unit/test_logs_converter.py
@@ -70,10 +70,14 @@ def test_api_request_produces_llm_span():
 
 def test_api_request_cache_tokens():
     span = _api_request_to_span(_req_attrs(), RESOURCE, NOW_NS)
-    # cache_read_tokens -> cache_tokens field
+    # cache_read_tokens -> cache_tokens field (cache-read).
     assert span.cache_tokens == 500
-    # cache_creation_tokens goes into attributes
-    assert span.attributes.get("cache_creation_tokens") == 100
+    # cache_creation_tokens -> cache_write_tokens (typed field, threaded
+    # through for cost reporting; was previously stuffed into the JSON
+    # attributes blob — see issue #93).
+    assert span.cache_write_tokens == 100
+    # And no longer leaks into the attribute bag.
+    assert "cache_creation_tokens" not in span.attributes
 
 
 def test_tool_result_success_produces_ok_span():
@@ -199,11 +203,13 @@ def test_event_sequence_in_attributes():
     assert span.attributes.get("event.sequence") == 99
 
 
-def test_cache_creation_tokens_in_attributes():
+def test_cache_creation_tokens_populate_cache_write_field():
     span = _api_request_to_span(_req_attrs(**{"cache_creation_tokens": 256}), RESOURCE, NOW_NS)
-    # cache_creation_tokens goes into attributes dict, not the cache_tokens field
-    assert span.attributes.get("cache_creation_tokens") == 256
-    # cache_tokens field is for reads
+    # cache_creation_tokens now populates the typed cache_write_tokens field
+    # (issue #93). It used to live in span.attributes only, which meant the
+    # cost engine never charged for cache-write on this ingest path.
+    assert span.cache_write_tokens == 256
+    # cache_tokens (cache-read) is unaffected.
     assert span.cache_tokens == 500  # from default _req_attrs
 
 

--- a/tests/unit/test_spans_stats_repair.py
+++ b/tests/unit/test_spans_stats_repair.py
@@ -37,7 +37,7 @@ def _insert_minimal_span(conn, *, trace_id: str, span_id: str) -> None:
     now = dt.datetime.now(dt.timezone.utc)
     conn.execute(
         "INSERT INTO spans VALUES "
-        "($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12,$13,$14,$15,$16,$17,$18,$19,$20,$21,$22,$23,$24)",
+        "($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12,$13,$14,$15,$16,$17,$18,$19,$20,$21,$22,$23,$24,$25)",
         [
             span_id, trace_id, None, "session-1",
             "test-agent", "test-span", "internal", "ok",
@@ -46,6 +46,7 @@ def _insert_minimal_span(conn, *, trace_id: str, span_id: str) -> None:
             0, 0, 0, 0.0,
             None, None, "[]",
             None,  # billing_account (migration 4)
+            None,  # cache_write_tokens (migration 5)
         ],
     )
 

--- a/tokenjam/api/routes/logs.py
+++ b/tokenjam/api/routes/logs.py
@@ -53,10 +53,12 @@ def _api_request_to_span(
     start_time = _ts_to_datetime(timestamp_ns)
     end_time = start_time + timedelta(milliseconds=duration_ms)
 
+    # CACHE_CREATION_TOKENS used to land in extra_attrs as a JSON blob only.
+    # It's now threaded through to cache_write_tokens (issue #93) so cache-
+    # write cost reporting matches the live OTLP path.
     extra_attrs: dict[str, Any] = {}
     for key in (
         ClaudeCodeEvents.SPEED,
-        ClaudeCodeEvents.CACHE_CREATION_TOKENS,
         ClaudeCodeEvents.EVENT_SEQUENCE,
     ):
         if key in attrs:
@@ -81,6 +83,7 @@ def _api_request_to_span(
         input_tokens=_safe_int(attrs.get(ClaudeCodeEvents.INPUT_TOKENS)),
         output_tokens=_safe_int(attrs.get(ClaudeCodeEvents.OUTPUT_TOKENS)),
         cache_tokens=_safe_int(attrs.get(ClaudeCodeEvents.CACHE_READ_TOKENS, 0)),
+        cache_write_tokens=_safe_int(attrs.get(ClaudeCodeEvents.CACHE_CREATION_TOKENS, 0)),
         cost_usd=float(attrs[ClaudeCodeEvents.COST_USD]) if ClaudeCodeEvents.COST_USD in attrs else None,
         attributes=extra_attrs,
     )
@@ -326,6 +329,11 @@ def _codex_sse_event_to_span(
         input_tokens=_safe_int(attrs.get(CodexEvents.INPUT_TOKEN_COUNT)),
         output_tokens=_safe_int(attrs.get(CodexEvents.OUTPUT_TOKEN_COUNT)),
         cache_tokens=_safe_int(attrs.get(CodexEvents.CACHED_TOKEN_COUNT, 0)),
+        # OpenAI's automatic prompt caching (the source of CACHED_TOKEN_COUNT)
+        # does not separately bill or surface "cache creation" tokens —
+        # cached_tokens are read-hits only, and the equivalent of cache writes
+        # is billed at the standard input rate. So no cache_write_tokens field
+        # to populate for Codex spans. Issue #93.
         attributes=extra_attrs,
     )
 

--- a/tokenjam/core/db.py
+++ b/tokenjam/core/db.py
@@ -118,7 +118,11 @@ CREATE TABLE IF NOT EXISTS spans (
     cost_usd            DOUBLE,
     request_type        TEXT,
     conversation_id     TEXT,
-    events              JSON DEFAULT '[]'
+    events              JSON DEFAULT '[]',
+    -- cache_write_tokens (cache-CREATION tokens) added by migration 5.
+    -- Kept separate from cache_tokens (cache-read) because they bill at
+    -- different rates. See models.py::NormalizedSpan for the read/write split.
+    cache_write_tokens  BIGINT
 );
 
 CREATE TABLE IF NOT EXISTS alerts (
@@ -194,6 +198,14 @@ MIGRATIONS: list[tuple[int, str]] = [
         "ALTER TABLE spans    ADD COLUMN IF NOT EXISTS billing_account TEXT;\n"
         "ALTER TABLE sessions ADD COLUMN IF NOT EXISTS plan_tier       TEXT DEFAULT 'unknown'"
     )),
+    # Migration 5: cache_write_tokens on spans. Issue #94.
+    # NormalizedSpan and the cost engine started threading cache-write
+    # tokens through in PR #92 (live OTLP path) but the count was never
+    # persisted — only the resulting cost_usd landed. This column makes
+    # per-token-class reporting possible. NULL on backfilled rows; the
+    # _row_to_span helper coerces NULL -> None and ingest writes 0 for
+    # spans that don't carry the count.
+    (5, "ALTER TABLE spans ADD COLUMN IF NOT EXISTS cache_write_tokens BIGINT"),
 ]
 
 
@@ -252,6 +264,7 @@ def _row_to_span(row: tuple, columns: list[str]) -> NormalizedSpan:
         input_tokens=_int_or_none(d.get("input_tokens")),
         output_tokens=_int_or_none(d.get("output_tokens")),
         cache_tokens=_int_or_none(d.get("cache_tokens")),
+        cache_write_tokens=_int_or_none(d.get("cache_write_tokens")),
         cost_usd=d.get("cost_usd"),
         request_type=d.get("request_type"),
         conversation_id=d.get("conversation_id"),
@@ -375,9 +388,10 @@ class DuckDBBackend:
             "name, kind, status_code, status_message, start_time, end_time, "
             "duration_ms, attributes, provider, model, tool_name, "
             "input_tokens, output_tokens, cache_tokens, cost_usd, "
-            "request_type, conversation_id, events, billing_account"
+            "request_type, conversation_id, events, billing_account, "
+            "cache_write_tokens"
             ") VALUES "
-            "($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12,$13,$14,$15,$16,$17,$18,$19,$20,$21,$22,$23,$24)",
+            "($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12,$13,$14,$15,$16,$17,$18,$19,$20,$21,$22,$23,$24,$25)",
             [
                 span.span_id, span.trace_id, span.parent_span_id, span.session_id,
                 span.agent_id, span.name, span.kind.value, span.status_code.value,
@@ -385,7 +399,7 @@ class DuckDBBackend:
                 json.dumps(span.attributes), span.provider, span.model, span.tool_name,
                 span.input_tokens, span.output_tokens, span.cache_tokens, span.cost_usd,
                 span.request_type, span.conversation_id, json.dumps(span.events),
-                span.billing_account,
+                span.billing_account, span.cache_write_tokens,
             ],
         )
 

--- a/tokenjam/core/ingest_adapters/helicone.py
+++ b/tokenjam/core/ingest_adapters/helicone.py
@@ -149,6 +149,13 @@ def _record_to_span(record: dict[str, Any]) -> NormalizedSpan | None:
         response.get("cache_read_input_tokens")
         or record.get("cache_read_input_tokens")
     )
+    # Anthropic-via-Helicone surfaces cache-creation tokens on the response
+    # object alongside cache-read. Threading the count through so cache-write
+    # cost reporting matches the live OTLP path (issue #93).
+    cache_write = (
+        response.get("cache_creation_input_tokens")
+        or record.get("cache_creation_input_tokens")
+    )
 
     cost = (
         record.get("cost_usd")
@@ -205,6 +212,7 @@ def _record_to_span(record: dict[str, Any]) -> NormalizedSpan | None:
         input_tokens=int(input_tokens) if input_tokens is not None else None,
         output_tokens=int(output_tokens) if output_tokens is not None else None,
         cache_tokens=int(cache_read) if cache_read is not None else None,
+        cache_write_tokens=int(cache_write) if cache_write is not None else None,
         cost_usd=float(cost) if cost is not None else None,
         request_type="completion",
         conversation_id=conversation_id,

--- a/tokenjam/core/ingest_adapters/langfuse.py
+++ b/tokenjam/core/ingest_adapters/langfuse.py
@@ -121,6 +121,14 @@ def _observation_to_span(obs: dict[str, Any]) -> NormalizedSpan | None:
         or usage_details.get("cacheReadInputTokens")
         or None
     )
+    # Anthropic-via-Langfuse exposes cache-CREATION tokens under a parallel
+    # set of keys. Threading the count through so the cache-write side of
+    # cost reporting matches the live OTLP path (issue #93).
+    cache_write = (
+        usage_details.get("input_cache_creation")
+        or usage_details.get("cacheCreationInputTokens")
+        or None
+    )
 
     model = obs.get("model")
     provider, billing_account = _model_to_provider(model)
@@ -169,6 +177,7 @@ def _observation_to_span(obs: dict[str, Any]) -> NormalizedSpan | None:
         input_tokens=int(input_tokens) if input_tokens is not None else None,
         output_tokens=int(output_tokens) if output_tokens is not None else None,
         cache_tokens=int(cache_read) if cache_read is not None else None,
+        cache_write_tokens=int(cache_write) if cache_write is not None else None,
         cost_usd=float(cost) if cost is not None else None,
         request_type=("completion" if obs_type == "GENERATION" else None),
         conversation_id=str(conversation_id),


### PR DESCRIPTION
Two related follow-ups to #92, which fixed the live OTLP path to charge cache-creation tokens but left two gaps.

Closes #93. Closes #94.

## #94 — Persist `cache_write_tokens` on the spans table

#92 threaded `cache_write_tokens` through `NormalizedSpan` and the cost engine, but the raw count was never written to DuckDB — only the resulting `cost_usd` landed. So you could see total cost but couldn't query *"how much of last month's spend was cache_write"* or *"which sessions had unusually heavy cache creation."*

- **Migration 5**: `ALTER TABLE spans ADD COLUMN IF NOT EXISTS cache_write_tokens BIGINT` (safe to re-run, no backfill needed).
- Fresh installs get the column via the updated `CREATE TABLE` in the initial schema.
- Named-column `INSERT` in ingest is extended.
- `_row_to_span` deserializes the new column.
- `NULL` on backfilled rows — distinguishes "no data" from "genuinely 0".

## #93 — Thread cache_write through the three remaining adapters

- **`tokenjam/core/ingest_adapters/langfuse.py`** — reads `input_cache_creation` (and the legacy `cacheCreationInputTokens` alias) from `usageDetails`.
- **`tokenjam/core/ingest_adapters/helicone.py`** — reads `cache_creation_input_tokens` from `response` or `record` (mirrors the cache_read fallback pattern).
- **`tokenjam/api/routes/logs.py`** — Claude Code's `CACHE_CREATION_TOKENS` attribute was being stuffed into the JSON attribute blob and ignored by the cost engine. Now threads into the typed `cache_write_tokens` field. Codex doesn't have a cache-creation concept (OpenAI's automatic prompt caching only bills cache-*reads* at a discount; "writes" are billed at the standard input rate), so the Codex handler stays as-is with an inline comment explaining the gap.

## Tests

**Updated:**
- Migration-count assertions in `tests/integration/test_db.py` bumped 4 → 5.
- `tests/unit/test_spans_stats_repair.py`'s positional `INSERT` helper now supplies the 25th column (NULL for cache_write_tokens).
- `tests/unit/test_logs_converter.py`: the two tests asserting `cache_creation_tokens` lived in the JSON attribute bag now assert it populates the typed `cache_write_tokens` field instead.

**New regression coverage:**
- `_observation_to_span` (Langfuse): modern key, legacy camelCase alias, "absent → None".
- `_record_to_span` (Helicone): nested-response key, record-level fallback, "absent → None".

**626/626 tests pass** (was 620; +6 new regression tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)