### PR TITLE
docs: sync release-test playbooks with v0.3.4 surface

### DIFF
--- a/tests/manual-new-release-tests.md
+++ b/tests/manual-new-release-tests.md
@@ -13,8 +13,15 @@ Run this after a new release publishes to PyPI to verify it works end-to-end. Th
 tj uninstall --yes 2>/dev/null
 rm -rf ~/.tj ~/.config/tj .tj
 
-pip3 install --upgrade tokenjam
+# Recommended install path (PEP 668-safe on Homebrew Python and
+# Debian 12+/Ubuntu 24+). `--force` so we reinstall even if a prior
+# version is present.
+pipx install --force tokenjam
 tj --version
+
+# Older `pip3 install --upgrade tokenjam` path still works inside
+# a clean venv but fails on system Python — that's the bug pipx
+# solves, and verifying pipx is what we ship docs telling users to do.
 ```
 
 **Pass criteria:** version matches the release being tested.
@@ -65,6 +72,32 @@ tj optimize --json | python3 -c \
 ```
 
 **Pass criteria:** every positional analyzer name runs without crashing. Optional analyzers (`cache-recommend`, `trim`) surface clear hints when their prereqs aren't met instead of erroring.
+
+## 4b. TokenMaxx tier classification
+
+```bash
+tj tokenmaxx
+# [ ] Bordered "TokenJam TokenMaxxing Report" panel renders
+# [ ] On api plan: shows absolute spend; no multiplier line
+# [ ] Action line surfaces either downsize savings or "no obvious
+#     savings flagged yet" (both are valid)
+
+# Verify the JSON tier label is one of the six valid v0.3.4 tiers.
+tj tokenmaxx --json | python3 -c \
+  "import json,sys;d=json.load(sys.stdin);ok={'TokenSipper','TokenModerator','TokenMaxxer','TokenSuperMaxxer','TokenMegaMaxxer','TokenGigaMaxxer'};assert d['tier'] in ok,d['tier'];print('ok:',d['tier'])"
+
+# Reconfigure to a subscription plan and re-run — the multiplier line
+# should appear. Pick whichever plan matches your test config.
+tj onboard --claude-code --reconfigure --plan max_5x
+tj tokenmaxx
+# [ ] Multiplier line "That's N× your Max 5x plan cost ($100/mo flat)."
+# [ ] Tier may shift if the multiplier crosses a boundary
+
+# Flip back to api so subsequent steps render dollar figures.
+tj onboard --claude-code --reconfigure --plan api
+```
+
+**Pass criteria:** the report renders without crashing, the JSON `tier` field carries one of the 6 v0.3.4 tier names, and the multiplier line appears under a subscription plan.
 
 ## 5. Backfill adapters (smoke against committed fixtures)
 
@@ -123,9 +156,44 @@ Spot-check:
 - [ ] Cost page shows non-zero USD values
 - [ ] Sidebar theme toggle works
 
+### Offline-UI verification (v0.3.4 — PR #88)
+
+Open Chrome DevTools (or your browser's equivalent) → **Network tab** → reload `http://127.0.0.1:7391/`.
+
+- [ ] **Zero failed requests** to `fonts.googleapis.com`, `fonts.gstatic.com`, `esm.sh`, or `tokenjam.dev`
+- [ ] Dashboard interactivity works (sidebar nav, tab switches) — proves the vendored Preact / htm under `/ui/vendor/` is being served, not loading from the CDN
+- [ ] Favicon renders (data: URL, no external fetch)
+
+Bonus: turn off wifi entirely, hard-refresh, and confirm the page still renders + the JS still hydrates. The whole dashboard must work air-gapped.
+
 ```bash
 tj stop
 ```
+
+## 9. Cache cost-correctness (v0.3.4 — PRs #90 + #92)
+
+Cache-only spans (cache_read > 0, input/output = 0) used to be costed at $0. Cache-creation tokens on the live OTLP path used to be silently dropped. Both fixed in v0.3.4.
+
+```bash
+# Spans table now has cache_write_tokens (migration 5).
+duckdb ~/.tj/telemetry.duckdb "PRAGMA table_info(spans)" 2>/dev/null \
+  | grep cache_write_tokens \
+  && echo "ok: cache_write_tokens column present"
+
+# Any captured Anthropic cache-hit span should have non-zero cost_usd.
+duckdb ~/.tj/telemetry.duckdb "
+  SELECT COUNT(*) AS hits,
+         MIN(cost_usd) AS min_cost
+  FROM spans
+  WHERE cache_tokens > 0
+    AND (input_tokens = 0 OR input_tokens IS NULL)
+    AND (output_tokens = 0 OR output_tokens IS NULL)
+" 2>/dev/null
+# [ ] If hits > 0: min_cost > 0 (cache hits ARE being costed; was $0 pre-0.3.4)
+# [ ] If hits = 0: this release's runs didn't trigger a pure cache-only span — fine, unit tests cover the path
+```
+
+If you don't have `duckdb` CLI installed, skip the SQL checks — the unit + synthetic tests covering these paths run in CI and are the canonical verification.
 
 ---
 
@@ -166,14 +234,16 @@ tj stop
 
 | Step | Pass criteria |
 |------|--------------|
-| 1 | `pip install --upgrade tokenjam` succeeds, version matches release |
+| 1 | `pipx install --force tokenjam` succeeds, version matches release |
 | 2 | Onboard prompts for plan tier; config records it; no auto `usd = 200` written |
 | 3 | Example runs without DB-lock errors; CLI shows real USD values |
-| 4 | All four optimize analyzers run; caveat appears in downgrade JSON; `plan` + `pricing_mode` in JSON output |
+| 4 | All optimize analyzers run; caveat appears in downgrade JSON; `plan` + `pricing_mode` in JSON output |
+| 4b | `tj tokenmaxx` renders the bordered report panel; JSON `tier` is one of the 6 v0.3.4 tier names; subscription plan shows multiplier line |
 | 5 | All three backfill adapters ingest from fixtures; re-runs are idempotent |
 | 6 | `--compare previous` produces a diff report; `--export-config` writes a snippet with caveat comments |
 | 7 | `tj policy list` renders the unified table |
-| 8 | `tj serve` starts, web UI loads, HTTP fallback works while server holds lock |
+| 8 | `tj serve` starts, web UI loads, HTTP fallback works while server holds lock; **zero external requests in DevTools Network tab** (offline-UI fix shipped in v0.3.4) |
+| 9 | `cache_write_tokens` column present on the spans table (migration 5); cache-hit spans show non-zero cost_usd |
 | Claude Code | Onboard writes settings.json + projects.json; re-run is a no-op |
 | Codex | Onboard writes `[otel]` + `[mcp_servers.tj]` to codex config; secret synced |
 

--- a/tests/manual-pre-release-testing.md
+++ b/tests/manual-pre-release-testing.md
@@ -176,6 +176,33 @@ tj optimize --json | python3 -c \
   "import json,sys;r=json.load(sys.stdin);assert 'plan' in r and 'pricing_mode' in r;print('ok: plan-tier metadata present')"
 ```
 
+### 6f. TokenMaxx (v0.3.4 — six-tier ladder)
+
+```bash
+tj tokenmaxx
+# [ ] Bordered "TokenJam TokenMaxxing Report" panel renders
+# [ ] On api plan: shows absolute spend; no multiplier line
+# [ ] `tj optimize` reference in the action line renders in green bold
+# [ ] Share-line is teal, mentions @tokenjamdev (NOT #tokenmaxx)
+
+# Tier label must be one of the v0.3.4 six.
+tj tokenmaxx --json | python3 -c \
+  "import json,sys;d=json.load(sys.stdin);ok={'TokenSipper','TokenModerator','TokenMaxxer','TokenSuperMaxxer','TokenMegaMaxxer','TokenGigaMaxxer'};assert d['tier'] in ok,d['tier'];print('ok:',d['tier'])"
+
+# Force a different tier by exercising a subscription plan (use whatever
+# plan matches your test data — heavy usage on a Pro plan will land you
+# higher up the ladder than the same usage on a Max-20x plan).
+tj onboard --claude-code --reconfigure --plan max_5x
+tj tokenmaxx
+# [ ] Output now shows "That's N× your Max 5x plan cost ($100/mo flat)."
+# [ ] Tier name follows the v0.3.4 ladder (Sipper / Moderator / Maxxer /
+#     SuperMaxxer / MegaMaxxer / GigaMaxxer)
+# [ ] At thresholds: 1× / 4× / 10× / 20× / 50× crosses tier boundaries
+
+# Reset to api before continuing
+tj onboard --claude-code --reconfigure --plan api
+```
+
 ## 7. Plan-tier-aware rendering
 
 Reconfigure to a subscription plan and re-run `tj optimize` — output should reframe.
@@ -317,6 +344,41 @@ Spot-check (don't repeat every theme/typography detail — those are one-time UI
 
 If any UI element regresses *visibly broken* relative to main, dig in. Otherwise move on.
 
+### Offline-UI verification (v0.3.4 — issue #87 / PR #88)
+
+The dashboard must work fully offline. The "local-first, no data egress" pitch breaks the moment a render-time external load happens.
+
+Open Chrome DevTools (or your browser's equivalent) → **Network tab** → reload `http://127.0.0.1:7391/`.
+
+- [ ] **Zero failed requests** to `fonts.googleapis.com`, `fonts.gstatic.com`, `esm.sh`, or `tokenjam.dev`
+- [ ] Dashboard interactivity works (sidebar nav, tab switches) — proves the vendored Preact / htm under `/ui/vendor/` is serving correctly
+- [ ] Favicon renders (data: URL, no external fetch)
+
+The `tests/unit/test_ui_offline.py` regression test pins this contract in CI, but a manual eyeball catches anything the regex assertions miss (e.g. background-image URLs in CSS, inline `fetch()` calls in JS).
+
+### Cache cost-correctness (v0.3.4 — PRs #90 + #92)
+
+```bash
+# Spans table has cache_write_tokens (migration 5).
+duckdb ~/.tj/telemetry.duckdb "PRAGMA table_info(spans)" 2>/dev/null \
+  | grep cache_write_tokens \
+  && echo "ok: cache_write_tokens column present"
+
+# Any Anthropic cache-hit span (cache_read>0, no input/output) is now
+# costed. Pre-0.3.4 these were dropped as no-ops and silently $0.
+duckdb ~/.tj/telemetry.duckdb "
+  SELECT COUNT(*) AS hits, MIN(cost_usd) AS min_cost
+  FROM spans
+  WHERE cache_tokens > 0
+    AND (input_tokens = 0 OR input_tokens IS NULL)
+    AND (output_tokens = 0 OR output_tokens IS NULL)
+" 2>/dev/null
+# [ ] If hits > 0: min_cost > 0
+# [ ] If hits = 0: this run didn't trigger a pure cache-only span — fine
+```
+
+If `duckdb` CLI isn't installed, skip — the unit + synthetic tests covering these paths run in CI.
+
 ## 14. Clean up
 
 ```bash
@@ -402,6 +464,7 @@ tj status && tj traces && tj cost --since 1h
 tj optimize           # all analyzers
 tj optimize downsize
 tj optimize cache
+tj tokenmaxx          # six-tier ladder
 tj backfill langfuse --source-file tests/fixtures/langfuse_real_response.json
 tj backfill helicone --source-file tests/fixtures/helicone_real_response.json
 tj backfill otlp --source-file tests/fixtures/otlp_sample.json


### PR DESCRIPTION
Both playbooks predate the v0.3.x pivot work and were missing several v0.3.4 verification steps.

## `manual-new-release-tests.md` (post-release smoke)

- **Step 1**: `pip3 install --upgrade tokenjam` → `pipx install --force tokenjam`. Same artifact, but pipx is now what we tell users to run.
- **Step 4b NEW**: TokenMaxx tier classification. Verifies JSON `tier` field is in the 6-tier set (`{TokenSipper, TokenModerator, TokenMaxxer, TokenSuperMaxxer, TokenMegaMaxxer, TokenGigaMaxxer}`) — catches a silent rename in either direction. Verifies the multiplier line appears under a subscription plan.
- **Step 8 extended**: offline-UI verification. DevTools Network tab check for zero render-time requests to `fonts.googleapis.com`, `fonts.gstatic.com`, `esm.sh`, `tokenjam.dev`. Bonus: hard-refresh with wifi off.
- **Step 9 NEW**: cache cost-correctness (PRs #90 + #92). Two `duckdb` queries verifying (a) the `cache_write_tokens` column from migration 5 is present, (b) cache-hit spans have non-zero `cost_usd`. Skip-safe when duckdb CLI isn't installed.
- **Pass-criteria summary table** updated to include the new steps.

## `manual-pre-release-testing.md` (deep pre-release)

- **Section 6f NEW**: TokenMaxx (six-tier ladder). Same JSON tier-membership check + verifies the rendering details (green-bold `tj optimize` ref, teal share-line with `@tokenjamdev`, tier-boundary thresholds 1× / 4× / 10× / 20× / 50×).
- **Section 13 extended**: same offline-UI Network-tab check + note that `test_ui_offline.py` pins this in CI but a manual eyeball catches CSS background-image URLs or inline `fetch()` calls the regex test might miss.
- **Section 13 cache cost-correctness** sub-section mirroring step 9 in the smoke.
- **Quick test snippet** at the bottom: added `tj tokenmaxx`.

## Footprint
- 2 files modified, +137 / -4 lines
- No structural reorganization; all changes are additions or in-place updates

Both playbooks now reflect the v0.3.4 surface area.

🤖 Generated with [Claude Code](https://claude.com/claude-code)