### PR TITLE
fix: escape [budget.<provider>] in onboard plan message (#157)

### DIFF
--- a/tests/unit/test_onboard_plan.py
+++ b/tests/unit/test_onboard_plan.py
@@ -53,6 +53,16 @@ def test_plain_onboard_no_plan_noninteractive_writes_no_plan(tmp_path):
     assert "plan =" not in cfg
 
 
+def test_plan_message_shows_section_name(tmp_path):
+    # Regression for #157: the "written to [budget.<provider>]" confirmation must
+    # NOT have its TOML section header eaten by Rich markup parsing (which left
+    # the message reading "(written to )").
+    res, _ = _onboard(tmp_path, "--plan", "api")
+    assert res.exit_code == 0, res.output
+    assert "[budget.anthropic]" in res.output, res.output
+    assert "(written to )" not in res.output
+
+
 def test_plain_onboard_writes_valid_toml(tmp_path):
     import sys
     if sys.version_info >= (3, 11):

--- a/tokenjam/cli/cmd_onboard.py
+++ b/tokenjam/cli/cmd_onboard.py
@@ -9,6 +9,7 @@ import sys
 from pathlib import Path
 
 import click
+from rich.markup import escape
 
 from tokenjam.core.config import find_config_file
 from tokenjam.utils.formatting import console
@@ -157,8 +158,11 @@ retention_days = 90
         console.print(f"[green]\u2713[/green] Default daily budget: "
                       f"[bold]${budget:.2f}[/bold] per agent")
     if plan_tier:
+        # Escape the TOML section header \u2014 Rich treats `[budget.<provider>]` as a
+        # markup tag and would strip it, leaving "(written to )". See issue #157.
+        plan_section = escape(f"[budget.{plan_provider}]")
         console.print(f"[green]\u2713[/green] Plan tier: "
-                      f"[bold]{plan_tier}[/bold] (written to [budget.{plan_provider}])")
+                      f"[bold]{plan_tier}[/bold] (written to {plan_section})")
     if daemon_msg:
         console.print(f"[green]\u2713[/green] {daemon_msg}")
 


### PR DESCRIPTION
Fixes #157.

## Problem
`tj onboard` printed `✓ Plan tier: api (written to )` — the `[budget.<provider>]`
section header was missing because `console.print` (Rich) treated it as a markup
tag and stripped it.

## Fix
Escape the section header with `rich.markup.escape()` before printing, so it
renders literally as `(written to [budget.anthropic])`. The plan was always
written correctly to the config; only the confirmation message was affected.

Regression introduced by the #4 fix (plain `tj onboard` honoring `--plan`).

## Tests
- New regression test `test_plan_message_shows_section_name` — asserts the
  confirmation keeps the section header (verified to fail on the buggy code and
  pass on the fix).
- ruff ✅ · mypy ✅ · onboard suite (25 tests) ✅
