### PR TITLE
Show active (compute) time alongside wall-clock in Status (#147)

### DIFF
--- a/tests/integration/test_api.py
+++ b/tests/integration/test_api.py
@@ -540,6 +540,26 @@ async def test_status_and_traces_agree_on_agent_ids(client):
     assert trace_agents == status_agents
 
 
+async def test_status_exposes_active_seconds(client, db):
+    """Status payload carries active (compute) time alongside wall-clock (#147)."""
+    from tests.factories import make_llm_span, make_session
+
+    db.upsert_session(make_session(agent_id="a1", session_id="s1", status="completed"))
+    for ms in (1000.0, 2000.0, 3000.0):
+        sp = make_llm_span(agent_id="a1", duration_ms=ms)
+        sp.session_id = "s1"
+        db.insert_span(sp)
+
+    resp = await client.get("/api/v1/status")
+    assert resp.status_code == 200
+    agents = {a["agent_id"]: a for a in resp.json()["agents"]}
+    assert "a1" in agents
+    a = agents["a1"]
+    assert "active_seconds" in a and "duration_seconds" in a
+    # 6000 ms of spans → 6.0 s active; distinct from wall-clock duration_seconds.
+    assert a["active_seconds"] == pytest.approx(6.0)
+
+
 # ── Budget ─────────────────────────────────────────────────────────────────
 
 async def test_post_budget_zero_clears_limit(db):

--- a/tests/integration/test_cli.py
+++ b/tests/integration/test_cli.py
@@ -97,6 +97,21 @@ def test_status_exits_1_when_active_alerts(runner, db, config):
     assert data["has_active_alerts"] is True
 
 
+def test_status_json_includes_active_and_elapsed(runner, db, config):
+    """Status JSON carries active (compute) time + wall-clock elapsed (#147)."""
+    session = _seed_agent_and_session(db)
+    for ms in (1500.0, 2500.0):
+        sp = make_llm_span(agent_id="test-agent", duration_ms=ms)
+        sp.session_id = session.session_id
+        db.insert_span(sp)
+
+    result = _invoke(runner, db, config, ["status", "--json"])
+    assert result.exit_code == 0
+    a = json.loads(result.output)["agents"][0]
+    assert "active_seconds" in a and "duration_seconds" in a
+    assert a["active_seconds"] == 4.0   # 4000 ms of spans
+
+
 # -- traces tests --
 
 def test_traces_json_output_is_valid_json(runner, db, config):

--- a/tests/unit/test_db_helpers.py
+++ b/tests/unit/test_db_helpers.py
@@ -1,0 +1,35 @@
+"""Unit tests for small db.py query helpers."""
+from __future__ import annotations
+
+import pytest
+
+from tokenjam.core.db import InMemoryBackend, session_active_seconds
+from tests.factories import make_llm_span, make_session
+
+
+@pytest.fixture
+def db():
+    backend = InMemoryBackend()
+    yield backend
+    backend.close()
+
+
+def test_active_seconds_sums_span_durations(db):
+    sess = make_session(agent_id="a1", session_id="s1", status="completed")
+    db.upsert_session(sess)
+    for ms in (1000.0, 2500.0, 500.0):
+        sp = make_llm_span(agent_id="a1", duration_ms=ms)
+        sp.session_id = "s1"
+        db.insert_span(sp)
+    # 4000 ms total → 4.0 s of active (compute) time.
+    assert session_active_seconds(db.conn, "s1") == pytest.approx(4.0)
+
+
+def test_active_seconds_none_when_no_spans(db):
+    sess = make_session(agent_id="a1", session_id="s-empty", status="completed")
+    db.upsert_session(sess)
+    assert session_active_seconds(db.conn, "s-empty") is None
+
+
+def test_active_seconds_none_for_unknown_session(db):
+    assert session_active_seconds(db.conn, "does-not-exist") is None

--- a/tests/unit/test_lens_ui_regression.py
+++ b/tests/unit/test_lens_ui_regression.py
@@ -165,3 +165,18 @@ def test_overview_error_handling_is_asymmetric(html):
     assert "api('/cost/compare', { since, compare: 'previous' }).catch(() => null)" in html
     assert "api('/optimize', { since, fast: 'true' }).catch(() => null)" in html
     assert "api('/drift').catch(() => ({ agents: [] }))" in html
+
+
+# --- #147: status tile shows Active (compute) time + relabeled Elapsed ----- #
+def test_status_tile_shows_active_and_elapsed(html):
+    # A coarse formatter for multi-day wall-clock spans, so "3087m" reads "2d 3h".
+    assert "function fmtDurLong" in html
+    # Active time is sourced from the new status payload field.
+    assert "a.active_seconds" in html
+    # The wall-clock row is relabeled Elapsed and uses the coarse formatter;
+    # Active is a distinct row using the fine-grained one.
+    assert "fmtDurLong(a.duration_seconds" in html
+    assert 'Active <span class="info-btn"' in html
+    assert 'Elapsed <span class="info-btn"' in html
+    # The misleading bare "Duration" label is gone from the status tile.
+    assert '<span class="label">Duration</span>' not in html

--- a/tokenjam/api/routes/status.py
+++ b/tokenjam/api/routes/status.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 from fastapi import APIRouter, Depends, Request
 
 from tokenjam.api.deps import require_api_key
-from tokenjam.core.db import _row_to_session
+from tokenjam.core.db import _row_to_session, session_active_seconds
 from tokenjam.core.models import AlertFilters
 from tokenjam.utils.time_parse import utcnow
 
@@ -54,6 +54,12 @@ async def get_status(
             if sessions:
                 session = sessions[0]
 
+        # Active (compute) time = sum of span durations for the session.
+        # Distinct from the wall-clock duration_seconds below — see issue #147.
+        active_seconds = None
+        if session is not None and hasattr(db, "conn"):
+            active_seconds = session_active_seconds(db.conn, session.session_id)
+
         today_cost = db.get_daily_cost(aid, utcnow().date())
 
         # Active (unacknowledged, unsuppressed) alerts
@@ -73,6 +79,7 @@ async def get_status(
             "error_count": session.error_count if session else 0,
             "active_alerts": len(active_alerts),
             "duration_seconds": session.duration_seconds if session else None,
+            "active_seconds": active_seconds,
             "started_at": session.started_at.isoformat() if session and session.started_at else None,
             "total_cost_usd": float(session.total_cost_usd) if session and session.total_cost_usd is not None else 0.0,
         }

--- a/tokenjam/cli/cmd_status.py
+++ b/tokenjam/cli/cmd_status.py
@@ -65,6 +65,14 @@ def cmd_status(ctx: click.Context, agent: str | None, output_json: bool) -> None
             if sessions:
                 session = sessions[0]
 
+        # Active (compute) time = sum of span durations; distinct from the
+        # wall-clock duration_seconds, which spans days for resumed sessions
+        # (issue #147).
+        active_seconds = None
+        if session is not None and hasattr(db, "conn"):
+            from tokenjam.core.db import session_active_seconds
+            active_seconds = session_active_seconds(db.conn, session.session_id)
+
         today_cost = db.get_daily_cost(aid, utcnow().date())
 
         # Budget from config: per-agent overrides defaults
@@ -94,6 +102,8 @@ def cmd_status(ctx: click.Context, agent: str | None, output_json: bool) -> None
             "tool_call_count": session.tool_call_count if session else 0,
             "error_count": session.error_count if session else 0,
             "active_alerts": len(active_alerts),
+            "duration_seconds": session.duration_seconds if session else None,
+            "active_seconds": active_seconds,
         }
         agents_data.append(agent_data)
 
@@ -127,19 +137,30 @@ def cmd_status(ctx: click.Context, agent: str | None, output_json: bool) -> None
     ctx.exit(1 if has_active_alerts else 0)
 
 
+def _fmt_dur(seconds: float | None, *, coarse: bool = False) -> str:
+    """Human duration. coarse=True caps at days/hours for long wall-clock spans."""
+    if seconds is None:
+        return "-"
+    secs = int(seconds)
+    if coarse and secs >= 3600:
+        mins = secs // 60
+        d, rem = divmod(mins, 1440)
+        h, m = divmod(rem, 60)
+        return f"{d}d {h}h" if d else f"{h}h {m}m"
+    mins, s = divmod(secs, 60)
+    if mins >= 60:
+        h, m = divmod(mins, 60)
+        return f"{h}h {m}m"
+    return f"{mins}m {s}s"
+
+
 def _print_agent_status(data: dict, active_alerts: list, session: object | None) -> None:
     status = data["status"]
     icon = status_icon(status)
     style = "green" if status == "active" else "dim"
 
-    duration_str = ""
-    if session and hasattr(session, "duration_seconds") and session.duration_seconds:
-        secs = int(session.duration_seconds)
-        mins, s = divmod(secs, 60)
-        duration_str = f"   ({mins}m {s}s)"
-
     console.print(f"[{style}]{icon}[/] [bold]{data['agent_id']}[/bold]   "
-                  f"{status}{duration_str}")
+                  f"{status}")
     console.print()
 
     cost_str = format_cost(data["cost_today"])
@@ -155,6 +176,16 @@ def _print_agent_status(data: dict, active_alerts: list, session: object | None)
     if data["error_count"]:
         tool_str += f"  ({data['error_count']} failed)"
     console.print(f"  Tool calls:     {tool_str}")
+
+    # Active = compute time (Σ span durations); Elapsed = wall-clock, which can
+    # span days for resumed sessions (issue #147).
+    if data.get("active_seconds") is not None or data.get("duration_seconds") is not None:
+        parts = []
+        if data.get("active_seconds") is not None:
+            parts.append(f"active {_fmt_dur(data['active_seconds'])}")
+        if data.get("duration_seconds") is not None:
+            parts.append(f"[dim]elapsed {_fmt_dur(data['duration_seconds'], coarse=True)}[/dim]")
+        console.print(f"  Duration:       {' · '.join(parts)}")
 
     if data["session_id"]:
         console.print(f"  Active session: {data['session_id']}")

--- a/tokenjam/core/db.py
+++ b/tokenjam/core/db.py
@@ -292,6 +292,26 @@ def _row_to_session(row: tuple, columns: list[str]) -> SessionRecord:
     )
 
 
+def session_active_seconds(conn, session_id: str) -> float | None:
+    """
+    Active (compute) time for a session: the sum of its span durations, in
+    seconds. Distinct from `SessionRecord.duration_seconds`, which is wall-clock
+    (`ended_at - started_at`) and can span days for resumed Claude Code sessions.
+
+    Returns None when the session has no spans with a recorded duration (so
+    callers can omit the field rather than show a misleading 0).
+    """
+    if session_id is None:
+        return None
+    row = conn.execute(
+        "SELECT SUM(duration_ms) FROM spans WHERE session_id = $1",
+        [session_id],
+    ).fetchone()
+    if not row or row[0] is None:
+        return None
+    return float(row[0]) / 1000.0
+
+
 def _int_or_none(val: object) -> int | None:
     if val is None:
         return None

--- a/tokenjam/ui/index.html
+++ b/tokenjam/ui/index.html
@@ -726,6 +726,19 @@ function fmtDur(ms) {
   const s = Math.round((ms % 60000)/1000);
   return m + 'm ' + s + 's';
 }
+// Coarse formatter for long wall-clock spans (resumed sessions run for days).
+// fmtDur tops out at minutes — "3087m" reads as a runaway; this shows "2d 3h".
+function fmtDurLong(ms) {
+  if (ms == null) return '-';
+  if (ms < 60000) return fmtDur(ms);
+  const totalMin = Math.floor(ms/60000);
+  const d = Math.floor(totalMin/1440);
+  const h = Math.floor((totalMin % 1440)/60);
+  const m = totalMin % 60;
+  if (d > 0) return d + 'd ' + h + 'h';
+  if (h > 0) return h + 'h ' + m + 'm';
+  return m + 'm';
+}
 function fmtAgo(iso) {
   if (!iso) return '-';
   const d = new Date(iso);
@@ -1045,7 +1058,8 @@ function StatusView({ params }) {
           <div class="card-row"><span class="label">Cost today <span class="info-btn">i<span class="info-tip">Estimated from token usage. If you're on a subscription plan (e.g. Claude Max), your actual spend may differ.</span></span></span><span class="value">${fmtCost(a.cost_today)}</span></div>
           <div class="card-row"><span class="label">Tokens</span><span class="value">${fmtTokens(a.input_tokens)} in / ${fmtTokens(a.output_tokens)} out</span></div>
           <div class="card-row"><span class="label">Tool calls</span><span class="value">${a.tool_call_count}${a.error_count ? ' (' + a.error_count + ' failed)' : ''}</span></div>
-          ${a.duration_seconds != null ? html`<div class="card-row"><span class="label">Duration</span><span class="value">${fmtDur(a.duration_seconds * 1000)}</span></div>` : null}
+          ${a.active_seconds != null ? html`<div class="card-row"><span class="label">Active <span class="info-btn">i<span class="info-tip">Compute time — the sum of this session's span durations. The work actually done.</span></span></span><span class="value">${fmtDur(a.active_seconds * 1000)}</span></div>` : null}
+          ${a.duration_seconds != null ? html`<div class="card-row"><span class="label">Elapsed <span class="info-btn">i<span class="info-tip">Wall-clock from session start to last activity. Resumed Claude Code sessions span days, so this can be far larger than Active time.</span></span></span><span class="value">${fmtDurLong(a.duration_seconds * 1000)}</span></div>` : null}
           ${a.last_span_time ? html`<div class="card-row"><span class="label">Last seen</span><span class="value">${fmtAgo(a.last_span_time)}</span></div>` : null}
           ${a.active_alerts > 0 ? html`<div class="card-row"><span class="label">Alerts</span><span class="value" style="color:var(--error)">${a.active_alerts} active</span></div>` : null}
           <div class="card-links">


### PR DESCRIPTION
Closes #147.

## Problem
The Status tile showed only wall-clock `Duration` (`ended_at − started_at`). Claude Code sessions resume across days, so a tile reading `Duration: 3087m` (~51h) looks like a runaway session when the agent was actually active for minutes. Active time (Σ span `duration_ms`) already exists in the data — it just wasn't surfaced.

## Fix
Surface **active (compute) time** alongside the wall-clock value across every Status surface:

- **`core/db.py`** — `session_active_seconds(conn, session_id)`: sum of span durations in seconds; returns `None` when the session has no timed spans (so callers omit rather than show a misleading `0`).
- **`/api/v1/status`** — payload now carries `active_seconds` next to `duration_seconds`.
- **UI status tile** (`ui/index.html`) — new **Active** row (compute time) + the wall-clock row relabeled **Elapsed**, each with an explanatory tooltip. Added `fmtDurLong` so multi-day spans render `2d 3h` instead of `3087m`.
- **CLI `tj status`** — replaced the misleading inline `(3087m 0s)` with a `Duration: active 12m 3s · elapsed 2d 3h` row; both fields included in `--json`.

Example CLI output for a resumed session (12m active, 51h elapsed):
```
● claude-code   active
  ...
  Duration:       active 12m 3s · elapsed 2d 3h
```

## Scope note
The issue scoped UI + API; I also applied it to `tj status` (CLI) since it had the identical defect. MCP `get_status` proxies the API and maps explicit fields, so it's unaffected (the new field is simply not mapped) — left out of scope.

## Verification
- `ruff check tokenjam/` ✅ · `mypy` ✅ · full suite **768 passed** ✅
- Tests added: core helper unit tests (sum / no-spans / unknown-session), `/api/v1/status` `active_seconds`, CLI `--json` fields, and a Lens UI regression pinning the Active/Elapsed labels + `fmtDurLong` (and asserting the bare "Duration" label is gone).
- UI offline regression (`test_ui_offline.py`) still green — no external loads added.

🤖 Generated with [Claude Code](https://claude.com/claude-code)