### PR TITLE
#110: Extract plan-tier framing into core/framing.py

### DIFF
--- a/tests/integration/test_api.py
+++ b/tests/integration/test_api.py
@@ -238,6 +238,54 @@ async def test_get_cost_returns_aggregated_rows(client):
     assert "total_cost_usd" in data
 
 
+_FRAMING_KEYS = {
+    "pricing_mode", "plan_tier", "plan_label", "plan_monthly_usd",
+    "subscription_share_pct", "api_share_pct", "display_rule", "qualifier_text",
+}
+
+
+async def test_cost_response_includes_framing_block(client):
+    await _ingest_sample_span(client)
+    resp = await client.get("/api/v1/cost")
+    assert resp.status_code == 200
+    framing = resp.json()["framing"]
+    assert _FRAMING_KEYS <= set(framing)
+
+
+async def test_optimize_response_includes_framing_block(client):
+    await _ingest_sample_span(client)
+    resp = await client.get("/api/v1/optimize?since=30d")
+    assert resp.status_code == 200
+    data = resp.json()
+    if data.get("error") == "no_data":
+        pytest.skip("no spans landed for optimize in this fixture")
+    assert _FRAMING_KEYS <= set(data["framing"])
+
+
+async def test_budget_framing_reflects_configured_subscription_plan(db):
+    """The budget surface has no window, so framing falls back to the
+    declared plan in config (#110)."""
+    from tokenjam.core.config import ProviderBudget
+
+    cfg = TjConfig(
+        version="1",
+        security=SecurityConfig(ingest_secret=INGEST_SECRET),
+        api=ApiConfig(auth=ApiAuthConfig(enabled=False)),
+    )
+    cfg.budgets["anthropic"] = ProviderBudget(plan="max_5x")
+    pipeline = IngestPipeline(db=db, config=cfg)
+    app = create_app(config=cfg, db=db, ingest_pipeline=pipeline)
+    transport = httpx.ASGITransport(app=app)
+    async with httpx.AsyncClient(transport=transport, base_url="http://test") as c:
+        resp = await c.get("/api/v1/budget")
+    assert resp.status_code == 200
+    framing = resp.json()["framing"]
+    assert framing["pricing_mode"] == "subscription"
+    assert framing["plan_tier"] == "max_5x"
+    assert framing["plan_label"] == "Max 5x plan"
+    assert framing["display_rule"] == "suppress_dollars_for_subscription_share"
+
+
 async def test_get_alerts_returns_list(client):
     resp = await client.get("/api/v1/alerts")
     assert resp.status_code == 200

--- a/tests/unit/test_cmd_tokenmaxx.py
+++ b/tests/unit/test_cmd_tokenmaxx.py
@@ -1,14 +1,33 @@
 """Unit tests for `tj tokenmaxx`."""
 from __future__ import annotations
 
+import pytest
+
 from tokenjam.cli.cmd_tokenmaxx import (
     Tier,
     _TIERS,
     _classify,
-    _config_declared_plan,
-    _plan_label_and_fee,
 )
 from tokenjam.core.config import ProviderBudget, TjConfig
+# Plan-tier helpers moved to the shared framing module (#110); tokenmaxx now
+# consumes them from there.
+from tokenjam.core.framing import PLAN_LABEL_AND_FEE
+from tokenjam.core.framing import config_declared_plan as _config_declared_plan
+
+
+def _plan_label_and_fee(plan_tier):
+    """Shim mirroring the old cmd_tokenmaxx helper's contract (returns None for
+    unknown / api / local / None) on top of the shared PLAN_LABEL_AND_FEE."""
+    if plan_tier is None:
+        return None
+    return PLAN_LABEL_AND_FEE.get(plan_tier)
+
+
+@pytest.fixture(autouse=True)
+def _isolate_home(monkeypatch, tmp_path):
+    """Keep config_declared_plan's global fallback from reading this machine's
+    ~/.config/tj/config.toml during the no-budgets test."""
+    monkeypatch.setattr("pathlib.Path.home", lambda: tmp_path)
 
 
 # ───────────────────────────── classification ─────────────────────────────

--- a/tests/unit/test_framing.py
+++ b/tests/unit/test_framing.py
@@ -1,0 +1,249 @@
+"""Unit tests for tokenjam.core.framing (issue #110)."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+import pytest
+
+from tokenjam.core.framing import (
+    DISPLAY_SHOW_DOLLARS,
+    DISPLAY_SHOW_DOLLARS_WITH_QUALIFIER,
+    DISPLAY_SUPPRESS_SUBSCRIPTION,
+    DISPLAY_SUPPRESS_UNKNOWN,
+    DISPLAY_TOKENS_ONLY,
+    Framing,
+    WindowSummary,
+    compute_framing,
+    config_declared_plan,
+    dominant_plan,
+    pricing_mode_for,
+    render_dollar,
+    render_savings,
+)
+
+
+# --------------------------------------------------------------------------- #
+# config stubs
+# --------------------------------------------------------------------------- #
+@dataclass
+class _Budget:
+    plan: str | None = None
+
+
+class _Config:
+    def __init__(self, budgets: dict | None = None):
+        self.budgets = budgets or {}
+
+
+@pytest.fixture(autouse=True)
+def _isolate_home(monkeypatch, tmp_path):
+    """Point Path.home() at an empty tmp dir so config_declared_plan's global
+    fallback never reads this dev machine's ~/.config/tj/config.toml."""
+    monkeypatch.setattr("pathlib.Path.home", lambda: tmp_path)
+
+
+# --------------------------------------------------------------------------- #
+# pure helpers
+# --------------------------------------------------------------------------- #
+@pytest.mark.parametrize(
+    "plan_tier,expected",
+    [
+        ("local", "local"),
+        ("api", "api"),
+        ("pro", "subscription"),
+        ("max_5x", "subscription"),
+        ("max_20x", "subscription"),
+        ("plus", "subscription"),
+        ("team", "subscription"),
+        ("enterprise", "subscription"),
+        ("unknown", "unknown"),
+        ("garbage", "unknown"),
+    ],
+)
+def test_pricing_mode_for(plan_tier, expected):
+    assert pricing_mode_for(plan_tier) == expected
+
+
+def test_dominant_plan_empty_defaults_to_api():
+    assert dominant_plan({}) == "api"
+
+
+def test_dominant_plan_all_unknown():
+    assert dominant_plan({"unknown": 5}) == "unknown"
+
+
+def test_dominant_plan_most_common_known_wins():
+    assert dominant_plan({"api": 2, "max_5x": 7, "unknown": 3}) == "max_5x"
+
+
+def test_config_declared_plan_from_active_config():
+    cfg = _Config({"anthropic": _Budget(plan="max_5x")})
+    assert config_declared_plan(cfg) == "max_5x"
+
+
+def test_config_declared_plan_none_when_unset():
+    assert config_declared_plan(_Config()) is None
+
+
+def test_config_declared_plan_sorted_provider_order():
+    cfg = _Config({"openai": _Budget(plan="plus"), "anthropic": _Budget(plan="pro")})
+    # 'anthropic' sorts before 'openai'
+    assert config_declared_plan(cfg) == "pro"
+
+
+# --------------------------------------------------------------------------- #
+# compute_framing — one path per pricing_mode
+# --------------------------------------------------------------------------- #
+def test_compute_framing_api_clean():
+    f = compute_framing(
+        _Config(),
+        WindowSummary(total_cost_usd=47.0, total_tokens=1000, sessions=10,
+                      plan_tier_mix={"api": 10}),
+    )
+    assert f.pricing_mode == "api"
+    assert f.plan_tier == "api"
+    assert f.display_rule == DISPLAY_SHOW_DOLLARS
+    assert f.qualifier_text is None
+    assert f.api_share_pct == 100.0
+
+
+def test_compute_framing_api_with_unknown_qualifier():
+    f = compute_framing(
+        _Config(),
+        WindowSummary(total_cost_usd=47.0, total_tokens=1000, sessions=10,
+                      plan_tier_mix={"api": 7, "unknown": 3}),
+    )
+    assert f.pricing_mode == "api"
+    assert f.display_rule == DISPLAY_SHOW_DOLLARS_WITH_QUALIFIER
+    assert f.qualifier_text is not None
+    assert "3 of 10" in f.qualifier_text
+
+
+def test_compute_framing_subscription():
+    f = compute_framing(
+        _Config(),
+        WindowSummary(total_cost_usd=148.0, total_tokens=2_000_000, sessions=20,
+                      plan_tier_mix={"max_5x": 20}),
+    )
+    assert f.pricing_mode == "subscription"
+    assert f.plan_tier == "max_5x"
+    assert f.plan_label == "Max 5x plan"
+    assert f.plan_monthly_usd == 100.0
+    assert f.display_rule == DISPLAY_SUPPRESS_SUBSCRIPTION
+    assert f.subscription_share_pct == 100.0
+
+
+def test_compute_framing_subscription_mixed_window_qualifier():
+    f = compute_framing(
+        _Config(),
+        WindowSummary(total_cost_usd=148.0, total_tokens=2_000_000, sessions=20,
+                      plan_tier_mix={"max_5x": 17, "api": 3}),
+    )
+    assert f.pricing_mode == "subscription"
+    assert f.display_rule == DISPLAY_SUPPRESS_SUBSCRIPTION
+    assert f.qualifier_text is not None
+    assert "subscription-billed" in f.qualifier_text
+    assert f.subscription_share_pct == 85.0
+    assert f.api_share_pct == 15.0
+
+
+def test_compute_framing_local():
+    f = compute_framing(
+        _Config(),
+        WindowSummary(total_cost_usd=0.0, total_tokens=5000, sessions=4,
+                      plan_tier_mix={"local": 4}),
+    )
+    assert f.pricing_mode == "local"
+    assert f.display_rule == DISPLAY_TOKENS_ONLY
+    assert "no marginal cost" in (f.qualifier_text or "")
+
+
+def test_compute_framing_all_unknown_suppressed():
+    f = compute_framing(
+        _Config(),
+        WindowSummary(total_cost_usd=10.0, total_tokens=500, sessions=5,
+                      plan_tier_mix={"unknown": 5}),
+    )
+    assert f.pricing_mode == "unknown"
+    assert f.display_rule == DISPLAY_SUPPRESS_UNKNOWN
+    assert "tj onboard --reconfigure" in (f.qualifier_text or "")
+
+
+def test_compute_framing_empty_data_falls_back_to_declared_plan():
+    # No window data at all (e.g. /api/v1/budget) → use the declared plan.
+    cfg = _Config({"anthropic": _Budget(plan="max_20x")})
+    f = compute_framing(cfg, WindowSummary())
+    assert f.pricing_mode == "subscription"
+    assert f.plan_tier == "max_20x"
+    assert f.plan_label == "Max 20x plan"
+
+
+def test_compute_framing_empty_data_no_plan_defaults_api():
+    f = compute_framing(_Config(), WindowSummary())
+    assert f.pricing_mode == "api"
+
+
+def test_compute_framing_accepts_dict_window():
+    f = compute_framing(
+        _Config(),
+        {"total_cost_usd": 5.0, "total_tokens": 100, "sessions": 1,
+         "plan_tier_mix": {"api": 1}},
+    )
+    assert f.pricing_mode == "api"
+
+
+# --------------------------------------------------------------------------- #
+# render_dollar / render_savings
+# --------------------------------------------------------------------------- #
+def test_render_dollar_api():
+    f = Framing(pricing_mode="api")
+    assert render_dollar(148.0, f) == "$148"
+    assert render_dollar(5.94, f) == "$5.94"
+
+
+def test_render_dollar_subscription_share_of_cycle():
+    f = Framing(pricing_mode="subscription", plan_monthly_usd=100.0)
+    assert render_dollar(12.4, f) == "12.4% of cycle"
+
+
+def test_render_dollar_local_dash():
+    assert render_dollar(99.0, Framing(pricing_mode="local")) == "—"
+
+
+def test_render_dollar_none():
+    assert render_dollar(None, Framing(pricing_mode="api")) == "—"
+
+
+def test_render_savings_api_dollars():
+    f = Framing(pricing_mode="api")
+    assert render_savings(148.0, 999, f) == "$148"
+
+
+def test_render_savings_subscription_token_share():
+    f = Framing(pricing_mode="subscription", window_total_tokens=1000)
+    assert render_savings(None, 124, f) == "12.4% of cycle tokens"
+
+
+def test_render_savings_local_token_count():
+    f = Framing(pricing_mode="local")
+    assert render_savings(None, 1_200_000, f) == "1.2M tokens"
+
+
+def test_render_savings_none_dash():
+    f = Framing(pricing_mode="api")
+    assert render_savings(None, None, f) == "—"
+
+
+def test_framing_to_dict_has_contract_fields():
+    f = compute_framing(
+        _Config(),
+        WindowSummary(total_cost_usd=1.0, total_tokens=1, sessions=1,
+                      plan_tier_mix={"api": 1}),
+    )
+    d = f.to_dict()
+    for key in (
+        "pricing_mode", "plan_tier", "plan_label", "plan_monthly_usd",
+        "subscription_share_pct", "api_share_pct", "display_rule",
+        "qualifier_text",
+    ):
+        assert key in d

--- a/tokenjam/api/routes/budget.py
+++ b/tokenjam/api/routes/budget.py
@@ -8,6 +8,7 @@ from fastapi.responses import JSONResponse
 from pydantic import BaseModel
 
 from tokenjam.api.deps import require_api_key
+from tokenjam.core.framing import WindowSummary, compute_framing
 from tokenjam.core.config import (
     AgentConfig,
     BudgetConfig,
@@ -31,9 +32,15 @@ def _budget_payload(config, agent_ids: list[str]) -> dict:
         eff = _b(resolve_effective_budget(aid, config))
         agents[aid] = {"configured": raw, "effective": eff}
 
+    # Plan-tier framing block (#110). The budget surface has no time window, so
+    # framing falls back to the user's declared plan (compute_framing reads it
+    # from config when the window mix is empty).
+    framing = compute_framing(config, WindowSummary())
+
     return {
         "defaults": _b(config.defaults.budget),
         "agents": agents,
+        "framing": framing.to_dict(),
     }
 
 

--- a/tokenjam/api/routes/cost.py
+++ b/tokenjam/api/routes/cost.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 from fastapi import APIRouter, Depends, Request
 
 from tokenjam.api.deps import require_api_key
+from tokenjam.core.framing import WindowSummary, compute_framing, plan_tier_mix
 from tokenjam.core.models import CostFilters
 from tokenjam.utils.time_parse import parse_since
 
@@ -19,14 +20,35 @@ async def get_cost(
     group_by: str = "day",
 ) -> dict:
     db = request.app.state.db
+    config = request.app.state.config
+    since_dt = parse_since(since) if since else None
+    until_dt = parse_since(until) if until else None
     filters = CostFilters(
         agent_id=agent_id,
-        since=parse_since(since) if since else None,
-        until=parse_since(until) if until else None,
+        since=since_dt,
+        until=until_dt,
         group_by=group_by,
     )
     rows = db.get_cost_summary(filters)
     total = sum(r.cost_usd for r in rows)
+    total_tokens = sum(r.input_tokens + r.output_tokens for r in rows)
+
+    # Plan-tier framing block — single source shared with the CLI (#110). Lets
+    # the local web UI render the same suppressed/qualified dollar figures.
+    conn = getattr(db, "conn", None)
+    mix = (
+        plan_tier_mix(conn, since_dt, until_dt, agent_id)
+        if conn is not None else {}
+    )
+    framing = compute_framing(
+        config,
+        WindowSummary(
+            total_cost_usd=total,
+            total_tokens=total_tokens,
+            sessions=sum(mix.values()),
+            plan_tier_mix=mix,
+        ),
+    )
     return {
         "rows": [
             {
@@ -40,4 +62,6 @@ async def get_cost(
             for r in rows
         ],
         "total_cost_usd": total,
+        "total_tokens": total_tokens,
+        "framing": framing.to_dict(),
     }

--- a/tokenjam/api/routes/cost_compare.py
+++ b/tokenjam/api/routes/cost_compare.py
@@ -14,6 +14,7 @@ from fastapi import APIRouter, Depends, HTTPException, Query, Request
 
 from tokenjam.api.deps import require_api_key
 from tokenjam.core.cost import compute_cost_diff
+from tokenjam.core.framing import WindowSummary, compute_framing, plan_tier_mix
 from tokenjam.utils.time_parse import parse_since, utcnow
 
 router = APIRouter()
@@ -63,6 +64,22 @@ def get_cost_compare(
             "total_tokens": w.total_tokens,
             "total_cost_usd": w.total_cost_usd,
         }
+    # Plan-tier framing for the current window (#110), so the UI frames the
+    # comparison's dollar deltas identically to the CLI.
+    conn = getattr(db, "conn", None)
+    mix = (
+        plan_tier_mix(conn, diff.current.since, diff.current.until, agent_id)
+        if conn is not None else {}
+    )
+    framing = compute_framing(
+        request.app.state.config,
+        WindowSummary(
+            total_cost_usd=diff.current.total_cost_usd,
+            total_tokens=diff.current.total_tokens,
+            sessions=sum(mix.values()),
+            plan_tier_mix=mix,
+        ),
+    )
     return {
         "current": _wt(diff.current),
         "previous": _wt(diff.previous),
@@ -72,4 +89,5 @@ def get_cost_compare(
         "tokens_delta_pct": diff.tokens_delta_pct,
         "by_agent": diff.by_agent,
         "by_model": diff.by_model,
+        "framing": framing.to_dict(),
     }

--- a/tokenjam/api/routes/optimize.py
+++ b/tokenjam/api/routes/optimize.py
@@ -19,6 +19,7 @@ from typing import Any
 from fastapi import APIRouter, Depends, HTTPException, Query, Request
 
 from tokenjam.api.deps import require_api_key
+from tokenjam.core.framing import WindowSummary, compute_framing, plan_tier_mix
 from tokenjam.core.optimize import build_report, report_to_dict
 from tokenjam.utils.time_parse import parse_since, utcnow
 
@@ -84,21 +85,24 @@ def get_optimize(
     conn = getattr(db, "conn", None)
     if conn is not None:
         try:
-            clauses = ["started_at >= $1", "started_at < $2"]
-            params: list = [since_dt, until_dt]
-            if agent_id:
-                clauses.append(f"agent_id = ${len(params) + 1}")
-                params.append(agent_id)
-            where = " AND ".join(clauses)
-            rows = conn.execute(
-                f"SELECT COALESCE(plan_tier, 'unknown'), COUNT(*) FROM sessions "
-                f"WHERE {where} GROUP BY 1",
-                params,
-            ).fetchall()
-            payload["plan_tier_mix"] = {str(r[0]): int(r[1]) for r in rows}
+            payload["plan_tier_mix"] = plan_tier_mix(conn, since_dt, until_dt, agent_id)
         except Exception:
             payload["plan_tier_mix"] = {}
     else:
         payload["plan_tier_mix"] = {}
+
+    # Plan-tier framing block (#110) — built from the report window + the
+    # plan-tier mix above, so the local web UI frames recoverable-savings and
+    # spend figures identically to the CLI.
+    w = report.window
+    payload["framing"] = compute_framing(
+        config,
+        WindowSummary(
+            total_cost_usd=float(getattr(w, "total_cost_usd", 0.0) or 0.0),
+            total_tokens=int(getattr(w, "total_tokens", 0) or 0),
+            sessions=int(getattr(w, "sessions", 0) or 0),
+            plan_tier_mix=payload["plan_tier_mix"],
+        ),
+    ).to_dict()
 
     return payload

--- a/tokenjam/cli/cmd_optimize.py
+++ b/tokenjam/cli/cmd_optimize.py
@@ -6,6 +6,13 @@ import json
 import click
 from rich.markup import escape as _rich_escape
 
+from tokenjam.core.framing import (
+    PLAN_LABEL_AND_FEE,
+    config_declared_plan,
+    dominant_plan,
+    plan_tier_mix,
+    pricing_mode_for,
+)
 from tokenjam.core.optimize import (
     ANALYZER_REGISTRY,
     MODEL_DOWNGRADE_CAVEAT,
@@ -16,7 +23,6 @@ from tokenjam.core.optimize import (
     report_from_dict,
     report_to_dict,
 )
-from tokenjam.otel.semconv import SUBSCRIPTION_PLAN_TIERS
 from tokenjam.utils.formatting import (
     console,
     format_cost,
@@ -24,71 +30,10 @@ from tokenjam.utils.formatting import (
 )
 from tokenjam.utils.time_parse import parse_since, utcnow
 
-
-# Subscription plan label + flat monthly fee. Used in the implied-API-value
-# header line. Keys must match SessionRecord.plan_tier values. Plans whose
-# fee is contract-priced (enterprise, team variants) have no fee here — the
-# header line skips the multiplier in that case.
-_PLAN_LABEL_AND_FEE: dict[str, tuple[str, float | None]] = {
-    "pro":        ("Pro plan",         20.0),
-    "max_5x":     ("Max 5x plan",     100.0),
-    "max_20x":    ("Max 20x plan",    200.0),
-    "plus":       ("ChatGPT Plus",     20.0),
-    "team":       ("ChatGPT Team",      None),
-    "enterprise": ("ChatGPT Enterprise", None),
-}
-
-
-def _pricing_mode_for(plan_tier: str) -> str:
-    """Mirror SessionRecord.pricing_mode without needing an instance."""
-    if plan_tier == "local":
-        return "local"
-    if plan_tier in SUBSCRIPTION_PLAN_TIERS:
-        return "subscription"
-    if plan_tier == "api":
-        return "api"
-    return "unknown"
-
-
-def _dominant_plan(plan_mix: dict[str, int]) -> str:
-    """
-    Pick the rendering mode from the plan-tier mix.
-
-    - If plan_mix is empty (e.g. spans inserted without sessions in test
-      fixtures), default to 'api' — the historical rendering mode. Real
-      users always have a populated sessions table because IngestPipeline
-      creates sessions before writing spans.
-    - If any non-unknown plan_tier is present, return the most common one.
-    - Otherwise return 'unknown' (the caller handles dollar suppression).
-    """
-    if not plan_mix:
-        return "api"
-    known = {k: v for k, v in plan_mix.items() if k != "unknown"}
-    if not known:
-        return "unknown"
-    return max(known.items(), key=lambda kv: kv[1])[0]
-
-
-def _config_declared_plan(config) -> str | None:
-    """
-    Return the user's currently-declared plan tier from config.
-
-    Pulls from `[budget.<provider>].plan` — the field set by
-    `tj onboard --reconfigure`. When multiple providers declare a plan
-    we surface the first one in sorted order (deterministic). Returns
-    None when no provider has a plan declared.
-
-    This is used by the optimize renderer to surface a note when the
-    historical plan-tier mix disagrees with the user's currently-
-    declared plan (#71 finding 1) — without overriding the data-driven
-    rendering, which would be dishonest about what actually happened.
-    """
-    budgets = getattr(config, "budgets", None) or {}
-    for provider in sorted(budgets.keys()):
-        plan = getattr(budgets[provider], "plan", None)
-        if plan:
-            return str(plan)
-    return None
+# Plan-tier framing helpers (PLAN_LABEL_AND_FEE, pricing_mode_for,
+# dominant_plan, config_declared_plan, plan_tier_mix) live in
+# tokenjam.core.framing — the single source shared with cmd_tokenmaxx and the
+# REST API. See issue #110.
 
 
 @click.command("optimize")
@@ -233,11 +178,11 @@ def cmd_optimize(
             budget_usd_override=budget_usd,
         )
 
-        plan_mix = _plan_tier_mix(conn, since_dt, until_dt, agent)
+        plan_mix = plan_tier_mix(conn, since_dt, until_dt, agent)
 
-    dominant = _dominant_plan(plan_mix)
-    pricing_mode = _pricing_mode_for(dominant)
-    declared_plan = _config_declared_plan(config)
+    dominant = dominant_plan(plan_mix)
+    pricing_mode = pricing_mode_for(dominant)
+    declared_plan = config_declared_plan(config)
 
     # --export-config branch: write the snippet to disk and exit. Skips
     # the normal rendering path. The user reads the snippet file and
@@ -319,22 +264,6 @@ def cmd_optimize(
         _render_diff_dict(cost_diff_dict)
 
 
-def _plan_tier_mix(conn, since, until, agent_id: str | None) -> dict[str, int]:
-    """Count sessions by plan_tier inside the analysis window."""
-    clauses = ["started_at >= $1", "started_at < $2"]
-    params: list = [since, until]
-    if agent_id:
-        clauses.append(f"agent_id = ${len(params) + 1}")
-        params.append(agent_id)
-    where = " AND ".join(clauses)
-    rows = conn.execute(
-        f"SELECT COALESCE(plan_tier, 'unknown'), COUNT(*) FROM sessions "
-        f"WHERE {where} GROUP BY 1",
-        params,
-    ).fetchall()
-    return {str(r[0]): int(r[1]) for r in rows}
-
-
 # ---------------------------------------------------------------------------
 # Human-readable renderer
 # ---------------------------------------------------------------------------
@@ -365,7 +294,7 @@ def _render_report(
             f"Run [bold]tj onboard --reconfigure[/bold] to set your plan.[/dim]\n"
         )
     elif pricing_mode == "subscription":
-        label, fee = _PLAN_LABEL_AND_FEE.get(dominant_plan, (dominant_plan, None))
+        label, fee = PLAN_LABEL_AND_FEE.get(dominant_plan, (dominant_plan, None))
         plan_suffix = f", ${fee:.0f}/mo flat" if fee else ""
         console.print(
             f"\nAnalyzing [bold]{w.sessions}[/bold] sessions, "
@@ -415,9 +344,9 @@ def _render_report(
     if (
         declared_plan
         and declared_plan != dominant_plan
-        and declared_plan in _PLAN_LABEL_AND_FEE  # only flag subscription deltas
+        and declared_plan in PLAN_LABEL_AND_FEE  # only flag subscription deltas
     ):
-        label, _ = _PLAN_LABEL_AND_FEE[declared_plan]
+        label, _ = PLAN_LABEL_AND_FEE[declared_plan]
         console.print(
             f"[dim]Note: your config declares "
             f"[bold]{label}[/bold] but historical sessions ran under "

--- a/tokenjam/cli/cmd_tokenmaxx.py
+++ b/tokenjam/cli/cmd_tokenmaxx.py
@@ -20,6 +20,7 @@ from dataclasses import dataclass
 
 import click
 
+from tokenjam.core.framing import PLAN_LABEL_AND_FEE, config_declared_plan
 from tokenjam.utils.formatting import console, format_cost  # noqa: F401  (kept for back-compat imports)
 from tokenjam.utils.time_parse import parse_since, utcnow
 
@@ -101,8 +102,8 @@ def cmd_tokenmaxx(ctx: click.Context, since: str, output_json: bool) -> None:
     monthly_spend = spend_usd * (30.0 / window_days)
 
     # Plan multiplier — only for subscription users with a declared plan.
-    declared_plan = _config_declared_plan(config)
-    plan_info = _plan_label_and_fee(declared_plan)
+    declared_plan = config_declared_plan(config)
+    plan_info = PLAN_LABEL_AND_FEE.get(declared_plan) if declared_plan else None
     multiplier = None
     if plan_info and plan_info[1]:
         multiplier = monthly_spend / plan_info[1]
@@ -191,63 +192,6 @@ def _fetch(db, config, since_dt, until_dt, since_str) -> tuple[float, float, int
 
 
 # ───────────────────────────── helpers ────────────────────────────────────
-
-def _config_declared_plan(config) -> str | None:
-    """Return the user's declared subscription plan tier.
-
-    Checks the active config first; if no `[budget.<provider>].plan` is set
-    (common when running from a project dir whose `.tj/config.toml` has no
-    `[budget]` section), falls back to peeking at the global config at
-    `~/.config/tj/config.toml`. Without this fallback, tokenmaxx silently
-    rendered api-pricing framing in subdirectories even when the user had
-    set their plan globally via `tj onboard`. Issue #106.
-    """
-    budgets = getattr(config, "budgets", None) or {}
-    for provider in sorted(budgets.keys()):
-        plan = getattr(budgets[provider], "plan", None)
-        if plan:
-            return str(plan)
-
-    # Active config has no plan — peek at the global config file directly.
-    try:
-        import sys
-        from pathlib import Path
-        if sys.version_info >= (3, 11):
-            import tomllib
-        else:
-            import tomli as tomllib  # type: ignore[no-redef]
-        global_path = Path.home() / ".config" / "tj" / "config.toml"
-        if not global_path.exists():
-            return None
-        with open(global_path, "rb") as f:
-            raw = tomllib.load(f)
-        budget_block = raw.get("budget") or {}
-        for provider in sorted(budget_block.keys()):
-            plan = (budget_block[provider] or {}).get("plan")
-            if plan:
-                return str(plan)
-    except (OSError, Exception):  # noqa: BLE001
-        return None
-    return None
-
-
-def _plan_label_and_fee(plan_tier: str | None) -> tuple[str, float | None] | None:
-    """
-    Mirror cmd_optimize._PLAN_LABEL_AND_FEE without importing it (avoid
-    circular import risk and keep tokenmaxx independently testable).
-    """
-    if plan_tier is None:
-        return None
-    table: dict[str, tuple[str, float | None]] = {
-        "pro":        ("Pro plan",          20.0),
-        "max_5x":     ("Max 5x plan",      100.0),
-        "max_20x":    ("Max 20x plan",     200.0),
-        "plus":       ("ChatGPT Plus",      20.0),
-        "team":       ("ChatGPT Team",       None),
-        "enterprise": ("ChatGPT Enterprise", None),
-    }
-    return table.get(plan_tier)
-
 
 # ───────────────────────────── rendering ──────────────────────────────────
 

--- a/tokenjam/core/framing.py
+++ b/tokenjam/core/framing.py
@@ -1,0 +1,329 @@
+"""Shared plan-tier-aware framing for dollar / token figures.
+
+Single source of truth for the rules that decide whether a dollar figure is
+shown verbatim, suppressed in favour of token-share framing, or annotated with
+a qualifier. Consumed by the CLI commands (`tj cost` / `tj optimize` /
+`tj tokenmaxx`) and emitted into REST API responses as a ``framing`` block so
+the local web UI renders identical numbers without re-deriving the rules in
+JavaScript.
+
+This module *reads* plan-tier / pricing-mode; it does not define them. The
+canonical derivation lives on ``SessionRecord.pricing_mode`` and the
+``SUBSCRIPTION_PLAN_TIERS`` frozenset in :mod:`tokenjam.otel.semconv`.
+
+Honesty discipline (see CLAUDE.md Critical Rule 14): subscription users never
+see a raw dollar figure that includes subscription traffic without
+qualification; local users see tokens only; unknown-plan users see dollars with
+an "may overstate" qualifier.
+"""
+from __future__ import annotations
+
+from dataclasses import asdict, dataclass, field
+from typing import Any
+
+from tokenjam.otel.semconv import SUBSCRIPTION_PLAN_TIERS
+from tokenjam.utils.formatting import format_tokens
+
+# Subscription plan label + flat monthly fee. Keys must match
+# SessionRecord.plan_tier values. Plans whose fee is contract-priced
+# (team / enterprise) have no fee here — callers skip the multiplier in that
+# case. This is the single copy; cmd_optimize / cmd_tokenmaxx import it.
+PLAN_LABEL_AND_FEE: dict[str, tuple[str, float | None]] = {
+    "pro":        ("Pro plan",          20.0),
+    "max_5x":     ("Max 5x plan",      100.0),
+    "max_20x":    ("Max 20x plan",     200.0),
+    "plus":       ("ChatGPT Plus",      20.0),
+    "team":       ("ChatGPT Team",       None),
+    "enterprise": ("ChatGPT Enterprise", None),
+}
+
+# display_rule values — the UI / CLI reads this to pick a rendering path.
+DISPLAY_SHOW_DOLLARS = "show_dollars"
+DISPLAY_SHOW_DOLLARS_WITH_QUALIFIER = "show_dollars_with_qualifier"
+DISPLAY_SUPPRESS_SUBSCRIPTION = "suppress_dollars_for_subscription_share"
+DISPLAY_TOKENS_ONLY = "tokens_only"
+DISPLAY_SUPPRESS_UNKNOWN = "suppress_dollars_unknown"
+
+
+def pricing_mode_for(plan_tier: str) -> str:
+    """Mirror ``SessionRecord.pricing_mode`` without needing an instance."""
+    if plan_tier == "local":
+        return "local"
+    if plan_tier in SUBSCRIPTION_PLAN_TIERS:
+        return "subscription"
+    if plan_tier == "api":
+        return "api"
+    return "unknown"
+
+
+def dominant_plan(plan_mix: dict[str, int]) -> str:
+    """Pick the rendering plan tier from a plan-tier session-count mix.
+
+    - Empty mix (e.g. spans inserted without sessions in test fixtures) →
+      ``"api"``, the historical rendering mode. Real users always have a
+      populated sessions table.
+    - Any non-unknown plan_tier present → the most common one.
+    - Otherwise → ``"unknown"`` (the caller suppresses dollars).
+    """
+    if not plan_mix:
+        return "api"
+    known = {k: v for k, v in plan_mix.items() if k != "unknown"}
+    if not known:
+        return "unknown"
+    return max(known.items(), key=lambda kv: kv[1])[0]
+
+
+def config_declared_plan(config: Any) -> str | None:
+    """Return the user's declared plan tier from config.
+
+    Checks the active config first; if no ``[budget.<provider>].plan`` is set
+    (common when running from a project dir whose ``.tj/config.toml`` has no
+    ``[budget]`` section), falls back to peeking at the global config at
+    ``~/.config/tj/config.toml``. Without this fallback, framing silently
+    rendered api-pricing in subdirectories even when the user had set their
+    plan globally via ``tj onboard`` (issue #106). When multiple providers
+    declare a plan, the first in sorted order wins (deterministic).
+    """
+    budgets = getattr(config, "budgets", None) or {}
+    for provider in sorted(budgets.keys()):
+        plan = getattr(budgets[provider], "plan", None)
+        if plan:
+            return str(plan)
+
+    # Active config has no plan — peek at the global config file directly.
+    try:
+        import sys
+        from pathlib import Path
+        if sys.version_info >= (3, 11):
+            import tomllib
+        else:
+            import tomli as tomllib  # type: ignore[no-redef]
+        global_path = Path.home() / ".config" / "tj" / "config.toml"
+        if not global_path.exists():
+            return None
+        with open(global_path, "rb") as f:
+            raw = tomllib.load(f)
+        budget_block = raw.get("budget") or {}
+        for provider in sorted(budget_block.keys()):
+            plan = (budget_block[provider] or {}).get("plan")
+            if plan:
+                return str(plan)
+    except Exception:  # noqa: BLE001 — best-effort fallback, never fatal
+        return None
+    return None
+
+
+@dataclass
+class WindowSummary:
+    """Minimal window aggregate that :func:`compute_framing` consumes.
+
+    Callers can also pass any object/dict exposing these attributes (e.g. an
+    ``OptimizeReport.window``); :func:`compute_framing` reads them defensively.
+    """
+    total_cost_usd: float = 0.0
+    total_tokens: int = 0
+    sessions: int = 0
+    plan_tier_mix: dict[str, int] = field(default_factory=dict)
+
+
+@dataclass
+class Framing:
+    """Plan-tier framing decision for a window of usage."""
+    pricing_mode: str = "unknown"
+    plan_tier: str = "unknown"
+    plan_label: str | None = None
+    plan_monthly_usd: float | None = None
+    subscription_share_pct: float = 0.0
+    api_share_pct: float = 0.0
+    display_rule: str = DISPLAY_SHOW_DOLLARS
+    qualifier_text: str | None = None
+    # Window totals carried so renderers can compute token-share without a
+    # second query (used by render_savings in subscription mode).
+    window_total_tokens: int = 0
+    window_total_cost_usd: float = 0.0
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+
+def _attr(obj: Any, name: str, default: Any) -> Any:
+    """Read ``name`` from an object attr or a dict key, with a default."""
+    if obj is None:
+        return default
+    if isinstance(obj, dict):
+        return obj.get(name, default)
+    return getattr(obj, name, default)
+
+
+def compute_framing(
+    config: Any,
+    window_summary: Any,
+    by_provider_breakdown: Any = None,
+) -> Framing:
+    """Compute the plan-tier framing for a window.
+
+    ``window_summary`` is a :class:`WindowSummary`, an ``OptimizeReport.window``,
+    or any object/dict exposing ``total_cost_usd``, ``total_tokens``,
+    ``sessions`` and ``plan_tier_mix`` (session counts by plan tier).
+
+    ``by_provider_breakdown`` is accepted for forward-compatibility (refining
+    the API-only dollar split in mixed windows); the core decision does not
+    require it.
+    """
+    mix: dict[str, int] = dict(_attr(window_summary, "plan_tier_mix", {}) or {})
+    total_cost = float(_attr(window_summary, "total_cost_usd", 0.0) or 0.0)
+    total_tokens = int(_attr(window_summary, "total_tokens", 0) or 0)
+
+    total_sessions = sum(mix.values())
+    sub_sessions = sum(v for k, v in mix.items() if k in SUBSCRIPTION_PLAN_TIERS)
+    api_sessions = int(mix.get("api", 0))
+    unknown_sessions = int(mix.get("unknown", 0))
+
+    dom = dominant_plan(mix)
+    # When the window carries no plan-tier data at all, prefer the user's
+    # declared plan so framing-only contexts (e.g. /api/v1/budget) still reflect
+    # a subscription user. This deliberately diverges from the CLI's data-driven
+    # `dominant_plan` (which the CLI calls directly) — compute_framing is the
+    # UI/API path and benefits from the config fallback.
+    if not mix:
+        declared = config_declared_plan(config)
+        if declared:
+            dom = declared
+
+    mode = pricing_mode_for(dom)
+    label, fee = PLAN_LABEL_AND_FEE.get(dom, (None, None))
+
+    sub_pct = (100.0 * sub_sessions / total_sessions) if total_sessions else 0.0
+    api_pct = (100.0 * api_sessions / total_sessions) if total_sessions else 0.0
+    all_unknown = total_sessions > 0 and unknown_sessions == total_sessions
+
+    display_rule = DISPLAY_SHOW_DOLLARS
+    qualifier: str | None = None
+
+    if all_unknown:
+        display_rule = DISPLAY_SUPPRESS_UNKNOWN
+        qualifier = (
+            "Plan tier unknown — figures may overstate actual cost. "
+            "Run `tj onboard --reconfigure`."
+        )
+    elif mode == "subscription":
+        display_rule = DISPLAY_SUPPRESS_SUBSCRIPTION
+        if api_sessions > 0:
+            qualifier = (
+                f"{sub_pct:.1f}% of this window was subscription-billed; "
+                f"dollar figures reflect API traffic only."
+            )
+    elif mode == "local":
+        display_rule = DISPLAY_TOKENS_ONLY
+        qualifier = "Local inference — no marginal cost."
+    elif mode == "api":
+        if unknown_sessions > 0:
+            display_rule = DISPLAY_SHOW_DOLLARS_WITH_QUALIFIER
+            qualifier = (
+                f"{unknown_sessions} of {total_sessions} sessions have unknown "
+                f"plan tier; dollar figures may overstate actual cost. "
+                f"Run `tj onboard --reconfigure`."
+            )
+
+    return Framing(
+        pricing_mode=mode,
+        plan_tier=dom,
+        plan_label=label,
+        plan_monthly_usd=fee,
+        subscription_share_pct=round(sub_pct, 1),
+        api_share_pct=round(api_pct, 1),
+        display_rule=display_rule,
+        qualifier_text=qualifier,
+        window_total_tokens=total_tokens,
+        window_total_cost_usd=total_cost,
+    )
+
+
+def _fmt_usd(value: float) -> str:
+    """Compact USD for tiles: whole dollars when round, else 2dp."""
+    value = round(value, 2)
+    if value == int(value):
+        return f"${int(value):,}"
+    return f"${value:,.2f}"
+
+
+def render_dollar(value: float | None, framing: Framing) -> str:
+    """Render a single dollar value framed for the pricing mode.
+
+    Returns e.g. ``"$148"`` (api), ``"12.4% of cycle"`` (subscription with a
+    known plan fee), or ``"—"`` (local, or no value).
+    """
+    if value is None:
+        return "—"
+    mode = framing.pricing_mode
+    if mode == "local":
+        return "—"
+    if mode == "subscription":
+        if framing.plan_monthly_usd:
+            pct = 100.0 * value / framing.plan_monthly_usd
+            return f"{pct:.1f}% of cycle"
+        return "—"
+    # api / unknown — dollars shown (qualifier carried separately on Framing)
+    return _fmt_usd(value)
+
+
+def render_savings(
+    value_usd: float | None,
+    value_tokens: int | None,
+    framing: Framing,
+) -> str:
+    """Render a savings / recoverable figure framed for the pricing mode.
+
+    - api / unknown: dollars (``"$148"``)
+    - subscription: token-share of the cycle (``"12.4% of cycle tokens"``)
+    - local: token count (``"1.2M tokens"``)
+
+    Returns ``"—"`` when the relevant figure is unavailable.
+    """
+    mode = framing.pricing_mode
+    if mode == "subscription":
+        if value_tokens is None:
+            return "—"
+        if framing.window_total_tokens > 0:
+            pct = 100.0 * value_tokens / framing.window_total_tokens
+            return f"{pct:.1f}% of cycle tokens"
+        return f"{format_tokens(value_tokens)} tokens"
+    if mode == "local":
+        if value_tokens is None:
+            return "—"
+        return f"{format_tokens(value_tokens)} tokens"
+    # api / unknown
+    if value_usd is None:
+        return "—"
+    return _fmt_usd(value_usd)
+
+
+def plan_tier_mix(
+    conn: Any,
+    since: Any = None,
+    until: Any = None,
+    agent_id: str | None = None,
+) -> dict[str, int]:
+    """Count sessions by plan_tier inside an optional window.
+
+    Single home for the ``SELECT plan_tier, COUNT(*) FROM sessions`` query used
+    by ``cmd_optimize`` and the ``/api/v1/optimize`` + ``/api/v1/cost`` routes.
+    """
+    clauses: list[str] = []
+    params: list[Any] = []
+    if since is not None:
+        params.append(since)
+        clauses.append(f"started_at >= ${len(params)}")
+    if until is not None:
+        params.append(until)
+        clauses.append(f"started_at < ${len(params)}")
+    if agent_id:
+        params.append(agent_id)
+        clauses.append(f"agent_id = ${len(params)}")
+    where = (" WHERE " + " AND ".join(clauses)) if clauses else ""
+    rows = conn.execute(
+        f"SELECT COALESCE(plan_tier, 'unknown'), COUNT(*) FROM sessions{where} "
+        f"GROUP BY 1",
+        params,
+    ).fetchall()
+    return {str(r[0]): int(r[1]) for r in rows}

--- a/tokenjam/core/framing.py
+++ b/tokenjam/core/framing.py
@@ -309,21 +309,25 @@ def plan_tier_mix(
     Single home for the ``SELECT plan_tier, COUNT(*) FROM sessions`` query used
     by ``cmd_optimize`` and the ``/api/v1/optimize`` + ``/api/v1/cost`` routes.
     """
+    # Built by concatenating static fragments (never f-string SQL, per CLAUDE.md
+    # Critical Rule 7). Placeholder indices are appended as the params list grows;
+    # every value is bound through a $N parameter, never interpolated.
     clauses: list[str] = []
     params: list[Any] = []
     if since is not None:
         params.append(since)
-        clauses.append(f"started_at >= ${len(params)}")
+        clauses.append("started_at >= $" + str(len(params)))
     if until is not None:
         params.append(until)
-        clauses.append(f"started_at < ${len(params)}")
+        clauses.append("started_at < $" + str(len(params)))
     if agent_id:
         params.append(agent_id)
-        clauses.append(f"agent_id = ${len(params)}")
+        clauses.append("agent_id = $" + str(len(params)))
     where = (" WHERE " + " AND ".join(clauses)) if clauses else ""
-    rows = conn.execute(
-        f"SELECT COALESCE(plan_tier, 'unknown'), COUNT(*) FROM sessions{where} "
-        f"GROUP BY 1",
-        params,
-    ).fetchall()
+    sql = (
+        "SELECT COALESCE(plan_tier, 'unknown'), COUNT(*) FROM sessions"
+        + where
+        + " GROUP BY 1"
+    )
+    rows = conn.execute(sql, params).fetchall()
     return {str(r[0]): int(r[1]) for r in rows}


### PR DESCRIPTION
Closes #110.

Foundation for the Lens UI work: a single source of truth for plan-tier-aware
rendering, consumed by both the CLI and the REST API so the web UI can render
identical dollar/token figures without re-deriving the rules in JavaScript.

## What changed

**New module `tokenjam/core/framing.py`**
- `Framing` dataclass (`pricing_mode`, `plan_tier`, `plan_label`,
  `plan_monthly_usd`, `subscription_share_pct`, `api_share_pct`,
  `display_rule`, `qualifier_text`, plus window totals).
- `compute_framing(config, window_summary, by_provider_breakdown)`.
- `render_dollar(value, framing)` and `render_savings(value_usd, value_tokens, framing)`.
- Shared helpers `pricing_mode_for` / `dominant_plan` / `config_declared_plan`
  (with the #106 global-config fallback) / `plan_tier_mix`.

**CLI migration (output unchanged)**
- `cmd_optimize.py` and `cmd_tokenmaxx.py` import the helpers from the shared
  module and drop their local copies. `cmd_cost.py` did not apply framing
  before and still doesn't (its rendering is untouched).

**API**
- `/api/v1/cost`, `/api/v1/cost/compare`, `/api/v1/optimize`, `/api/v1/budget`
  now return a top-level `framing` block. Callers that ignore it keep working.

## Tests
- `tests/unit/test_framing.py` — one path per `pricing_mode`
  (api / subscription / local / unknown), mixed windows, empty data, and both
  render helpers.
- `tests/integration/test_api.py` — framing block present on the endpoints and
  reflects a configured subscription plan.
- Full suite: 665 passed; `mypy` and `ruff` clean.

## Scope guardrails honoured
- No change to `SessionRecord.plan_tier` / `pricing_mode` derivation.
- No new config field.
- CLI behaviour unchanged.