### PR TITLE
Track A part 1: weekly GitHub traffic archive workflow

### DIFF
--- a/.github/scripts/archive_traffic.py
+++ b/.github/scripts/archive_traffic.py
@@ -1,0 +1,125 @@
+#!/usr/bin/env python3
+"""
+Archive this repo's GitHub Traffic API data into traffic/<ISO-year>-W<week>.json.
+
+GitHub's Traffic API only retains the last 14 days, so this runs weekly (see
+.github/workflows/traffic-archive.yml) and commits a point-in-time snapshot —
+the longitudinal record the 14-day window can't otherwise provide.
+
+The output schema is fixed by the growth-instrumentation brief and consumed by
+the Cowork spreadsheet-fill job; keep it stable across releases.
+
+Auth: reads GITHUB_TOKEN + GITHUB_REPOSITORY from the environment (both provided
+automatically by GitHub Actions). The default workflow token works because the
+workflow grants `administration: read`, which the Traffic API requires.
+
+Failure mode: any API error raises and the process exits non-zero, so the run
+shows red in the Actions tab (the Cowork health check then alerts on the missing
+file). No-data weeks still write the file — its existence is the success signal.
+"""
+from __future__ import annotations
+
+import json
+import os
+import sys
+import urllib.request
+from datetime import datetime, timezone
+from pathlib import Path
+
+API_ROOT = "https://api.github.com"
+
+
+def _get(path: str, token: str):
+    """GET an api.github.com path and return parsed JSON. Raises on any error."""
+    req = urllib.request.Request(
+        f"{API_ROOT}{path}",
+        headers={
+            "Authorization": f"Bearer {token}",
+            "Accept": "application/vnd.github+json",
+            "X-GitHub-Api-Version": "2022-11-28",
+            "User-Agent": "tokenjam-traffic-archive",
+        },
+    )
+    with urllib.request.urlopen(req, timeout=30) as resp:
+        return json.load(resp)
+
+
+def _daily(payload: dict, key: str) -> list[dict]:
+    """Normalize the views/clones inner array (keyed 'views'/'clones') to 'daily'."""
+    return [
+        {"timestamp": d["timestamp"], "count": d["count"], "uniques": d["uniques"]}
+        for d in payload.get(key, [])
+    ]
+
+
+def build_record(views: dict, clones: dict, referrers: list, paths: list,
+                 repo: str, now: datetime) -> dict:
+    """Assemble the combined archive record matching the fixed brief schema."""
+    iso_year, iso_week, _ = now.isocalendar()
+    iso_week_str = f"{iso_year}-W{iso_week:02d}"
+    return {
+        "archived_at": now.strftime("%Y-%m-%dT%H:%M:%SZ"),
+        "iso_week": iso_week_str,
+        "repo": repo,
+        "views": {
+            "count": views.get("count", 0),
+            "uniques": views.get("uniques", 0),
+            "daily": _daily(views, "views"),
+        },
+        "clones": {
+            "count": clones.get("count", 0),
+            "uniques": clones.get("uniques", 0),
+            "daily": _daily(clones, "clones"),
+        },
+        "referrers": [
+            {"referrer": r["referrer"], "count": r["count"], "uniques": r["uniques"]}
+            for r in (referrers or [])
+        ],
+        "paths": [
+            {"path": p["path"], "title": p.get("title", ""),
+             "count": p["count"], "uniques": p["uniques"]}
+            for p in (paths or [])
+        ],
+    }
+
+
+def main() -> int:
+    token = os.environ.get("GITHUB_TOKEN")
+    repo = os.environ.get("GITHUB_REPOSITORY")  # "owner/name"
+    if not token or not repo:
+        print("error: GITHUB_TOKEN and GITHUB_REPOSITORY must be set", file=sys.stderr)
+        return 1
+
+    views = _get(f"/repos/{repo}/traffic/views", token)
+    clones = _get(f"/repos/{repo}/traffic/clones", token)
+    referrers = _get(f"/repos/{repo}/traffic/popular/referrers", token)
+    paths = _get(f"/repos/{repo}/traffic/popular/paths", token)
+
+    now = datetime.now(timezone.utc)
+    record = build_record(views, clones, referrers, paths, repo, now)
+    iso_week_str = record["iso_week"]
+
+    out_dir = Path("traffic")
+    out_dir.mkdir(exist_ok=True)
+    out_path = out_dir / f"{iso_week_str}.json"
+    # Overwrite is intentional: a week's archive is a point-in-time snapshot, so
+    # a manual re-run or late-firing schedule just refreshes it (idempotent).
+    out_path.write_text(json.dumps(record, indent=2) + "\n", encoding="utf-8")
+
+    print(
+        f"wrote {out_path} (views={record['views']['count']}, "
+        f"clones={record['clones']['count']}, "
+        f"referrers={len(record['referrers'])}, paths={len(record['paths'])})"
+    )
+
+    # Expose the ISO week to the workflow for the commit message.
+    gh_output = os.environ.get("GITHUB_OUTPUT")
+    if gh_output:
+        with open(gh_output, "a", encoding="utf-8") as fh:
+            fh.write(f"iso_week={iso_week_str}\n")
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.github/scripts/archive_traffic.py
+++ b/.github/scripts/archive_traffic.py
@@ -22,6 +22,7 @@ from __future__ import annotations
 import json
 import os
 import sys
+import urllib.error
 import urllib.request
 from datetime import datetime, timezone
 from pathlib import Path
@@ -30,7 +31,13 @@ API_ROOT = "https://api.github.com"
 
 
 def _get(path: str, token: str):
-    """GET an api.github.com path and return parsed JSON. Raises on any error."""
+    """GET an api.github.com path and return parsed JSON. Raises on any error.
+
+    On an HTTP error, surface the status, GitHub's response message, and the
+    relevant rate-limit / SSO headers to stderr before re-raising — a bare
+    `HTTPError: 403 Forbidden` hides whether the cause is a missing token scope,
+    an unapproved fine-grained PAT, or SAML SSO authorization.
+    """
     req = urllib.request.Request(
         f"{API_ROOT}{path}",
         headers={
@@ -40,8 +47,20 @@ def _get(path: str, token: str):
             "User-Agent": "tokenjam-traffic-archive",
         },
     )
-    with urllib.request.urlopen(req, timeout=30) as resp:
-        return json.load(resp)
+    try:
+        with urllib.request.urlopen(req, timeout=30) as resp:
+            return json.load(resp)
+    except urllib.error.HTTPError as exc:
+        body = exc.read().decode("utf-8", "replace")[:600]
+        sso = exc.headers.get("X-GitHub-SSO")
+        remaining = exc.headers.get("X-RateLimit-Remaining")
+        print(
+            f"error: GET {path} -> HTTP {exc.code} {exc.reason}\n"
+            f"  body: {body}\n"
+            f"  x-github-sso: {sso}  x-ratelimit-remaining: {remaining}",
+            file=sys.stderr,
+        )
+        raise
 
 
 def _daily(payload: dict, key: str) -> list[dict]:

--- a/.github/workflows/traffic-archive.yml
+++ b/.github/workflows/traffic-archive.yml
@@ -1,0 +1,42 @@
+name: traffic-archive
+
+# Weekly snapshot of the GitHub Traffic API (which only retains 14 days) into
+# traffic/<year>-W<week>.json. This is the ONLY writer to main in the growth-
+# instrumentation system; the Cowork jobs only read what this commits.
+on:
+  schedule:
+    - cron: '0 12 * * 0'   # Sundays at 12:00 UTC
+  workflow_dispatch:        # manual trigger for backfill / testing
+
+permissions:
+  contents: write
+  administration: read     # required for the Traffic API; without it the API returns 403
+
+jobs:
+  archive:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - name: Archive traffic data
+        id: archive
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_REPOSITORY: ${{ github.repository }}
+        run: python .github/scripts/archive_traffic.py
+
+      - name: Commit and push the archive
+        run: |
+          git config user.name  "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add traffic/
+          if git diff --cached --quiet; then
+            echo "No changes — archive already current for ${{ steps.archive.outputs.iso_week }}."
+            exit 0
+          fi
+          git commit -m "chore(traffic): archive week ${{ steps.archive.outputs.iso_week }}"
+          git push

--- a/.github/workflows/traffic-archive.yml
+++ b/.github/workflows/traffic-archive.yml
@@ -9,8 +9,7 @@ on:
   workflow_dispatch:        # manual trigger for backfill / testing
 
 permissions:
-  contents: write
-  administration: read     # required for the Traffic API; without it the API returns 403
+  contents: write          # to commit the archive back to the branch
 
 jobs:
   archive:

--- a/.github/workflows/traffic-archive.yml
+++ b/.github/workflows/traffic-archive.yml
@@ -24,7 +24,13 @@ jobs:
       - name: Archive traffic data
         id: archive
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # The Traffic API requires Administration:Read, which the default
+          # GITHUB_TOKEN cannot be granted (there is no such permissions: key —
+          # a literal `administration` value is a workflow parse error, and the
+          # default token 403s on these endpoints). So this step authenticates
+          # with a PAT stored as the TRAFFIC_PAT repo secret. See the PR / README
+          # Setup notes for the minimum scope (Administration: Read on this repo).
+          GITHUB_TOKEN: ${{ secrets.TRAFFIC_PAT }}
           GITHUB_REPOSITORY: ${{ github.repository }}
         run: python .github/scripts/archive_traffic.py
 

--- a/.github/workflows/traffic-archive.yml
+++ b/.github/workflows/traffic-archive.yml
@@ -28,8 +28,17 @@ jobs:
           # GITHUB_TOKEN cannot be granted (there is no such permissions: key —
           # a literal `administration` value is a workflow parse error, and the
           # default token 403s on these endpoints). So this step authenticates
-          # with a PAT stored as the TRAFFIC_PAT repo secret. See the PR / README
-          # Setup notes for the minimum scope (Administration: Read on this repo).
+          # with a PAT stored as the TRAFFIC_PAT repo secret.
+          #
+          # TRAFFIC_PAT must be a fine-grained PAT with ALL of:
+          #   - Resource owner = Metabuilder-Labs (the ORG, not a personal
+          #     account — otherwise it can't see this repo: 403 "Resource not
+          #     accessible by personal access token")
+          #   - Repository access = this repo
+          #   - Repository permissions -> Administration: Read  (the one the
+          #     Traffic API needs; separate from Contents/Metadata)
+          # A classic PAT with the `repo` scope also works. See the README/PR
+          # Setup notes.
           GITHUB_TOKEN: ${{ secrets.TRAFFIC_PAT }}
           GITHUB_REPOSITORY: ${{ github.repository }}
         run: python .github/scripts/archive_traffic.py

--- a/traffic/2026-W25.json
+++ b/traffic/2026-W25.json
@@ -1,0 +1,271 @@
+{
+  "archived_at": "2026-06-20T18:49:20Z",
+  "iso_week": "2026-W25",
+  "repo": "Metabuilder-Labs/tokenjam",
+  "views": {
+    "count": 1782,
+    "uniques": 407,
+    "daily": [
+      {
+        "timestamp": "2026-06-06T00:00:00Z",
+        "count": 21,
+        "uniques": 9
+      },
+      {
+        "timestamp": "2026-06-07T00:00:00Z",
+        "count": 61,
+        "uniques": 26
+      },
+      {
+        "timestamp": "2026-06-08T00:00:00Z",
+        "count": 81,
+        "uniques": 18
+      },
+      {
+        "timestamp": "2026-06-09T00:00:00Z",
+        "count": 126,
+        "uniques": 21
+      },
+      {
+        "timestamp": "2026-06-10T00:00:00Z",
+        "count": 56,
+        "uniques": 18
+      },
+      {
+        "timestamp": "2026-06-11T00:00:00Z",
+        "count": 49,
+        "uniques": 18
+      },
+      {
+        "timestamp": "2026-06-12T00:00:00Z",
+        "count": 78,
+        "uniques": 14
+      },
+      {
+        "timestamp": "2026-06-13T00:00:00Z",
+        "count": 162,
+        "uniques": 47
+      },
+      {
+        "timestamp": "2026-06-14T00:00:00Z",
+        "count": 200,
+        "uniques": 92
+      },
+      {
+        "timestamp": "2026-06-15T00:00:00Z",
+        "count": 244,
+        "uniques": 36
+      },
+      {
+        "timestamp": "2026-06-16T00:00:00Z",
+        "count": 122,
+        "uniques": 42
+      },
+      {
+        "timestamp": "2026-06-17T00:00:00Z",
+        "count": 100,
+        "uniques": 39
+      },
+      {
+        "timestamp": "2026-06-18T00:00:00Z",
+        "count": 194,
+        "uniques": 36
+      },
+      {
+        "timestamp": "2026-06-19T00:00:00Z",
+        "count": 288,
+        "uniques": 52
+      }
+    ]
+  },
+  "clones": {
+    "count": 1695,
+    "uniques": 484,
+    "daily": [
+      {
+        "timestamp": "2026-06-06T00:00:00Z",
+        "count": 5,
+        "uniques": 4
+      },
+      {
+        "timestamp": "2026-06-07T00:00:00Z",
+        "count": 5,
+        "uniques": 4
+      },
+      {
+        "timestamp": "2026-06-08T00:00:00Z",
+        "count": 114,
+        "uniques": 39
+      },
+      {
+        "timestamp": "2026-06-09T00:00:00Z",
+        "count": 136,
+        "uniques": 55
+      },
+      {
+        "timestamp": "2026-06-10T00:00:00Z",
+        "count": 13,
+        "uniques": 8
+      },
+      {
+        "timestamp": "2026-06-11T00:00:00Z",
+        "count": 10,
+        "uniques": 7
+      },
+      {
+        "timestamp": "2026-06-12T00:00:00Z",
+        "count": 40,
+        "uniques": 18
+      },
+      {
+        "timestamp": "2026-06-13T00:00:00Z",
+        "count": 30,
+        "uniques": 19
+      },
+      {
+        "timestamp": "2026-06-14T00:00:00Z",
+        "count": 43,
+        "uniques": 18
+      },
+      {
+        "timestamp": "2026-06-15T00:00:00Z",
+        "count": 211,
+        "uniques": 72
+      },
+      {
+        "timestamp": "2026-06-16T00:00:00Z",
+        "count": 92,
+        "uniques": 40
+      },
+      {
+        "timestamp": "2026-06-17T00:00:00Z",
+        "count": 119,
+        "uniques": 50
+      },
+      {
+        "timestamp": "2026-06-18T00:00:00Z",
+        "count": 489,
+        "uniques": 146
+      },
+      {
+        "timestamp": "2026-06-19T00:00:00Z",
+        "count": 388,
+        "uniques": 132
+      }
+    ]
+  },
+  "referrers": [
+    {
+      "referrer": "github.com",
+      "count": 345,
+      "uniques": 89
+    },
+    {
+      "referrer": "Google",
+      "count": 18,
+      "uniques": 13
+    },
+    {
+      "referrer": "linkedin.com",
+      "count": 16,
+      "uniques": 15
+    },
+    {
+      "referrer": "t.co",
+      "count": 16,
+      "uniques": 11
+    },
+    {
+      "referrer": "statics.teams.cdn.office.net",
+      "count": 5,
+      "uniques": 4
+    },
+    {
+      "referrer": "com.linkedin.android",
+      "count": 4,
+      "uniques": 2
+    },
+    {
+      "referrer": "l.facebook.com",
+      "count": 2,
+      "uniques": 2
+    },
+    {
+      "referrer": "lm.facebook.com",
+      "count": 2,
+      "uniques": 2
+    },
+    {
+      "referrer": "teams.public.onecdn.static.microsoft",
+      "count": 2,
+      "uniques": 2
+    },
+    {
+      "referrer": "jira.espace.ws",
+      "count": 2,
+      "uniques": 1
+    }
+  ],
+  "paths": [
+    {
+      "path": "/metabuilder-labs/tokenjam",
+      "title": "Overview",
+      "count": 491,
+      "uniques": 340
+    },
+    {
+      "path": "/Metabuilder-Labs/tokenjam",
+      "title": "Overview",
+      "count": 316,
+      "uniques": 63
+    },
+    {
+      "path": "/Metabuilder-Labs/tokenjam/pulls",
+      "title": "/pulls",
+      "count": 156,
+      "uniques": 10
+    },
+    {
+      "path": "/Metabuilder-Labs/tokenjam/issues",
+      "title": "/issues",
+      "count": 104,
+      "uniques": 19
+    },
+    {
+      "path": "/Metabuilder-Labs/tokenjam/stargazers",
+      "title": "/stargazers",
+      "count": 63,
+      "uniques": 4
+    },
+    {
+      "path": "/Metabuilder-Labs/tokenjam/blob/main/docs/screenshots/tj-status.png",
+      "title": "/blob/main/docs/screenshots/tj-status.png",
+      "count": 59,
+      "uniques": 33
+    },
+    {
+      "path": "/Metabuilder-Labs/tokenjam/tree/main/tests",
+      "title": "/tree/main/tests",
+      "count": 22,
+      "uniques": 3
+    },
+    {
+      "path": "/Metabuilder-Labs/tokenjam/commits/main",
+      "title": "/commits/main",
+      "count": 20,
+      "uniques": 6
+    },
+    {
+      "path": "/Metabuilder-Labs/tokenjam/graphs/contributors",
+      "title": "/graphs/contributors",
+      "count": 20,
+      "uniques": 5
+    },
+    {
+      "path": "/Metabuilder-Labs/tokenjam/releases",
+      "title": "/releases",
+      "count": 14,
+      "uniques": 3
+    }
+  ]
+}


### PR DESCRIPTION
Part 1 of the growth-instrumentation brief (`.claude/growth-instrumentation-brief.md`): the weekly Action that archives the GitHub Traffic API into the repo. This is the **only writer to `main`** in the system; the Cowork jobs (Part 2, separate) read what it commits. Part 2 is out of scope here.

## What's here
- **`.github/workflows/traffic-archive.yml`** — Sundays 12:00 UTC + `workflow_dispatch`. Steps: checkout → setup-python 3.12 → run the script → auto-commit/push as `github-actions[bot]` with `chore(traffic): archive week <year>-W<week>`. Idempotent: if a re-run produces identical content the commit is skipped (no error); any API failure exits non-zero (red in Actions) and prints the HTTP status + body for diagnosis.
- **`.github/scripts/archive_traffic.py`** — stdlib `urllib` only (no deps). Calls the four Traffic endpoints (views, clones, popular/referrers, popular/paths) and writes `traffic/<ISO-year>-W<week>.json` in the brief's exact schema (the `views`/`clones` inner arrays are normalized to `daily`).

## ✅ Pre-merge evidence (live `workflow_dispatch` on this branch)
- **Green run:** https://github.com/Metabuilder-Labs/tokenjam/actions/runs/27880550823 (conclusion: success)
- **Workflow-authored auto-commit** (by `github-actions[bot]`, *not* the agent): https://github.com/Metabuilder-Labs/tokenjam/commit/0d6ba928581f84e71d8da2559a8feca6bb8a959b — `chore(traffic): archive week 2026-W25`, adding `traffic/2026-W25.json`.
- **Archive validates** against the brief schema: `iso_week=2026-W25`, views 1782 / uniques 407, clones 1695 / uniques 484, 10 referrers, 10 paths (top referrer `github.com`). Matches a manual Traffic API curl.

This satisfies Part 1 ACs #2 (dispatch produces the current-week JSON in the documented shape), #4 (file committed by the workflow itself), and #5 (run URL in the PR).

## ⚠️ Setup required (auth) — read before relying on this
The brief's stated auth (`GITHUB_TOKEN` + `permissions: administration: read`) **does not work**, proven with live runs:
- `administration` is **not a valid `permissions:` key** → `HTTP 422: Unexpected value 'administration'` (workflow won't parse). Removed.
- the default `GITHUB_TOKEN` **403s** on the Traffic API regardless ([failed run](https://github.com/Metabuilder-Labs/tokenjam/actions/runs/27879656562)). It can't be granted Administration:Read.

So the workflow authenticates the Traffic call with a **`TRAFFIC_PAT` repo secret** (the token value never enters the repo — only `${{ secrets.TRAFFIC_PAT }}`). The commit/push still uses the default token (`contents: write`).

### Provisioning `TRAFFIC_PAT` (one-time) — and the gotchas that cost an afternoon
Create a **fine-grained PAT** and add it as repo secret **`TRAFFIC_PAT`**. All three of these are required — miss any one and you get `403 "Resource not accessible by personal access token"` (authenticated, but the resource is invisible to the token):

1. **Resource owner = `Metabuilder-Labs`** (the **org**) — *not* your personal account. A personal-owned token cannot see org repos and 403s with the exact message above. This is the easy one to get wrong.
2. **Repository access** = `tokenjam` (this repo).
3. **Repository permissions → Administration: `Read`** — this specific permission is what the Traffic API needs; it's separate from Contents/Metadata and is *not* added by default.
   - If the org requires approval for fine-grained tokens, approve it: Org → Settings → Personal access tokens → pending requests.

A **classic PAT with the `repo` scope** also works and skips the resource-owner/approval dance (use if SAML SSO isn't enforced — it wasn't here).

> On a fresh clone the workflow fails until `TRAFFIC_PAT` exists — expected; Part 2's Sunday health check surfaces it. The same gotchas are also documented inline in the workflow's env comment so they survive after this PR is merged.

> Branch protection: the brief's single-writer design commits straight to `main`. If `main` blocks direct pushes, allow `github-actions` to bypass, or the auto-commit step will fail.

🤖 Generated with [Claude Code](https://claude.com/claude-code)