### PR TITLE
chore: rename agent-targeted test runners with `agent-` prefix

### DIFF
--- a/tests/agent-post-release-runner.md
+++ b/tests/agent-post-release-runner.md
@@ -1,0 +1,134 @@
+# Post-release Test Runner
+
+Generic instructions for a sub-agent to execute a release-specific post-release test pass against the **published artifact** (PyPI + npm) and produce a structured log a human can review.
+
+This file does not change between releases. Each release authors a focused `tests/agent-post-release-vX.Y.Z.md` companion checklist; the runner consumes that file.
+
+The comprehensive human-walkable playbook lives at `tests/manual-new-release-tests.md` — that's the reference for what's testable. The release-specific files for the runner pull only the v0.X.Y-critical subset.
+
+---
+
+## Your job (as the sub-agent reading this)
+
+1. **Find the release-specific checklist** at `tests/agent-post-release-v<VERSION>.md`. `VERSION` will be in the parent's prompt (e.g. "v0.4.0"). If you can't determine the version, read `pyproject.toml` and use that — but flag the uncertainty in the log.
+
+2. **Set up an isolated environment.** Post-release tests use the *published* PyPI artifact, so they install via `pipx`. To avoid touching the user's real install, set `HOME` to a fresh tmp directory for the entire run:
+
+   ```bash
+   export RUN_HOME="$(mktemp -d -t tj-postrelease-XXXXXX)"
+   export ORIG_HOME="$HOME"
+   export HOME="$RUN_HOME"
+   echo "Running in isolated HOME: $RUN_HOME"
+   ```
+
+   Restore `HOME` at the end of the run (success or failure):
+
+   ```bash
+   export HOME="$ORIG_HOME"
+   ```
+
+   pipx will install into `$RUN_HOME/.local/pipx/venvs/tokenjam/`, completely separate from any existing install.
+
+3. **Verify pipx is available** before starting:
+
+   ```bash
+   command -v pipx || { echo "pipx not found — abort"; exit 2; }
+   ```
+
+   If pipx isn't installed, abort with a clear message — post-release tests verify the recommended install path, which is pipx.
+
+4. **Walk every step in the release-specific file, in order.** Same structured shape as the pre-release runner:
+
+   ```markdown
+   ## Step N: Brief title
+
+   **What:** one-line description
+
+   **Setup:** (optional) commands that prepare state but aren't themselves tested
+
+   **Test:** the commands whose output you must capture and evaluate
+
+   **Expected:** plain-English pass criteria
+
+   **Assertions:** (optional) commands that print `ok:` on pass
+   ```
+
+   For each step:
+   - Run **Setup** silently
+   - Run **Test** and capture output
+   - Compare to **Expected**, decide PASS / FAIL / UNCLEAR
+   - Run **Assertions**; treat missing `ok:` as FAIL with actual output
+
+5. **Write the result log** to `tests/results/agent-post-release-<VERSION>-<TIMESTAMP>.md`. Use the same format the pre-release runner uses:
+
+   ````markdown
+   # Post-release test results — v<VERSION>
+
+   - **Run at:** <ISO timestamp>
+   - **Isolated HOME:** <path>
+   - **Tested artifact:** pipx-installed `tokenjam` from PyPI
+   - **Checklist:** tests/agent-post-release-v<VERSION>.md
+   - **Result:** N/M steps PASS, K FAIL, J UNCLEAR
+
+   ---
+
+   ## Step 1: <title>
+
+   **Status:** ✅ PASS / ❌ FAIL / ⚠️ UNCLEAR
+
+   **Test commands:**
+   ```bash
+   <commands run>
+   ```
+
+   **Output:**
+   ```
+   <captured stdout + stderr, trimmed if >50 lines>
+   ```
+
+   **Notes:** <one-line observation>
+
+   ---
+   ````
+
+6. **End with a final summary** listing PASS/FAIL/UNCLEAR steps, plus a recommendation: "Release is healthy" / "Hold — N failures" / "Investigate — UNCLEAR steps need a human."
+
+7. **Clean up.** After the summary, remove the isolated HOME directory:
+
+   ```bash
+   export HOME="$ORIG_HOME"
+   rm -rf "$RUN_HOME"
+   ```
+
+   Log this as the last action in the result file.
+
+---
+
+## Network and timing
+
+The first step (`pipx install`) hits PyPI and takes 30–60 seconds depending on the connection. Don't time out. Subsequent commands run locally against the installed venv.
+
+## Output trimming
+
+Same rule as the pre-release runner: if a step's output is >50 lines, keep the first 30 and the last 10 with `... [N lines omitted] ...` in the middle.
+
+## When a step is UNCLEAR
+
+Same rules as pre-release: mark UNCLEAR rather than guessing. Continue past FAILs unless the install itself broke.
+
+## What you should NOT do
+
+- **Do not** unset or modify the user's real `HOME` — only `$RUN_HOME`.
+- **Do not** modify any source files in the working tree.
+- **Do not** commit anything.
+- **Do not** call `tj uninstall --yes` or `pipx uninstall` against the real `HOME`. The isolation makes that unnecessary; doing it would wipe the user's real install.
+- **Do not** skip the cleanup step.
+
+## Output file
+
+After the run, print:
+```
+Results written to tests/results/agent-post-release-<VERSION>-<TIMESTAMP>.md
+Summary: <N>/<M> PASS, <K> FAIL, <J> UNCLEAR
+HOME restored. Isolated dir removed: <path>
+```

--- a/tests/agent-post-release-v0.4.0.md
+++ b/tests/agent-post-release-v0.4.0.md
@@ -1,0 +1,315 @@
+# Post-release checklist — v0.4.0
+
+Focused on verifying the **published artifact** (PyPI) actually installs and the v0.4.0-new surfaces work end-to-end against a real user-style install. The runner (`tests/agent-post-release-runner.md`) walks each step in order with an isolated `$HOME`, so this won't touch the developer's real install.
+
+The comprehensive human playbook is at `tests/manual-new-release-tests.md` if a reviewer wants every section. This file is the agent-runnable subset.
+
+**What's new in v0.4.0** (so you know what we're validating):
+- TokenJam Lens UI rebrand (Overview + Optimize + real charts)
+- Reuse — 5th analyzer + `tj report --reuse` artifact export
+- `cache_write_tokens` surfaced through DB → API → CLI → UI
+- `core/framing.py` — plan-tier-aware rendering across CLI + API
+- Onboard `--plan` honored on the plain path (#148)
+- `tj mcp` works without the `[mcp]` extra (fastmcp in base deps, #131)
+
+---
+
+## Step 1: Install from PyPI
+
+**What:** the published v0.4.0 artifact installs cleanly via the recommended path.
+
+**Setup:**
+```bash
+# Runner has already set HOME to an isolated tmp dir
+pipx uninstall tokenjam 2>/dev/null || true   # safe: isolated HOME has no prior install
+```
+
+**Test:**
+```bash
+pipx install tokenjam
+"$HOME/.local/bin/tj" --version
+```
+
+**Expected:**
+- `pipx install` succeeds (writes `installed package tokenjam 0.4.0`)
+- `tj --version` reports `tj, version 0.4.0`
+- No "Installing to existing venv" message — the isolated HOME guarantees a fresh venv
+
+**Assertions:**
+```bash
+"$HOME/.local/bin/tj" --version | grep -q "0.4.0" && echo "ok: 0.4.0 installed"
+```
+
+---
+
+## Step 2: First-run onboard
+
+**What:** plain `tj onboard --plan` works on a fresh install — covers #148 (the plain-path plan tier fix).
+
+**Test:**
+```bash
+"$HOME/.local/bin/tj" onboard --no-daemon --budget 0 --plan max_5x </dev/null
+grep '^plan = ' "$HOME/.config/tj/config.toml" || \
+  grep '^plan = ' .tj/config.toml
+```
+
+**Expected:**
+- Command exits 0
+- Either `~/.config/tj/config.toml` or `.tj/config.toml` exists and contains `plan = "max_5x"` under `[budget.anthropic]`
+- All 4 capture toggles are present (`prompts`, `completions`, `tool_inputs`, `tool_outputs`)
+- No `openclawwatch` substring anywhere in the written config
+
+**Assertions:**
+```bash
+python3 -c "
+import pathlib, os
+candidates = [pathlib.Path.home() / '.config/tj/config.toml', pathlib.Path('.tj/config.toml')]
+cfg = next((p for p in candidates if p.exists()), None)
+assert cfg, 'no config file found'
+t = cfg.read_text()
+assert 'plan = \"max_5x\"' in t
+assert all(f'{k} = false' in t for k in ('prompts','completions','tool_inputs','tool_outputs'))
+assert 'openclawwatch' not in t
+print('ok: onboard writes plan + 4 capture toggles + no stale URL')
+"
+```
+
+---
+
+## Step 3: `tj mcp` is importable out of the box (no extra needed)
+
+**What:** verifies the #101 fix (fastmcp moved into base deps) still holds. Pre-fix, `tj mcp` errored on fresh installs unless the user remembered `pipx install 'tokenjam[mcp]'`.
+
+**Test:**
+```bash
+"$HOME/.local/bin/tj" mcp --help
+```
+
+**Expected:**
+- Exit code 0
+- Help text describes the MCP stdio server
+- No `ImportError`, no "fastmcp not installed" message
+
+**Assertions:**
+```bash
+"$HOME/.local/bin/tj" mcp --help 2>&1 | grep -qi "mcp\|claude code\|stdio" && echo "ok: tj mcp loadable"
+```
+
+---
+
+## Step 4: `tj optimize` runs all 5 analyzers + carries the framing block
+
+**What:** even with no data, `tj optimize` should exit cleanly and surface a friendly "no data" message; the JSON output should carry the v0.4.0 contract (framing block, all 5 analyzer slots).
+
+**Test:**
+```bash
+"$HOME/.local/bin/tj" optimize --since 30d --json
+```
+
+**Expected:**
+- Exit code 0
+- Output is valid JSON with either:
+  - an `error: "no_data"` shape (fresh install, no spans yet), OR
+  - a full report with `findings` containing `reuse`, `cache`, `script`, `trim`, `cache-recommend` keys + a top-level `framing` object
+- No Python tracebacks
+
+**Assertions:**
+```bash
+"$HOME/.local/bin/tj" optimize --since 30d --json | python3 -c "
+import json, sys
+d = json.load(sys.stdin)
+if d.get('error') == 'no_data':
+    print('ok: no_data shape (expected on fresh install)')
+else:
+    f = d.get('findings', {})
+    assert 'reuse' in f, 'reuse missing'
+    assert 'framing' in d, 'framing block missing'
+    print('ok: contract intact (findings + framing)')
+"
+```
+
+---
+
+## Step 5: `tj cost` shows the CACHE R / CACHE W column headers
+
+**What:** verify the cost-transparency fix from #149 is in the published artifact. Even with no data, the table header should list the cache columns.
+
+**Test:**
+```bash
+"$HOME/.local/bin/tj" cost --since 30d --group-by model
+```
+
+**Expected:**
+- Either:
+  - a message indicating no cost data (fresh install), OR
+  - a table whose header row includes `CACHE R` and `CACHE W` alongside `TOKENS IN` / `TOKENS OUT`
+- No tracebacks
+
+**Notes:** populated CACHE values can't be verified here (no real data), but the column header presence is the published-artifact check. The pre-release pass already verified populated values.
+
+---
+
+## Step 6: `tj tokenmaxx` works on a subscription plan tier
+
+**What:** the marquee shareable command — verify it renders the bordered panel and the multiplier line.
+
+**Test:**
+```bash
+"$HOME/.local/bin/tj" tokenmaxx
+"$HOME/.local/bin/tj" tokenmaxx --json
+```
+
+**Expected:**
+- Either a bordered "TokenJam TokenMaxxing Report" panel, OR a friendly "not enough data" message
+- JSON output is valid; if data exists, `tier` is one of the 6 valid tier names
+
+**Assertions:**
+```bash
+"$HOME/.local/bin/tj" tokenmaxx --json | python3 -c "
+import json, sys
+d = json.load(sys.stdin)
+ok = {'TokenSipper','TokenModerator','TokenMaxxer','TokenSuperMaxxer','TokenMegaMaxxer','TokenGigaMaxxer'}
+tier = d.get('tier')
+# Fresh install may report 'unknown' or omit tier — that's OK
+assert tier is None or tier in ok or 'spend' in d, f'unexpected tokenmaxx shape: {d}'
+print('ok: tokenmaxx shape valid')
+"
+```
+
+---
+
+## Step 7: `tj serve` starts and the Lens UI renders "TokenJam Lens"
+
+**What:** the marquee UI rebrand — verify `/` returns HTML titled "TokenJam Lens" and `/api/v1/version` reports 0.4.0.
+
+**Setup:**
+```bash
+"$HOME/.local/bin/tj" serve > "$HOME/tj-serve.log" 2>&1 &
+TJ_SERVE_PID=$!
+sleep 4
+```
+
+**Test:**
+```bash
+curl -s -f http://127.0.0.1:7391/health
+curl -s http://127.0.0.1:7391/api/v1/version
+curl -s http://127.0.0.1:7391/ | grep -oE '<title>[^<]+</title>'
+```
+
+**Expected:**
+- `/health` returns `{"status":"ok","version":"0.4.0"}`
+- `/api/v1/version` returns `{"version":"0.4.0"}`
+- The HTML `<title>` is exactly `<title>TokenJam Lens</title>`
+- No connection refused / no 500s
+
+**Assertions:**
+```bash
+curl -s "http://127.0.0.1:7391/api/v1/version" | python3 -c "
+import json, sys
+d = json.load(sys.stdin)
+assert d['version'] == '0.4.0', f'wrong version: {d}'
+print('ok: published 0.4.0 daemon responding')
+"
+curl -s http://127.0.0.1:7391/ | python3 -c "
+import sys
+html = sys.stdin.read()
+assert '<title>TokenJam Lens</title>' in html, 'brand title missing'
+assert '#/overview' in html or 'overview' in html.lower(), 'overview default route missing'
+print('ok: Lens brand + overview default route')
+"
+```
+
+**Teardown:**
+```bash
+kill $TJ_SERVE_PID 2>/dev/null || true
+"$HOME/.local/bin/tj" stop 2>/dev/null || true
+```
+
+---
+
+## Step 8: `tj uninstall` prints the correct pipx hint
+
+**What:** verifies the #131 fix — `tj uninstall` detects pipx installs and prints `pipx uninstall tokenjam` (not `pip uninstall`).
+
+**Test:**
+```bash
+"$HOME/.local/bin/tj" uninstall --yes 2>&1 | tail -5
+```
+
+**Expected:**
+- The command exits 0 (or 1; both are OK if it had nothing to clean)
+- The final hint reads "**To remove the package itself, run: pipx uninstall tokenjam**" (or similar with `pipx`)
+- NOT `pip uninstall tokenjam` — that was the pre-#131 wording and won't work on a pipx install
+
+**Assertions:**
+```bash
+out=$("$HOME/.local/bin/tj" uninstall --yes 2>&1 || true)
+echo "$out" | grep -qE "pipx uninstall tokenjam" && echo "ok: pipx-aware uninstall hint"
+```
+
+---
+
+## Step 9: pipx-injected provider SDK is importable through the pipx venv interpreter
+
+**What:** verifies the #131 documented pattern — provider SDKs (e.g. `anthropic`) injected via `pipx inject tokenjam` are reachable from the pipx venv's Python. This is how users run the example scripts.
+
+**Test:**
+```bash
+pipx install --force tokenjam   # re-install since Step 8 may have removed it
+pipx inject tokenjam anthropic
+PIPX_PY="$(pipx environment --value PIPX_LOCAL_VENVS)/tokenjam/bin/python"
+"$PIPX_PY" -c "import anthropic; print('ok: anthropic importable via pipx venv')"
+```
+
+**Expected:**
+- `pipx inject` succeeds without errors
+- The pipx venv interpreter can `import anthropic` cleanly
+- The `ok:` print appears
+
+**Notes:** This step hits PyPI again (for `anthropic`), so it may take 10–30 seconds.
+
+---
+
+## Step 10: artifact files ship in the wheel
+
+**What:** verify the v0.4.0 artifact actually ships the Lens UI files + pricing TOML + vendored uPlot. Catches the class of bugs where `[tool.hatch.build.targets.wheel]` somehow excludes them.
+
+**Test:**
+```bash
+PIPX_PKG_ROOT="$(pipx environment --value PIPX_LOCAL_VENVS)/tokenjam/lib"
+find "$PIPX_PKG_ROOT" -path "*/tokenjam/ui/index.html" -o -path "*/tokenjam/ui/vendor/uplot.js" -o -path "*/tokenjam/pricing/models.toml" | head
+```
+
+**Expected:**
+- All three paths exist under the installed package
+- `uplot.js` is non-trivially sized (>10 KB — confirms it's the real vendored library, not a placeholder)
+
+**Assertions:**
+```bash
+PIPX_PKG_ROOT="$(pipx environment --value PIPX_LOCAL_VENVS)/tokenjam/lib"
+INDEX=$(find "$PIPX_PKG_ROOT" -path "*/tokenjam/ui/index.html" | head -1)
+UPLOT=$(find "$PIPX_PKG_ROOT" -path "*/tokenjam/ui/vendor/uplot.js" | head -1)
+PRICING=$(find "$PIPX_PKG_ROOT" -path "*/tokenjam/pricing/models.toml" | head -1)
+[ -f "$INDEX" ] && [ -f "$UPLOT" ] && [ -f "$PRICING" ] && \
+  [ "$(wc -c < "$UPLOT")" -gt 10000 ] && \
+  echo "ok: UI + uPlot + pricing.toml ship in the wheel"
+```
+
+---
+
+## Final summary the runner produces
+
+```
+**Recommendation:** Release v0.4.0 is healthy / Hold — <N> failures / Investigate — <K> UNCLEAR steps
+
+**Steps PASSED:**  <numbers>
+**Steps FAILED:**  <numbers>
+**Steps UNCLEAR:** <numbers>
+
+**Notable observations:**
+- <any one-liners worth surfacing>
+
+HOME restored. Isolated dir removed: <path>
+```
+
+If all 10 steps PASS, the published artifact is verified end-to-end and the release is healthy. If anything FAILs, file an issue, decide whether to yank the release from PyPI/npm, and either patch or roll forward.

--- a/tests/agent-pre-release-runner.md
+++ b/tests/agent-pre-release-runner.md
@@ -2,13 +2,13 @@
 
 Generic instructions for a sub-agent to execute a release-specific pre-release test pass and produce a structured log a human can review.
 
-This file does not change between releases. Each release authors a focused `tests/manual-pre-release-vX.Y.Z.md` companion checklist; the runner consumes that file.
+This file does not change between releases. Each release authors a focused `tests/agent-pre-release-vX.Y.Z.md` companion checklist; the runner consumes that file.
 
 ---
 
 ## Your job (as the sub-agent reading this)
 
-1. **Find the release-specific checklist** at `tests/manual-pre-release-v<VERSION>.md`. `VERSION` will be in the parent's prompt (e.g. "v0.4.0"). If you can't determine the version, read `pyproject.toml` and assume the next minor version — but flag this uncertainty in the log.
+1. **Find the release-specific checklist** at `tests/agent-pre-release-v<VERSION>.md`. `VERSION` will be in the parent's prompt (e.g. "v0.4.0"). If you can't determine the version, read `pyproject.toml` and assume the next minor version — but flag this uncertainty in the log.
 
 2. **Verify environment before starting.** Run these checks; abort with a clear message if anything fails:
 
@@ -43,7 +43,7 @@ This file does not change between releases. Each release authors a focused `test
    - Compare captured output to **Expected**. Decide PASS / FAIL / UNCLEAR.
    - Run **Assertions** commands if present. They print `ok:` on pass. If they don't print `ok:`, mark FAIL with the actual output.
 
-4. **Write the result log** to `tests/results/manual-pre-release-<VERSION>-<TIMESTAMP>.md`. Create the `tests/results/` directory if it doesn't exist. Use this format:
+4. **Write the result log** to `tests/results/agent-pre-release-<VERSION>-<TIMESTAMP>.md`. Create the `tests/results/` directory if it doesn't exist. Use this format:
 
    ````markdown
    # Pre-release test results — v<VERSION>
@@ -51,7 +51,7 @@ This file does not change between releases. Each release authors a focused `test
    - **Run at:** <ISO timestamp>
    - **Branch:** <branch name>
    - **HEAD:** <short SHA>
-   - **Checklist:** tests/manual-pre-release-v<VERSION>.md
+   - **Checklist:** tests/agent-pre-release-v<VERSION>.md
    - **Result:** N/M steps PASS, K FAIL, J UNCLEAR
 
    ---
@@ -104,7 +104,7 @@ If the daemon crashes mid-run, restart it and re-run the most recent step before
 
 After the run, print:
 ```
-Results written to tests/results/manual-pre-release-<VERSION>-<TIMESTAMP>.md
+Results written to tests/results/agent-pre-release-<VERSION>-<TIMESTAMP>.md
 Summary: <N>/<M> PASS, <K> FAIL, <J> UNCLEAR
 ```
 

--- a/tests/agent-pre-release-v0.4.0.md
+++ b/tests/agent-pre-release-v0.4.0.md
@@ -1,6 +1,6 @@
 # Pre-release checklist — v0.4.0
 
-Focused on the delta since v0.3.5. The runner (`tests/manual-pre-release-runner.md`) walks each step in order.
+Focused on the delta since v0.3.5. The runner (`tests/agent-pre-release-runner.md`) walks each step in order.
 
 **What's new in v0.4.0** (so you know what we're validating):
 - TokenJam Lens UI rebrand (Overview triage screen + Optimize tab + real charts)
@@ -11,7 +11,7 @@ Focused on the delta since v0.3.5. The runner (`tests/manual-pre-release-runner.
 - Security: `.tj/config.toml` untracked + CI guard
 - Onboard: plain `tj onboard --plan` honored; tool_inputs capture toggle added; stale URLs removed
 
-Stable surfaces (ingest, alerts, drift, schema validation, MCP server) are **not** in scope — they're covered by the standing pre-release playbook in `tests/manual-pre-release-testing.md`.
+Stable surfaces (ingest, alerts, drift, schema validation, MCP server) are **not** in scope — they're covered by the standing pre-release playbook in `tests/agent-pre-release-testing.md`.
 
 ---
 

--- a/tests/results/agent-pre-release-v0.4.0-20260619T202233Z.md
+++ b/tests/results/agent-pre-release-v0.4.0-20260619T202233Z.md
@@ -3,7 +3,7 @@
 - **Run at:** 2026-06-19T20:22:33Z
 - **Branch:** main
 - **HEAD:** 4dd2185
-- **Checklist:** tests/manual-pre-release-v0.4.0.md
+- **Checklist:** tests/agent-pre-release-v0.4.0.md
 - **Result:** 8/12 PASS, 1 FAIL, 3 UNCLEAR
 
 > **Pre-flight note:** `pyproject.toml` still reads `version = "0.3.5"`, and both `tj --version` and `/api/v1/version` report `0.3.5`. The version has **not** been bumped to 0.4.0 yet. All steps below were run against the 0.3.5 build, since that's what the daemon is serving. Per Critical Rule 15, the version bump must happen before the release is cut.

--- a/tests/results/agent-pre-release-v0.4.0-20260619T205108Z.md
+++ b/tests/results/agent-pre-release-v0.4.0-20260619T205108Z.md
@@ -3,7 +3,7 @@
 - **Run at:** 2026-06-19T20:51:08Z
 - **Branch:** main
 - **HEAD:** ae94d41
-- **Checklist:** tests/manual-pre-release-v0.4.0.md
+- **Checklist:** tests/agent-pre-release-v0.4.0.md
 - **Result:** 11/12 steps PASS, 0 FAIL, 1 UNCLEAR
 
 Note: daemon is running v0.3.5 (pre-bump) per parent prompt — Step 1 marked UNCLEAR as flagged.


### PR DESCRIPTION
Distinguish the sub-agent-runnable test runners from the human-walked manual playbooks. Same content, clearer naming.

## Renames

| Old name | New name | Audience |
|---|---|---|
| \`tests/manual-pre-release-runner.md\` | \`tests/agent-pre-release-runner.md\` | sub-agent |
| \`tests/manual-pre-release-v0.4.0.md\` | \`tests/agent-pre-release-v0.4.0.md\` | sub-agent |
| \`tests/manual-post-release-runner.md\` | \`tests/agent-post-release-runner.md\` | sub-agent (new for v0.4.0) |
| \`tests/manual-post-release-v0.4.0.md\` | \`tests/agent-post-release-v0.4.0.md\` | sub-agent (new for v0.4.0) |

## Unchanged

\`tests/manual-pre-release-testing.md\` and \`tests/manual-new-release-tests.md\` keep their \`manual-\` prefix — those are the comprehensive human-walkable playbooks the maintainer runs by hand, and external references (CHANGELOG, etc.) already point at those names.

## Also

- Moved the two existing pre-release result logs to the matching new naming
- Updated their internal \`Checklist:\` reference to the renamed file
- Updated cross-references inside each renamed agent doc (no broken links)

No content changes; pure rename + internal cross-reference updates.

## After this lands

To delegate to a sub-agent:
- Pre-release: "Read \`tests/agent-pre-release-runner.md\` and execute the pre-release pass for v<VERSION>"
- Post-release: "Read \`tests/agent-post-release-runner.md\` and execute the post-release pass for v<VERSION>"

🤖 Generated with [Claude Code](https://claude.com/claude-code)