### PR TITLE
Bump version to 0.3.5

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "tokenjam"
-version = "0.3.4"
+version = "0.3.5"
 description = "TokenJam — local-first OTel-native observability for Autonomous AI agents"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/sdk-ts/package.json
+++ b/sdk-ts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tokenjam/sdk",
-  "version": "0.3.4",
+  "version": "0.3.5",
   "description": "TypeScript SDK for TokenJam — local-first observability for AI agents",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",


### PR DESCRIPTION
Version bump for the v0.3.5 release. Both `pyproject.toml` and `sdk-ts/package.json` to 0.3.5.

See https://github.com/Metabuilder-Labs/tokenjam/releases/tag/v0.3.5 (after publish) for the full notes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)