### PR TITLE
Fix #108: pipx-aware uninstall hint + post-release playbook fixes

### DIFF
--- a/tests/manual-new-release-tests.md
+++ b/tests/manual-new-release-tests.md
@@ -10,12 +10,13 @@ Run this after a new release publishes to PyPI to verify it works end-to-end. Th
 ## 1. Install the published release
 
 ```bash
-tj uninstall --yes 2>/dev/null
+tj uninstall --yes 2>/dev/null   # removes data, config, daemon
+pipx uninstall tokenjam 2>/dev/null   # remove the pipx venv so --force gets a pristine one
 rm -rf ~/.tj ~/.config/tj .tj
 
 # Recommended install path (PEP 668-safe on Homebrew Python and
 # Debian 12+/Ubuntu 24+). `--force` so we reinstall even if a prior
-# version is present.
+# version somehow survived above.
 pipx install --force tokenjam
 tj --version
 
@@ -24,27 +25,35 @@ tj --version
 # solves, and verifying pipx is what we ship docs telling users to do.
 ```
 
-**Pass criteria:** version matches the release being tested.
+**Pass criteria:** version matches the release being tested. `pipx install` reports a fresh venv (not "Installing to existing venv 'tokenjam'") thanks to the `pipx uninstall` step.
 
-## 2. Onboard
+## 2. Onboard (sets plan tier via the integration flow)
+
+Bare `tj onboard` only prompts for daily budget — plan tier is set by the integration onboarding flows (`--claude-code` / `--codex`) per the v0.3.x design. For the smoke pass we onboard against Claude Code to write the `plan` field:
 
 ```bash
-tj onboard --no-daemon   # daemon auto-installs by default; --no-daemon for this smoke pass
+tj onboard --claude-code --plan api --no-daemon
+# --plan api → writes `plan = "api"` non-interactively (so dollar rendering
+#              kicks in for the rest of the smoke)
+# --no-daemon → skip launchd/systemd install for this smoke pass
 ```
 
-The prompt should ask for plan tier (api / pro / max_5x / max_20x). Pick `api` so dollar rendering kicks in for the rest of the smoke.
-
 ```bash
-grep "^plan = " ~/.config/tj/config.toml || grep "^plan = " .tj/config.toml
-# [ ] plan field is set; no auto-written usd = 200 in [budget.anthropic]
+grep '^plan = ' ~/.config/tj/config.toml
+# [ ] plan field is set under [budget.anthropic]; no auto-written usd = 200
 ```
 
 ## 3. Drive an example + verify CLI
 
+The example scripts import provider SDKs (`anthropic`, `openai`, ...) that are not tokenjam dependencies. `pipx install tokenjam` isolates tokenjam in its own venv, so the SDKs aren't importable from system Python either. Inject them into the pipx venv and run via that interpreter:
+
 ```bash
+pipx inject tokenjam anthropic openai
+PIPX_PY="$(pipx environment --value PIPX_LOCAL_VENVS)/tokenjam/bin/python"
+
 cd ~/tokenjam
 source .env.local
-python3 examples/single_provider/anthropic_agent.py
+"$PIPX_PY" examples/single_provider/anthropic_agent.py
 
 tj status        # agent with cost > $0, tokens > 0
 tj traces        # waterfall renders
@@ -142,8 +151,10 @@ tj policy list
 tj serve &
 sleep 2
 
-# HTTP fallback while server holds the lock
-python3 examples/single_provider/litellm_agent.py
+# HTTP fallback while server holds the lock.
+# Inject litellm into the pipx venv first (one-time per smoke run):
+pipx inject tokenjam litellm
+"$PIPX_PY" examples/single_provider/litellm_agent.py
 tj cost --since 1h   # works via API fallback
 
 open http://127.0.0.1:7391/

--- a/tokenjam/cli/cmd_uninstall.py
+++ b/tokenjam/cli/cmd_uninstall.py
@@ -4,11 +4,25 @@ import json
 import re
 import shutil
 import subprocess
+import sys
 from pathlib import Path
 
 import click
 
 from tokenjam.utils.formatting import console
+
+
+def _package_uninstall_hint() -> str:
+    """Return the right uninstall command for how the user installed.
+
+    pipx is the canonical install path (per README and docs/installation.md).
+    A pipx install lives at ~/.local/share/pipx/venvs/tokenjam/... — detect
+    that and recommend `pipx uninstall`, otherwise fall back to `pip uninstall`
+    for venv / pip installs.
+    """
+    if "pipx/venvs/" in sys.executable.replace("\\", "/"):
+        return "pipx uninstall tokenjam"
+    return "pip uninstall tokenjam"
 
 
 @click.command("uninstall")
@@ -156,4 +170,4 @@ def cmd_uninstall(ctx: click.Context, yes: bool) -> None:
 
     console.print()
     console.print("[green]TokenJam data and config removed.[/green]")
-    console.print("To remove the package itself, run: [bold]pip uninstall tokenjam[/bold]")
+    console.print(f"To remove the package itself, run: [bold]{_package_uninstall_hint()}[/bold]")


### PR DESCRIPTION
Closes #108.

External contributor @ashwmu filed three high-quality findings against the post-release smoke-test playbook (`tests/manual-new-release-tests.md`) when run via its own prescribed pipx path. All three reproduce against current main; this PR ships all the fixes.

## What changed

**Code fix (Finding 3b):**

- `tj uninstall` now detects pipx installs via `sys.executable` containing `pipx/venvs/` and prints `pipx uninstall tokenjam`. Falls back to `pip uninstall tokenjam` for venv/pip installs.

**Playbook fixes (Findings 1, 2, 3a):**

- **Step 1 (Finding 3a)** — added `pipx uninstall tokenjam` between `tj uninstall --yes` and `pipx install --force`. Without it, `pipx install --force` reused the existing venv ("Installing to existing venv 'tokenjam'") instead of recreating from scratch.
- **Step 2 (Finding 1)** — replaced bare `tj onboard --no-daemon` with `tj onboard --claude-code --plan api --no-daemon`. Bare `tj onboard` only prompts for daily budget in v0.3.x; plan tier is set via the integration flows.
- **Step 3 (Finding 2)** — example scripts import provider SDKs (`anthropic`, `openai`, ...) that are not tokenjam dependencies. The pipx venv doesn't carry them and system Python doesn't either. Added `pipx inject tokenjam anthropic openai` and run examples via the pipx venv's Python. Same pattern applied to Step 8's `litellm_agent.py` reference.

## Verification

- `tj uninstall` print path manually checked for both pipx and venv installs.
- Playbook walks correctly end-to-end through the new Step 1–3 sequence.
- No production-code logic changes outside the one print line in `cmd_uninstall.py`.

## Test plan

- [ ] Run `tj uninstall --yes` after a `pipx install` → final hint reads `pipx uninstall tokenjam`.
- [ ] Run `tj uninstall --yes` after a `pip install -e .` in a venv → final hint reads `pip uninstall tokenjam`.
- [ ] Walk through Step 1–3 of `tests/manual-new-release-tests.md` end-to-end on a fresh pipx install — all assertions pass without manual workarounds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: ashwmu <noreply@github.com>