### PR TITLE
fix(#124): make the daemon DB layer safe for concurrent API requests

### DIFF
--- a/tests/integration/test_api.py
+++ b/tests/integration/test_api.py
@@ -1,6 +1,8 @@
 """Integration tests for the REST API using httpx.AsyncClient + ASGITransport."""
 from __future__ import annotations
 
+import asyncio
+
 import pytest
 import httpx
 
@@ -331,6 +333,27 @@ async def test_cost_cycle_block_honors_provider_cycle_start_day(db):
     async with httpx.AsyncClient(transport=transport, base_url="http://test") as c:
         cycle = (await c.get("/api/v1/cost")).json()["cycle"]
     assert cycle["start_day"] == 15
+
+
+async def test_overview_endpoint_set_survives_concurrent_requests(client):
+    """#124: the daemon's sync (`def`) read routes (`/optimize`,
+    `/cost/compare`) run in Starlette's threadpool, so concurrent requests reach
+    DuckDB from several threads at once. A single shared connection aborts the
+    process under that load; per-thread cursors (DuckDBBackend.conn) make it
+    safe. Fire the Overview's endpoint set concurrently, repeatedly, and assert
+    every response is 200 — the issue's acceptance criterion."""
+    await _ingest_sample_span(client)
+    endpoints = [
+        "/api/v1/cost?since=7d",
+        "/api/v1/optimize?fast=true&since=30d",
+        "/api/v1/cost/compare?since=7d&compare=previous",
+        "/api/v1/traces",
+        "/api/v1/budget",
+    ]
+    for _ in range(5):  # several rounds so threadpool overlap is likely
+        results = await asyncio.gather(*(client.get(u) for u in endpoints * 3))
+        bad = [(str(r.url), r.status_code) for r in results if r.status_code != 200]
+        assert not bad, bad
 
 
 async def test_optimize_response_includes_framing_block(client):

--- a/tokenjam/core/db.py
+++ b/tokenjam/core/db.py
@@ -5,6 +5,7 @@ and migration runner. DuckDB only — never import sqlite3.
 from __future__ import annotations
 
 import json
+import threading
 from datetime import date, datetime
 from pathlib import Path
 from typing import Protocol, runtime_checkable
@@ -373,8 +374,32 @@ class DuckDBBackend:
     def __init__(self, config: StorageConfig) -> None:
         db_path = Path(config.path).expanduser()
         db_path.parent.mkdir(parents=True, exist_ok=True)
-        self.conn = duckdb.connect(str(db_path))
-        run_migrations(self.conn)
+        self._conn = duckdb.connect(str(db_path))
+        run_migrations(self._conn)
+        self._local = threading.local()
+
+    @property
+    def conn(self) -> duckdb.DuckDBPyConnection:
+        """A per-thread DuckDB cursor over the shared database (#124).
+
+        The daemon's sync (`def`) read routes (`/optimize`, `/cost/compare`)
+        run in Starlette's threadpool, so concurrent requests can reach the DB
+        from several threads at once. A single DuckDB *connection object* is NOT
+        safe for concurrent use — overlapping `execute()` calls abort the
+        process (SIGABRT). Cursors created via `connect().cursor()` are
+        independent connections over the *same* database that ARE safe to use
+        concurrently from different threads (the DuckDB-recommended pattern), so
+        each thread lazily gets and reuses its own cursor. All cursors share one
+        database, so a write on one thread is visible to reads on another.
+
+        Single-threaded callers (tests, the CLI) always see the same cursor, so
+        behavior is unchanged for them.
+        """
+        cur = getattr(self._local, "cursor", None)
+        if cur is None:
+            cur = self._conn.cursor()
+            self._local.cursor = cur
+        return cur
 
     # -- writes --
 
@@ -815,7 +840,8 @@ class DuckDBBackend:
         return count
 
     def close(self) -> None:
-        self.conn.close()
+        # Closing the root connection tears down the database and all cursors.
+        self._conn.close()
 
 
 # ---------------------------------------------------------------------------
@@ -826,9 +852,13 @@ class InMemoryBackend(DuckDBBackend):
     """In-memory DuckDB backend for tests. Same implementation, no disk I/O."""
 
     def __init__(self) -> None:
-        # Bypass DuckDBBackend.__init__ to use :memory:
-        self.conn = duckdb.connect(":memory:")
-        run_migrations(self.conn)
+        # Bypass DuckDBBackend.__init__ to use :memory:. Cursors of an in-memory
+        # connection share the same in-memory database, so the per-thread cursor
+        # property (#124) works identically here — including cross-thread
+        # visibility, which the threadpool-backed integration tests rely on.
+        self._conn = duckdb.connect(":memory:")
+        run_migrations(self._conn)
+        self._local = threading.local()
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Closes #124 (follow-up surfaced while building the Lens Overview, #114).

## Problem
The daemon serves the REST API over a **single** DuckDB connection. The sync (`def`) read routes — `/optimize` and `/cost/compare` — run in Starlette's threadpool, so two overlapping requests (the Overview's fan-out, a UI poll + CLI, or two browser tabs) could drive the same DuckDB connection from multiple threads. A single DuckDB connection object is **not** safe for concurrent use: overlapping execute/fetch corrupts the shared result set (a reader gets `None` rows) and can abort the process (SIGABRT). #114 worked around it by making the Overview fetch sequentially; this fixes the root cause.

## Fix
`DuckDBBackend.conn` is now a **per-thread cursor** over one shared database:

- DuckDB cursors created via `connect().cursor()` are independent connections that **are** safe to use concurrently from different threads (the DuckDB-recommended multi-threading pattern), while still sharing one database — so a write on one thread is visible to reads on another.
- Each thread lazily gets and reuses its own cursor via `threading.local`. Single-threaded callers (tests, the CLI) always see one cursor, so behavior is unchanged.
- **No call-site changes** — every existing `db.conn.execute(...)` becomes thread-safe transparently. `InMemoryBackend` gets the same treatment (in-memory cursors share the same DB, so cross-thread visibility holds for the threadpool-backed integration tests).

I verified the underlying behavior empirically before implementing: a single shared connection hammered from 8+ threads SIGABRTs; per-thread cursors run clean (0 errors) with cross-cursor visibility and concurrent read/write.

## Test
`test_overview_endpoint_set_survives_concurrent_requests` fires the Overview endpoint set (including both sync routes) concurrently over several rounds and asserts every response is 200 — the issue's acceptance criterion. **Confirmed it fails on the pre-fix single-connection code** (`TypeError: 'NoneType' object is not subscriptable` from a corrupted mid-fetch result) and passes with the per-thread cursor.

Full CI set green locally (762 passed), mypy + ruff clean on `db.py`.

> Built in an isolated `git worktree` off `main`.