### PR TITLE
Fix #187: suppress raw dollar figures for subscription/local users on web table & trace surfaces

### DIFF
--- a/tests/integration/test_api.py
+++ b/tests/integration/test_api.py
@@ -20,7 +20,7 @@ from tokenjam.core.config import (
 )
 from tokenjam.core.db import InMemoryBackend
 from tokenjam.core.ingest import IngestPipeline
-from tests.factories import make_llm_span, make_tool_span
+from tests.factories import make_llm_span, make_session, make_tool_span
 
 
 INGEST_SECRET = "test-secret-token"
@@ -304,6 +304,51 @@ async def test_cost_response_includes_framing_block(client):
     assert resp.status_code == 200
     framing = resp.json()["framing"]
     assert _FRAMING_KEYS <= set(framing)
+
+
+# --- #187: /traces + trace-detail carry a framing block so the web UI can ---- #
+# --- suppress / reframe raw dollar costs for subscription / local users. ----- #
+def _seed_trace_with_plan(db, plan_tier, *, trace_id, session_id="sess-187"):
+    """Insert a session (carrying plan_tier) + a matching LLM span so the trace
+    surfaces in /traces and the framing query has a session to read."""
+    db.upsert_session(make_session(session_id=session_id, plan_tier=plan_tier))
+    db.insert_span(make_llm_span(
+        session_id=session_id, trace_id=trace_id, cost_usd=1.23,
+        billing_account="anthropic",
+    ))
+
+
+async def test_traces_response_includes_framing_block(db, client):
+    _seed_trace_with_plan(db, "api", trace_id="aa" * 16)
+    framing = (await client.get("/api/v1/traces")).json()["framing"]
+    assert _FRAMING_KEYS <= set(framing)
+
+
+async def test_trace_detail_includes_framing_block(db, client):
+    tid = "bb" * 16
+    _seed_trace_with_plan(db, "max_5x", trace_id=tid)
+    body = (await client.get(f"/api/v1/traces/{tid}")).json()
+    assert _FRAMING_KEYS <= set(body["framing"])
+    # Detail scopes the plan determination to the trace's agent → subscription.
+    assert body["framing"]["pricing_mode"] == "subscription"
+
+
+@pytest.mark.parametrize("plan_tier,expected_mode", [
+    ("max_5x", "subscription"),
+    ("api", "api"),
+    ("local", "local"),
+    ("unknown", "unknown"),
+])
+async def test_traces_framing_reflects_plan_tier(
+    db, client, monkeypatch, tmp_path, plan_tier, expected_mode,
+):
+    """The /traces framing pricing_mode tracks the session plan tier across the
+    full matrix (#187). HOME is isolated so the unknown case can't pick up this
+    dev machine's global ~/.config/tj plan via compute_framing's fallback."""
+    monkeypatch.setattr("pathlib.Path.home", lambda: tmp_path)
+    _seed_trace_with_plan(db, plan_tier, trace_id="cc" * 16)
+    framing = (await client.get("/api/v1/traces")).json()["framing"]
+    assert framing["pricing_mode"] == expected_mode
 
 
 async def test_cost_cycle_block_defaults_to_calendar_month(client):

--- a/tests/unit/test_lens_ui_regression.py
+++ b/tests/unit/test_lens_ui_regression.py
@@ -226,3 +226,32 @@ def test_recoverable_tile_titles_share_one_weight(html):
     assert ".rec-amount.ok" in html          # green content line preserved (AC #4)
     # No state-specific rule bolds the title for the at_ceiling tile.
     assert ".rec-tile.ok .rec-name" not in html
+
+
+# --- #187: suppress raw $ for subscription/local on table & trace surfaces --- #
+def test_cost_table_cells_route_through_framing(html):
+    # The per-row + footer COST cells must reframe like the hero (useTokens /
+    # fmtFramedDollar), not render raw fmtCost. The bug was bare fmtCost cells.
+    assert "<td>${fmtCost(r.cost_usd)}</td>" not in html
+    assert "<td>${fmtCost(total)}</td>" not in html
+    assert "${useTokens ? fmtTokens(_costVal(r, true)) : fmtFramedDollar(r.cost_usd, framing)}" in html
+    assert "${useTokens ? fmtTokens(totalTokens) : fmtFramedDollar(total, framing)}" in html
+
+
+def test_traces_list_cost_routes_through_framing(html):
+    # Traces list COST column must consume the framing block, not raw fmtCost.
+    assert "<td>${fmtCost(t.cost_usd)}</td>" not in html
+    assert "${fmtFramedDollar(t.cost_usd, framing)}" in html
+    # The screen actually pulls the framing block off the /traces response.
+    assert "setFraming(td.framing || null)" in html
+
+
+def test_trace_detail_costs_route_through_framing(html):
+    # Waterfall bar label, tooltip line, and the span-detail panel all reframe —
+    # no bare per-span fmtCost (the bar label + tooltip both used s.cost_usd).
+    assert "fmtCost(s.cost_usd)" not in html
+    assert "${fmtCost(sel.cost_usd)}" not in html
+    assert "const costFramed = fmtFramedDollar(s.cost_usd, framing)" in html
+    assert "${fmtFramedDollar(sel.cost_usd, framing)}" in html
+    # Trace detail pulls the framing block off the /traces/{id} response.
+    assert "setFraming(d.framing || null)" in html

--- a/tokenjam/api/routes/traces.py
+++ b/tokenjam/api/routes/traces.py
@@ -5,10 +5,35 @@ from __future__ import annotations
 from fastapi import APIRouter, Depends, Request
 
 from tokenjam.api.deps import require_api_key
+from tokenjam.core.framing import (
+    WindowSummary,
+    compute_framing,
+    plan_determination_mix,
+)
 from tokenjam.core.models import TraceFilters
 from tokenjam.utils.time_parse import parse_since
 
 router = APIRouter(dependencies=[Depends(require_api_key)])
+
+
+def _traces_framing(request: Request, agent_id: str | None) -> dict:
+    """Plan-tier framing block for trace cost figures (#187).
+
+    Traces and trace-detail are not window-scoped views, so the plan is derived
+    from a window-INDEPENDENT session mix (`plan_determination_mix`) — the same
+    helper `/cost` uses. The web UI consumes this block to suppress / reframe raw
+    dollar costs for subscription / local users (honesty discipline, Rule 14)
+    instead of re-deriving the suppression rules in JS (single compute path).
+    """
+    db = request.app.state.db
+    config = request.app.state.config
+    conn = getattr(db, "conn", None)
+    mix = plan_determination_mix(conn, agent_id) if conn is not None else {}
+    framing = compute_framing(
+        config,
+        WindowSummary(plan_tier_mix=mix, sessions=sum(mix.values())),
+    )
+    return framing.to_dict()
 
 
 @router.get("/traces")
@@ -48,6 +73,7 @@ async def list_traces(
             for t in traces
         ],
         "count": len(traces),
+        "framing": _traces_framing(request, agent_id),
     }
 
 
@@ -55,10 +81,15 @@ async def list_traces(
 async def get_trace(request: Request, trace_id: str) -> dict:
     db = request.app.state.db
     spans = db.get_trace_spans(trace_id)
+    # Scope the plan determination to this trace's agent when known (falls back
+    # to the whole install) so subscription / local cost suppression matches the
+    # Traces list and Cost screen.
+    agent_id = next((s.agent_id for s in spans if getattr(s, "agent_id", None)), None)
     return {
         "trace_id": trace_id,
         "spans": [_span_to_dict(s) for s in spans],
         "span_count": len(spans),
+        "framing": _traces_framing(request, agent_id),
     }
 
 

--- a/tokenjam/ui/index.html
+++ b/tokenjam/ui/index.html
@@ -1114,6 +1114,7 @@ function TracesListView({ params }) {
   const setFilter = (k, v) => navigate('traces', { since, result, agent_id: agentId, [k]: v }, DEFAULTS);
 
   const [traces, setTraces] = useState([]);
+  const [framing, setFraming] = useState(null);
   const [agentStatus, setAgentStatus] = useState({});
 
   const load = useCallback(async () => {
@@ -1122,6 +1123,7 @@ function TracesListView({ params }) {
       api('/status'),
     ]);
     setTraces(td.traces || []);
+    setFraming(td.framing || null);
     const map = {};
     for (const a of (sd.agents || [])) map[a.agent_id] = a.status;
     setAgentStatus(map);
@@ -1158,7 +1160,7 @@ function TracesListView({ params }) {
               <td>${friendlySpanName(t.name)}</td>
               <td>${fmtAgo(t.start_time)}</td>
               <td>${fmtDur(t.duration_ms)}</td>
-              <td>${fmtCost(t.cost_usd)}</td>
+              <td>${fmtFramedDollar(t.cost_usd, framing)}</td>
               <td><span class="badge badge-${t.status_code}">${t.status_code}</span></td>
               <td>${st ? html`<span class="status-dot ${st}" style="margin-right:5px"></span><span class="badge badge-${st}">${st}</span>` : html`<span style="color:var(--text-dim)">-</span>`}</td>
               <td>${t.span_count}</td>
@@ -1185,10 +1187,11 @@ function dedup(traces) {
 // ============================
 function TraceDetailView({ traceId }) {
   const [spans, setSpans] = useState([]);
+  const [framing, setFraming] = useState(null);
   const [selected, setSelected] = useState(null);
 
   useEffect(() => {
-    api('/traces/' + traceId).then(d => setSpans(d.spans || []));
+    api('/traces/' + traceId).then(d => { setSpans(d.spans || []); setFraming(d.framing || null); });
   }, [traceId]);
 
   if (!spans.length) return html`<div class="empty">Loading trace...</div>`;
@@ -1243,7 +1246,10 @@ function TraceDetailView({ traceId }) {
         const friendly = friendlySpanName(s.name);
         const isAgent = kind === 'agent';
         const detail = s.model || s.tool_name || '';
-        const costStr = s.cost_usd != null && s.cost_usd > 0 ? ' \u2014 ' + fmtCost(s.cost_usd) : '';
+        // Plan-tier framed cost (#187): subscription \u2192 "% of cycle", local \u2192 "\u2014"
+        // (suppressed; omitted from the compact bar label), api/unknown \u2192 "$X".
+        const costFramed = fmtFramedDollar(s.cost_usd, framing);
+        const costStr = s.cost_usd != null && s.cost_usd > 0 && costFramed !== '\u2014' ? ' \u2014 ' + costFramed : '';
         const barLabel = isAgent
           ? fmtDur(s.duration_ms) + costStr
           : (detail ? detail + ' \u2014 ' : '') + fmtDur(s.duration_ms) + costStr;
@@ -1256,7 +1262,7 @@ function TraceDetailView({ traceId }) {
         if (s.output_tokens != null) tipLines.push('Output tokens: ' + fmtTokens(s.output_tokens));
         if (s.cache_tokens) tipLines.push('Cache read: ' + fmtTokens(s.cache_tokens));
         if (s.cache_write_tokens) tipLines.push('Cache write: ' + fmtTokens(s.cache_write_tokens));
-        if (s.cost_usd != null) tipLines.push('Cost: ' + fmtCost(s.cost_usd));
+        if (s.cost_usd != null && costFramed !== '—') tipLines.push('Cost: ' + costFramed);
         const tooltip = tipLines.join('\n');
         return html`
           <div class="wf-row ${selected === s.span_id ? 'selected' : ''}" onClick=${() => setSelected(s.span_id)}>
@@ -1286,7 +1292,7 @@ function TraceDetailView({ traceId }) {
           ${sel.output_tokens != null ? html`<span class="dk">Output tokens</span><span class="dv">${fmtTokens(sel.output_tokens)}</span>` : null}
           ${sel.cache_tokens ? html`<span class="dk">Cache read</span><span class="dv">${fmtTokens(sel.cache_tokens)}</span>` : null}
           ${sel.cache_write_tokens ? html`<span class="dk">Cache write</span><span class="dv">${fmtTokens(sel.cache_write_tokens)}</span>` : null}
-          ${sel.cost_usd != null ? html`<span class="dk">Cost</span><span class="dv">${fmtCost(sel.cost_usd)}</span>` : null}
+          ${sel.cost_usd != null ? html`<span class="dk">Cost</span><span class="dv">${fmtFramedDollar(sel.cost_usd, framing)}</span>` : null}
           ${sel.agent_id ? html`<span class="dk">Agent</span><span class="dv">${sel.agent_id}</span>` : null}
           ${sel.conversation_id ? html`<span class="dk">Conversation</span><span class="dv">${sel.conversation_id}</span>` : null}
           ${sel.session_id ? html`<span class="dk">Session</span><span class="dv">${sel.session_id}</span>` : null}
@@ -1522,7 +1528,7 @@ function CostView({ params }) {
           <th>${tableMode === 'day' ? 'Date' : tableMode === 'agent' ? 'Agent' : 'Model'}</th>
           ${tableMode !== 'agent' ? html`<th>Agent</th>` : null}
           ${tableMode !== 'model' ? html`<th>Model</th>` : null}
-          <th>Input</th><th>Output</th><th>Cache R <span class="info-btn">i<span class="info-tip">Cache-read tokens (billed at the discounted cache-read rate).</span></span></th><th>Cache W <span class="info-btn">i<span class="info-tip">Cache-write (creation) tokens — often the dominant cost driver on cache-heavy workloads.</span></span></th><th>Cost <span class="info-btn">i<span class="info-tip">Estimated from token usage. If you're on a subscription plan (e.g. Claude Max), your actual spend may differ.</span></span></th>
+          <th>Input</th><th>Output</th><th>Cache R <span class="info-btn">i<span class="info-tip">Cache-read tokens (billed at the discounted cache-read rate).</span></span></th><th>Cache W <span class="info-btn">i<span class="info-tip">Cache-write (creation) tokens — often the dominant cost driver on cache-heavy workloads.</span></span></th><th>Cost ${useTokens ? '(tokens) ' : ''}<span class="info-btn">i<span class="info-tip">Estimated from token usage. If you're on a subscription plan (e.g. Claude Max), your actual spend may differ.</span></span></th>
         </tr></thead>
         <tbody>
           ${rows.map(r => html`
@@ -1534,7 +1540,7 @@ function CostView({ params }) {
               <td>${fmtTokens(r.output_tokens)}</td>
               <td>${fmtTokens(r.cache_tokens || 0)}</td>
               <td>${fmtTokens(r.cache_write_tokens || 0)}</td>
-              <td>${fmtCost(r.cost_usd)}</td>
+              <td>${useTokens ? fmtTokens(_costVal(r, true)) : fmtFramedDollar(r.cost_usd, framing)}</td>
             </tr>
           `)}
           <tr style="font-weight:600;border-top:2px solid var(--border)">
@@ -1543,7 +1549,7 @@ function CostView({ params }) {
             <td>${fmtTokens(totalOut)}</td>
             <td>${fmtTokens(rows.reduce((s, r) => s + (r.cache_tokens || 0), 0))}</td>
             <td>${fmtTokens(rows.reduce((s, r) => s + (r.cache_write_tokens || 0), 0))}</td>
-            <td>${fmtCost(total)}</td>
+            <td>${useTokens ? fmtTokens(totalTokens) : fmtFramedDollar(total, framing)}</td>
           </tr>
         </tbody>
       </table></div>


### PR DESCRIPTION
TokenJam's honesty discipline (Critical Rule 14 / `core/framing.py`) is that subscription / local-plan users never see raw dollar *spend* — the framing layer suppresses or reframes it. The Overview and Cost-screen **hero** numbers already do this, but several web surfaces still rendered raw `$`, undercutting the framing for exactly the users it protects.

## Summary
- **Cost detail table** — per-row COST cells + footer total now follow the hero's existing `useTokens` / `fmtFramedDollar` treatment (subscription/local → tokens; api/unknown → raw dollars, unchanged).
- **Traces list + trace-detail** — `/api/v1/traces` and `/api/v1/traces/{id}` now return a `framing` block (built from the window-independent `plan_determination_mix`, the same helper `/cost` uses); the screens consume it and reframe span/trace costs via `fmtFramedDollar`.
- The UI **consumes** the server framing decision — no suppression rules re-derived in JS (single compute path). No caveat language strengthened; api/unknown output is byte-identical.

## #187 per surface

### Cost detail table (UI only — `framing` already in scope)
**Symptom.** On one screen, the hero read "12.3M tokens" but every table row's COST showed `$1.2345` and the footer total showed raw dollars — two mental models.
**Root cause.** The hero/projection used `useTokens` / `fmtFramedDollar`; the table cells (`index.html:1534`, `:1542`) called bare `fmtCost`.
**Fix.** Per-row COST: `useTokens ? fmtTokens(_costVal(r, true)) : fmtFramedDollar(r.cost_usd, framing)`; footer: `useTokens ? fmtTokens(totalTokens) : fmtFramedDollar(total, framing)`. The COST column header gains a `(tokens)` suffix when `useTokens` (mirrors the chart title). api/unknown fall through `fmtFramedDollar` → `fmtCost`, unchanged.

### Traces list + trace-detail (needed a framing block)
**Symptom.** Traces list COST column (`:1158`) and trace-detail span costs (bar label, tooltip, span-detail panel) rendered raw `fmtCost`; those screens fetched no framing block.
**Root cause.** `/traces` and `/traces/{id}` returned no `framing`, so the UI had nothing to suppress with.
**Fix (backend).** New `_traces_framing(request, agent_id)` in `routes/traces.py` builds the block via `compute_framing(config, WindowSummary(plan_tier_mix=plan_determination_mix(conn, agent_id)))` — window-independent, consistent with the `/cost` route + CLAUDE.md's rule that dollar-bearing read routes return a `framing` block. `/traces` scopes to the list's `agent_id`; `/traces/{id}` scopes to the trace's own agent (derived from its spans).
**Fix (UI).** Both screens store `framing` from the response and render costs via `fmtFramedDollar` → subscription `"% of cycle"`, local `"—"` (suppressed; omitted from the compact waterfall bar label & tooltip), api/unknown `"$X"` (unchanged).

## Tests / Verification
- **Backend** (`tests/integration/test_api.py`): `/traces` + `/traces/{id}` now carry a `framing` block; a parametrized matrix asserts `pricing_mode` tracks the session plan tier (`max_5x`→subscription, `api`→api, `local`→local, `unknown`→unknown, with `HOME` isolated so the unknown case can't read this machine's global config).
- **UI static-grep** (`tests/unit/test_lens_ui_regression.py`): the table/traces/trace-detail cost cells route through the framing-aware formatter (`fmtFramedDollar` / `useTokens`), no bare `fmtCost` on those cost cells, and both trace screens pull the framing block off their response. `test_ui_offline.py` stays green.
- **Suite**: `pytest tests/unit/ tests/synthetic/ tests/agents/ tests/integration/` → **814 passed**. `ruff check tokenjam/` + `mypy tokenjam/` clean. `node --check` clean on the extracted app module.
- **Visual** (headless Chrome, seeded Claude Max subscription DB):
  - Cost table: header reads **"COST (TOKENS)"**, cells + footer show token counts (66.1k) — no raw `$`.
  - Traces list: COST column shows **"2.5% of cycle"**, "4.3% of cycle", … — no raw `$`.
  - Trace detail: waterfall bar label + tooltip render **"2.5% of cycle"**; a DOM dump confirms **zero** raw `$` amounts in the rendered (non-script) trace-detail body.

## What's NOT in this PR
- The spend **chart** + `fmtAxisTime` (fixed in #177/#178/#186) and the CLI `tj cost` (#175/#181) — untouched.
- No change to `core/framing.py` derivation logic — the suppression rules already live there; this PR only *consumes* them (`compute_framing` / `plan_determination_mix` / `render_dollar`/`fmtFramedDollar`).
- Adjacent (pre-existing, unrelated): `tests/integration/test_api.py` has a pre-existing unused-import (`AlertsConfig`, F401) on `main`, outside my diff hunks — left as-is per scope discipline (CI runs ruff as continue-on-error; `tokenjam/` is clean).

Closes #187

🤖 Generated with [Claude Code](https://claude.com/claude-code)