### PR TITLE
#122: one time basis for analyzer recoverable estimates

### DIFF
--- a/tests/unit/test_optimize_recoverable.py
+++ b/tests/unit/test_optimize_recoverable.py
@@ -47,16 +47,29 @@ def _insert_small_opus_session(db, session_id="a"):
         db.insert_span(tool)
 
 
-def test_downsize_recoverable_aliases_monthly_savings(db):
+def test_downsize_recoverable_uses_window_basis(db):
+    # estimated_recoverable_usd is the WINDOW savings (actual − alternative),
+    # not the 30-day projection — so it shares a time basis with the other
+    # analyzers (#122). monthly_savings_usd stays separate for the CLI.
     _insert_small_opus_session(db)
     since, until = _window()
     finding = analyze_model_downgrade(db.conn, since, until, None, 30.0)
     assert finding is not None
-    assert finding.estimated_recoverable_usd == finding.monthly_savings_usd
+    window_savings = max(finding.actual_cost_usd - finding.alternative_cost_usd, 0.0)
+    assert finding.estimated_recoverable_usd == pytest.approx(window_savings, abs=1e-6)
     assert finding.estimated_recoverable_usd > 0
     assert finding.estimated_recoverable_tokens == finding.candidate_tokens
     assert finding.estimate_basis
     assert finding.estimate_confidence == "heuristic"
+
+
+def test_downsize_window_basis_differs_from_monthly_projection(db):
+    # With a window shorter than 30d, the window recoverable must NOT equal the
+    # 30-day projection (the old aliasing bug #122).
+    _insert_small_opus_session(db)
+    since, until = _window()
+    finding = analyze_model_downgrade(db.conn, since, until, None, 7.0)
+    assert finding.estimated_recoverable_usd != finding.monthly_savings_usd
 
 
 # --------------------------------------------------------------------------- #

--- a/tokenjam/core/optimize/analyzers/model_downgrade.py
+++ b/tokenjam/core/optimize/analyzers/model_downgrade.py
@@ -201,13 +201,16 @@ def analyze_model_downgrade(
         window_total_tokens=window_total_tokens,
         percent_of_tokens=round(percent_tokens, 1),
         monthly_tokens_in_candidates=monthly_tokens_in_candidates,
-        # Recoverable-savings contract (#111): alias the existing monthly
-        # projection; tokens come from the candidate token total.
-        estimated_recoverable_usd=round(monthly_savings, 2),
+        # Recoverable-savings contract (#111). Use the WINDOW savings (not the
+        # 30-day projection) so every analyzer's estimated_recoverable_usd shares
+        # one time basis — "recoverable over the analyzed window" — and the
+        # Overview tiles are directly comparable (#122). monthly_savings_usd
+        # remains for the CLI's own projected-savings line.
+        estimated_recoverable_usd=round(savings_window, 6),
         estimated_recoverable_tokens=candidate_tokens,
         estimate_basis=(
-            "candidate sessions routed to a cheaper model — structural fit "
-            "only, no quality validation"
+            "candidate sessions routed to a cheaper model over the window — "
+            "structural fit only, no quality validation"
         ),
     )
 

--- a/tokenjam/core/optimize/analyzers/prompt_bloat.py
+++ b/tokenjam/core/optimize/analyzers/prompt_bloat.py
@@ -413,7 +413,7 @@ def run(ctx: AnalyzerContext) -> None:
         estimated_recoverable_usd=rec_usd,
         estimated_recoverable_tokens=rec_tokens,
         estimate_basis=(
-            "low-significance tokens predicted by LLMLingua-2 × input rate — "
-            "review before editing prompts"
+            "low-significance tokens (≈4 chars/token) predicted by LLMLingua-2 "
+            "× window input rate — review before editing prompts"
         ),
     )

--- a/tokenjam/ui/index.html
+++ b/tokenjam/ui/index.html
@@ -590,6 +590,7 @@ a.rec-tile.ok:hover { border-color: var(--success); }
   letter-spacing: 0.04em; color: var(--text-dim); margin: 22px 0 10px;
   display: flex; align-items: center; gap: 8px;
 }
+.band-window { text-transform: none; letter-spacing: 0; color: var(--text-faint); font-weight: 400; }
 a.band-hero { display: block; text-decoration: none; color: inherit; transition: border-color 0.15s; }
 a.band-hero:hover { border-color: var(--accent); }
 .tile-grid { display: grid; grid-template-columns: repeat(auto-fill, minmax(240px, 1fr)); gap: 14px; }
@@ -2010,7 +2011,7 @@ function OverviewView({ params }) {
     </div>
 
     <!-- Band 2: Recoverable waste -->
-    <div class="band-label">Recoverable waste <span class="estimated-tag" title="Heuristic estimates — review before acting">estimated</span></div>
+    <div class="band-label">Recoverable waste <span class="estimated-tag" title="Heuristic estimates — review before acting">estimated</span> <span class="band-window">· over the last ${since}</span></div>
     <div class="tile-grid">
       ${tiles.length === 0 ? html`<div class="empty">No recoverable candidates in this window.</div>`
         : tiles.map(t => {


### PR DESCRIPTION
Closes #122.

The `estimated_recoverable_usd` figures had mismatched time bases — `downsize`
aliased the 30-day projection (`monthly_savings_usd`) while `cache` / `script` /
`trim` were window-totals — so the Overview "recoverable" tiles weren't
comparable side by side.

## Fix (Option 1 — normalize)
- **downsize** now sets `estimated_recoverable_usd` to the **window savings**
  (actual − alternative over the analyzed window), matching the others. All four
  are now "recoverable over the analyzed window." `monthly_savings_usd` is kept
  for the CLI's "projected savings if pattern holds: $X/mo" line, so **CLI output
  is unchanged**.
- The Overview **"Recoverable waste"** band now shows the window
  ("· over the last 7d") so the shared basis is visible on screen.
- **trim**'s `estimate_basis` discloses the ≈4 chars/token conversion + that the
  rate is the window input rate (the reviewer's hover-text note).

## Tests
`estimated_recoverable_usd == actual − alternative` (window), and explicitly
**≠ the 30-day projection** for a sub-30d window (the old aliasing). Full suite
green (696); `ruff check tokenjam/` + `mypy` clean.

## Note
Chose Option 1 (single window basis) over Option 2 (per-finding `estimate_period`
field) — with all four on one basis there's nothing to disambiguate, and the
band label makes the window explicit. `tj optimize` CLI rendering is untouched.