### PR TITLE
Fix #177, #178: consistent Lens chart framing + local-timezone axis labels

### DIFF
--- a/tests/integration/test_cost_framing_window.py
+++ b/tests/integration/test_cost_framing_window.py
@@ -1,0 +1,130 @@
+"""#177 — /api/v1/cost plan-tier framing must be window-INDEPENDENT.
+
+The cost chart's tokens-vs-dollars unit and the qualifier banner are a property
+of the user's plan, not the selected time window. Before the fix, the framing
+mix was scoped to the window via ``session.started_at``; a 24h window with no
+in-window session *starts* (but recent spans from long-running sessions)
+collapsed to the empty-mix "api" default and rendered dollars, while a 7d/30d
+window rendered the subscription / unknown framing for the very same user.
+
+These tests seed long-running sessions whose ``started_at`` is outside the 24h
+window while their spans are recent, then assert the framing block is identical
+across 24h / 7d / 30d. Uses a real DuckDBBackend because the route's mix query
+runs against ``db.conn`` (InMemoryBackend has none and short-circuits to {}).
+"""
+from __future__ import annotations
+
+import dataclasses
+from datetime import timedelta
+
+import httpx
+import pytest
+
+from tokenjam.api.app import create_app
+from tokenjam.core.config import ProviderBudget, StorageConfig, TjConfig
+from tokenjam.core.db import DuckDBBackend
+from tokenjam.core.ingest import IngestPipeline
+from tokenjam.utils.time_parse import utcnow
+from tests.factories import make_llm_span, make_session
+
+
+@pytest.fixture(autouse=True)
+def _isolate_home(monkeypatch, tmp_path):
+    """Point Path.home() at an empty dir so config_declared_plan's global
+    fallback never reads the dev machine's ~/.config/tj/config.toml."""
+    monkeypatch.setattr("pathlib.Path.home", lambda: tmp_path)
+
+
+def _seed_long_running(db, plan_tier: str) -> None:
+    """40 sessions that STARTED 3–14 days ago but each have a span in the last
+    hour — the divergence that made 24h framing differ from 30d (#177)."""
+    now = utcnow()
+    for i in range(40):
+        days = 3 + (i % 12)
+        s = make_session(session_id=f"s-{i}", plan_tier=plan_tier)
+        s = dataclasses.replace(s, started_at=now - timedelta(days=days))
+        db.upsert_session(s)
+        db.insert_span(make_llm_span(
+            session_id=f"s-{i}", billing_account="anthropic",
+            start_time=now - timedelta(days=days),
+            input_tokens=5000, output_tokens=800, cost_usd=40.0,
+        ))
+        db.insert_span(make_llm_span(
+            session_id=f"s-{i}", billing_account="anthropic",
+            start_time=now - timedelta(hours=1, minutes=i % 50),
+            input_tokens=1000, output_tokens=200, cost_usd=5.0,
+        ))
+
+
+async def _framings_across_windows(db, config):
+    pipeline = IngestPipeline(db=db, config=config)
+    app = create_app(config=config, db=db, ingest_pipeline=pipeline)
+    transport = httpx.ASGITransport(app=app)
+    out = {}
+    async with httpx.AsyncClient(transport=transport, base_url="http://t") as c:
+        for win in ("24h", "7d", "30d"):
+            out[win] = (await c.get(f"/api/v1/cost?since={win}")).json()["framing"]
+    return out
+
+
+@pytest.mark.asyncio
+async def test_framing_consistent_across_windows_subscription(tmp_path):
+    """Declared subscription user → tokens framing on every window (AC #2)."""
+    db = DuckDBBackend(StorageConfig(path=str(tmp_path / "t.duckdb")))
+    config = TjConfig(version="1", budgets={"anthropic": ProviderBudget(plan="max_5x")})
+    _seed_long_running(db, plan_tier="unknown")  # data unstamped; plan declared
+    framings = await _framings_across_windows(db, config)
+    modes = {w: f["pricing_mode"] for w, f in framings.items()}
+    rules = {w: f["display_rule"] for w, f in framings.items()}
+    assert set(modes.values()) == {"subscription"}, modes
+    assert len(set(rules.values())) == 1, rules
+    db.close()
+
+
+@pytest.mark.asyncio
+async def test_framing_consistent_across_windows_subscription_from_data(tmp_path):
+    """Undeclared user whose sessions are subscription-stamped → tokens on
+    every window (no 24h dollars / 30d tokens split)."""
+    db = DuckDBBackend(StorageConfig(path=str(tmp_path / "t.duckdb")))
+    config = TjConfig(version="1")  # no declared plan
+    _seed_long_running(db, plan_tier="max_5x")
+    framings = await _framings_across_windows(db, config)
+    modes = {w: f["pricing_mode"] for w, f in framings.items()}
+    assert set(modes.values()) == {"subscription"}, modes
+    db.close()
+
+
+@pytest.mark.asyncio
+async def test_framing_consistent_across_windows_unknown(tmp_path):
+    """Undeclared user with all-unknown sessions → the SAME unknown framing on
+    every window (AC #4: one consistent choice, not 24h api / 30d unknown)."""
+    db = DuckDBBackend(StorageConfig(path=str(tmp_path / "t.duckdb")))
+    config = TjConfig(version="1")  # no declared plan
+    _seed_long_running(db, plan_tier="unknown")
+    framings = await _framings_across_windows(db, config)
+    modes = {w: f["pricing_mode"] for w, f in framings.items()}
+    rules = {w: f["display_rule"] for w, f in framings.items()}
+    assert set(modes.values()) == {"unknown"}, modes
+    assert len(set(rules.values())) == 1, rules
+    # The qualifier banner is the same on every window, too.
+    quals = {w: f["qualifier_text"] for w, f in framings.items()}
+    assert len(set(quals.values())) == 1, quals
+    db.close()
+
+
+@pytest.mark.asyncio
+async def test_window_totals_still_vary_by_window(tmp_path):
+    """Framing is window-independent, but the dollar/token TOTALS the chart
+    plots must still grow with the window — only the *framing* is pinned."""
+    db = DuckDBBackend(StorageConfig(path=str(tmp_path / "t.duckdb")))
+    config = TjConfig(version="1", budgets={"anthropic": ProviderBudget(plan="api")})
+    _seed_long_running(db, plan_tier="api")
+    pipeline = IngestPipeline(db=db, config=config)
+    app = create_app(config=config, db=db, ingest_pipeline=pipeline)
+    transport = httpx.ASGITransport(app=app)
+    async with httpx.AsyncClient(transport=transport, base_url="http://t") as c:
+        c24 = (await c.get("/api/v1/cost?since=24h")).json()
+        c30 = (await c.get("/api/v1/cost?since=30d")).json()
+    assert c24["framing"]["pricing_mode"] == c30["framing"]["pricing_mode"] == "api"
+    assert c30["total_cost_usd"] > c24["total_cost_usd"]
+    db.close()

--- a/tests/unit/test_framing.py
+++ b/tests/unit/test_framing.py
@@ -269,6 +269,27 @@ def test_render_savings_none_dash():
     assert render_savings(None, None, f) == "—"
 
 
+# --------------------------------------------------------------------------- #
+# plan_determination_mix — window-independent (#177)
+# --------------------------------------------------------------------------- #
+def test_plan_determination_mix_ignores_time_window():
+    """The framing mix must not be scoped to a window: a 24h-vs-30d split was
+    the root cause of window-dependent framing (#177). plan_determination_mix
+    passes since=until=None to plan_tier_mix, so it counts every session."""
+    from unittest.mock import MagicMock
+
+    from tokenjam.core.framing import plan_determination_mix
+
+    conn = MagicMock()
+    conn.execute.return_value.fetchall.return_value = [("max_5x", 3), ("unknown", 40)]
+    result = plan_determination_mix(conn, agent_id="agent-x")
+    assert result == {"max_5x": 3, "unknown": 40}
+    # The SQL is bound only with the agent_id — no started_at window clause.
+    sql, params = conn.execute.call_args[0]
+    assert "started_at" not in sql
+    assert params == ["agent-x"]
+
+
 def test_framing_to_dict_has_contract_fields():
     f = compute_framing(
         _Config(),

--- a/tests/unit/test_lens_ui_regression.py
+++ b/tests/unit/test_lens_ui_regression.py
@@ -60,6 +60,22 @@ def test_overview_chart_is_not_a_click_target(html):
     assert "View Cost details" in html
 
 
+# --- #178: chart x-axis ticks render in the browser's local timezone ------- #
+def test_axis_time_ticks_render_in_local_timezone(html):
+    # The hourly + date tick formatter must NOT pin to UTC — it formats the
+    # UTC epoch-second buckets in the viewer's local zone (a US-Pacific user
+    # sees their noon, not UTC's 7pm). Server data stays UTC; only labels shift.
+    import re
+
+    m = re.search(r"function fmtAxisTime\(epoch, bucket\) \{.*?\n\}", html, re.DOTALL)
+    assert m, "fmtAxisTime helper not found"
+    body = m.group(0)
+    assert "toLocaleTimeString" in body
+    assert "toLocaleDateString" in body
+    # The bug: the formatters previously forced { timeZone: 'UTC' }.
+    assert "timeZone: 'UTC'" not in body, "axis ticks must localize, not force UTC"
+
+
 # --- #129: run-rate denominator + caption + $ axis ------------------------- #
 def test_run_rate_uses_window_length_not_data_range(html):
     assert "function windowDays" in html

--- a/tokenjam/api/routes/cost.py
+++ b/tokenjam/api/routes/cost.py
@@ -7,7 +7,11 @@ from fastapi import APIRouter, Depends, Request
 
 from tokenjam.api.deps import require_api_key
 from tokenjam.core.cycle import cycle_bounds, effective_cycle_start_day
-from tokenjam.core.framing import WindowSummary, compute_framing, plan_tier_mix
+from tokenjam.core.framing import (
+    WindowSummary,
+    compute_framing,
+    plan_determination_mix,
+)
 from tokenjam.core.models import CostFilters
 from tokenjam.utils.time_parse import parse_since, utcnow
 
@@ -111,9 +115,13 @@ async def get_cost(
 
     # Plan-tier framing block — single source shared with the CLI (#110). Lets
     # the local web UI render the same suppressed/qualified dollar figures.
+    # The mix is window-INDEPENDENT (#177): the pricing mode + qualifier banner
+    # are a property of the user's plan, so the chart's tokens-vs-dollars unit
+    # stays consistent as the user switches windows. Only the window totals
+    # (above) and the `series` (below) are window-scoped.
     conn = getattr(db, "conn", None)
     mix = (
-        plan_tier_mix(conn, since_dt, until_dt, agent_id)
+        plan_determination_mix(conn, agent_id)
         if conn is not None else {}
     )
     framing = compute_framing(

--- a/tokenjam/core/framing.py
+++ b/tokenjam/core/framing.py
@@ -329,6 +329,14 @@ def compute_framing(
     # a subscription user. This deliberately diverges from the CLI's data-driven
     # `dominant_plan` (which the CLI calls directly) — compute_framing is the
     # UI/API path and benefits from the config fallback.
+    #
+    # The pricing mode (and thus the tokens-vs-dollars unit + qualifier banner)
+    # is a property of the user's PLAN, not the selected time window (#177).
+    # Framing callers therefore pass a window-INDEPENDENT session mix (the user's
+    # full history via `plan_determination_mix`); only the window totals above
+    # stay window-scoped. Without this, a 24h view (no in-window session starts →
+    # empty-mix "api" default) rendered dollars while a 30d view rendered the
+    # subscription / unknown framing for the very same user.
     declared = config_declared_plan(config)
     if not mix and declared:
         dom = declared
@@ -362,8 +370,12 @@ def compute_framing(
     elif mode == "subscription":
         display_rule = DISPLAY_SUPPRESS_SUBSCRIPTION
         if api_sessions > 0:
+            # Scope-neutral wording ("of sessions", not "this window"): the
+            # /cost route now frames off the user's full session history (#177)
+            # while the CLI / compare callers still pass a window-scoped mix —
+            # the phrasing must read truthfully for both.
             qualifier = (
-                f"{sub_pct:.1f}% of this window was subscription-billed; "
+                f"{sub_pct:.1f}% of sessions are subscription-billed; "
                 f"dollar figures reflect API traffic only."
             )
     elif mode == "local":
@@ -487,3 +499,19 @@ def plan_tier_mix(
     )
     rows = conn.execute(sql, params).fetchall()
     return {str(r[0]): int(r[1]) for r in rows}
+
+
+def plan_determination_mix(conn: Any, agent_id: str | None = None) -> dict[str, int]:
+    """Window-INDEPENDENT session plan-tier mix for framing decisions (#177).
+
+    The pricing mode (tokens vs dollars) and the qualifier banner are a property
+    of the user's plan, not the selected time window. Computing the mix over a
+    bounded window made a 24h view resolve differently from a 30d view for the
+    same user — e.g. a window with no in-window session *starts* (but recent
+    spans from long-running sessions) collapsed to the empty-mix "api" default
+    while a longer window read "unknown" or "subscription". Framing callers
+    therefore determine the plan from the user's FULL session history; only the
+    window totals (cost / tokens) remain window-scoped. ``agent_id`` still
+    narrows to a single agent when set — the plan is per-agent, not per-window.
+    """
+    return plan_tier_mix(conn, None, None, agent_id)

--- a/tokenjam/ui/index.html
+++ b/tokenjam/ui/index.html
@@ -917,12 +917,15 @@ function fmtAxisUsd(v) {
 }
 
 // Consistent time-axis labels (#136). Hourly buckets → "6 PM"; daily → "Jun 15"
-// — one format across every tick, no "6/15/26" mixed with "6/16". Formatted in
-// UTC to match the UTC-aligned buckets.
+// — one format across every tick, no "6/15/26" mixed with "6/16". The server
+// sends UTC epoch-second buckets, but the tick labels render in the browser's
+// LOCAL timezone (#178) — a US-Pacific user sees "12 PM", not UTC's "7 PM".
+// `new Date(epoch*1000)` already holds the correct instant; omitting `timeZone`
+// makes toLocale*String() format it in the viewer's local zone.
 function fmtAxisTime(epoch, bucket) {
   const d = new Date(epoch * 1000);
-  if (bucket === 'hour') return d.toLocaleTimeString(undefined, { hour: 'numeric', timeZone: 'UTC' });
-  return d.toLocaleDateString(undefined, { month: 'short', day: 'numeric', timeZone: 'UTC' });
+  if (bucket === 'hour') return d.toLocaleTimeString(undefined, { hour: 'numeric' });
+  return d.toLocaleDateString(undefined, { month: 'short', day: 'numeric' });
 }
 
 // uPlot hover tooltip (#128): crosshair → date + framed value(s) at the nearest


### PR DESCRIPTION
The Lens Overview / Cost spend chart presented the same user's data in different units depending on the selected time window, and rendered its x-axis ticks in UTC rather than the viewer's local timezone. Both are confusing-but-not-data-wrong bugs that erode trust in the dashboard.

## Summary
- **#177**: the chart's tokens-vs-dollars unit and the plan-tier qualifier banner are now a property of the user's **plan**, not the time window — consistent across 24h / 7d / 30d / 90d, and the Cost detail screen matches the Overview.
- **#178**: the chart x-axis tick labels render in the **browser's local timezone**; server data stays UTC.
- Backend-only fix for #177 (the UI already consumes the server `framing` block — no plan-tier framing is re-derived in JS). Honesty discipline preserved: subscription / local / unknown dollar-suppression is untouched.

## #177 — chart framing was window-dependent
**Symptom.** For one user, 24h showed token framing (no banner) while 7d/30d showed dollar framing with the "Plan tier unknown" qualifier — same data, different mental model per window.

**Re-verified against current `main`** (post-#184). It still reproduces for users **without** a declared plan, or whose session data diverges from the window. Seeding 40 long-running sessions (started 3–14 days ago, but with spans in the last hour) and hitting `/api/v1/cost`:

| window | before (main) | after |
|---|---|---|
| 24h | `api` / `show_dollars` (no banner) | `unknown` / `suppress_dollars_unknown` |
| 7d  | `unknown` / `suppress_dollars_unknown` | `unknown` / `suppress_dollars_unknown` |
| 30d | `unknown` / `suppress_dollars_unknown` | `unknown` / `suppress_dollars_unknown` |

(Undeclared, subscription-stamped sessions flipped 24h=`api`/dollars vs 30d=`subscription`/tokens — the exact reported class of bug.)

**Root cause.** `/api/v1/cost` derived its framing from a **window-scoped** session mix — `plan_tier_mix(conn, since, until, agent_id)`, keyed on `session.started_at`. That window diverges from the span-based cost totals: a 24h window with recent spans from sessions that *started* >24h ago has an **empty** session mix, so `dominant_plan({})` collapses to the `"api"` default (dollars), while a 7d/30d window sees the real `unknown` / subscription sessions and frames accordingly.

**Fix.** The pricing mode + qualifier banner are a property of the plan, so the cost route now determines them from a new **window-independent** `plan_determination_mix(conn, agent_id)` (the user's full session history). Only the window totals and the chart `series` stay window-scoped. The shared subscription qualifier is reworded scope-neutrally ("of sessions", not "this window") because the same `compute_framing` still serves the window-scoped CLI / `--compare` callers.

Acceptance criteria: subscription → tokens on every window; api → dollars; unknown → one consistent choice across all windows; Cost detail matches Overview. ✔

## #178 — x-axis showed UTC instead of local time
**Symptom.** A US-Pacific user on a 24h chart saw "7 PM" where it was actually noon local (PDT, −7h).

**Root cause.** `SpendChart`'s `fmtAxisTime` forced `{ timeZone: 'UTC' }` on both the hourly and date tick formatters.

**Fix.** Drop the explicit `timeZone` from the two tick formatters only. `new Date(epoch*1000)` already holds the correct instant; `toLocaleTimeString()` / `toLocaleDateString()` then format it in the viewer's local zone. Server buckets stay UTC. Trace-detail timestamps are untouched (out of scope per the issue).

## Tests / Verification
- `tests/integration/test_cost_framing_window.py` (new) — seeds the long-running-session divergence against a real DuckDB backend and asserts `/api/v1/cost` framing (mode + display_rule + qualifier) is identical across 24h/7d/30d for subscription (declared & data-driven) and unknown users, while the dollar/token **totals** still grow with the window.
- `tests/unit/test_framing.py` — `plan_determination_mix` passes `since=until=None` (no `started_at` clause), so the framing mix is window-independent.
- `tests/unit/test_lens_ui_regression.py` — static-grep guard asserting `fmtAxisTime` uses `toLocale*String` and no longer forces `timeZone: 'UTC'`.
- Full suite green: `pytest tests/unit/ tests/integration/ tests/synthetic/ tests/agents/` → **802 passed**. `ruff` + `mypy` clean on touched files. `node --check` clean on the extracted module.
- **Visual** (headless Chrome, machine TZ = PDT −0700, seeded subscription user):
  - Overview 24h and 30d both render "Spend (tokens)" + "% of cycle tokens" + "Max 5x plan" — consistent unit across windows.
  - Cost detail 24h chart matches the Overview (tokens), satisfying AC #5.
  - 24h axis reads local hours (12 PM → 12 PM) with the recent-activity bumps at ~6–10 AM local (their UTC afternoon equivalents would have read "1 PM"/"6 PM" pre-fix).

## What's NOT in this PR
- **Web Cost-table COST column framing.** The detail table's COST cells still render raw `$` via `fmtCost` (line 1537) for subscription users — pre-existing and independent of the chart (the chart-vs-table mismatch already existed at 7d/30d before this fix). It's the web analog of the CLI `tj cost` table fix (#175), and belongs in its own change rather than expanding this chart-framing PR.
- **Trace-detail timestamp localization** — explicitly left UTC per #178's scope note.
- **#179 staleness indicator** — a separate agent's concern.
- I did not extend the window-independent mix to `/optimize` or `/cost/compare`; #177 is scoped to the cost chart + Cost detail (both `/api/v1/cost`). Those routes remain window-scoped and can be aligned separately if desired.

Closes #177
Closes #178

🤖 Generated with [Claude Code](https://claude.com/claude-code)