### PR TITLE
Fix MCP base-dep gap (#101) + pricing-warning noise (#98)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,6 +41,11 @@ dependencies = [
     "httpx>=0.27",
     "apscheduler>=3.10",
     "websockets>=12.0",
+    # fastmcp ships in the base install (was in the [mcp] extra) so `tj mcp`
+    # works on a fresh `pipx install tokenjam` without requiring users to
+    # remember the extra. Claude Code's MCP integration is now a primary
+    # use case rather than an opt-in. Issue #101.
+    "fastmcp>=0.2",
 ]
 
 [project.urls]
@@ -54,7 +59,10 @@ crewai    = ["crewai>=0.28"]
 autogen   = ["pyautogen>=0.2"]
 litellm   = ["litellm>=1.40"]
 dev       = ["pytest", "pytest-asyncio", "httpx", "ruff", "mypy"]
-mcp       = ["fastmcp"]
+# Kept as a no-op extra for back-compat — `pipx install 'tokenjam[mcp]'` still
+# works, just installs the same fastmcp that's now in the base dependencies.
+# Documented in `docs/installation.md` so users know they no longer need it.
+mcp       = []
 # Trim analyzer (`tj optimize --finding prompt-bloat`). LLMLingua-2 pulls in
 # PyTorch and transformers, ~2GB total. Kept optional so the base install
 # stays small — most users don't run the bloat analyzer.

--- a/tests/unit/test_cost.py
+++ b/tests/unit/test_cost.py
@@ -2,6 +2,8 @@
 from __future__ import annotations
 import logging
 
+import pytest
+
 from tokenjam.core.cost import calculate_cost
 from tokenjam.core.pricing import load_pricing_table, get_rates
 
@@ -56,12 +58,60 @@ def test_calculate_cost_cache_read_only():
 
 
 def test_calculate_cost_unknown_model_uses_default(caplog):
+    # Use a unique provider/model so the dedupe set doesn't suppress this run.
     with caplog.at_level(logging.WARNING, logger="tokenjam.core.cost"):
-        cost = calculate_cost("unknown_provider", "unknown_model", 1_000_000, 1_000_000)
+        cost = calculate_cost("test_unknown_provider", "test_unknown_model", 1_000_000, 1_000_000)
     # Default rates: 0.50 input, 2.00 output per MTok
     # (1M/1M * 0.50) + (1M/1M * 2.00) = 2.50
     assert cost == 2.5
-    assert "No pricing data for unknown_provider/unknown_model" in caplog.text
+    assert "No pricing data for test_unknown_provider/test_unknown_model" in caplog.text
+
+
+def test_calculate_cost_unknown_model_warns_only_once_per_pair(caplog):
+    """Backfilling many spans of the same unknown model used to spam the
+    warning N times. Now it's emitted once per (provider, model) per
+    process. Issue #98."""
+    import tokenjam.core.cost as cost_mod
+    # Reset dedupe set so this test is isolated.
+    cost_mod._UNKNOWN_MODEL_WARNED.clear()
+
+    with caplog.at_level(logging.WARNING, logger="tokenjam.core.cost"):
+        for _ in range(5):
+            calculate_cost("test_provider_xyz", "test_model_xyz", 1000, 200)
+
+    # Exactly one warning, not five.
+    matching = [r for r in caplog.records if "test_provider_xyz/test_model_xyz" in r.message]
+    assert len(matching) == 1, f"expected 1 warning, got {len(matching)}"
+
+    # A DIFFERENT unknown model in the same process should still warn (once).
+    caplog.clear()
+    with caplog.at_level(logging.WARNING, logger="tokenjam.core.cost"):
+        for _ in range(3):
+            calculate_cost("test_provider_xyz", "different_model", 1000, 200)
+    matching = [r for r in caplog.records if "different_model" in r.message]
+    assert len(matching) == 1
+
+
+def test_deprecated_anthropic_base_models_are_priced():
+    """Dated variants (claude-sonnet-4-20250514, etc.) resolve via the
+    YYYYMMDD-stripping fallback to the deprecated base entries we added in
+    pricing/models.toml. Issue #98 — was previously falling through to
+    defaults and spamming warnings."""
+    # Sonnet 4 (deprecated): $3 / $15 per MTok
+    cost = calculate_cost("anthropic", "claude-sonnet-4-20250514", 1_000_000, 1_000_000)
+    assert cost == pytest.approx(18.0)  # 3 + 15
+
+    # Opus 4 (deprecated): $15 / $75 per MTok
+    cost = calculate_cost("anthropic", "claude-opus-4-20250514", 1_000_000, 1_000_000)
+    assert cost == pytest.approx(90.0)  # 15 + 75
+
+    # Opus 4.1 (deprecated): $15 / $75 per MTok
+    cost = calculate_cost("anthropic", "claude-opus-4-1-20250805", 1_000_000, 1_000_000)
+    assert cost == pytest.approx(90.0)
+
+    # Haiku 3.5 (retired): $0.80 / $4 per MTok
+    cost = calculate_cost("anthropic", "claude-haiku-3-5-20241022", 1_000_000, 1_000_000)
+    assert cost == pytest.approx(4.8)  # 0.8 + 4
 
 
 def test_calculate_cost_zero_tokens_returns_zero_no_warning(caplog):

--- a/tokenjam/core/cost.py
+++ b/tokenjam/core/cost.py
@@ -8,6 +8,12 @@ from tokenjam.core.pricing import get_rates, ModelRates, DEFAULT_INPUT_PER_MTOK,
 
 logger = logging.getLogger(__name__)
 
+# Dedupe the "No pricing data" warning to one log line per (provider, model)
+# pair per process. Backfilling a 247-session Claude Code project used to
+# emit the same warning hundreds of times in a row (issue #98). Now it
+# emits exactly once and stays out of the way.
+_UNKNOWN_MODEL_WARNED: set[tuple[str, str]] = set()
+
 
 def calculate_cost(
     provider: str,
@@ -35,11 +41,15 @@ def calculate_cost(
 
     rates = get_rates(provider, model)
     if rates is None:
-        logger.warning(
-            "No pricing data for %s/%s — using default rates. "
-            "Add to tokenjam/pricing/models.toml to get accurate costs.",
-            provider, model,
-        )
+        # Warn once per (provider, model) per process — see _UNKNOWN_MODEL_WARNED.
+        key = (provider, model)
+        if key not in _UNKNOWN_MODEL_WARNED:
+            _UNKNOWN_MODEL_WARNED.add(key)
+            logger.warning(
+                "No pricing data for %s/%s — using default rates. "
+                "Add to tokenjam/pricing/models.toml to get accurate costs.",
+                provider, model,
+            )
         rates = ModelRates(
             input_per_mtok=DEFAULT_INPUT_PER_MTOK,
             output_per_mtok=DEFAULT_OUTPUT_PER_MTOK,

--- a/tokenjam/mcp/server.py
+++ b/tokenjam/mcp/server.py
@@ -1,7 +1,20 @@
 """TokenJam MCP server — exposes observability data to Claude Code via stdio."""
 from __future__ import annotations
 
-from fastmcp import FastMCP
+try:
+    from fastmcp import FastMCP
+except ImportError as _import_err:  # pragma: no cover - defensive
+    # fastmcp moved into the base dependencies in v0.3.5 (issue #101). This
+    # fallback only triggers if a user manually uninstalled fastmcp or
+    # installed via an unusual route that excluded base deps. Surface a
+    # clean error pointing at the fix instead of the raw ImportError that
+    # Claude Code surfaces as "MCP server failed to start".
+    raise ImportError(
+        "tokenjam.mcp requires fastmcp, but it is not installed. "
+        "Reinstall TokenJam with `pipx install --force tokenjam` "
+        "(or `pip install --upgrade tokenjam` in a venv) — fastmcp is "
+        "shipped in the base install as of v0.3.5."
+    ) from _import_err
 
 mcp = FastMCP("tj")
 

--- a/tokenjam/pricing/models.toml
+++ b/tokenjam/pricing/models.toml
@@ -38,6 +38,42 @@ output_per_mtok = 4.00
 cache_read_per_mtok = 0.08
 cache_write_per_mtok = 1.00
 
+# ─── Deprecated Anthropic base models ──────────────────────────────────────
+# These rows exist so dated variants (e.g. `claude-sonnet-4-20250514`,
+# `claude-opus-4-20250514`) resolve via the YYYYMMDD-stripping fallback in
+# `get_rates`. Without these entries, dated names from the deprecated tier
+# fall through to default rates and spam the "No pricing data" warning. See
+# https://docs.anthropic.com/en/docs/about-claude/pricing for the rates.
+# Issue #98.
+
+# Claude Sonnet 4 (deprecated — superseded by Sonnet 4.5/4.6)
+[anthropic.claude-sonnet-4]
+input_per_mtok = 3.00
+output_per_mtok = 15.00
+cache_read_per_mtok = 0.30
+cache_write_per_mtok = 3.75
+
+# Claude Opus 4 (deprecated — superseded by Opus 4.5/4.6/4.7/4.8)
+[anthropic.claude-opus-4]
+input_per_mtok = 15.00
+output_per_mtok = 75.00
+cache_read_per_mtok = 1.50
+cache_write_per_mtok = 18.75
+
+# Claude Opus 4.1 (deprecated — superseded by Opus 4.5/4.6/4.7/4.8)
+[anthropic.claude-opus-4-1]
+input_per_mtok = 15.00
+output_per_mtok = 75.00
+cache_read_per_mtok = 1.50
+cache_write_per_mtok = 18.75
+
+# Claude Haiku 3.5 (retired except on Bedrock and Vertex)
+[anthropic.claude-haiku-3-5]
+input_per_mtok = 0.80
+output_per_mtok = 4.00
+cache_read_per_mtok = 0.08
+cache_write_per_mtok = 1.00
+
 [openai.gpt-4o]
 input_per_mtok = 2.50
 output_per_mtok = 10.00


### PR DESCRIPTION
Two real first-time-user papercuts on the v0.3.4 → social-launch surface.

Closes #98. Closes #101.

## #101 — `tj mcp` crashes on clean `pipx install tokenjam`

The MCP server module imported `fastmcp` at top level, but `fastmcp` was in the `[mcp]` optional extra. The README, docs, and `/tokenmaxxing` page all now recommend bare `pipx install tokenjam`. Result: Claude Code's MCP server fails to start on every fresh install.

**Fix:** moved `fastmcp` into base `[project] dependencies`. The `[mcp]` extra is kept (now an empty no-op list) so existing `pipx install 'tokenjam[mcp]'` invocations still work. Added a defensive try/except around the import that surfaces a clean reinstall hint if fastmcp is somehow missing (e.g. user uninstalled it manually) — better than the raw ImportError surfacing inside Claude Code's MCP-server dialog.

## #98 — "No pricing data" warning spams hundreds of times

Two related problems:

1. Dated deprecated models (`claude-sonnet-4-20250514`, `claude-opus-4-20250514`, `claude-haiku-3-5-20241022`) weren't resolving via the YYYYMMDD-stripping fallback because the **unsuffixed base names weren't in pricing/models.toml either**. Falling through to defaults + warning per span.
2. The warning fired **per call**, so a 247-session Claude Code backfill emitted hundreds of identical warnings.

**Fix part 1:** added the deprecated Anthropic base entries to `pricing/models.toml` at their docs-listed deprecated rates:

| Model | Input | Output | Cache Read | Cache Write |
|---|---|---|---|---|
| `claude-sonnet-4` | $3 | $15 | $0.30 | $3.75 |
| `claude-opus-4` | $15 | $75 | $1.50 | $18.75 |
| `claude-opus-4-1` | $15 | $75 | $1.50 | $18.75 |
| `claude-haiku-3-5` | $0.80 | $4 | $0.08 | $1 |

Dated variants now resolve via the existing fallback. Costs are now accurate for users still running deprecated tiers, not defaulted.

**Fix part 2:** module-level `_UNKNOWN_MODEL_WARNED` set in `calculate_cost()`. Each (provider, model) pair logs at most once per process. Backfill output is now ~one line per truly-unknown model, not one per span.

## Tests

- **New:** `test_calculate_cost_unknown_model_warns_only_once_per_pair` — asserts exactly one warning fires regardless of call count, and that a *different* unknown model still warns (once).
- **New:** `test_deprecated_anthropic_base_models_are_priced` — exercises dated-variant resolution end-to-end for all four deprecated base entries.
- **Updated:** the existing unknown-model test uses a unique provider/model name so the dedupe set doesn't suppress it.

**628/628 tests pass** (was 626; +2 new).

## Sets up the v0.3.5 release

These two fixes plus the docs landed since v0.3.4 (CLAUDE.md, playbooks, upgrade-instructions epilog, six-tier sweep) are a natural v0.3.5 bundle. After merge: run the pre-release playbook against `main`, then cut v0.3.5.

🤖 Generated with [Claude Code](https://claude.com/claude-code)