### PR TITLE
Fix #179: surface Claude Code connection staleness (onboard banner + tj doctor check)

### DIFF
--- a/tests/integration/test_cli.py
+++ b/tests/integration/test_cli.py
@@ -208,6 +208,60 @@ def test_doctor_exits_2_when_errors_present(runner, db, config):
     assert result.exit_code == 2
 
 
+def _clean_doctor_config(config, tmp_path):
+    """Configure `config` so only the check under test can produce a warning."""
+    config.storage.path = str(tmp_path / "test.duckdb")
+    config.security.ingest_secret = "test-secret"
+    config.agents["test-agent"].drift.enabled = False
+
+
+def test_doctor_no_staleness_warning_with_fresh_spans(runner, db, config, tmp_path):
+    """A just-recorded span keeps the freshness check green (no false alarm)."""
+    _clean_doctor_config(config, tmp_path)
+    span = make_llm_span(agent_id="test-agent", start_time=utcnow())
+    db.insert_span(span)
+    config_file = tmp_path / "tokenjam.toml"
+    config_file.write_text('version = "1"\n')
+    with patch("tokenjam.cli.cmd_doctor.find_config_file", return_value=config_file):
+        result = _invoke(runner, db, config, ["doctor", "--json"])
+    assert result.exit_code == 0
+    checks = json.loads(result.output)
+    freshness = [c for c in checks if c["name"] == "Live-span freshness"]
+    assert freshness and freshness[0]["level"] == "ok"
+
+
+def test_doctor_warns_on_stale_spans(runner, db, config, tmp_path):
+    """A newest span older than the 6h threshold warns (exit 1) with a restart hint."""
+    from datetime import timedelta
+
+    _clean_doctor_config(config, tmp_path)
+    span = make_llm_span(agent_id="test-agent", start_time=utcnow() - timedelta(hours=10))
+    db.insert_span(span)
+    config_file = tmp_path / "tokenjam.toml"
+    config_file.write_text('version = "1"\n')
+    with patch("tokenjam.cli.cmd_doctor.find_config_file", return_value=config_file):
+        result = _invoke(runner, db, config, ["doctor", "--json"])
+    assert result.exit_code == 1
+    checks = json.loads(result.output)
+    freshness = [c for c in checks if c["name"] == "Live-span freshness"]
+    assert freshness and freshness[0]["level"] == "warning"
+    assert "restart" in freshness[0]["message"].lower()
+
+
+def test_doctor_no_staleness_warning_when_no_spans(runner, db, config, tmp_path):
+    """An empty DB (pre-onboard) must not be mistaken for a stalled connection."""
+    _clean_doctor_config(config, tmp_path)
+    config_file = tmp_path / "tokenjam.toml"
+    config_file.write_text('version = "1"\n')
+    with patch("tokenjam.cli.cmd_doctor.find_config_file", return_value=config_file):
+        result = _invoke(runner, db, config, ["doctor", "--json"])
+    assert result.exit_code == 0
+    checks = json.loads(result.output)
+    freshness = [c for c in checks if c["name"] == "Live-span freshness"]
+    assert freshness and freshness[0]["level"] == "info"
+    assert not any(c["level"] == "warning" for c in checks)
+
+
 def test_doctor_warns_on_schema_without_capture(runner, db, config, tmp_path):
     config.agents["test-agent"] = AgentConfig(output_schema="schema.json")
     config.capture.tool_outputs = False

--- a/tokenjam/cli/cmd_doctor.py
+++ b/tokenjam/cli/cmd_doctor.py
@@ -51,6 +51,9 @@ def cmd_doctor(ctx: click.Context, output_json: bool, repair: bool) -> None:
     spans_stats_check = _check_spans_stats(ctx.obj["db"])
     checks.append(spans_stats_check)
 
+    # 10. Live-span staleness — flags a stalled OTLP connection (issue #179)
+    checks.append(_check_span_staleness(ctx.obj["db"]))
+
     if output_json:
         click.echo(json.dumps(checks, default=str))
     else:
@@ -240,6 +243,73 @@ def _check_spans_stats(db: object) -> dict:
         }
     return {"name": "Spans column statistics", "level": "ok",
             "message": "Column statistics are consistent."}
+
+
+# Spans older than this are treated as a stalled connection. Claude Code /
+# Codex flush their OTLP exporter on a short interval while running, so during
+# any active session the newest span is minutes old at most. A 6h gap means
+# either nothing has run (benign) or — the issue #179 failure mode — a running
+# agent is still exporting to a stale endpoint after `tj onboard` rewrote it.
+# 6h is wide enough to not nag overnight/weekend gaps, tight enough to catch a
+# same-day reconfigure-then-keep-working session.
+_SPAN_STALENESS_THRESHOLD_HOURS = 6
+
+
+def _check_span_staleness(db: object) -> dict:
+    """Warn when telemetry has stopped flowing despite spans existing (#179).
+
+    After `tj onboard --claude-code` rewrites the OTLP endpoint/secret, an
+    already-running Claude Code (or Codex) instance keeps exporting to the old
+    endpoint, so today's spans silently never arrive. The user sees a flat
+    chart and concludes "TokenJam isn't tracking anything." This check compares
+    the newest span's `start_time` to wall-clock and nudges a restart when the
+    gap exceeds the threshold.
+
+    Queries `db.conn` directly with parameterised SQL — `StorageBackend` has no
+    "newest span time" method, and `cmd_doctor` already accesses `db.conn` for
+    the spans-stats canary.
+    """
+    from datetime import timezone
+
+    from tokenjam.utils.time_parse import utcnow
+
+    conn = getattr(db, "conn", None)
+    if conn is None:
+        return {"name": "Live-span freshness", "level": "info",
+                "message": "Skipped — CLI is running through the HTTP API "
+                           "fallback (stop `tj serve` to access the DB directly)."}
+    try:
+        row = conn.execute("SELECT MAX(start_time) FROM spans").fetchone()
+    except duckdb.Error as e:
+        return {"name": "Live-span freshness", "level": "info",
+                "message": f"Skipped — could not query span timestamps: {e}"}
+
+    newest = row[0] if row else None
+    if newest is None:
+        # No spans at all — nothing to be stale. A genuinely empty DB is a
+        # pre-onboard state, not a stalled connection; don't false-warn.
+        return {"name": "Live-span freshness", "level": "info",
+                "message": "No spans recorded yet — nothing to check."}
+
+    # DuckDB TIMESTAMPTZ normally yields a tz-aware datetime; guard the naive
+    # case (assume UTC) so the subtraction never raises.
+    if newest.tzinfo is None:
+        newest = newest.replace(tzinfo=timezone.utc)
+
+    age_hours = (utcnow() - newest).total_seconds() / 3600.0
+    if age_hours > _SPAN_STALENESS_THRESHOLD_HOURS:
+        return {
+            "name": "Live-span freshness",
+            "level": "warning",
+            "message": (
+                f"Latest span is {age_hours:.1f}h old (threshold "
+                f"{_SPAN_STALENESS_THRESHOLD_HOURS}h) — if Claude Code or Codex "
+                "is running, restart it so it picks up the current OTLP endpoint "
+                "(or check your OTLP endpoint / `tj serve`)."
+            ),
+        }
+    return {"name": "Live-span freshness", "level": "ok",
+            "message": f"Most recent span is {age_hours:.1f}h old."}
 
 
 def _attempt_repairs(checks: list[dict], db: object, output_json: bool) -> None:

--- a/tokenjam/cli/cmd_onboard.py
+++ b/tokenjam/cli/cmd_onboard.py
@@ -566,8 +566,8 @@ def _onboard_claude_code(
     if not want_daemon:
         _warn_manual_serve_restart(stopped_for_db=stopped_for_db, no_daemon=True)
         console.print("[dim]Start the server:[/dim]  tj serve")
-    console.print("[dim]Restart Claude Code for settings to take effect.[/dim]")
-    console.print(f"[dim]Then run:[/dim]  tj status --agent {agent_id}")
+    _print_restart_banner("Claude Code")
+    console.print(f"[dim]After restarting, run:[/dim]  tj status --agent {agent_id}")
 
 
 def _onboard_codex(
@@ -808,7 +808,40 @@ def _onboard_codex(
     console.print(
         "[dim]Codex can now call TokenJam tools (open_dashboard, get_status, etc.) directly.[/dim]"
     )
-    console.print("[dim]Then run:[/dim]  tj traces")
+    _print_restart_banner("Codex")
+    console.print("[dim]After restarting, run:[/dim]  tj traces")
+
+
+def _print_restart_banner(app_name: str) -> None:
+    """Render a prominent restart-required banner at the end of onboarding.
+
+    Coding agents (Claude Code, Codex) read their OTLP exporter env vars once
+    at startup, not per request. After onboard rewrites the endpoint/ingest
+    secret, an already-running instance keeps exporting to the stale endpoint
+    and today's spans silently never reach TokenJam (issue #179). A single dim
+    one-liner was too easy to miss, so make this a Rich panel.
+    """
+    from rich.panel import Panel
+    from rich.text import Text
+
+    body = Text()
+    body.append("Restart ", style="bold")
+    body.append(app_name, style="bold yellow")
+    body.append(" now for the new settings to take effect.\n", style="bold")
+    body.append(
+        f"A {app_name} session already running will keep sending telemetry to "
+        "the old endpoint — today's activity won't reach TokenJam until you "
+        "restart it.",
+        style="dim",
+    )
+    console.print(
+        Panel(
+            body,
+            title="[bold]Action required[/bold]",
+            border_style="yellow",
+            padding=(1, 2),
+        )
+    )
 
 
 def _warn_manual_serve_restart(*, stopped_for_db: bool, no_daemon: bool) -> None:


### PR DESCRIPTION
After `tj onboard --claude-code` rewrites the OTLP endpoint/ingest secret, an already-running Claude Code (or Codex) instance keeps exporting to the *old* endpoint until it restarts — so today's spans silently never reach TokenJam. The user sees a flat Overview chart and concludes "TokenJam isn't tracking anything." This surfaces that staleness on two CLI surfaces so the connectivity failure is visible and actionable.

## Summary
- Add a prominent Rich restart **banner** at the end of both the `--claude-code` and `--codex` onboard flows (replacing the easy-to-miss dim one-liner).
- Add a `tj doctor` **"Live-span freshness"** check that warns (exit 1) when the newest span is stale, with a restart hint.

## Symptom / root cause / fix
- **Symptom:** after onboarding, the Overview 24h chart stays flat despite active usage; "I onboarded but nothing is being tracked" — the most common silent-failure mode.
- **Root cause:** coding agents read OTLP exporter env vars once at process startup, not per request. A session running across the reconfigure keeps hitting the stale endpoint (401s silently / hits a different daemon), and its spans are lost. New sessions started after restart flow correctly.
- **Fix (onboard, `cli/cmd_onboard.py`):** new `_print_restart_banner(app_name)` helper renders a yellow Rich `Panel` ("Action required") at the end of `_onboard_claude_code` (`cmd_onboard.py:569`) and `_onboard_codex` (`cmd_onboard.py:808`). Rich-formatted (no hardcoded unicode bullets, Rule 6). No pause/confirmation — auto-restart is out of scope.
- **Fix (doctor, `cli/cmd_doctor.py`):** new `_check_span_staleness(db)` (registered as check #10) queries `SELECT MAX(start_time) FROM spans` via `db.conn` with parameterised SQL (Rule 7), compares to `utcnow()` (Rule 9), and warns when the gap exceeds the threshold. Respects the exit-code contract — this is a **warning (exit 1)**, never an error. An empty DB returns `info` (benign pre-onboard state), so no false alarm.

### Threshold choice — 6h
Claude Code / Codex flush their OTLP exporter every few minutes while running, so during any active session the newest span is minutes old at most. **6h** is wide enough not to nag on overnight/weekend idle gaps, yet tight enough to catch the issue-#179 case: a same-day reconfigure followed by continued work in the un-restarted session. Defined as a named constant `_SPAN_STALENESS_THRESHOLD_HOURS` and surfaced in the check message.

## Tests / Verification
Extended `tests/integration/test_cli.py` (CliRunner + patched `load_config`/`open_db` with `InMemoryBackend`; spans via `tests/factories.py`):
- `test_doctor_no_staleness_warning_with_fresh_spans` — fresh span → `ok`, exit 0.
- `test_doctor_warns_on_stale_spans` — span 10h old → `warning`, exit 1, message contains a restart hint.
- `test_doctor_no_staleness_warning_when_no_spans` — empty DB → `info`, no warning.

`pytest tests/unit/ tests/integration/` → **710 passed**. `ruff check` and `mypy` clean for both touched CLI files.

Sample banner output:
```
╭────────────────────────────── Action required ───────────────────────────────╮
│  Restart Claude Code now for the new settings to take effect.                │
│  A Claude Code session already running will keep sending telemetry to the    │
│  old endpoint — today's activity won't reach TokenJam until you restart it.  │
╰──────────────────────────────────────────────────────────────────────────────╯
```

Sample doctor check (stale span):
```
⚠  Live-span freshness: Latest span is 10.0h old (threshold 6h) — if Claude Code
   or Codex is running, restart it so it picks up the current OTLP endpoint
   (or check your OTLP endpoint / `tj serve`).
```

## What's NOT in this PR
- **In-UI Overview "last span received Xh ago" indicator** (acceptance-criteria option 1) — touches `ui/index.html`, owned by a parallel agent; deferred to a follow-up.
- **Auto-restart Claude Code** (option 3) — too invasive; intentionally out of scope.

Closes #179

🤖 Generated with [Claude Code](https://claude.com/claude-code)