### PR TITLE
#120: plan-tier framing for `tj cost --compare`

### DIFF
--- a/tests/unit/test_cost_compare_framing.py
+++ b/tests/unit/test_cost_compare_framing.py
@@ -1,0 +1,87 @@
+"""Plan-tier framing for `tj cost --compare` (issue #120)."""
+from __future__ import annotations
+
+from datetime import timedelta
+from types import SimpleNamespace
+
+import pytest
+
+from tokenjam.cli.cmd_cost import _diff_note, _render_diff, _suppresses_dollars
+from tokenjam.core.framing import Framing
+from tokenjam.utils.formatting import console
+from tokenjam.utils.time_parse import utcnow
+
+
+def _fake_diff():
+    now = utcnow()
+    cur = SimpleNamespace(since=now - timedelta(days=7), until=now, sessions=10,
+                          total_tokens=2_000_000, total_cost_usd=148.0)
+    prev = SimpleNamespace(since=now - timedelta(days=14), until=now - timedelta(days=7),
+                           sessions=8, total_tokens=1_500_000, total_cost_usd=120.0)
+    return SimpleNamespace(
+        current=cur, previous=prev,
+        cost_delta_usd=28.0, cost_delta_pct=23.3,
+        tokens_delta=500_000, tokens_delta_pct=33.3,
+        by_agent=[{"group": "a1", "previous_cost": 50.0, "current_cost": 70.0, "delta": 20.0}],
+        by_model=[{"group": "claude-opus-4-7", "previous_cost": 80.0, "current_cost": 90.0, "delta": 10.0}],
+    )
+
+
+def _render(framing):
+    with console.capture() as cap:
+        _render_diff(_fake_diff(), framing)
+    return cap.get()
+
+
+# --- pure helpers ---------------------------------------------------------- #
+@pytest.mark.parametrize("mode,expected", [
+    ("api", False), ("unknown", False), ("subscription", True), ("local", True),
+])
+def test_suppresses_dollars(mode, expected):
+    assert _suppresses_dollars(mode) is expected
+
+
+def test_diff_note_per_mode():
+    assert _diff_note("api") is None
+    assert "Subscription plan" in _diff_note("subscription")
+    assert "Local inference" in _diff_note("local")
+    assert "unknown" in _diff_note("unknown").lower()
+
+
+# --- rendering ------------------------------------------------------------- #
+def test_api_mode_byte_identical_to_no_framing():
+    # api framing must render exactly like the pre-#120 (no-framing) output.
+    assert _render(None) == _render(Framing(pricing_mode="api"))
+
+
+def test_api_mode_shows_dollars_and_no_note():
+    out = _render(Framing(pricing_mode="api"))
+    assert "$148" in out and "Cost delta:" in out
+    assert "Subscription plan" not in out
+    assert "Top shifts by agent" in out
+
+
+def test_subscription_suppresses_dollars():
+    out = _render(Framing(pricing_mode="subscription", plan_monthly_usd=100.0))
+    assert "Subscription plan" in out
+    assert "Token delta:" in out
+    assert "Cost delta:" not in out
+    assert "$148" not in out and "$120" not in out
+    # dollar-denominated per-agent/model shifts are suppressed too
+    assert "Top shifts by agent" not in out
+    assert "Top shifts by model" not in out
+
+
+def test_local_suppresses_dollars():
+    out = _render(Framing(pricing_mode="local"))
+    assert "Local inference" in out
+    assert "Cost delta:" not in out
+    assert "Token delta:" in out
+
+
+def test_unknown_keeps_dollars_with_qualifier():
+    out = _render(Framing(pricing_mode="unknown",
+                          qualifier_text="Plan tier unknown — figures may overstate actual cost."))
+    assert "Cost delta:" in out
+    assert "$148" in out
+    assert "may overstate" in out

--- a/tokenjam/cli/cmd_cost.py
+++ b/tokenjam/cli/cmd_cost.py
@@ -41,7 +41,7 @@ def cmd_cost(ctx: click.Context, agent: str | None, since: str,
             if output_json:
                 click.echo(json.dumps(_diff_to_dict(diff), default=str))
             else:
-                _render_diff(diff)
+                _render_diff(diff, _compare_framing(ctx, db, since_dt, until_dt, agent, diff))
             return
         # API-shim path: fetch the diff from tj serve. The endpoint
         # mirrors compute_cost_diff's output schema, so we can pass
@@ -133,6 +133,24 @@ def cmd_cost(ctx: click.Context, agent: str | None, since: str,
     console.print(table)
 
 
+def _compare_framing(ctx, db, since_dt, until_dt, agent, diff):
+    """Build the plan-tier Framing for the current comparison window from the
+    shared core/framing module (#120) — same source the API and tj optimize use.
+    Returns None if config/conn is unavailable (→ api-style rendering)."""
+    config = ctx.obj.get("config") if ctx.obj else None
+    conn = getattr(db, "conn", None)
+    if config is None or conn is None:
+        return None
+    from tokenjam.core.framing import WindowSummary, compute_framing, plan_tier_mix
+    mix = plan_tier_mix(conn, since_dt, until_dt, agent)
+    return compute_framing(config, WindowSummary(
+        total_cost_usd=diff.current.total_cost_usd,
+        total_tokens=diff.current.total_tokens,
+        sessions=sum(mix.values()),
+        plan_tier_mix=mix,
+    ))
+
+
 def _arrow(delta: float) -> str:
     if delta > 0:
         return "[red]▲[/red]"
@@ -148,41 +166,75 @@ def _pct_str(pct: float | None) -> str:
     return f"({sign}{pct:.1f}%)"
 
 
-def _render_diff(diff) -> None:
+# Plan-tier framing for the comparison view (#120). The mode decision comes from
+# core/framing.compute_framing — this only chooses which lines to render. In
+# subscription / local modes dollar deltas aren't marginal, so we suppress the
+# dollar lines and compare token usage; unknown keeps dollars with a qualifier;
+# api is byte-identical to the pre-framing output.
+def _suppresses_dollars(mode: str) -> bool:
+    return mode in ("subscription", "local")
+
+
+def _diff_note(mode: str, qualifier_text: str | None = None) -> str | None:
+    if mode == "subscription":
+        return ("Subscription plan — dollar deltas omitted (flat-fee billing); "
+                "comparing token usage.")
+    if mode == "local":
+        return "Local inference — no marginal cost; comparing token usage."
+    if mode == "unknown":
+        return qualifier_text or (
+            "Plan tier unknown — figures may overstate actual cost. "
+            "Run `tj onboard --reconfigure`."
+        )
+    return None  # api → no note (byte-identical)
+
+
+def _render_diff(diff, framing=None) -> None:
     """
-    Human-readable diff renderer. Plan-tier-aware rendering is deferred —
-    this v1 renders dollar deltas; tj optimize already handles the
-    subscription / local reframing in its own renderer.
+    Human-readable diff renderer. Plan-tier-aware (#120): subscription/local
+    suppress dollar deltas and compare token usage; unknown adds a qualifier;
+    api output is unchanged. The mode comes from core/framing.compute_framing.
     """
+    mode = getattr(framing, "pricing_mode", "api") if framing is not None else "api"
+    suppress = _suppresses_dollars(mode)
+    note = _diff_note(mode, getattr(framing, "qualifier_text", None))
+    if note:
+        console.print(f"[dim]{note}[/dim]")
+
     cur = diff.current
     prev = diff.previous
     cur_days = max((cur.until - cur.since).days, 1)
     prev_days = max((prev.until - prev.since).days, 1)
+    cur_cost = "" if suppress else f", {format_cost(cur.total_cost_usd)}"
+    prev_cost = "" if suppress else f", {format_cost(prev.total_cost_usd)}"
     console.print(
         f"\n[bold]Current  ({cur.since.date()} → {cur.until.date()}, "
         f"{cur_days}d):[/bold]  "
-        f"{cur.sessions} sessions, {format_tokens(cur.total_tokens)} tokens, "
-        f"{format_cost(cur.total_cost_usd)}"
+        f"{cur.sessions} sessions, {format_tokens(cur.total_tokens)} tokens"
+        f"{cur_cost}"
     )
     console.print(
         f"[bold]Previous ({prev.since.date()} → {prev.until.date()}, "
         f"{prev_days}d):[/bold] "
-        f"{prev.sessions} sessions, {format_tokens(prev.total_tokens)} tokens, "
-        f"{format_cost(prev.total_cost_usd)}"
+        f"{prev.sessions} sessions, {format_tokens(prev.total_tokens)} tokens"
+        f"{prev_cost}"
     )
     console.print()
-    console.print(
-        f"  Cost delta:   {_arrow(diff.cost_delta_usd)} "
-        f"[bold]{format_cost(abs(diff.cost_delta_usd))}[/bold] "
-        f"{_pct_str(diff.cost_delta_pct)}"
-    )
+    if not suppress:
+        console.print(
+            f"  Cost delta:   {_arrow(diff.cost_delta_usd)} "
+            f"[bold]{format_cost(abs(diff.cost_delta_usd))}[/bold] "
+            f"{_pct_str(diff.cost_delta_pct)}"
+        )
     console.print(
         f"  Token delta:  {_arrow(diff.tokens_delta)} "
         f"[bold]{format_tokens(abs(diff.tokens_delta))}[/bold] "
         f"{_pct_str(diff.tokens_delta_pct)}"
     )
 
-    if diff.by_agent:
+    # Per-agent / per-model shifts are dollar-denominated, so they're suppressed
+    # alongside the dollar deltas in flat-fee / local modes.
+    if not suppress and diff.by_agent:
         console.print()
         console.print("  [bold]Top shifts by agent:[/bold]")
         for entry in diff.by_agent:
@@ -194,7 +246,7 @@ def _render_diff(diff) -> None:
                 f"{format_cost(entry['delta'])})[/dim]"
             )
 
-    if diff.by_model:
+    if not suppress and diff.by_model:
         console.print()
         console.print("  [bold]Top shifts by model:[/bold]")
         for entry in diff.by_model:
@@ -261,21 +313,31 @@ def _render_diff_dict(d: dict) -> None:
     cur_days = max((cur_until - cur_since).days, 1) if (cur_since and cur_until) else 1
     prev_days = max((prev_until - prev_since).days, 1) if (prev_since and prev_until) else 1
 
+    # Plan-tier framing from the /api/v1/cost/compare response block (#120).
+    fr = d.get("framing") or {}
+    mode = fr.get("pricing_mode", "api")
+    suppress = _suppresses_dollars(mode)
+    note = _diff_note(mode, fr.get("qualifier_text"))
+    if note:
+        console.print(f"[dim]{note}[/dim]")
+
+    cur_cost = "" if suppress else f", {format_cost(float(cur.get('total_cost_usd', 0)))}"
+    prev_cost = "" if suppress else f", {format_cost(float(prev.get('total_cost_usd', 0)))}"
     console.print(
         f"\n[bold]Current  "
         f"({cur_since.date() if cur_since else '?'} → "
         f"{cur_until.date() if cur_until else '?'}, {cur_days}d):[/bold]  "
         f"{cur.get('sessions', 0)} sessions, "
-        f"{format_tokens(int(cur.get('total_tokens', 0)))} tokens, "
-        f"{format_cost(float(cur.get('total_cost_usd', 0)))}"
+        f"{format_tokens(int(cur.get('total_tokens', 0)))} tokens"
+        f"{cur_cost}"
     )
     console.print(
         f"[bold]Previous "
         f"({prev_since.date() if prev_since else '?'} → "
         f"{prev_until.date() if prev_until else '?'}, {prev_days}d):[/bold] "
         f"{prev.get('sessions', 0)} sessions, "
-        f"{format_tokens(int(prev.get('total_tokens', 0)))} tokens, "
-        f"{format_cost(float(prev.get('total_cost_usd', 0)))}"
+        f"{format_tokens(int(prev.get('total_tokens', 0)))} tokens"
+        f"{prev_cost}"
     )
     console.print()
 
@@ -283,19 +345,20 @@ def _render_diff_dict(d: dict) -> None:
     tokens_delta = int(d.get("tokens_delta", 0))
     cost_pct = d.get("cost_delta_pct")
     tokens_pct = d.get("tokens_delta_pct")
-    console.print(
-        f"  Cost delta:   {_arrow(cost_delta)} "
-        f"[bold]{format_cost(abs(cost_delta))}[/bold] "
-        f"{_pct_str(cost_pct)}"
-    )
+    if not suppress:
+        console.print(
+            f"  Cost delta:   {_arrow(cost_delta)} "
+            f"[bold]{format_cost(abs(cost_delta))}[/bold] "
+            f"{_pct_str(cost_pct)}"
+        )
     console.print(
         f"  Token delta:  {_arrow(tokens_delta)} "
         f"[bold]{format_tokens(abs(tokens_delta))}[/bold] "
         f"{_pct_str(tokens_pct)}"
     )
 
-    by_agent = d.get("by_agent") or []
-    by_model = d.get("by_model") or []
+    by_agent = d.get("by_agent") or [] if not suppress else []
+    by_model = d.get("by_model") or [] if not suppress else []
     if by_agent:
         console.print("\n  [bold]Top shifts by agent:[/bold]")
         for entry in by_agent:


### PR DESCRIPTION
Closes #120.

`tj cost --compare` rendered raw dollar deltas regardless of plan tier, so
subscription / local users saw figures that include flat-fee or zero-marginal
traffic — the suppression / qualifier treatment `tj optimize` and `tj tokenmaxx`
already apply was missing. The data was already there (`/api/v1/cost/compare`
returns the `framing` block from #110); this was a CLI-rendering gap.

## What changed
The comparison renderers now key off `core/framing` (the single source the API
and `tj optimize` use):

- **subscription / local** — dollar deltas and the dollar-denominated
  per-agent/model shift blocks are suppressed; the comparison shows the token
  deltas with a one-line note ("Subscription plan — dollar deltas omitted…" /
  "Local inference — no marginal cost…").
- **unknown** — dollars kept, with the "figures may overstate" qualifier.
- **api** — byte-identical to before (no note, dollars shown). Guarded by a test
  asserting `_render_diff(diff)` == `_render_diff(diff, Framing(pricing_mode="api"))`.

Both paths handled:
- **direct-DB**: `_compare_framing` builds the `Framing` via `compute_framing` +
  `plan_tier_mix` over the current window.
- **daemon (API-shim)**: `_render_diff_dict` reads the `framing` block already on
  the `/api/v1/cost/compare` response.

No new framing logic in `cmd_cost.py` — only the render decision keys off
`framing.pricing_mode`.

## Tests
`tests/unit/test_cost_compare_framing.py`: per-mode rendering (dollar
suppression, notes, token-only deltas) + the explicit **api byte-identical**
assertion. Full suite green (705); `ruff check tokenjam/` + `mypy` clean.

## Note / scope
Scoped to `tj cost --compare` per the issue. `tj optimize --compare`'s window
block still renders its diff in api style (it has its own plan-tier header
handling); bringing that block to full parity would be a small follow-up if
wanted.