### PR TITLE
docs: add traffic-archive action to CLAUDE.md so future agents discover it

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -251,6 +251,19 @@ All steps are blocking — lint, typecheck, and tests must pass for CI to go gre
 
 There is no pre-commit configuration in this repo; `ruff` and `mypy` only run in CI. Run them locally before pushing.
 
+## Growth instrumentation — weekly traffic archive
+
+A separate `.github/workflows/traffic-archive.yml` runs every Sunday at 12:00 UTC (also `workflow_dispatch`) and archives the GitHub Traffic API (views / clones / referrers / paths — the only sources with the 14-day retention problem) into a JSON file at `traffic/<year>-W<week>.json`. **The archive lives on its own orphan branch `traffic-data`, not on `main`** — code and telemetry are deliberately separated, and `main`'s branch protection stays intact.
+
+Key facts:
+- The workflow uses `${{ secrets.TRAFFIC_PAT }}` (fine-grained PAT, resource owner = `Metabuilder-Labs` org, `Administration: Read` on this repo) for the Traffic API read — the default `GITHUB_TOKEN` returns 403 there. The push step uses the default `GITHUB_TOKEN` since `traffic-data` is unprotected.
+- The orphan-branch design was the close-out after several other paths (PAT-as-owner push, classic-protection bypass, rulesets bot-bypass) hit GitHub UI / API limitations. See PRs #171 / #172 / #173 for the trail. Don't try to move the archive back onto `main` — that path was explored and dead-ended.
+- The archive is the only growth-instrumentation surface in this repo. Health-check + spreadsheet-fill workflows were considered but descoped (Cowork sandbox couldn't reach external APIs, and GH Actions for the same was deemed overkill for a solo project). Manual review is the current model — fetch the JSON when wanted, hand it to an agent for analysis.
+- `growth/README.md` documents the schema + read-it-manually flow.
+- TRAFFIC_PAT expires Jun 20 2027 — renew before then.
+
+When adding any new automation that needs to *write* to the repo on a schedule, follow the same pattern: data on its own unprotected ref, code on `main`. Don't try to make `main` accept bot commits.
+
 ## Releases
 
 PyPI and npm publishes are triggered by GitHub Release events (`.github/workflows/publish-pypi.yml`, `publish-npm.yml`, both `on: release: types: [published]`). Release flow:


### PR DESCRIPTION
Single-paragraph addition under a new "Growth instrumentation" section in CLAUDE.md, between CI and Releases. Documents the four things any future agent needs to know: schedule, location (traffic-data orphan branch), PAT scope + auth contract, and the explicit "don't try to move it back onto main" guidance so we don't re-investigate the dead-end paths.

No code changes.