### PR TITLE
Fix #188: keep daily chart date labels UTC-aligned

### DIFF
--- a/tests/unit/test_lens_ui_regression.py
+++ b/tests/unit/test_lens_ui_regression.py
@@ -60,20 +60,24 @@ def test_overview_chart_is_not_a_click_target(html):
     assert "View Cost details" in html
 
 
-# --- #178: chart x-axis ticks render in the browser's local timezone ------- #
-def test_axis_time_ticks_render_in_local_timezone(html):
-    # The hourly + date tick formatter must NOT pin to UTC — it formats the
-    # UTC epoch-second buckets in the viewer's local zone (a US-Pacific user
-    # sees their noon, not UTC's 7pm). Server data stays UTC; only labels shift.
+# --- #178 / #188: chart x-axis tick timezone handling --------------------- #
+def test_axis_time_ticks_timezone_split(html):
+    # #178: HOURLY ticks localize — they format the UTC epoch-second buckets in
+    # the viewer's local zone (a US-Pacific user sees their noon, not UTC's 7pm).
+    # #188: DAILY date labels stay UTC, because the buckets are UTC-day-aligned;
+    # localizing a UTC-midnight key would print the previous local day for
+    # west-of-UTC users and no longer match the bucket span.
     import re
 
     m = re.search(r"function fmtAxisTime\(epoch, bucket\) \{.*?\n\}", html, re.DOTALL)
     assert m, "fmtAxisTime helper not found"
     body = m.group(0)
-    assert "toLocaleTimeString" in body
-    assert "toLocaleDateString" in body
-    # The bug: the formatters previously forced { timeZone: 'UTC' }.
-    assert "timeZone: 'UTC'" not in body, "axis ticks must localize, not force UTC"
+    hour_line = next(line for line in body.splitlines() if "toLocaleTimeString" in line)
+    date_line = next(line for line in body.splitlines() if "toLocaleDateString" in line)
+    # Hourly localizes (must NOT force UTC).
+    assert "timeZone: 'UTC'" not in hour_line, "hourly ticks must localize (#178)"
+    # Daily stays UTC-aligned (must force UTC).
+    assert "timeZone: 'UTC'" in date_line, "daily date labels stay UTC-aligned (#188)"
 
 
 # --- #129: run-rate denominator + caption + $ axis ------------------------- #

--- a/tokenjam/ui/index.html
+++ b/tokenjam/ui/index.html
@@ -918,14 +918,18 @@ function fmtAxisUsd(v) {
 
 // Consistent time-axis labels (#136). Hourly buckets → "6 PM"; daily → "Jun 15"
 // — one format across every tick, no "6/15/26" mixed with "6/16". The server
-// sends UTC epoch-second buckets, but the tick labels render in the browser's
-// LOCAL timezone (#178) — a US-Pacific user sees "12 PM", not UTC's "7 PM".
-// `new Date(epoch*1000)` already holds the correct instant; omitting `timeZone`
-// makes toLocale*String() format it in the viewer's local zone.
+// sends UTC epoch-second buckets.
+// Hourly ticks render in the browser's LOCAL timezone (#178) — a US-Pacific
+// user sees "12 PM", not UTC's "7 PM" — since an hour label is meaningful in
+// the viewer's zone. Daily labels, however, stay UTC (#188): the buckets are
+// UTC-day-aligned server-side, so localizing a UTC-midnight key would print
+// the PREVIOUS local day for west-of-UTC users and no longer match the bucket's
+// span. (True local-day labels would require local-day bucketing server-side —
+// deferred; see #188.)
 function fmtAxisTime(epoch, bucket) {
   const d = new Date(epoch * 1000);
   if (bucket === 'hour') return d.toLocaleTimeString(undefined, { hour: 'numeric' });
-  return d.toLocaleDateString(undefined, { month: 'short', day: 'numeric' });
+  return d.toLocaleDateString(undefined, { month: 'short', day: 'numeric', timeZone: 'UTC' });
 }
 
 // uPlot hover tooltip (#128): crosshair → date + framed value(s) at the nearest


### PR DESCRIPTION
The #178 fix (#186) localized all spend-chart x-axis labels. That's right for hourly ticks but wrong for daily buckets, which are UTC-day-aligned server-side — so a local-timezone label on a UTC-midnight key shows the previous local day for west-of-UTC users. This splits the formatter so hourly localizes and daily stays UTC.

## Summary
- `fmtAxisTime` in `ui/index.html`: hourly ticks keep localizing (#178); daily date labels regain `timeZone: 'UTC'` to stay coherent with the UTC-aligned buckets.
- Updated the UI regression test to assert the split (hourly localizes, daily forces UTC) rather than the previous "no UTC anywhere" check.

## #188 — daily labels off by a day for non-UTC users
- **Symptom:** a US-Pacific user on a 7d/30d/90d window saw daily buckets labeled one calendar day earlier than the bucket's UTC span.
- **Root cause:** `/api/v1/cost` buckets `series` by UTC day; #186 formatted those UTC-midnight keys with `toLocaleDateString()` (no `timeZone`), shifting the date for west-of-UTC viewers.
- **Fix:** daily formatter forces `timeZone: 'UTC'` again; hourly is untouched (stays local). Chose this over local-day server-side bucketing (option 1 in the issue) — that's a larger change not worth it for a low-severity cosmetic label on coarse daily granularity.

## Tests / Verification
- `tests/unit/test_lens_ui_regression.py::test_axis_time_ticks_timezone_split` — asserts the hourly line localizes and the daily line forces UTC.
- `tests/unit/test_ui_offline.py` still green; `node --check` clean on the extracted app module.

## What's NOT in this PR
- Local-day server-side bucketing (the "fully correct" option) — deferred; daily granularity in UTC is coherent and far cheaper.
- The honesty-discipline raw-dollar leak on the Cost table / Traces (#187) — separate concern, separate PR.

Closes #188

🤖 Generated with [Claude Code](https://claude.com/claude-code)