### PR TITLE
Pre-release fixes for v0.4.0: cache shim + downsize CLI empty-state

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -50,3 +50,6 @@ tj.toml
 # Superpowers skill output (internal planning artifacts, not for OSS)
 docs/superpowers/
 .gstack/
+
+# Per-release pre-release test logs — runner writes here, each run is local
+tests/results/

--- a/tests/manual-pre-release-runner.md
+++ b/tests/manual-pre-release-runner.md
@@ -1,0 +1,119 @@
+# Pre-release Test Runner
+
+Generic instructions for a sub-agent to execute a release-specific pre-release test pass and produce a structured log a human can review.
+
+This file does not change between releases. Each release authors a focused `tests/manual-pre-release-vX.Y.Z.md` companion checklist; the runner consumes that file.
+
+---
+
+## Your job (as the sub-agent reading this)
+
+1. **Find the release-specific checklist** at `tests/manual-pre-release-v<VERSION>.md`. `VERSION` will be in the parent's prompt (e.g. "v0.4.0"). If you can't determine the version, read `pyproject.toml` and assume the next minor version — but flag this uncertainty in the log.
+
+2. **Verify environment before starting.** Run these checks; abort with a clear message if anything fails:
+
+   ```bash
+   git rev-parse --abbrev-ref HEAD            # should be a clean branch (main or release/*)
+   git status --porcelain                     # should be empty (no uncommitted changes other than ignored files)
+   tj --version                               # daemon must respond
+   curl -s -f http://127.0.0.1:7391/health    # daemon must be running
+   ```
+
+   If `tj serve` isn't running, start it with `tj serve > /tmp/tj-prerelease.log 2>&1 &` and wait 3 seconds before continuing.
+
+3. **Walk every step in the release-specific file, in order.** Each step has a structured shape:
+
+   ```markdown
+   ## Step N: Brief title
+
+   **What:** one-line description of why this step exists
+
+   **Setup:** (optional) commands that prepare state but aren't themselves tested
+
+   **Test:** the commands whose output you must capture and evaluate
+
+   **Expected:** plain-English pass criteria — compare captured output against these
+
+   **Assertions:** (optional) commands that print `ok:` if they pass; treat absence of `ok:` as fail
+   ```
+
+   For each step:
+   - Run **Setup** commands if present. Don't log their output unless they fail.
+   - Run **Test** commands. Capture stdout + stderr.
+   - Compare captured output to **Expected**. Decide PASS / FAIL / UNCLEAR.
+   - Run **Assertions** commands if present. They print `ok:` on pass. If they don't print `ok:`, mark FAIL with the actual output.
+
+4. **Write the result log** to `tests/results/manual-pre-release-<VERSION>-<TIMESTAMP>.md`. Create the `tests/results/` directory if it doesn't exist. Use this format:
+
+   ````markdown
+   # Pre-release test results — v<VERSION>
+
+   - **Run at:** <ISO timestamp>
+   - **Branch:** <branch name>
+   - **HEAD:** <short SHA>
+   - **Checklist:** tests/manual-pre-release-v<VERSION>.md
+   - **Result:** N/M steps PASS, K FAIL, J UNCLEAR
+
+   ---
+
+   ## Step 1: <title>
+
+   **Status:** ✅ PASS / ❌ FAIL / ⚠️ UNCLEAR
+
+   **Test commands:**
+   ```bash
+   <commands run>
+   ```
+
+   **Output:**
+   ```
+   <captured stdout + stderr, trimmed if very long>
+   ```
+
+   **Notes:** <one-line observation; especially for UNCLEAR>
+
+   ---
+
+   ## Step 2: ...
+   ````
+
+5. **End with a final summary section** that lists the PASS/FAIL/UNCLEAR step numbers, the SHA + branch under test, and a recommendation: "Ready to release" / "Hold — N failures" / "Investigate — UNCLEAR steps need a human."
+
+---
+
+## Output trimming
+
+If a step's output is more than ~50 lines, keep the first 30 and the last 10 with `... [N lines omitted] ...` in the middle. The point is enough context for a human reviewer to recognize the shape of the output; full transcripts go to `/tmp/tj-prerelease.log` automatically via the daemon.
+
+## What to do when a step is UNCLEAR
+
+Mark UNCLEAR rather than guessing if you can't tell whether output matches **Expected** — for example:
+- The output mentions a number you can't verify without context (e.g., "spend total: $X")
+- A subprocess timed out
+- The CLI prints colored output that's hard to compare against plain-text expectations
+
+A human reviewer will look at every UNCLEAR step, so it's not a failure — it's a "needs human eyes" flag.
+
+## What to do when a step FAILS
+
+Record the failure in the log and **continue** to the rest of the steps unless the failure clearly invalidates the environment (e.g., daemon crashed). The point is to surface every issue in one pass, not stop at the first.
+
+If the daemon crashes mid-run, restart it and re-run the most recent step before continuing — note the crash in the log.
+
+## Output file
+
+After the run, print:
+```
+Results written to tests/results/manual-pre-release-<VERSION>-<TIMESTAMP>.md
+Summary: <N>/<M> PASS, <K> FAIL, <J> UNCLEAR
+```
+
+The parent agent will read the log and decide release readiness.
+
+## What you should NOT do
+
+- Do not modify any source files (no test fixes, no playbook edits) — the runner is read-only on the codebase.
+- Do not commit anything to git.
+- Do not interact with external services (no web requests beyond localhost).
+- Do not skip steps because they look slow.
+- Do not infer pass/fail from CI status — this is a live test pass against the actual daemon.

--- a/tests/manual-pre-release-v0.4.0.md
+++ b/tests/manual-pre-release-v0.4.0.md
@@ -1,0 +1,291 @@
+# Pre-release checklist — v0.4.0
+
+Focused on the delta since v0.3.5. The runner (`tests/manual-pre-release-runner.md`) walks each step in order.
+
+**What's new in v0.4.0** (so you know what we're validating):
+- TokenJam Lens UI rebrand (Overview triage screen + Optimize tab + real charts)
+- Reuse — 5th analyzer + `tj report --reuse` artifact export
+- `core/framing.py` — single source of truth for plan-tier rendering
+- `estimated_recoverable_usd` contract on every savings analyzer
+- `cache_write_tokens` surfaced through DB → API → CLI → UI
+- Security: `.tj/config.toml` untracked + CI guard
+- Onboard: plain `tj onboard --plan` honored; tool_inputs capture toggle added; stale URLs removed
+
+Stable surfaces (ingest, alerts, drift, schema validation, MCP server) are **not** in scope — they're covered by the standing pre-release playbook in `tests/manual-pre-release-testing.md`.
+
+---
+
+## Step 1: Baseline — daemon is current
+
+**What:** confirm the daemon is running the code under test, not an old version.
+
+**Test:**
+```bash
+tj --version
+curl -s http://127.0.0.1:7391/api/v1/version
+```
+
+**Expected:**
+- Both commands report the same version
+- Version matches what's in `pyproject.toml` (`grep '^version' pyproject.toml`)
+
+---
+
+## Step 2: TokenMaxx — api plan (no multiplier line)
+
+**What:** verify `tj tokenmaxx` renders the bordered panel on api-pricing mode without the multiplier line.
+
+**Setup:**
+```bash
+tj onboard --claude-code --reconfigure --plan api
+```
+
+**Test:**
+```bash
+tj tokenmaxx
+```
+
+**Expected:**
+- A bordered "TokenJam TokenMaxxing Report" panel renders
+- An absolute USD/mo spend figure appears (e.g., "Your spend: $X/mo")
+- **No** multiplier line ("That's N× your plan cost") — api users don't get one
+- An action line mentioning either downsize savings or "no obvious savings flagged yet"
+
+---
+
+## Step 3: TokenMaxx — subscription plan (multiplier line appears)
+
+**What:** verify subscription rendering activates the multiplier line and tier classification works across plan boundaries.
+
+**Setup:**
+```bash
+tj onboard --claude-code --reconfigure --plan max_5x
+```
+
+**Test:**
+```bash
+tj tokenmaxx
+```
+
+**Expected:**
+- Bordered panel renders
+- A line like "That's N× your Max 5x plan cost ($100/mo flat)" appears
+- The tier label is one of: TokenSipper / TokenModerator / TokenMaxxer / TokenSuperMaxxer / TokenMegaMaxxer / TokenGigaMaxxer
+
+**Assertions:**
+```bash
+tj tokenmaxx --json | python3 -c "import json,sys;d=json.load(sys.stdin);ok={'TokenSipper','TokenModerator','TokenMaxxer','TokenSuperMaxxer','TokenMegaMaxxer','TokenGigaMaxxer'};assert d['tier'] in ok,d['tier'];assert d.get('plan_multiplier') is not None;print('ok:',d['tier'],'mult=',d['plan_multiplier'])"
+```
+
+---
+
+## Step 4: Restore api plan for the rest of the run
+
+**What:** flip back to api so subsequent dollar-bearing checks render literal dollars.
+
+**Test:**
+```bash
+tj onboard --claude-code --reconfigure --plan api
+```
+
+**Expected:**
+- Command exits 0
+- `grep '^plan = ' ~/.config/tj/config.toml` shows `plan = "api"`
+
+---
+
+## Step 5: Run all five analyzers — no crashes
+
+**What:** verify every registered analyzer (downsize / cache / cache-recommend / script / trim / reuse) executes without errors. Optional analyzers should print clear hints when prereqs aren't met, not crash.
+
+**Test:**
+```bash
+tj optimize --since 30d
+```
+
+**Expected:**
+- Output contains "Downsize", "Cache", "Cache recommend", "Script", "Trim", **"Reuse"** sections (or honest "not ready" / "no candidates" hints for any)
+- No Python tracebacks
+- No "ERROR" lines
+- Plan-tier banner appears if applicable ("Plan tier unknown" qualifier or similar)
+
+**Assertions:**
+```bash
+tj optimize --json | python3 -c "import json,sys;d=json.load(sys.stdin);f=d['findings'];assert 'reuse' in f,'reuse missing';assert 'cache' in f,'cache missing';assert 'script' in f,'script missing';print('ok: all wave-2 analyzers in findings')"
+```
+
+---
+
+## Step 6: Reuse — the brand new analyzer
+
+**What:** verify `tj optimize reuse` runs and produces honest output, and `tj report --reuse` writes both HTML and Markdown artifacts (or exits 0 with the friendly empty message if no clusters).
+
+**Test:**
+```bash
+tj optimize reuse --since 30d
+tj report --reuse --no-open
+```
+
+**Expected:**
+- `tj optimize reuse` either lists clusters with cache-reuse + script-replacement numbers, OR prints "No clusters above threshold" — both are valid outcomes
+- `tj report --reuse --no-open` either:
+  - writes `reuse-*.html` and `reuse-*-*.md` files under `~/.cache/tokenjam/reports/` and exits 0, OR
+  - prints "No repeated planning detected" and exits 0 without writing files
+- No tracebacks either way
+
+**Assertions:**
+```bash
+tj optimize --json | python3 -c "import json,sys;d=json.load(sys.stdin);r=d['findings']['reuse'];assert 'estimate_basis' in r and 'review' in r['estimate_basis'].lower();print('ok: reuse contract intact')"
+```
+
+---
+
+## Step 7: `tj cost` shows cache R + cache W columns
+
+**What:** verify the cost-transparency fix from #149 — cache-read and cache-write tokens appear in the table.
+
+**Test:**
+```bash
+tj cost --since 30d --group-by model
+```
+
+**Expected:**
+- Header row includes `CACHE R` and `CACHE W` columns (alongside `TOKENS IN` / `TOKENS OUT`)
+- At least one data row OR a "no data" message; if data exists, the cache columns are populated (not all zeros)
+- A totals row at the bottom
+
+**Assertions:**
+```bash
+curl -s "http://127.0.0.1:7391/api/v1/cost?since=30d&group_by=model" | python3 -c "import json,sys;d=json.load(sys.stdin);assert 'total_cache_write_tokens' in d,'total missing';assert all('cache_write_tokens' in r for r in d.get('rows',[])),'row field missing';print('ok: cache_write surfaced in API')"
+```
+
+---
+
+## Step 8: `tj onboard --plan` on plain path
+
+**What:** verify #148 — bare `tj onboard --plan` actually writes the plan field (was silent no-op pre-v0.4.0). Needs care because plain `tj onboard` refuses to overwrite an existing global config (correct safety behavior), so we run the test against a temporarily isolated `XDG_CONFIG_HOME` instead of touching the real user config.
+
+**Setup:**
+```bash
+TMP=$(mktemp -d)
+HOME_BAK="$HOME"
+# Isolate config + data into the tmp dir so the user's real global config
+# isn't seen by `tj onboard`. find_config_file walks $HOME/.config/tj/ —
+# pointing HOME at a fresh dir bypasses any existing config cleanly.
+export HOME="$TMP"
+cd "$TMP"
+```
+
+**Test:**
+```bash
+tj onboard --no-daemon --budget 0 --plan max_5x </dev/null
+grep '^plan = ' .tj/config.toml
+```
+
+**Expected:**
+- Command exits 0
+- `.tj/config.toml` contains `plan = "max_5x"` under `[budget.anthropic]`
+- File also contains all 4 capture toggles: `prompts = false`, `completions = false`, `tool_inputs = false`, `tool_outputs = false`
+- No `openclawwatch` substring anywhere in the file
+
+**Assertions:**
+```bash
+python3 -c "import pathlib,re;t=pathlib.Path('.tj/config.toml').read_text();assert 'plan = \"max_5x\"' in t;assert all(f'{k} = false' in t for k in ('prompts','completions','tool_inputs','tool_outputs'));assert 'openclawwatch' not in t;print('ok: onboard writes plan + all 4 capture toggles + no stale URL')"
+export HOME="$HOME_BAK"
+cd - >/dev/null
+```
+
+---
+
+## Step 9: Lens UI — default route + footer version
+
+**What:** verify the dashboard lands on Overview (not Status) and the footer fetches the live version.
+
+**Test:**
+```bash
+curl -s http://127.0.0.1:7391/ | grep -E '<title>|window.location.hash|tj-version' | head -5
+curl -s http://127.0.0.1:7391/api/v1/version
+```
+
+**Expected:**
+- `<title>` contains "TokenJam Lens"
+- The HTML references `#/overview` as the default route (and **not** `location.hash = '#/status'` as a render-time redirect — that was issue #132)
+- `/api/v1/version` returns the same version as Step 1
+
+**Assertions:**
+```bash
+python3 -c "import urllib.request;html=urllib.request.urlopen('http://127.0.0.1:7391/').read().decode();assert 'TokenJam Lens' in html;assert 'overview' in html.lower();assert 'class=\"chart-card band-hero\"' not in html,'chart-as-button regression';print('ok: brand + default route + drill-link guards intact')"
+```
+
+---
+
+## Step 10: `/api/v1/optimize` carries the framing block + reuse
+
+**What:** verify the API contract — every dollar-bearing endpoint includes a `framing` block, and `findings.reuse` is present.
+
+**Test:**
+```bash
+curl -s "http://127.0.0.1:7391/api/v1/optimize?since=30d" | python3 -m json.tool | head -40
+```
+
+**Expected:**
+- The response includes a top-level `framing` key with `pricing_mode`, `plan_tier`, `display_rule` fields
+- The `findings` object includes a `reuse` key
+- `downgrade` is either null or a typed object with `estimated_recoverable_usd`, `monthly_savings_usd`, and a non-empty caveat
+
+**Assertions:**
+```bash
+curl -s "http://127.0.0.1:7391/api/v1/optimize?since=30d" | python3 -c "import json,sys;d=json.load(sys.stdin);assert 'framing' in d and 'pricing_mode' in d['framing'];assert 'reuse' in d['findings'];g=d.get('downgrade');assert g is None or g.get('estimated_recoverable_usd') is not None;print('ok: framing + reuse + downgrade contract')"
+```
+
+---
+
+## Step 11: Backfill smoke — sanity check, no regression
+
+**What:** quick check that the three fixture-based backfill adapters haven't regressed under the v0.4.0 changes.
+
+**Test:**
+```bash
+tj backfill langfuse --source-file tests/fixtures/langfuse_real_response.json
+tj backfill helicone --source-file tests/fixtures/helicone_real_response.json
+tj backfill otlp --source-file tests/fixtures/otlp_sample.json
+```
+
+**Expected:**
+- Each command reports either "wrote N new spans" or "skipped N already present" — both are valid (depends on prior runs)
+- No tracebacks
+- Exit code 0 for all three
+
+---
+
+## Step 12: CLAUDE.md tracked-secret guard test (the meta one)
+
+**What:** confirm the CI test from #150 actually runs and passes — meta-check that the guardrail we added is effective.
+
+**Test:**
+```bash
+pytest tests/unit/test_no_tracked_dev_secrets.py -v
+```
+
+**Expected:**
+- One test (`test_tj_config_not_tracked`) runs and passes
+- No warnings about `.tj/config.toml` being tracked
+
+---
+
+## Final summary the runner produces
+
+After all 12 steps, the result log should end with:
+
+```
+**Recommendation:** Ready to release v0.4.0 / Hold — <N> failures / Investigate — <K> UNCLEAR steps
+
+**Steps PASSED:**  1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12  (or whichever subset)
+**Steps FAILED:**  <numbers>
+**Steps UNCLEAR:** <numbers>
+
+**Notable observations:**
+- <any one-liners worth surfacing>
+```
+
+If everything passes, the release-cut PR can be opened directly. If anything FAILs or is UNCLEAR, the parent agent investigates before cutting.

--- a/tokenjam/cli/cmd_optimize.py
+++ b/tokenjam/cli/cmd_optimize.py
@@ -264,6 +264,7 @@ def cmd_optimize(
         report, agent=agent, plan_mix=plan_mix,
         dominant_plan=dominant, pricing_mode=pricing_mode,
         declared_plan=declared_plan,
+        requested=list(findings) if findings else None,
     )
     if cost_diff is not None:
         from tokenjam.cli.cmd_cost import _render_diff
@@ -286,6 +287,7 @@ def _render_report(
     dominant_plan: str = "unknown",
     pricing_mode: str = "unknown",
     declared_plan: str | None = None,
+    requested: list[str] | None = None,
 ) -> None:
     w = report.window
     scope_tag = f", {agent}" if agent else ""
@@ -375,10 +377,24 @@ def _render_report(
         console.print()
 
     # ----- Model-downgrade body -----
+    # Render an explicit "no candidates" empty state when the analyzer ran
+    # but found nothing — the Optimize web tab does this (PR #130 / issue
+    # #126) and the CLI used to silently skip the section, which makes
+    # reviewers think the analyzer didn't run. Skip the empty state when
+    # the user asked for a different positional subset (`tj optimize cache`
+    # shouldn't mention downsize at all).
+    downsize_was_requested = (not requested) or ("downsize" in requested)
     if report.downgrade is not None:
         _render_downgrade(
             report.downgrade,
             pricing_mode=("unknown" if all_unknown else pricing_mode),
+        )
+        console.print()
+    elif downsize_was_requested:
+        console.print(
+            "  [bold]① Downsize:[/bold] "
+            "[dim]no candidates in this window — sessions don't match the "
+            "smaller-model shape (small input/output, few tool calls).[/dim]"
         )
         console.print()
 
@@ -411,6 +427,7 @@ def _render_report(
     # falling into "No candidates flagged" (issue #68 §15).
     rendered_any = (
         report.downgrade is not None
+        or downsize_was_requested  # we emit a "no candidates" empty state
         or (pricing_mode == "api" and bool(report.budgets))
         or rendered_any_wave2
     )

--- a/tokenjam/core/api_backend.py
+++ b/tokenjam/core/api_backend.py
@@ -91,6 +91,11 @@ class ApiBackend:
                 model=r["model"],
                 input_tokens=r.get("input_tokens", 0),
                 output_tokens=r.get("output_tokens", 0),
+                # Cache fields added in #149; the API serializes them but this
+                # shim was missed, so `tj cost` silently showed 0s in the cache
+                # columns whenever the daemon was up. Mirror the wider contract.
+                cache_tokens=r.get("cache_tokens", 0),
+                cache_write_tokens=r.get("cache_write_tokens", 0),
                 cost_usd=r.get("cost_usd", 0.0),
             )
             for r in data.get("rows", [])


### PR DESCRIPTION
Two bugs surfaced by the v0.4.0 pre-release test pass against an install with the daemon running, plus the testing-infra MD files that caught them.

## Bugs fixed

### 1. \`tj cost\` cache columns silently 0 with daemon up

PR #149 added \`cache_tokens\` + \`cache_write_tokens\` to the DB row, API response, and CLI rendering — but missed the \`ApiBackend\` shim that the CLI uses when \`tj serve\` is running. The shim dropped the cache fields on the floor, so they defaulted to 0 even though the JSON response carried the real values.

**Before** (with daemon running):
```
MODEL                TOKENS IN   TOKENS OUT   CACHE R   CACHE W   COST
claude-opus-4-8      294.2k      1.8M         0         0         \$468.5259
claude-opus-4-7      38.8k       3.3M         0         0         \$1115.4432
```

**After:**
```
MODEL                TOKENS IN   TOKENS OUT   CACHE R   CACHE W   COST
claude-opus-4-8      294.2k      1.8M         698.8M    0         \$468.5259
claude-opus-4-7      38.8k       3.3M         1530.9M   1.5M      \$1115.4432
```

Cost-transparency contract from #149 is now intact across both the direct-DB and daemon-up modes.

### 2. \`tj optimize\` silently skips the Downsize section when no candidates exist

The Optimize web tab fixed this in PR #130 (issue #126) by rendering an explicit "no candidates" state. The CLI render path was overlooked. When other analyzers find content (cache, script, trim, …), the catch-all "No candidates flagged" message doesn't fire either, so Downsize disappears without explanation — reviewers think the analyzer didn't run.

The CLI now mirrors the UI: explicit \`① Downsize: no candidates in this window — sessions don't match the smaller-model shape (small input/output, few tool calls).\` empty state. Guarded by the positional \`findings\` filter so \`tj optimize cache\` (asking for just cache) doesn't add Downsize noise.

## Testing infrastructure (new)

- \`tests/manual-pre-release-runner.md\` — generic instructions for a sub-agent: find the release-specific checklist, walk each step, capture output, write a structured log to \`tests/results/\`.
- \`tests/manual-pre-release-v0.4.0.md\` — focused 12-step checklist for the v0.4.0 release. Each step has the structured shape the runner expects (Setup / Test / Expected / Assertions).
- \`.gitignore\` adds \`tests/results/\` — per-run logs are local artifacts, not committed.
- The v0.4.0 checklist also hardens Step 8 (plain \`tj onboard --plan\`) to isolate \`HOME\` rather than risking the user's real global config.

## Verification

- \`pytest tests/unit/ tests/integration/\`: **659 passed**
- Live with daemon up: both fixes confirmed by direct \`tj cost\` + \`tj optimize\` runs.
- This PR's fixes are themselves what the pre-release pass will verify when re-run.

## What's NOT in this PR (filed as deferred)

- **\`tj report --reuse\` errors when daemon holds the DB lock** — needs an HTTP fallback path. Deferring to v0.4.1; workaround is \`tj stop\` first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)