### PR TITLE
#111: Add estimated_recoverable_usd to every savings analyzer

### DIFF
--- a/tests/unit/test_optimize_recoverable.py
+++ b/tests/unit/test_optimize_recoverable.py
@@ -192,4 +192,5 @@ def test_trim_recoverable_none_when_capture_off(db):
     finding = report.findings["trim"]
     assert finding.enabled is False
     assert finding.estimated_recoverable_usd is None
-    assert finding.estimate_basis == "" or finding.estimate_basis is not None
+    # Not-ready path doesn't set a basis (default empty string).
+    assert finding.estimate_basis == ""

--- a/tests/unit/test_optimize_recoverable.py
+++ b/tests/unit/test_optimize_recoverable.py
@@ -1,0 +1,195 @@
+"""Per-analyzer estimated-recoverable-USD tests (issue #111)."""
+from __future__ import annotations
+
+from datetime import timedelta
+
+import pytest
+
+from tokenjam.core.config import CaptureConfig, TjConfig
+from tokenjam.core.db import InMemoryBackend
+from tokenjam.core.optimize import analyze_model_downgrade, build_report
+from tokenjam.core.optimize.analyzers.cache_efficacy import (
+    CacheEfficacyRow,
+    estimate_cache_recoverable,
+)
+from tokenjam.core.optimize.analyzers.prompt_bloat import estimate_trim_recoverable
+from tokenjam.utils.time_parse import utcnow
+from tests.factories import make_llm_span, make_session, make_tool_span
+
+
+@pytest.fixture
+def db():
+    backend = InMemoryBackend()
+    yield backend
+    backend.close()
+
+
+def _window():
+    return utcnow() - timedelta(days=30), utcnow() + timedelta(hours=1)
+
+
+# --------------------------------------------------------------------------- #
+# downsize — aliases the existing monthly projection
+# --------------------------------------------------------------------------- #
+def _insert_small_opus_session(db, session_id="a"):
+    start = utcnow() - timedelta(days=2)
+    llm = make_llm_span(
+        agent_id="claude-code-x", model="claude-opus-4-7", provider="anthropic",
+        input_tokens=1000, output_tokens=200, cost_usd=0.030,
+        session_id=session_id, start_time=start,
+    )
+    db.insert_span(llm)
+    for _ in range(2):
+        tool = make_tool_span(agent_id="claude-code-x", tool_name="Read",
+                              trace_id=llm.trace_id)
+        tool.session_id = session_id
+        tool.start_time = start
+        db.insert_span(tool)
+
+
+def test_downsize_recoverable_aliases_monthly_savings(db):
+    _insert_small_opus_session(db)
+    since, until = _window()
+    finding = analyze_model_downgrade(db.conn, since, until, None, 30.0)
+    assert finding is not None
+    assert finding.estimated_recoverable_usd == finding.monthly_savings_usd
+    assert finding.estimated_recoverable_usd > 0
+    assert finding.estimated_recoverable_tokens == finding.candidate_tokens
+    assert finding.estimate_basis
+    assert finding.estimate_confidence == "heuristic"
+
+
+# --------------------------------------------------------------------------- #
+# cache — efficacy-gap heuristic (pure helper)
+# --------------------------------------------------------------------------- #
+def test_cache_recoverable_matches_hand_calculation():
+    # opus-4-7: input 5.00/MTok, cache_read 0.50/MTok → delta 4.50.
+    # 1M input, 0 cache → efficacy 0 → gap 0.80 → 800K recoverable tokens.
+    # usd = 800_000/1e6 * 4.50 = 3.60
+    row = CacheEfficacyRow(
+        provider="anthropic", model="claude-opus-4-7",
+        input_tokens=1_000_000, cache_tokens=0, efficacy=0.0,
+        support="full", flagged=True,
+    )
+    usd, tokens = estimate_cache_recoverable([row])
+    assert tokens == 800_000
+    assert usd == pytest.approx(3.60, abs=0.01)
+
+
+def test_cache_recoverable_none_when_no_caching_dimension():
+    # An unknown model falls back to default rates with cache_read = 0 → no
+    # caching dimension → no estimate.
+    row = CacheEfficacyRow(
+        provider="madeup", model="no-such-model",
+        input_tokens=1_000_000, cache_tokens=0, efficacy=0.0,
+        support="unsupported", flagged=False,
+    )
+    usd, tokens = estimate_cache_recoverable([row])
+    assert usd is None
+    assert tokens is None
+
+
+def test_cache_recoverable_none_when_already_at_ceiling():
+    row = CacheEfficacyRow(
+        provider="anthropic", model="claude-opus-4-7",
+        input_tokens=1_000_000, cache_tokens=4_000_000, efficacy=0.95,
+        support="full", flagged=False,
+    )
+    usd, tokens = estimate_cache_recoverable([row])
+    assert usd is None and tokens is None
+
+
+# --------------------------------------------------------------------------- #
+# script — sum of clustered session cost
+# --------------------------------------------------------------------------- #
+def test_script_recoverable_sums_cluster_session_cost(db):
+    start = utcnow() - timedelta(days=2)
+    # 20 identical single-Read sessions clear MIN_CLUSTER_INSTANCES.
+    for i in range(20):
+        sid = f"sess-{i}"
+        db.upsert_session(make_session(
+            agent_id="agent-x", session_id=sid,
+            input_tokens=500, output_tokens=100, total_cost_usd=0.10,
+        ))
+        tool = make_tool_span(agent_id="agent-x", tool_name="Read")
+        tool.session_id = sid
+        tool.start_time = start
+        db.insert_span(tool)
+
+    cfg = TjConfig(version="1")  # capture.tool_inputs default off → name-only clusters
+    since, until = _window()
+    report = build_report(db=db, config=cfg, since=since, until=until,
+                          findings=["script"])
+    finding = report.findings["script"]
+    assert finding.clusters, "expected one cluster of 20 identical sessions"
+    # 20 sessions × $0.10 = $2.00
+    assert finding.estimated_recoverable_usd == pytest.approx(2.00, abs=0.001)
+    # 20 sessions × (500 + 100) tokens = 12_000
+    assert finding.estimated_recoverable_tokens == 12_000
+    assert finding.estimate_basis
+
+
+def test_script_recoverable_none_when_no_clusters(db):
+    # A single tool span — no cluster above threshold.
+    tool = make_tool_span(agent_id="agent-x", tool_name="Read")
+    tool.session_id = "solo"
+    tool.start_time = utcnow() - timedelta(days=1)
+    db.insert_span(tool)
+    db.upsert_session(make_session(agent_id="agent-x", session_id="solo",
+                                   total_cost_usd=0.10))
+    cfg = TjConfig(version="1")
+    since, until = _window()
+    report = build_report(db=db, config=cfg, since=since, until=until,
+                          findings=["script"])
+    finding = report.findings["script"]
+    assert not finding.clusters
+    assert finding.estimated_recoverable_usd is None
+    assert finding.estimated_recoverable_tokens is None
+
+
+# --------------------------------------------------------------------------- #
+# trim — low-significance tokens × input rate (helper) + not-ready state
+# --------------------------------------------------------------------------- #
+# --------------------------------------------------------------------------- #
+# serialization — the fields surface in the /api/v1/optimize response shape
+# --------------------------------------------------------------------------- #
+def test_recoverable_fields_survive_report_to_dict_round_trip(db):
+    from tokenjam.core.optimize import report_from_dict, report_to_dict
+
+    _insert_small_opus_session(db)
+    cfg = TjConfig(version="1")
+    since, until = _window()
+    report = build_report(db=db, config=cfg, since=since, until=until,
+                          findings=["downsize", "cache", "script", "trim"])
+    payload = report_to_dict(report)
+
+    # downsize lives in the typed slot
+    assert "estimated_recoverable_usd" in payload["downgrade"]
+    assert "estimate_basis" in payload["downgrade"]
+    # wave-2 findings carry the fields too
+    for name in ("cache", "script", "trim"):
+        if name in payload.get("findings", {}):
+            assert "estimated_recoverable_usd" in payload["findings"][name]
+            assert "estimate_confidence" in payload["findings"][name]
+
+    # and they round-trip back through report_from_dict
+    rebuilt = report_from_dict(payload)
+    assert (rebuilt.downgrade.estimated_recoverable_usd
+            == report.downgrade.estimated_recoverable_usd)
+
+
+def test_trim_recoverable_helper_prices_tokens():
+    # 100K low-significance tokens at $5/MTok = $0.50
+    assert estimate_trim_recoverable(100_000, 5.00) == pytest.approx(0.50, abs=1e-6)
+
+
+def test_trim_recoverable_none_when_capture_off(db):
+    _insert_small_opus_session(db)
+    cfg = TjConfig(version="1", capture=CaptureConfig(prompts=False))
+    since, until = _window()
+    report = build_report(db=db, config=cfg, since=since, until=until,
+                          findings=["trim"])
+    finding = report.findings["trim"]
+    assert finding.enabled is False
+    assert finding.estimated_recoverable_usd is None
+    assert finding.estimate_basis == "" or finding.estimate_basis is not None

--- a/tokenjam/core/optimize/analyzers/cache_efficacy.py
+++ b/tokenjam/core/optimize/analyzers/cache_efficacy.py
@@ -57,12 +57,62 @@ class CacheEfficacyRow:
     flagged:       bool            # surfaced as a recommendation candidate
 
 
+# Realistic cache-read efficacy ceiling. The recoverable estimate measures the
+# gap between current efficacy and this ceiling — not 100%, which is never
+# achievable (system + first-call input is always uncached).
+EFFICACY_CEILING = 0.80
+
+
 @dataclass
 class CacheEfficacyFinding:
     """All (provider, model) rows in the window, plus the flagged subset."""
     rows:        list[CacheEfficacyRow] = field(default_factory=list)
     flagged:     list[CacheEfficacyRow] = field(default_factory=list)
     confidence:  str = "structural"
+    # Recoverable-savings contract (#111). See types.DowngradeFinding for the
+    # field semantics. None when no row has a caching dimension to recover.
+    estimated_recoverable_usd:    float | None = None
+    estimated_recoverable_tokens: int | None   = None
+    estimate_basis:               str          = ""
+    estimate_confidence:          str          = "heuristic"
+
+
+def estimate_cache_recoverable(
+    rows: list[CacheEfficacyRow],
+) -> tuple[float | None, int | None]:
+    """Estimate recoverable spend from closing the cache-efficacy gap.
+
+    For each (provider, model) row with a known cache-read rate, take the gap
+    between current efficacy and the 80% ceiling, apply it to the row's input
+    tokens, and price the shifted tokens at the input-vs-cache rate delta.
+    Returns (usd, tokens) summed across rows, or (None, None) when no row has a
+    caching dimension to recover against.
+    """
+    from tokenjam.core.pricing import get_rates
+
+    total_usd = 0.0
+    total_tokens = 0
+    any_priced = False
+    for r in rows:
+        rates = get_rates(r.provider, r.model)
+        if rates is None or rates.cache_read_per_mtok <= 0:
+            continue
+        rate_delta = rates.input_per_mtok - rates.cache_read_per_mtok
+        if rate_delta <= 0:
+            continue
+        gap = max(0.0, EFFICACY_CEILING - r.efficacy)
+        if gap <= 0:
+            continue
+        recoverable_tokens = gap * r.input_tokens
+        if recoverable_tokens <= 0:
+            continue
+        any_priced = True
+        total_usd += (recoverable_tokens / 1_000_000) * rate_delta
+        total_tokens += int(recoverable_tokens)
+
+    if not any_priced:
+        return None, None
+    return round(total_usd, 6), total_tokens
 
 
 def _compute_rows(conn, since, until, agent_id: str | None) -> list[CacheEfficacyRow]:
@@ -119,7 +169,14 @@ def run(ctx: AnalyzerContext) -> None:
     rows = _compute_rows(ctx.conn, ctx.since, ctx.until, ctx.agent_id)
     if not rows:
         return
+    rec_usd, rec_tokens = estimate_cache_recoverable(rows)
     ctx.report.findings["cache"] = CacheEfficacyFinding(
         rows=rows,
         flagged=[r for r in rows if r.flagged],
+        estimated_recoverable_usd=rec_usd,
+        estimated_recoverable_tokens=rec_tokens,
+        estimate_basis=(
+            "gap between current cache-read efficacy and 80% ceiling at the "
+            "input-vs-cache rate delta"
+        ),
     )

--- a/tokenjam/core/optimize/analyzers/model_downgrade.py
+++ b/tokenjam/core/optimize/analyzers/model_downgrade.py
@@ -201,6 +201,14 @@ def analyze_model_downgrade(
         window_total_tokens=window_total_tokens,
         percent_of_tokens=round(percent_tokens, 1),
         monthly_tokens_in_candidates=monthly_tokens_in_candidates,
+        # Recoverable-savings contract (#111): alias the existing monthly
+        # projection; tokens come from the candidate token total.
+        estimated_recoverable_usd=round(monthly_savings, 2),
+        estimated_recoverable_tokens=candidate_tokens,
+        estimate_basis=(
+            "candidate sessions routed to a cheaper model — structural fit "
+            "only, no quality validation"
+        ),
     )
 
 

--- a/tokenjam/core/optimize/analyzers/prompt_bloat.py
+++ b/tokenjam/core/optimize/analyzers/prompt_bloat.py
@@ -85,6 +85,11 @@ class BloatPrompt:
     estimated_token_reduction: int = 0
 
 
+# Rough characters-per-token ratio for English prose. Used to convert the
+# char-denominated bloat measurement into a token-denominated estimate.
+CHARS_PER_TOKEN = 4
+
+
 @dataclass
 class PromptBloatFinding:
     """Aggregate findings + per-prompt details."""
@@ -96,6 +101,51 @@ class PromptBloatFinding:
     per_prompt:        list[BloatPrompt] = field(default_factory=list)
     confidence:        str = "structural"
     hint:              str | None = None
+    # Recoverable-savings contract (#111). See types.DowngradeFinding for field
+    # semantics. None when the analyzer is not ready (capture off, extra
+    # missing) or no bloat was found.
+    estimated_recoverable_usd:    float | None = None
+    estimated_recoverable_tokens: int | None   = None
+    estimate_basis:               str          = ""
+    estimate_confidence:          str          = "heuristic"
+
+
+def estimate_trim_recoverable(
+    low_sig_tokens: int, avg_input_rate_per_mtok: float
+) -> float:
+    """Price low-significance tokens at the window-average input rate."""
+    return round((low_sig_tokens / 1_000_000) * avg_input_rate_per_mtok, 6)
+
+
+def _window_avg_input_rate(conn, since, until, agent_id: str | None) -> float:
+    """Input-token-weighted average input rate ($/MTok) across the window's
+    model mix, used to price trimmable tokens."""
+    from tokenjam.core.pricing import get_rates
+
+    clauses = ["start_time >= $1", "start_time < $2",
+               "provider IS NOT NULL", "model IS NOT NULL"]
+    params: list[Any] = [since, until]
+    if agent_id:
+        clauses.append(f"agent_id = ${len(params) + 1}")
+        params.append(agent_id)
+    where = " AND ".join(clauses)
+    rows = conn.execute(
+        f"SELECT provider, model, COALESCE(SUM(input_tokens), 0) "
+        f"FROM spans WHERE {where} GROUP BY provider, model",
+        params,
+    ).fetchall()
+    weighted = 0.0
+    total = 0
+    for provider, model, in_tok in rows:
+        in_tok = int(in_tok or 0)
+        if in_tok <= 0:
+            continue
+        rates = get_rates(str(provider), str(model))
+        if rates is None:
+            continue
+        weighted += rates.input_per_mtok * in_tok
+        total += in_tok
+    return (weighted / total) if total > 0 else 0.0
 
 
 def _try_import_llmlingua():
@@ -340,6 +390,19 @@ def run(ctx: AnalyzerContext) -> None:
     # Sort by bloat absolute volume — biggest opportunities first.
     per_prompt.sort(key=lambda p: p.bloat_chars, reverse=True)
 
+    # Recoverable-savings estimate (#111): low-significance tokens across all
+    # scored prompts (not just the top-10 retained for display), priced at the
+    # window-average input rate. None when nothing was flagged.
+    low_sig_tokens = int(total_bloat / CHARS_PER_TOKEN) if total_bloat > 0 else 0
+    rec_usd: float | None = None
+    rec_tokens: int | None = None
+    if low_sig_tokens > 0:
+        avg_rate = _window_avg_input_rate(
+            ctx.conn, ctx.since, ctx.until, ctx.agent_id
+        )
+        rec_usd = estimate_trim_recoverable(low_sig_tokens, avg_rate)
+        rec_tokens = low_sig_tokens
+
     ctx.report.findings["trim"] = PromptBloatFinding(
         enabled=True,
         prompts_scored=prompts_scored,
@@ -347,4 +410,10 @@ def run(ctx: AnalyzerContext) -> None:
         total_bloat_chars=total_bloat,
         total_chars=total_chars,
         per_prompt=per_prompt[:10],
+        estimated_recoverable_usd=rec_usd,
+        estimated_recoverable_tokens=rec_tokens,
+        estimate_basis=(
+            "low-significance tokens predicted by LLMLingua-2 × input rate — "
+            "review before editing prompts"
+        ),
     )

--- a/tokenjam/core/optimize/analyzers/workflow_restructure.py
+++ b/tokenjam/core/optimize/analyzers/workflow_restructure.py
@@ -104,6 +104,12 @@ class WorkflowRestructureFinding:
         "Conservative cluster detection. Review each cluster before replacing "
         "with a script — value variation that the heuristic can't see may matter."
     )
+    # Recoverable-savings contract (#111). See types.DowngradeFinding for field
+    # semantics. None when no cluster cleared the threshold.
+    estimated_recoverable_usd:    float | None = None
+    estimated_recoverable_tokens: int | None   = None
+    estimate_basis:               str          = ""
+    estimate_confidence:          str          = "heuristic"
 
 
 def _extract_tool_input(attrs: Any) -> Any:
@@ -164,21 +170,29 @@ def run(ctx: AnalyzerContext) -> None:
 
     # Build the report rows. Only clusters above the threshold are surfaced.
     interesting: list[WorkflowCluster] = []
+    total_cluster_cost = 0.0   # recoverable USD: full cost of clustered sessions
+    total_cluster_tokens = 0   # recoverable tokens: replacing the call frees them
     for signature, members in cluster_members.items():
         if len(members) < MIN_CLUSTER_INSTANCES:
             continue
 
-        # Aggregate session-level cost + duration for the cluster.
+        # Aggregate session-level cost + tokens + duration for the cluster.
         placeholders = ",".join(f"${i + 1}" for i in range(len(members)))
         agg = ctx.conn.execute(
             f"SELECT "
             f"COALESCE(AVG(total_cost_usd), 0.0), "
-            f"COALESCE(AVG(EXTRACT(EPOCH FROM (ended_at - started_at))), 0.0) "
+            f"COALESCE(AVG(EXTRACT(EPOCH FROM (ended_at - started_at))), 0.0), "
+            f"COALESCE(SUM(total_cost_usd), 0.0), "
+            f"COALESCE(SUM(input_tokens + output_tokens + cache_tokens), 0) "
             f"FROM sessions WHERE session_id IN ({placeholders})",
             members,
         ).fetchone()
         avg_cost = float(agg[0] or 0.0) if agg else 0.0
         avg_duration = float(agg[1] or 0.0) if agg else 0.0
+        cluster_cost = float(agg[2] or 0.0) if agg else 0.0
+        cluster_tokens = int(agg[3] or 0) if agg else 0
+        total_cluster_cost += cluster_cost
+        total_cluster_tokens += cluster_tokens
 
         signature_repr: list[dict] = []
         for tool_name, arg_sig in signature:
@@ -199,8 +213,19 @@ def run(ctx: AnalyzerContext) -> None:
     # are the biggest savings opportunities.
     interesting.sort(key=lambda c: c.instances, reverse=True)
 
+    has_clusters = bool(interesting)
     ctx.report.findings["script"] = WorkflowRestructureFinding(
         clusters=interesting,
         sessions_examined=len(session_signatures),
         degraded=not has_tool_inputs,
+        estimated_recoverable_usd=(
+            round(total_cluster_cost, 6) if has_clusters else None
+        ),
+        estimated_recoverable_tokens=(
+            total_cluster_tokens if has_clusters else None
+        ),
+        estimate_basis=(
+            "total cost of sessions matching a deterministic call-pattern — "
+            "replacing the cluster with a script eliminates the LLM call entirely"
+        ),
     )

--- a/tokenjam/core/optimize/runner.py
+++ b/tokenjam/core/optimize/runner.py
@@ -247,6 +247,10 @@ def report_from_dict(d: dict) -> OptimizeReport:
             window_total_tokens=int(dd.get("window_total_tokens", 0)),
             percent_of_tokens=float(dd.get("percent_of_tokens", 0.0)),
             monthly_tokens_in_candidates=int(dd.get("monthly_tokens_in_candidates", 0)),
+            estimated_recoverable_usd=dd.get("estimated_recoverable_usd"),
+            estimated_recoverable_tokens=dd.get("estimated_recoverable_tokens"),
+            estimate_basis=str(dd.get("estimate_basis", "")),
+            estimate_confidence=str(dd.get("estimate_confidence", "heuristic")),
         )
 
     budgets = []
@@ -322,6 +326,10 @@ def _build_finding_constructors() -> dict:
         return CacheEfficacyFinding(
             rows=rows, flagged=flagged,
             confidence=d.get("confidence", "structural"),
+            estimated_recoverable_usd=d.get("estimated_recoverable_usd"),
+            estimated_recoverable_tokens=d.get("estimated_recoverable_tokens"),
+            estimate_basis=d.get("estimate_basis", ""),
+            estimate_confidence=d.get("estimate_confidence", "heuristic"),
         )
 
     def _cache_recommend(d: dict) -> CacheRecommendFinding:
@@ -344,6 +352,10 @@ def _build_finding_constructors() -> dict:
             degraded=bool(d.get("degraded", False)),
             confidence=d.get("confidence", "structural"),
             caveat=d.get("caveat", ""),
+            estimated_recoverable_usd=d.get("estimated_recoverable_usd"),
+            estimated_recoverable_tokens=d.get("estimated_recoverable_tokens"),
+            estimate_basis=d.get("estimate_basis", ""),
+            estimate_confidence=d.get("estimate_confidence", "heuristic"),
         )
 
     def _prompt_bloat(d: dict) -> PromptBloatFinding:
@@ -362,6 +374,10 @@ def _build_finding_constructors() -> dict:
             per_prompt=per_prompt,
             confidence=d.get("confidence", "structural"),
             hint=d.get("hint"),
+            estimated_recoverable_usd=d.get("estimated_recoverable_usd"),
+            estimated_recoverable_tokens=d.get("estimated_recoverable_tokens"),
+            estimate_basis=d.get("estimate_basis", ""),
+            estimate_confidence=d.get("estimate_confidence", "heuristic"),
         )
 
     return {

--- a/tokenjam/core/optimize/runner.py
+++ b/tokenjam/core/optimize/runner.py
@@ -8,10 +8,11 @@ so downsize must run first when both are selected.
 from __future__ import annotations
 
 from dataclasses import asdict
-from datetime import datetime, timezone
+from datetime import datetime
 from typing import Any
 
 from tokenjam.core.config import TjConfig
+from tokenjam.utils.time_parse import utcnow
 from tokenjam.core.optimize.registry import ANALYZER_REGISTRY
 from tokenjam.core.optimize.types import (
     AnalyzerContext,
@@ -39,7 +40,8 @@ THIN_DATA_DAYS = 7
 
 
 def _utcnow() -> datetime:
-    return datetime.now(tz=timezone.utc)
+    # Canonical timezone-aware UTC (CLAUDE.md Rule 9).
+    return utcnow()
 
 
 def summarize_window(
@@ -209,8 +211,8 @@ def report_from_dict(d: dict) -> OptimizeReport:
 
     w = d.get("window") or {}
     window = WindowSummary(
-        since=_parse_dt(w.get("since")) or datetime.now(tz=timezone.utc),
-        until=_parse_dt(w.get("until")) or datetime.now(tz=timezone.utc),
+        since=_parse_dt(w.get("since")) or _utcnow(),
+        until=_parse_dt(w.get("until")) or _utcnow(),
         days=float(w.get("days", 0.0)),
         sessions=int(w.get("sessions", 0)),
         spans=int(w.get("spans", 0)),
@@ -260,8 +262,8 @@ def report_from_dict(d: dict) -> OptimizeReport:
             provider=str(bb.get("provider", "")),
             budget_usd=float(bb.get("budget_usd", 0.0)),
             cycle_start_day=int(bb.get("cycle_start_day", 1)),
-            cycle_start=_parse_dt(bb.get("cycle_start")) or datetime.now(tz=timezone.utc),
-            cycle_end=_parse_dt(bb.get("cycle_end")) or datetime.now(tz=timezone.utc),
+            cycle_start=_parse_dt(bb.get("cycle_start")) or _utcnow(),
+            cycle_end=_parse_dt(bb.get("cycle_end")) or _utcnow(),
             days_into_cycle=float(bb.get("days_into_cycle", 0.0)),
             days_remaining=float(bb.get("days_remaining", 0.0)),
             window_spend_usd=float(bb.get("window_spend_usd", 0.0)),

--- a/tokenjam/core/optimize/types.py
+++ b/tokenjam/core/optimize/types.py
@@ -54,6 +54,16 @@ class DowngradeFinding:
     window_total_tokens:        int   = 0  # input + output + cache, all sessions
     percent_of_tokens:          float = 0.0
     monthly_tokens_in_candidates: int = 0  # projected to a 30-day month
+    # Recoverable-savings contract (#111). estimated_recoverable_usd is for
+    # api-billed framing; estimated_recoverable_tokens for subscription / local.
+    # None means "no estimate available for this finding state". estimate_basis
+    # is the one-line heuristic explanation surfaced behind the "estimated" tag.
+    # estimate_confidence is the estimate's confidence (distinct from any
+    # structural `confidence` on wave-2 findings); always "heuristic" in v1.
+    estimated_recoverable_usd:    float | None = None
+    estimated_recoverable_tokens: int | None   = None
+    estimate_basis:               str          = ""
+    estimate_confidence:          str          = "heuristic"
 
 
 @dataclass


### PR DESCRIPTION
Closes #111.

Every analyzer that produces a usable recommendation now also produces a
consistent, **heuristic** estimated-recoverable figure, so the Lens Overview can
summarize "recoverable waste" in one band. The honesty discipline carries
forward — every number is "estimated recoverable", never "saves you", and each
analyzer keeps its existing caveat language.

## Contract (added to each savings analyzer's result dataclass)
- `estimated_recoverable_usd: float | None` — api-billed framing
- `estimated_recoverable_tokens: int | None` — subscription / local framing
- `estimate_basis: str` — one-line heuristic explanation (the "estimated" tag's hover text)
- `estimate_confidence: str = "heuristic"` — named distinctly from the
  pre-existing structural `confidence` field on the wave-2 findings to avoid a
  semantic clash.

`None` means "no estimate for this finding state" (e.g. trim with capture off).

## Per-analyzer heuristic
- **downsize** — aliases the existing `monthly_savings_usd`; tokens from `candidate_tokens`.
- **cache** — gap to an 80% efficacy ceiling × input tokens × (input − cache-read rate delta), summed across rows. `None` for models with no cache-read rate.
- **script** — full cost (and tokens) of the sessions in each deterministic cluster.
- **trim** — low-significance tokens × window-average input rate. `None` when capture is off or `llmlingua` is missing.
- **cache-recommend / budget-projection** — intentionally emit no figure (not savings analyzers).

## Plumbing
- Fields serialize through `report_to_dict` (so `/api/v1/optimize` carries them) and round-trip through `report_from_dict`.
- CLI rendering is unchanged — the new fields are read by the API/UI, not the existing render paths.

## Tests
`tests/unit/test_optimize_recoverable.py`: per-analyzer USD within a
hand-calculated bound, `None` in not-ready states, non-empty `estimate_basis`,
and a `report_to_dict` / `report_from_dict` round-trip. Full suite green; `mypy`
and `ruff` clean.

## Scope guardrails honoured
No new analyzer; no change to which analyzers run by default; registry pattern
unchanged; CLI output format unchanged.