### PR TITLE
#17: surface cache_write_tokens so cost reconciles from shown tokens

### DIFF
--- a/tests/integration/test_api.py
+++ b/tests/integration/test_api.py
@@ -238,6 +238,32 @@ async def test_get_cost_returns_aggregated_rows(client):
     assert "total_cost_usd" in data
 
 
+async def test_trace_detail_includes_cache_write_tokens(db, client):
+    """The traces API exposes cache_write_tokens so per-span cost reconciles
+    from the displayed columns (#17 — it was the ~91% cost driver, hidden)."""
+    sp = make_llm_span(agent_id="a", model="claude-opus-4-8", provider="anthropic",
+                       input_tokens=2, output_tokens=465, cache_tokens=243597,
+                       cache_write_tokens=209000, cost_usd=1.4423)
+    db.insert_span(sp)
+    resp = await client.get(f"/api/v1/traces/{sp.trace_id}")
+    assert resp.status_code == 200
+    span = resp.json()["spans"][0]
+    assert span["cache_tokens"] == 243597
+    assert span["cache_write_tokens"] == 209000
+
+
+async def test_cost_rows_carry_cache_tokens(db, client):
+    """`/api/v1/cost` rows + totals include cache-read and cache-write (#17)."""
+    sp = make_llm_span(agent_id="a", model="claude-opus-4-8", provider="anthropic",
+                       input_tokens=2, output_tokens=465, cache_tokens=243597,
+                       cache_write_tokens=209000, cost_usd=1.4423)
+    db.insert_span(sp)
+    data = (await client.get("/api/v1/cost?group_by=model")).json()
+    assert data["rows"][0]["cache_tokens"] == 243597
+    assert data["rows"][0]["cache_write_tokens"] == 209000
+    assert data["total_cache_write_tokens"] == 209000
+
+
 async def test_cost_includes_window_series_for_chart(client):
     """/api/v1/cost carries a window-bucketed series (per bucket+agent+model)
     plus the bucket size and window bounds so the chart can span the full

--- a/tests/unit/test_lens_ui_regression.py
+++ b/tests/unit/test_lens_ui_regression.py
@@ -114,3 +114,10 @@ def test_cache_at_ceiling_not_volume_gated(html):
     # the classifier reads the ceiling from the response.
     assert "CACHE_MIN_INPUT" not in html
     assert "fd.efficacy_ceiling" in html
+
+
+# --- #17: cache-write surfaced in trace detail + cost table ---------------- #
+def test_cache_write_rendered(html):
+    # trace-detail panel + waterfall tooltip + Cost table show cache-write.
+    assert "cache_write_tokens" in html
+    assert "Cache write" in html

--- a/tokenjam/api/routes/cost.py
+++ b/tokenjam/api/routes/cost.py
@@ -110,12 +110,16 @@ async def get_cost(
                 "model": r.model,
                 "input_tokens": r.input_tokens,
                 "output_tokens": r.output_tokens,
+                "cache_tokens": r.cache_tokens,
+                "cache_write_tokens": r.cache_write_tokens,
                 "cost_usd": r.cost_usd,
             }
             for r in rows
         ],
         "total_cost_usd": total,
         "total_tokens": total_tokens,
+        "total_cache_tokens": sum(r.cache_tokens for r in rows),
+        "total_cache_write_tokens": sum(r.cache_write_tokens for r in rows),
         **_window_series(conn, agent_id, since_dt, until_dt),
         "framing": framing.to_dict(),
     }

--- a/tokenjam/api/routes/traces.py
+++ b/tokenjam/api/routes/traces.py
@@ -84,7 +84,8 @@ def _span_to_dict(span: object) -> dict:
         "tool_name": span.tool_name,
         "input_tokens": span.input_tokens,
         "output_tokens": span.output_tokens,
-        "cache_tokens": span.cache_tokens,
+        "cache_tokens": span.cache_tokens,            # cache-READ tokens
+        "cache_write_tokens": span.cache_write_tokens,  # cache-CREATE tokens (#17)
         "cost_usd": span.cost_usd,
         "request_type": span.request_type,
         "conversation_id": span.conversation_id,

--- a/tokenjam/cli/cmd_cost.py
+++ b/tokenjam/cli/cmd_cost.py
@@ -71,6 +71,8 @@ def cmd_cost(ctx: click.Context, agent: str | None, since: str,
     )
     rows = db.get_cost_summary(filters)
     total = sum(r.cost_usd for r in rows)
+    total_in = sum(r.input_tokens for r in rows)
+    total_out = sum(r.output_tokens for r in rows)
 
     if output_json:
         click.echo(json.dumps({
@@ -83,51 +85,51 @@ def cmd_cost(ctx: click.Context, agent: str | None, since: str,
         console.print("[dim]No cost data found for the given filters.[/dim]")
         return
 
+    # CACHE R / CACHE W columns make cost reconcilable from the shown tokens —
+    # cache-write is often the dominant driver and was previously invisible (#17).
+    cache_r = sum(r.cache_tokens for r in rows)
+    cache_w = sum(r.cache_write_tokens for r in rows)
     if group_by == "day":
-        table = make_table("DATE", "AGENT", "MODEL", "TOKENS IN", "TOKENS OUT", "COST")
+        table = make_table("DATE", "AGENT", "MODEL", "TOKENS IN", "TOKENS OUT", "CACHE R", "CACHE W", "COST")
         for r in rows:
             table.add_row(
-                r.group,
-                r.agent_id or "-",
-                r.model or "-",
-                format_tokens(r.input_tokens),
-                format_tokens(r.output_tokens),
+                r.group, r.agent_id or "-", r.model or "-",
+                format_tokens(r.input_tokens), format_tokens(r.output_tokens),
+                format_tokens(r.cache_tokens), format_tokens(r.cache_write_tokens),
                 format_cost(r.cost_usd),
             )
+        table.add_row("", "", "", format_tokens(total_in), format_tokens(total_out),
+                      format_tokens(cache_r), format_tokens(cache_w),
+                      f"[bold]{format_cost(total)}[/bold]")
     elif group_by == "agent":
-        table = make_table("AGENT", "MODEL", "TOKENS IN", "TOKENS OUT", "COST")
+        table = make_table("AGENT", "MODEL", "TOKENS IN", "TOKENS OUT", "CACHE R", "CACHE W", "COST")
         for r in rows:
             table.add_row(
-                r.group,
-                r.model or "-",
-                format_tokens(r.input_tokens),
-                format_tokens(r.output_tokens),
+                r.group, r.model or "-",
+                format_tokens(r.input_tokens), format_tokens(r.output_tokens),
+                format_tokens(r.cache_tokens), format_tokens(r.cache_write_tokens),
                 format_cost(r.cost_usd),
             )
+        table.add_row("", "", format_tokens(total_in), format_tokens(total_out),
+                      format_tokens(cache_r), format_tokens(cache_w),
+                      f"[bold]{format_cost(total)}[/bold]")
     elif group_by == "model":
-        table = make_table("MODEL", "TOKENS IN", "TOKENS OUT", "COST")
+        table = make_table("MODEL", "TOKENS IN", "TOKENS OUT", "CACHE R", "CACHE W", "COST")
         for r in rows:
             table.add_row(
                 r.group,
-                format_tokens(r.input_tokens),
-                format_tokens(r.output_tokens),
+                format_tokens(r.input_tokens), format_tokens(r.output_tokens),
+                format_tokens(r.cache_tokens), format_tokens(r.cache_write_tokens),
                 format_cost(r.cost_usd),
             )
+        table.add_row("", format_tokens(total_in), format_tokens(total_out),
+                      format_tokens(cache_r), format_tokens(cache_w),
+                      f"[bold]{format_cost(total)}[/bold]")
     elif group_by == "tool":
+        # Tool grouping has no token dimension — cost only.
         table = make_table("TOOL", "COST")
         for r in rows:
-            table.add_row(
-                r.group,
-                format_cost(r.cost_usd),
-            )
-
-    if group_by == "day":
-        table.add_row("", "", "", "", "[bold]TOTAL[/bold]", f"[bold]{format_cost(total)}[/bold]")
-    elif group_by == "agent":
-        table.add_row("", "", "", "[bold]TOTAL[/bold]", f"[bold]{format_cost(total)}[/bold]")
-    elif group_by == "model":
-        table.add_row("", "", "[bold]TOTAL[/bold]", f"[bold]{format_cost(total)}[/bold]")
-    elif group_by == "tool":
+            table.add_row(r.group, format_cost(r.cost_usd))
         table.add_row("[bold]TOTAL[/bold]", f"[bold]{format_cost(total)}[/bold]")
 
     console.print(table)

--- a/tokenjam/core/db.py
+++ b/tokenjam/core/db.py
@@ -613,24 +613,28 @@ class DuckDBBackend:
             idx += 1
         where = " AND ".join(clauses)
 
+        # Cache-read + cache-write are summed alongside in/out so callers can
+        # show the full token picture (cache-write is often the dominant cost
+        # driver yet was invisible above the DB — issue #17).
+        token_cols = (
+            "COALESCE(SUM(input_tokens), 0), "
+            "COALESCE(SUM(output_tokens), 0), "
+            "COALESCE(SUM(cache_tokens), 0), "
+            "COALESCE(SUM(cache_write_tokens), 0), "
+            "COALESCE(SUM(cost_usd), 0.0) "
+        )
         if filters.group_by in ("agent", "model"):
             sql = (
-                f"SELECT {group_expr} AS grp, agent_id, model, "
-                f"COALESCE(SUM(input_tokens), 0), "
-                f"COALESCE(SUM(output_tokens), 0), "
-                f"COALESCE(SUM(cost_usd), 0.0) "
-                f"FROM spans WHERE {where} "
+                f"SELECT {group_expr} AS grp, agent_id, model, " + token_cols
+                + f"FROM spans WHERE {where} "
                 f"GROUP BY grp, agent_id, model "
                 f"ORDER BY grp DESC"
             )
         else:
             # day / tool: group only by the primary expression to avoid cross-product
             sql = (
-                f"SELECT {group_expr} AS grp, NULL AS agent_id, NULL AS model, "
-                f"COALESCE(SUM(input_tokens), 0), "
-                f"COALESCE(SUM(output_tokens), 0), "
-                f"COALESCE(SUM(cost_usd), 0.0) "
-                f"FROM spans WHERE {where} "
+                f"SELECT {group_expr} AS grp, NULL AS agent_id, NULL AS model, " + token_cols
+                + f"FROM spans WHERE {where} "
                 f"GROUP BY grp "
                 f"ORDER BY grp DESC"
             )
@@ -638,7 +642,9 @@ class DuckDBBackend:
         return [
             CostRow(
                 group=str(r[0]), agent_id=r[1], model=r[2],
-                input_tokens=r[3] or 0, output_tokens=r[4] or 0, cost_usd=r[5] or 0.0,
+                input_tokens=r[3] or 0, output_tokens=r[4] or 0,
+                cache_tokens=r[5] or 0, cache_write_tokens=r[6] or 0,
+                cost_usd=r[7] or 0.0,
             )
             for r in rows
         ]

--- a/tokenjam/core/models.py
+++ b/tokenjam/core/models.py
@@ -229,6 +229,8 @@ class CostRow:
     model:        str | None  = None
     input_tokens: int         = 0
     output_tokens: int        = 0
+    cache_tokens: int         = 0   # cache-READ tokens
+    cache_write_tokens: int   = 0   # cache-CREATE tokens (the hidden cost driver, #17)
     cost_usd:     float       = 0.0
 
 

--- a/tokenjam/ui/index.html
+++ b/tokenjam/ui/index.html
@@ -1208,6 +1208,8 @@ function TraceDetailView({ traceId }) {
         if (s.tool_name) tipLines.push('Tool: ' + s.tool_name);
         if (s.input_tokens != null) tipLines.push('Input tokens: ' + fmtTokens(s.input_tokens));
         if (s.output_tokens != null) tipLines.push('Output tokens: ' + fmtTokens(s.output_tokens));
+        if (s.cache_tokens) tipLines.push('Cache read: ' + fmtTokens(s.cache_tokens));
+        if (s.cache_write_tokens) tipLines.push('Cache write: ' + fmtTokens(s.cache_write_tokens));
         if (s.cost_usd != null) tipLines.push('Cost: ' + fmtCost(s.cost_usd));
         const tooltip = tipLines.join('\n');
         return html`
@@ -1236,6 +1238,8 @@ function TraceDetailView({ traceId }) {
           ${sel.tool_name ? html`<span class="dk">Tool</span><span class="dv">${sel.tool_name}</span>` : null}
           ${sel.input_tokens != null ? html`<span class="dk">Input tokens</span><span class="dv">${fmtTokens(sel.input_tokens)}</span>` : null}
           ${sel.output_tokens != null ? html`<span class="dk">Output tokens</span><span class="dv">${fmtTokens(sel.output_tokens)}</span>` : null}
+          ${sel.cache_tokens ? html`<span class="dk">Cache read</span><span class="dv">${fmtTokens(sel.cache_tokens)}</span>` : null}
+          ${sel.cache_write_tokens ? html`<span class="dk">Cache write</span><span class="dv">${fmtTokens(sel.cache_write_tokens)}</span>` : null}
           ${sel.cost_usd != null ? html`<span class="dk">Cost</span><span class="dv">${fmtCost(sel.cost_usd)}</span>` : null}
           ${sel.agent_id ? html`<span class="dk">Agent</span><span class="dv">${sel.agent_id}</span>` : null}
           ${sel.conversation_id ? html`<span class="dk">Conversation</span><span class="dv">${sel.conversation_id}</span>` : null}
@@ -1438,7 +1442,7 @@ function CostView({ params }) {
           <th>${tableMode === 'day' ? 'Date' : tableMode === 'agent' ? 'Agent' : 'Model'}</th>
           ${tableMode !== 'agent' ? html`<th>Agent</th>` : null}
           ${tableMode !== 'model' ? html`<th>Model</th>` : null}
-          <th>Input</th><th>Output</th><th>Cost <span class="info-btn">i<span class="info-tip">Estimated from token usage. If you're on a subscription plan (e.g. Claude Max), your actual spend may differ.</span></span></th>
+          <th>Input</th><th>Output</th><th>Cache R <span class="info-btn">i<span class="info-tip">Cache-read tokens (billed at the discounted cache-read rate).</span></span></th><th>Cache W <span class="info-btn">i<span class="info-tip">Cache-write (creation) tokens — often the dominant cost driver on cache-heavy workloads.</span></span></th><th>Cost <span class="info-btn">i<span class="info-tip">Estimated from token usage. If you're on a subscription plan (e.g. Claude Max), your actual spend may differ.</span></span></th>
         </tr></thead>
         <tbody>
           ${rows.map(r => html`
@@ -1448,6 +1452,8 @@ function CostView({ params }) {
               ${tableMode !== 'model' ? html`<td class="mono">${r.model || '-'}</td>` : null}
               <td>${fmtTokens(r.input_tokens)}</td>
               <td>${fmtTokens(r.output_tokens)}</td>
+              <td>${fmtTokens(r.cache_tokens || 0)}</td>
+              <td>${fmtTokens(r.cache_write_tokens || 0)}</td>
               <td>${fmtCost(r.cost_usd)}</td>
             </tr>
           `)}
@@ -1455,6 +1461,8 @@ function CostView({ params }) {
             <td colspan=${1 + (tableMode !== 'agent' ? 1 : 0) + (tableMode !== 'model' ? 1 : 0)}></td>
             <td>${fmtTokens(totalIn)}</td>
             <td>${fmtTokens(totalOut)}</td>
+            <td>${fmtTokens(rows.reduce((s, r) => s + (r.cache_tokens || 0), 0))}</td>
+            <td>${fmtTokens(rows.reduce((s, r) => s + (r.cache_write_tokens || 0), 0))}</td>
             <td>${fmtCost(total)}</td>
           </tr>
         </tbody>


### PR DESCRIPTION
Closes #17 (from the v0.3.5 smoke test #141 — MEDIUM; highest end-user value).

On cache-heavy Opus traffic, **cache-write is ~91% of cost but was invisible
above the DB**: the traces API omitted the field and the UI / `tj cost` never
showed cache tokens, so a displayed cost couldn't be derived from its own
columns. The reporter's span:

```
input 2 · output 465 · cache_read 243597 · cost $1.442306  (claude-opus-4-8)
→ ~209k cache-WRITE tokens account for the missing ~$1.31
```

## Fix
- **traces API** (`_span_to_dict`) returns `cache_write_tokens` alongside `cache_tokens` (read).
- **UI trace-detail** panel + waterfall tooltip render **Cache read** + **Cache write** — per-span cost now reconciles on screen.
- **Aggregate**: `CostRow` + `get_cost_summary` sum cache-read/write; `/api/v1/cost` rows carry both + window totals; the **UI Cost table** and **`tj cost`** gain `CACHE R` / `CACHE W` columns (tool grouping stays cost-only).

## Tests
Trace detail + `/api/v1/cost` expose cache-write (the reporter's exact span reconciles); UI guard for the rendered fields. Full suite green (651); ruff/mypy clean.

> Note: built in an isolated `git worktree` to avoid the shared-HEAD collisions we'd been hitting.