### PR TITLE
Track A part 1 follow-up: workflow pushes as PAT owner to satisfy main-branch protection

### DIFF
--- a/.github/workflows/traffic-archive.yml
+++ b/.github/workflows/traffic-archive.yml
@@ -35,8 +35,11 @@ jobs:
           #     account — otherwise it can't see this repo: 403 "Resource not
           #     accessible by personal access token")
           #   - Repository access = this repo
-          #   - Repository permissions -> Administration: Read  (the one the
-          #     Traffic API needs; separate from Contents/Metadata)
+          #   - Repository permissions:
+          #       * Administration: Read   — the Traffic API read (this step)
+          #       * Contents: Write        — the commit/push step (the owner is a
+          #         repo admin, so the push bypasses main's branch protection)
+          #       * Metadata: Read         — auto-included
           # A classic PAT with the `repo` scope also works. See the README/PR
           # Setup notes.
           GITHUB_TOKEN: ${{ secrets.TRAFFIC_PAT }}
@@ -44,13 +47,24 @@ jobs:
         run: python .github/scripts/archive_traffic.py
 
       - name: Commit and push the archive
+        env:
+          # Push as the PAT owner (a repo admin), not the default GITHUB_TOKEN /
+          # github-actions[bot]. main is a protected branch that blocks the bot;
+          # the admin owner's push bypasses protection. TRAFFIC_PAT therefore
+          # needs Contents: Write (to push) in addition to Administration: Read
+          # (for the Traffic API read above). Passed via env so the token value
+          # is masked in logs and never echoed in the run script.
+          TRAFFIC_PAT: ${{ secrets.TRAFFIC_PAT }}
+          GH_REPO: ${{ github.repository }}
+          GH_REF_NAME: ${{ github.ref_name }}
         run: |
-          git config user.name  "github-actions[bot]"
-          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          # Commit authored as the maintainer so it attributes to their account.
+          git config user.name  "Anil Murty"
+          git config user.email "anil.murty@gmail.com"
           git add traffic/
           if git diff --cached --quiet; then
             echo "No changes — archive already current for ${{ steps.archive.outputs.iso_week }}."
             exit 0
           fi
           git commit -m "chore(traffic): archive week ${{ steps.archive.outputs.iso_week }}"
-          git push
+          git push "https://x-access-token:${TRAFFIC_PAT}@github.com/${GH_REPO}.git" "HEAD:${GH_REF_NAME}"

--- a/traffic/2026-W25.json
+++ b/traffic/2026-W25.json
@@ -1,5 +1,5 @@
 {
-  "archived_at": "2026-06-20T18:49:20Z",
+  "archived_at": "2026-06-20T19:14:45Z",
   "iso_week": "2026-W25",
   "repo": "Metabuilder-Labs/tokenjam",
   "views": {


### PR DESCRIPTION
Follow-up to #171. `main` is a protected branch (`protected: true`), so the weekly archive's auto-commit as `github-actions[bot]` would be **blocked** once it runs against `main`. This changes the commit/push step to push as the **`TRAFFIC_PAT` owner** — a repo admin, whose push bypasses branch protection — with the commit authored as the maintainer.

## What changed (`.github/workflows/traffic-archive.yml`, commit/push step only)
- `git user.name = "Anil Murty"`, `user.email = anil.murty@gmail.com` → the archive commit attributes to the maintainer's account, not the bot.
- Push via `https://x-access-token:${TRAFFIC_PAT}@github.com/${GH_REPO}.git HEAD:${GH_REF_NAME}` instead of the default `GITHUB_TOKEN`.
- `TRAFFIC_PAT` is passed via `env:` (masked by Actions) and used only inside the push URL — never echoed (`run` blocks aren't `set -x`).
- No change to the Traffic-API read step (still uses `TRAFFIC_PAT` for Administration:Read). The script is untouched.

## ✅ Pre-merge evidence (live `workflow_dispatch` on this branch)
- **Green run:** https://github.com/Metabuilder-Labs/tokenjam/actions/runs/27881182576 (success)
- **Auto-commit authored as the maintainer** (not the bot): https://github.com/Metabuilder-Labs/tokenjam/commit/2a036909c1de86f68cb8a7ea9affd2288b8683d3
  ```
  author:    Anil Murty <anil.murty@gmail.com>
  committer: Anil Murty <anil.murty@gmail.com>
  msg:       chore(traffic): archive week 2026-W25
  ```
  (refreshed `traffic/2026-W25.json` — the `archived_at` delta — pushed via the PAT URL.)

This confirms the author identity + PAT-push mechanism. **The branch is unprotected, so it can't by itself prove the `main` bypass** — that's an inherently post-merge check (the PAT-push workflow must be on `main` and dispatched against `main`).

### Post-merge verification (the success criterion: a commit on `main` authored as "Anil Murty")
After this merges, dispatch once against `main`:
```bash
gh workflow run traffic-archive.yml --ref main
```
Success = a `chore(traffic): archive week …` commit lands on protected `main`, authored as **Anil Murty** (proving the admin PAT push bypassed protection). I'm happy to run this and paste the `main` run URL + commit the moment it's merged — just say go.

## Setup (auth) — `TRAFFIC_PAT` now needs two permissions
Fine-grained PAT, added as repo secret **`TRAFFIC_PAT`**, with **all** of:
1. **Resource owner = `Metabuilder-Labs`** (the **org**, not a personal account — a personal-owned token can't see this repo and 403s with `"Resource not accessible by personal access token"`).
2. **Repository access** = `tokenjam`.
3. **Repository permissions:**
   - **Administration: Read** — required by the Traffic API read step.
   - **Contents: Write** — required by this commit/push step (the admin owner's push bypasses `main`'s protection).
   - **Metadata: Read** — auto-included.

(A classic PAT with the `repo` scope also works, if SAML SSO isn't enforced.) These same notes are duplicated inline in the workflow's comments so they survive after this PR merges. Current secret already holds a token with these scopes (resource owner `Metabuilder-Labs`, expires Jun 20 2027) — no rotation needed.

> If you ever want to stop the maintainer-authored commits and revert to the bot, you'd instead need `github-actions` allowed to bypass the branch-protection rule.

🤖 Generated with [Claude Code](https://claude.com/claude-code)