### PR TITLE
fix(#138): run-rate cycle honors [budget.<provider>] cycle_start_day

### DIFF
--- a/tests/integration/test_api.py
+++ b/tests/integration/test_api.py
@@ -304,6 +304,35 @@ async def test_cost_response_includes_framing_block(client):
     assert _FRAMING_KEYS <= set(framing)
 
 
+async def test_cost_cycle_block_defaults_to_calendar_month(client):
+    """With no [budget.<provider>] cycle configured, the run-rate cycle falls
+    back to the calendar month (start_day=1) (#138)."""
+    cycle = (await client.get("/api/v1/cost")).json()["cycle"]
+    assert cycle["start_day"] == 1
+    assert {"start", "end", "days_remaining"} <= set(cycle)
+    assert cycle["end"] > cycle["start"]
+    assert cycle["days_remaining"] >= 1
+
+
+async def test_cost_cycle_block_honors_provider_cycle_start_day(db):
+    """A configured [budget.<provider>] cycle_start_day is surfaced on the cost
+    response so the UI projects to the real cycle end, not the calendar month."""
+    from tokenjam.core.config import ProviderBudget
+
+    cfg = TjConfig(
+        version="1",
+        security=SecurityConfig(ingest_secret=INGEST_SECRET),
+        api=ApiConfig(auth=ApiAuthConfig(enabled=False)),
+    )
+    cfg.budgets["anthropic"] = ProviderBudget(cycle_start_day=15)
+    pipeline = IngestPipeline(db=db, config=cfg)
+    app = create_app(config=cfg, db=db, ingest_pipeline=pipeline)
+    transport = httpx.ASGITransport(app=app)
+    async with httpx.AsyncClient(transport=transport, base_url="http://test") as c:
+        cycle = (await c.get("/api/v1/cost")).json()["cycle"]
+    assert cycle["start_day"] == 15
+
+
 async def test_optimize_response_includes_framing_block(client):
     await _ingest_sample_span(client)
     resp = await client.get("/api/v1/optimize?since=30d")

--- a/tests/unit/test_cycle.py
+++ b/tests/unit/test_cycle.py
@@ -1,0 +1,83 @@
+"""Billing-cycle bounds shared by budget-projection + cost run-rate (#138)."""
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+from tokenjam.core.config import ProviderBudget, TjConfig
+from tokenjam.core.cycle import cycle_bounds, effective_cycle_start_day
+
+
+def _dt(y, m, d, h=0):
+    return datetime(y, m, d, h, tzinfo=timezone.utc)
+
+
+# --- cycle_bounds: default start_day=1 == calendar month ------------------- #
+def test_cycle_bounds_calendar_month():
+    cs, ce = cycle_bounds(_dt(2026, 6, 19, 12), start_day=1)
+    assert cs == _dt(2026, 6, 1)
+    assert ce == _dt(2026, 7, 1)
+
+
+def test_cycle_bounds_calendar_month_december_wraps_year():
+    cs, ce = cycle_bounds(_dt(2026, 12, 5), start_day=1)
+    assert cs == _dt(2026, 12, 1)
+    assert ce == _dt(2027, 1, 1)
+
+
+# --- cycle_bounds: explicit cycle_start_day -------------------------------- #
+def test_cycle_bounds_explicit_start_day_after():
+    # now is on/after the start day -> cycle started this month.
+    cs, ce = cycle_bounds(_dt(2026, 6, 19), start_day=15)
+    assert cs == _dt(2026, 6, 15)
+    assert ce == _dt(2026, 7, 15)
+
+
+def test_cycle_bounds_explicit_start_day_before():
+    # now is before the start day -> cycle started last month.
+    cs, ce = cycle_bounds(_dt(2026, 6, 10), start_day=15)
+    assert cs == _dt(2026, 5, 15)
+    assert ce == _dt(2026, 6, 15)
+
+
+def test_cycle_bounds_clamps_high_start_day():
+    # start_day > 28 is clamped to 28 (avoids Feb month-length edge cases).
+    # June 19 is before the 28th, so the cycle started May 28.
+    cs, ce = cycle_bounds(_dt(2026, 6, 19), start_day=31)
+    assert cs == _dt(2026, 5, 28)
+    assert ce == _dt(2026, 6, 28)
+
+
+# --- effective_cycle_start_day: config resolution -------------------------- #
+def _cfg(**budgets) -> TjConfig:
+    cfg = TjConfig(version="1")
+    cfg.budgets = dict(budgets)
+    return cfg
+
+
+def test_effective_start_day_none_configured_falls_back_to_one():
+    assert effective_cycle_start_day(_cfg()) == 1
+
+
+def test_effective_start_day_default_only_is_calendar_month():
+    assert effective_cycle_start_day(_cfg(anthropic=ProviderBudget())) == 1
+
+
+def test_effective_start_day_single_explicit_is_honored():
+    cfg = _cfg(anthropic=ProviderBudget(cycle_start_day=15))
+    assert effective_cycle_start_day(cfg) == 15
+
+
+def test_effective_start_day_agreeing_providers_honored():
+    cfg = _cfg(
+        anthropic=ProviderBudget(cycle_start_day=15),
+        openai=ProviderBudget(cycle_start_day=15),
+    )
+    assert effective_cycle_start_day(cfg) == 15
+
+
+def test_effective_start_day_conflicting_providers_fall_back():
+    cfg = _cfg(
+        anthropic=ProviderBudget(cycle_start_day=15),
+        openai=ProviderBudget(cycle_start_day=20),
+    )
+    assert effective_cycle_start_day(cfg) == 1

--- a/tests/unit/test_lens_ui_regression.py
+++ b/tests/unit/test_lens_ui_regression.py
@@ -104,8 +104,20 @@ def test_axis_time_labels_consistent(html):
 # --- #134: run-rate is cycle-relative, not a fixed ×30 --------------------- #
 def test_run_rate_is_cycle_relative(html):
     assert "function cycleRemaining" in html
-    assert "by end of ${cyc.label}" in html
+    assert "by ${cyc.label}" in html
     assert "over 30 days" not in html  # the circular/undershooting framing is gone
+
+
+# --- #138: run-rate cycle honors [budget.<provider>] cycle_start_day -------- #
+def test_run_rate_cycle_honors_server_bounds(html):
+    # cycleRemaining now reads server-provided cycle bounds (cycle_start_day
+    # aware) instead of always assuming the calendar month.
+    assert "function cycleRemaining(cycle)" in html
+    assert "cycle.days_remaining" in html
+    assert "cycle.start_day" in html
+    # Both run-rate call sites pass the response's cycle block through.
+    assert "cycleRemaining(cost.cycle)" in html
+    assert "cycleRemaining(costResp && costResp.cycle)" in html
 
 
 # --- #135: cache at_ceiling not gated on input volume --------------------- #

--- a/tokenjam/api/routes/cost.py
+++ b/tokenjam/api/routes/cost.py
@@ -1,14 +1,37 @@
 """GET /api/v1/cost — aggregated cost data."""
 from __future__ import annotations
 
+import math
+
 from fastapi import APIRouter, Depends, Request
 
 from tokenjam.api.deps import require_api_key
+from tokenjam.core.cycle import cycle_bounds, effective_cycle_start_day
 from tokenjam.core.framing import WindowSummary, compute_framing, plan_tier_mix
 from tokenjam.core.models import CostFilters
 from tokenjam.utils.time_parse import parse_since, utcnow
 
 router = APIRouter(dependencies=[Depends(require_api_key)])
+
+
+def _cycle_block(config) -> dict:
+    """Current billing-cycle bounds for the run-rate caption (#138).
+
+    Honors `[budget.<provider>] cycle_start_day` when configured, falling back
+    to the calendar month (start_day=1). The UI projects the run-rate to
+    `cycle.end` instead of assuming a calendar-month boundary, so a user on a
+    non-calendar cycle gets an honest "by <cycle end>" caption.
+    """
+    now = utcnow()
+    start_day = effective_cycle_start_day(config)
+    cs, ce = cycle_bounds(now, start_day)
+    days_remaining = max(1, math.ceil((ce - now).total_seconds() / 86400.0))
+    return {
+        "start": int(cs.timestamp()),
+        "end": int(ce.timestamp()),
+        "days_remaining": days_remaining,
+        "start_day": start_day,
+    }
 
 
 def _window_series(conn, agent_id, since_dt, until_dt) -> dict:
@@ -121,5 +144,6 @@ async def get_cost(
         "total_cache_tokens": sum(r.cache_tokens for r in rows),
         "total_cache_write_tokens": sum(r.cache_write_tokens for r in rows),
         **_window_series(conn, agent_id, since_dt, until_dt),
+        "cycle": _cycle_block(config),
         "framing": framing.to_dict(),
     }

--- a/tokenjam/core/cycle.py
+++ b/tokenjam/core/cycle.py
@@ -1,0 +1,51 @@
+"""
+Billing-cycle bounds, shared by the budget-projection analyzer and the cost
+API's run-rate caption (#138).
+
+A "cycle" is a monthly window that begins on `cycle_start_day` of each month
+(configured per-provider via `[budget.<provider>] cycle_start_day`). With
+`cycle_start_day = 1` this is exactly the calendar month, which is the fallback
+when no provider cycle is configured.
+"""
+from __future__ import annotations
+
+from datetime import datetime
+
+
+def cycle_bounds(now: datetime, start_day: int) -> tuple[datetime, datetime]:
+    """
+    Return (cycle_start, cycle_end) for the monthly cycle that contains `now`,
+    given a cycle that begins on `start_day` of each month.
+
+    `start_day` is clamped to 1..28 to avoid month-length edge cases (Feb).
+    `cycle_end` is the *next* cycle's start (exclusive upper bound).
+    """
+    start_day = max(1, min(start_day, 28))
+    if now.day >= start_day:
+        cs = now.replace(day=start_day, hour=0, minute=0, second=0, microsecond=0)
+    else:
+        prev_month_year = now.year if now.month > 1 else now.year - 1
+        prev_month = now.month - 1 if now.month > 1 else 12
+        cs = datetime(prev_month_year, prev_month, start_day, tzinfo=now.tzinfo)
+    next_month_year = cs.year + (1 if cs.month == 12 else 0)
+    next_month = 1 if cs.month == 12 else cs.month + 1
+    ce = datetime(next_month_year, next_month, start_day, tzinfo=cs.tzinfo)
+    return cs, ce
+
+
+def effective_cycle_start_day(config) -> int:
+    """
+    The `cycle_start_day` to use for the *global* run-rate caption (the Overview
+    / Cost chart projects a single cross-provider figure, so it needs one cycle).
+
+    Honors `[budget.<provider>] cycle_start_day` when the configured providers
+    agree on a single non-default value; falls back to 1 (calendar month) when
+    none are configured or they conflict — we don't guess between competing
+    cycles. Per-provider projections (the budget-projection analyzer) always use
+    each provider's own `cycle_start_day` and are unaffected by this resolution.
+    """
+    days = {b.cycle_start_day for b in config.budgets.values()}
+    days.discard(1)  # default == calendar month; not a distinguishing signal
+    if len(days) == 1:
+        return next(iter(days))
+    return 1

--- a/tokenjam/core/optimize/analyzers/budget_projection.py
+++ b/tokenjam/core/optimize/analyzers/budget_projection.py
@@ -11,27 +11,10 @@ from datetime import datetime, timedelta
 from typing import Any
 
 from tokenjam.core.config import ProviderBudget
+# Shared with the cost API's run-rate caption (#138) — one home for cycle math.
+from tokenjam.core.cycle import cycle_bounds as _cycle_bounds
 from tokenjam.core.optimize.registry import register
 from tokenjam.core.optimize.types import AnalyzerContext, BudgetProjection
-
-
-def _cycle_bounds(now: datetime, start_day: int) -> tuple[datetime, datetime]:
-    """
-    Return (cycle_start, cycle_end) for the cycle that contains `now`,
-    given a monthly cycle that begins on `start_day` of each month.
-    """
-    start_day = max(1, min(start_day, 28))  # clamp; avoids Feb edge cases
-    if now.day >= start_day:
-        cs = now.replace(day=start_day, hour=0, minute=0, second=0, microsecond=0)
-    else:
-        prev_month_year = now.year if now.month > 1 else now.year - 1
-        prev_month = now.month - 1 if now.month > 1 else 12
-        cs = datetime(prev_month_year, prev_month, start_day, tzinfo=now.tzinfo)
-    # cycle_end = next cycle_start
-    next_month_year = cs.year + (1 if cs.month == 12 else 0)
-    next_month = 1 if cs.month == 12 else cs.month + 1
-    ce = datetime(next_month_year, next_month, start_day, tzinfo=cs.tzinfo)
-    return cs, ce
 
 
 def _spend_in_window(

--- a/tokenjam/ui/index.html
+++ b/tokenjam/ui/index.html
@@ -853,15 +853,32 @@ function runRateProjection(windowTotal, since, days = 1) {
   return (windowTotal / Math.max(windowDays(since), 1 / 24)) * days;
 }
 
-// Days left in the current calendar cycle (this month) + its name. The run-rate
+// Days left in the current billing cycle + a caption label. The run-rate
 // projection is cycle-relative ("~$X by end of June") rather than a fixed ×30,
 // which was circular at a 30d window and undershot at 90d (#134, matches
-// lens-architecture §10).
-function cycleRemaining() {
+// lens-architecture §10). Honors the server-provided cycle bounds, which
+// respect [budget.<provider>] cycle_start_day (#138) — so a non-calendar
+// cycle (e.g. start_day=15) reads "by Jul 15", not "by end of June". Falls
+// back to the calendar month when the cost response carries no cycle block.
+function cycleRemaining(cycle) {
+  if (cycle && typeof cycle.end === 'number') {
+    const days = Math.max(1, cycle.days_remaining || 1);
+    let label;
+    if ((cycle.start_day || 1) === 1) {
+      // Calendar month: name the month that's ending. cycle.end is 00:00 on the
+      // 1st of the next month, so step back a day to land in the ending month.
+      const m = new Date((cycle.end - 86400) * 1000);
+      label = 'end of ' + m.toLocaleString(undefined, { month: 'long', timeZone: 'UTC' });
+    } else {
+      // Custom cycle: a dated form ("Jul 15"); "end of <month>" would mislead.
+      label = new Date(cycle.end * 1000).toLocaleDateString(undefined, { month: 'short', day: 'numeric', timeZone: 'UTC' });
+    }
+    return { days, label };
+  }
   const now = new Date();
   const end = new Date(now.getFullYear(), now.getMonth() + 1, 0);  // last day of month
   const days = Math.max(1, Math.ceil((end - now) / 86400000));
-  return { days, label: now.toLocaleString(undefined, { month: 'long' }) };
+  return { days, label: 'end of ' + now.toLocaleString(undefined, { month: 'long' }) };
 }
 
 // Compact $-prefixed axis tick formatter (#129): "$0", "$25", "$1.5k" — no
@@ -1373,9 +1390,9 @@ function CostView({ params }) {
   const fmtY = useTokens ? fmtTokens : fmtCost;
 
   // Run-rate (total view only): per-day average over the FULL window length
-  // (not the data range — #129), projected to the end of the calendar cycle
-  // (#134), drawn as a dashed line. Single linear figure, no forecasting.
-  const cyc = cycleRemaining();
+  // (not the data range — #129), projected to the end of the billing cycle
+  // (#134/#138), drawn as a dashed line. Single linear figure, no forecasting.
+  const cyc = cycleRemaining(costResp && costResp.cycle);
   let runRate = null, projection = null;
   if (groupBy === 'total' && series && series.data[1] && series.data[1].length) {
     const windowTotal = useTokens ? totalTokens : total;
@@ -1431,7 +1448,7 @@ function CostView({ params }) {
             <${SpendChart} data=${series.data} labels=${series.labels} height=${160}
               fmtY=${fmtY} axisFmtY=${useTokens ? fmtTokens : fmtAxisUsd} runRate=${runRate}
               showLegend=${groupBy !== 'total'} bucket=${series.bucket} />
-            ${projection ? html`<div class="chart-foot">At this pace, ~${projection} by end of ${cyc.label} <span class="dim">(linear run-rate, not a forecast)</span></div>` : null}
+            ${projection ? html`<div class="chart-foot">At this pace, ~${projection} by ${cyc.label} <span class="dim">(linear run-rate, not a forecast)</span></div>` : null}
           ` : html`<div class="empty" style="padding:32px 0">No spend in this window.</div>`}
       </div>
     ` : null}
@@ -1980,7 +1997,7 @@ function OverviewView({ params }) {
   const series = buildCostSeries(cost, 'total', useTokens);
   const totalDisplay = useTokens ? (fmtTokens(cost.total_tokens || 0) + ' tokens') : fmtFramedDollar(cost.total_cost_usd || 0, framing);
   const trendPct = d.compare ? (useTokens ? d.compare.tokens_delta_pct : d.compare.cost_delta_pct) : null;
-  const cyc = cycleRemaining();
+  const cyc = cycleRemaining(cost.cycle);
   let runRate = null, projection = null;
   if (series && series.data[1] && series.data[1].length) {
     const windowTotal = useTokens ? (cost.total_tokens || 0) : (cost.total_cost_usd || 0);
@@ -2015,7 +2032,7 @@ function OverviewView({ params }) {
       </div>
       ${series ? html`<${SpendChart} data=${series.data} labels=${series.labels} height=${130} fmtY=${useTokens ? fmtTokens : fmtCost} axisFmtY=${useTokens ? fmtTokens : fmtAxisUsd} runRate=${runRate} bucket=${series.bucket} />`
         : html`<div class="empty" style="padding:24px 0">No spend in this window.</div>`}
-      ${projection ? html`<div class="chart-foot">At this pace, ~${projection} by end of ${cyc.label} <span class="dim">(linear run-rate, not a forecast)</span></div>` : null}
+      ${projection ? html`<div class="chart-foot">At this pace, ~${projection} by ${cyc.label} <span class="dim">(linear run-rate, not a forecast)</span></div>` : null}
     </div>
 
     <!-- Band 2: Recoverable waste -->


### PR DESCRIPTION
Closes #138 (follow-up from PR #137 / #134 review).

## Problem
The Overview/Cost run-rate caption ("~\$X by end of June") projected to the **calendar-month** boundary via `cycleRemaining()` in the UI, ignoring a user's configured non-calendar billing cycle (`[budget.<provider>] cycle_start_day`). With `cycle_start_day = 15` the framing was off by ~half a month — the `budget-projection` analyzer already honors the cycle, so this was an honesty-parity gap.

## Fix
- **`tokenjam/core/cycle.py`** (new) — `cycle_bounds()` extracted from the budget-projection analyzer (now its single home — the analyzer imports it, no duplicated cycle math). Plus `effective_cycle_start_day(config)` to resolve the *global* caption's cycle: honors a single agreed `cycle_start_day` across configured provider budgets; falls back to calendar month (`start_day=1`) when none are configured or providers conflict (we don't guess between competing cycles). Per-provider projections are unaffected.
- **`/api/v1/cost`** now returns a `cycle` block `{start, end, days_remaining, start_day}` so the server-side cycle config reaches the UI (the issue's suggested plumbing).
- **`cycleRemaining(cycle)`** reads those bounds. Calendar cycles still read "by end of June"; custom cycles read a dated form ("by Jul 15"). Falls back to calendar-month math if the response carries no cycle block.

## Tests
- `tests/unit/test_cycle.py` — bounds for default + explicit `cycle_start_day`, the 28-day clamp, December year-wrap; config resolution including the conflict fallback.
- `tests/integration/test_api.py` — `/api/v1/cost` surfaces the cycle block (defaults to `start_day=1`) and honors a configured provider `cycle_start_day=15`.
- `tests/unit/test_lens_ui_regression.py` — guards the new server-driven caption + both call sites.

Full CI set green locally (761 passed), mypy clean on changed files, UI passes `node --check`.

> Built in an isolated `git worktree` off `main`.