### PR TITLE
Fix #105, #106: version drift, /health, tokenmaxx fallback, trim hint markup

### DIFF
--- a/tokenjam/__init__.py
+++ b/tokenjam/__init__.py
@@ -1,1 +1,6 @@
-__version__ = "0.1.9"
+from importlib.metadata import PackageNotFoundError, version as _pkg_version
+
+try:
+    __version__ = _pkg_version("tokenjam")
+except PackageNotFoundError:
+    __version__ = "0.0.0+unknown"

--- a/tokenjam/api/app.py
+++ b/tokenjam/api/app.py
@@ -75,6 +75,7 @@ def create_app(
     from tokenjam.api.routes.agents import router as agents_router
     from tokenjam.api.routes.optimize import router as optimize_router
     from tokenjam.api.routes.cost_compare import router as cost_compare_router
+    from tokenjam.api.routes.version import router as version_router, health_router
 
     app.include_router(spans_router, prefix="/api/v1")
     app.include_router(traces_router, prefix="/api/v1")
@@ -87,6 +88,8 @@ def create_app(
     app.include_router(agents_router, prefix="/api/v1")
     app.include_router(optimize_router, prefix="/api/v1")
     app.include_router(cost_compare_router, prefix="/api/v1")
+    app.include_router(version_router, prefix="/api/v1")
+    app.include_router(health_router)  # /health — no prefix, for uptime probes
     app.include_router(metrics_router)  # /metrics — no prefix
     app.include_router(otlp_router)  # /v1/traces, /v1/metrics, /v1/logs — no prefix
 

--- a/tokenjam/api/routes/version.py
+++ b/tokenjam/api/routes/version.py
@@ -1,0 +1,20 @@
+"""GET /api/v1/version — package version, used by the UI footer.
+GET /health — process liveness probe (alias for uptime tooling, no prefix)."""
+from __future__ import annotations
+
+from fastapi import APIRouter
+
+from tokenjam import __version__
+
+router = APIRouter()
+health_router = APIRouter()
+
+
+@router.get("/version")
+async def get_version() -> dict:
+    return {"version": __version__}
+
+
+@health_router.get("/health")
+async def get_health() -> dict:
+    return {"status": "ok", "version": __version__}

--- a/tokenjam/cli/cmd_report.py
+++ b/tokenjam/cli/cmd_report.py
@@ -19,6 +19,7 @@ from datetime import datetime, timezone
 from pathlib import Path
 
 import click
+from rich.markup import escape as _rich_escape
 
 from tokenjam.utils.formatting import console
 
@@ -82,7 +83,7 @@ def _render_trim_report(
 
     if not finding.enabled:
         # Show the hint inline rather than producing an empty HTML file.
-        console.print(f"[yellow]Trim analyzer not ready:[/yellow]\n{finding.hint}")
+        console.print(f"[yellow]Trim analyzer not ready:[/yellow]\n{_rich_escape(finding.hint)}")
         return
 
     if not finding.per_prompt:

--- a/tokenjam/cli/cmd_tokenmaxx.py
+++ b/tokenjam/cli/cmd_tokenmaxx.py
@@ -193,12 +193,41 @@ def _fetch(db, config, since_dt, until_dt, since_str) -> tuple[float, float, int
 # ───────────────────────────── helpers ────────────────────────────────────
 
 def _config_declared_plan(config) -> str | None:
-    """Mirror cmd_optimize._config_declared_plan."""
+    """Return the user's declared subscription plan tier.
+
+    Checks the active config first; if no `[budget.<provider>].plan` is set
+    (common when running from a project dir whose `.tj/config.toml` has no
+    `[budget]` section), falls back to peeking at the global config at
+    `~/.config/tj/config.toml`. Without this fallback, tokenmaxx silently
+    rendered api-pricing framing in subdirectories even when the user had
+    set their plan globally via `tj onboard`. Issue #106.
+    """
     budgets = getattr(config, "budgets", None) or {}
     for provider in sorted(budgets.keys()):
         plan = getattr(budgets[provider], "plan", None)
         if plan:
             return str(plan)
+
+    # Active config has no plan — peek at the global config file directly.
+    try:
+        import sys
+        from pathlib import Path
+        if sys.version_info >= (3, 11):
+            import tomllib
+        else:
+            import tomli as tomllib  # type: ignore[no-redef]
+        global_path = Path.home() / ".config" / "tj" / "config.toml"
+        if not global_path.exists():
+            return None
+        with open(global_path, "rb") as f:
+            raw = tomllib.load(f)
+        budget_block = raw.get("budget") or {}
+        for provider in sorted(budget_block.keys()):
+            plan = (budget_block[provider] or {}).get("plan")
+            if plan:
+                return str(plan)
+    except (OSError, Exception):  # noqa: BLE001
+        return None
     return None
 
 

--- a/tokenjam/ui/index.html
+++ b/tokenjam/ui/index.html
@@ -529,7 +529,7 @@ tr.clickable:hover td.chevron { color: var(--accent); }
     <a href="/docs" target="_blank" class="footer-link"><span class="icon">&#x2737;</span> API docs</a>
     <a href="https://github.com/Metabuilder-Labs/tokenjam" target="_blank" class="footer-link"><span class="icon">&#x2197;</span> GitHub</a>
     <button class="theme-toggle" id="theme-toggle" aria-label="Toggle theme"><span class="icon" id="theme-icon">&#x2299;</span> <span id="theme-label">System</span></button>
-    <div class="version">v0.1.4</div>
+    <div class="version" id="tj-version">…</div>
   </div>
 </nav>
 
@@ -1281,6 +1281,15 @@ function App() {
 }
 
 render(html`<${App} />`, document.getElementById('app'));
+
+// Footer version — fetched from /api/v1/version (same-origin, offline-safe).
+fetch('/api/v1/version')
+  .then(r => r.ok ? r.json() : null)
+  .then(d => {
+    const el = document.getElementById('tj-version');
+    if (el && d && d.version) el.textContent = 'v' + d.version;
+  })
+  .catch(() => {});
 </script>
 <script>
   // Theme toggle: cycles dark → light → system


### PR DESCRIPTION
## Summary

Closes #106 (all 3 items) and #105.

- **Version drift** — `tokenjam/__init__.py` now reads from `importlib.metadata.version("tokenjam")`. New `GET /api/v1/version` endpoint; UI footer fetches it instead of the hardcoded `v0.1.4`. Same-origin fetch, no CDN — Critical Rule 18 (offline UI) preserved.
- **`/health` alias** — returns `{"status":"ok","version":"..."}` for uptime probes. `/api/v1/status` is unchanged.
- **tokenmaxx global fallback** — `_config_declared_plan` peeks at `~/.config/tj/config.toml` when the active config has no `[budget]` section, so the plan-multiplier line renders correctly from project subdirs.
- **#105** — `tj report --trim` not-ready hint now wraps `finding.hint` with `rich.markup.escape()` so the literal `[capture]` renders instead of being silently eaten by Rich's parser.

## Test plan

- [x] `pytest tests/unit/test_ui_offline.py tests/unit/test_cmd_tokenmaxx.py tests/integration/test_api.py` — 45 pass
- [x] Live: `curl /health` → `{"status":"ok","version":"0.3.4"}`
- [x] Live: `curl /api/v1/version` → `{"version":"0.3.4"}`
- [x] Live: UI footer shows `v0.3.4` (fetched, not hardcoded)
- [x] Repro: tmp project with empty `.tj/config.toml` + global with `plan = "max_5x"` → `_config_declared_plan` returns `max_5x` (was `None`)
- [ ] `tj report --trim` with `[capture] prompts = false` — hint now shows `[capture]` literally
- [ ] After version bump to 0.3.5, footer auto-updates to `v0.3.5` without further edits

🤖 Generated with [Claude Code](https://claude.com/claude-code)