### PR TITLE
Fix #191: suppress raw dollar figures for subscription/local users on Status, Optimize & Reuse web surfaces

### DIFF
--- a/tests/integration/test_api.py
+++ b/tests/integration/test_api.py
@@ -351,6 +351,32 @@ async def test_traces_framing_reflects_plan_tier(
     assert framing["pricing_mode"] == expected_mode
 
 
+# --- #191: /status carries a framing block so the agent cards' "Cost today" -- #
+# --- figure can suppress / reframe raw dollars for subscription / local. ----- #
+async def test_status_response_includes_framing_block(db, client):
+    _seed_trace_with_plan(db, "api", trace_id="dd" * 16, session_id="sess-191")
+    data = (await client.get("/api/v1/status")).json()
+    assert _FRAMING_KEYS <= set(data["framing"])
+
+
+@pytest.mark.parametrize("plan_tier,expected_mode", [
+    ("max_5x", "subscription"),
+    ("api", "api"),
+    ("local", "local"),
+    ("unknown", "unknown"),
+])
+async def test_status_framing_reflects_plan_tier(
+    db, client, monkeypatch, tmp_path, plan_tier, expected_mode,
+):
+    """The /status framing pricing_mode tracks the session plan tier (#191).
+    HOME is isolated so the unknown case can't pick up this machine's global
+    ~/.config/tj plan via compute_framing's config fallback."""
+    monkeypatch.setattr("pathlib.Path.home", lambda: tmp_path)
+    _seed_trace_with_plan(db, plan_tier, trace_id="ee" * 16, session_id="sess-191")
+    framing = (await client.get("/api/v1/status")).json()["framing"]
+    assert framing["pricing_mode"] == expected_mode
+
+
 async def test_cost_cycle_block_defaults_to_calendar_month(client):
     """With no [budget.<provider>] cycle configured, the run-rate cycle falls
     back to the calendar month (start_day=1) (#138)."""

--- a/tests/unit/test_lens_ui_regression.py
+++ b/tests/unit/test_lens_ui_regression.py
@@ -259,3 +259,33 @@ def test_trace_detail_costs_route_through_framing(html):
     assert "${fmtFramedDollar(sel.cost_usd, framing)}" in html
     # Trace detail pulls the framing block off the /traces/{id} response.
     assert "setFraming(d.framing || null)" in html
+
+
+# --- #191: suppress raw $ on Status, Optimize & Reuse/script surfaces -------- #
+def test_status_card_cost_today_routes_through_framing(html):
+    # Status agent cards' "Cost today" must consume the /status framing block,
+    # not render raw fmtCost(a.cost_today).
+    assert "${fmtCost(a.cost_today)}" not in html
+    assert "${fmtFramedDollar(a.cost_today, data.framing)}" in html
+
+
+def test_optimize_window_comparison_routes_through_framing(html):
+    # The window-comparison cost delta must reframe for subscription/local.
+    assert "${fmtCost(Math.abs(st.cmp.cost_delta_usd))}" not in html
+    assert "${fmtFramedDollar(Math.abs(st.cmp.cost_delta_usd), framing)}" in html
+
+
+def test_optimize_budget_projection_routes_through_framing(html):
+    # Budget-projection run-rate / ceiling / overage must reframe, not raw $.
+    assert "${fmtCost(b.monthly_run_rate_usd)}" not in html
+    assert "${fmtCost(b.budget_usd)}" not in html
+    assert "${fmtCost(b.projected_overage_usd)}" not in html
+    assert "${fmtFramedDollar(b.monthly_run_rate_usd, framing)}" in html
+    assert "${fmtFramedDollar(b.budget_usd, framing)}" in html
+    assert "${fmtFramedDollar(b.projected_overage_usd, framing)}" in html
+
+
+def test_optimize_cluster_avg_cost_routes_through_framing(html):
+    # The script/reuse cluster table "Avg cost" cell must reframe, not raw $.
+    assert "${fmtCost(c.avg_cost_usd)}" not in html
+    assert "${fmtFramedDollar(c.avg_cost_usd, framing)}" in html

--- a/tokenjam/api/routes/status.py
+++ b/tokenjam/api/routes/status.py
@@ -5,6 +5,11 @@ from fastapi import APIRouter, Depends, Request
 
 from tokenjam.api.deps import require_api_key
 from tokenjam.core.db import _row_to_session, session_active_seconds
+from tokenjam.core.framing import (
+    WindowSummary,
+    compute_framing,
+    plan_determination_mix,
+)
 from tokenjam.core.models import AlertFilters
 from tokenjam.utils.time_parse import utcnow
 
@@ -85,7 +90,20 @@ async def get_status(
         }
         agents_data.append(agent_data)
 
+    # Plan-tier framing block so the agent cards' "Cost today" figure suppresses
+    # / reframes raw dollars for subscription / local users (#191) — the web UI
+    # consumes this rather than re-deriving the rules in JS (single compute
+    # path). Window-INDEPENDENT mix (`plan_determination_mix`), as on /traces.
+    config = request.app.state.config
+    conn = getattr(db, "conn", None)
+    mix = plan_determination_mix(conn, agent_id) if conn is not None else {}
+    framing = compute_framing(
+        config,
+        WindowSummary(plan_tier_mix=mix, sessions=sum(mix.values())),
+    )
+
     return {
         "agents": agents_data,
         "has_active_alerts": has_active_alerts,
+        "framing": framing.to_dict(),
     }

--- a/tokenjam/ui/index.html
+++ b/tokenjam/ui/index.html
@@ -1074,7 +1074,7 @@ function StatusView({ params }) {
             ${a.agent_id}
             <span class="badge badge-${a.status}" style="margin-left:auto">${a.status}</span>
           </div>
-          <div class="card-row"><span class="label">Cost today <span class="info-btn">i<span class="info-tip">Estimated from token usage. If you're on a subscription plan (e.g. Claude Max), your actual spend may differ.</span></span></span><span class="value">${fmtCost(a.cost_today)}</span></div>
+          <div class="card-row"><span class="label">Cost today <span class="info-btn">i<span class="info-tip">Estimated from token usage. If you're on a subscription plan (e.g. Claude Max), your actual spend may differ.</span></span></span><span class="value">${fmtFramedDollar(a.cost_today, data.framing)}</span></div>
           <div class="card-row"><span class="label">Tokens</span><span class="value">${fmtTokens(a.input_tokens)} in / ${fmtTokens(a.output_tokens)} out</span></div>
           <div class="card-row"><span class="label">Tool calls</span><span class="value">${a.tool_call_count}${a.error_count ? ' (' + a.error_count + ' failed)' : ''}</span></div>
           ${a.active_seconds != null ? html`<div class="card-row"><span class="label">Active <span class="info-btn">i<span class="info-tip">Compute time — the sum of this session's span durations. The work actually done.</span></span></span><span class="value">${fmtDur(a.active_seconds * 1000)}</span></div>` : null}
@@ -2215,7 +2215,7 @@ function OptimizeFinding({ name, opt, framing }) {
       body = (fd.clusters || []).length ? html`
         <div class="opt-line">${fd.clusters.length} deterministic-pattern cluster(s).</div>
         <table class="opt-table"><thead><tr><th>Instances</th><th>Signature</th><th>Avg cost</th></tr></thead>
-          <tbody>${fd.clusters.map(c => html`<tr><td>${c.instances}×</td><td class="mono">${(c.signature || []).map(s => s.tool).join(' → ').slice(0, 60)}</td><td>${fmtCost(c.avg_cost_usd)}</td></tr>`)}</tbody></table>
+          <tbody>${fd.clusters.map(c => html`<tr><td>${c.instances}×</td><td class="mono">${(c.signature || []).map(s => s.tool).join(' → ').slice(0, 60)}</td><td>${fmtFramedDollar(c.avg_cost_usd, framing)}</td></tr>`)}</tbody></table>
         ${fd.caveat ? html`<div class="opt-caveat">! ${fd.caveat}</div>` : null}`
         : html`<div class="opt-line dim">No clusters above threshold (≥20 identical signatures).</div>`;
     } else if (name === 'trim') {
@@ -2299,10 +2299,10 @@ function OptimizeView({ params }) {
     ${!st.loading && st.opt ? html`
       ${framing && framing.qualifier_text ? html`<div class="qualifier">${framing.qualifier_text}</div>` : null}
       ${st.cmp ? html`<div class="chart-card"><div class="chart-title">Window comparison (${compare})</div>
-        <div class="opt-line">Cost ${st.cmp.cost_delta_usd >= 0 ? '▲' : '▼'} ${fmtCost(Math.abs(st.cmp.cost_delta_usd))} ${st.cmp.cost_delta_pct != null ? '(' + st.cmp.cost_delta_pct.toFixed(1) + '%)' : ''} · Tokens ${st.cmp.tokens_delta >= 0 ? '▲' : '▼'} ${fmtTokens(Math.abs(st.cmp.tokens_delta))}</div></div>` : null}
+        <div class="opt-line">Cost ${st.cmp.cost_delta_usd >= 0 ? '▲' : '▼'} ${fmtFramedDollar(Math.abs(st.cmp.cost_delta_usd), framing)} ${st.cmp.cost_delta_pct != null ? '(' + st.cmp.cost_delta_pct.toFixed(1) + '%)' : ''} · Tokens ${st.cmp.tokens_delta >= 0 ? '▲' : '▼'} ${fmtTokens(Math.abs(st.cmp.tokens_delta))}</div></div>` : null}
       ${order.map(n => html`<${OptimizeFinding} name=${n} opt=${st.opt} framing=${framing} />`)}
       ${(st.opt.budgets || []).length ? html`<section class="opt-section"><div class="opt-title">Budget projection</div>
-        ${st.opt.budgets.map(b => html`<div class="opt-line">${b.provider}: run rate ${fmtCost(b.monthly_run_rate_usd)}/mo vs ${fmtCost(b.budget_usd)}/cycle ${b.over_budget ? html`<span style="color:var(--error)">— projected over by ${fmtCost(b.projected_overage_usd)}</span>` : '— within budget'}</div>`)}
+        ${st.opt.budgets.map(b => html`<div class="opt-line">${b.provider}: run rate ${fmtFramedDollar(b.monthly_run_rate_usd, framing)}/mo vs ${fmtFramedDollar(b.budget_usd, framing)}/cycle ${b.over_budget ? html`<span style="color:var(--error)">— projected over by ${fmtFramedDollar(b.projected_overage_usd, framing)}</span>` : '— within budget'}</div>`)}
       </section>` : null}
     ` : null}
   `;


### PR DESCRIPTION
Follow-up to #187 (PR #190), which suppressed raw `$` for subscription/local users on the Cost table + Traces + trace-detail. The same honesty-discipline leak (Critical Rule 14 / `core/framing.py`) persisted on four surfaces #187 didn't enumerate.

## Summary
- **Status agent cards** — "Cost today" now consumes a `framing` block (new on `/api/v1/status`) and reframes for subscription/local.
- **Optimize window comparison**, **budget projection**, and the **cluster "Avg cost"** cell now route through the `framing` block the Optimize component already holds — no backend change for those.
- The UI **consumes** the server framing decision; no suppression rules re-derived in JS (single compute path). No caveat language strengthened; api/unknown output is byte-identical.

## Per surface (symptom → root cause → fix)

### Status agent cards — "Cost today" (`index.html:1077`)
**Symptom.** `fmtCost(a.cost_today)` → raw `$` for subscription/local users.
**Root cause.** The Status screen fetched no `framing` block.
**Fix (backend).** `/api/v1/status` now returns a `framing` block built from the window-independent `plan_determination_mix` → `compute_framing` (the same pattern as #187's `_traces_framing`).
**Fix (UI).** The card renders `fmtFramedDollar(a.cost_today, data.framing)`.

### Optimize — framing already in scope (`OptimizeView`/`OptimizeFinding` hold `st.opt.framing`)
- **Window comparison** (`:2302`): `fmtCost(Math.abs(st.cmp.cost_delta_usd))` → `fmtFramedDollar(..., framing)`.
- **Budget projection** (`:2305`): run-rate / ceiling / overage — three `fmtCost` → `fmtFramedDollar(..., framing)`.
- **Cluster "Avg cost"** (`:2218`, the `script` analyzer's cluster table): `fmtCost(c.avg_cost_usd)` → `fmtFramedDollar(c.avg_cost_usd, framing)`.

For all of these: subscription → "% of cycle", local → suppressed "—", api/unknown → "$X" unchanged (`fmtFramedDollar` falls through to `fmtCost`).

## Tests / Verification
- **Backend** (`tests/integration/test_api.py`): `/status` now carries a `framing` block; a parametrized matrix asserts `pricing_mode` tracks the session plan tier (`max_5x`→subscription, `api`→api, `local`→local, `unknown`→unknown, with `HOME` isolated so the unknown case can't read this machine's global config).
- **UI static-grep** (`tests/unit/test_lens_ui_regression.py`): the Status card, window comparison, budget-projection (×3), and cluster cost cell route through `fmtFramedDollar` and no bare `fmtCost` survives on them. `test_ui_offline.py` stays green.
- **Suite**: `pytest tests/unit/ tests/synthetic/ tests/agents/ tests/integration/` → **823 passed**. `ruff check tokenjam/` + `mypy tokenjam/` clean. `node --check` clean on the app module.
- **Visual** (headless Chrome, seeded Claude Max subscription DB; DOM dump confirms **zero** raw `$` in the rendered body of both pages):
  - Status: cards read "Cost today: 19.0% of cycle" / "15.0% of cycle".
  - Optimize: window comparison "Cost ▼ 16.0% of cycle (-32.0%)"; budget projection "run rate 34.0% of cycle/mo vs 50.0% of cycle/cycle — within budget".

## What's NOT in this PR
- Cost table / Traces / trace-detail (done in #190); the spend **chart** (#186); CLI `tj cost` (#175/#181) — untouched.
- The `script` cluster "Avg cost" cell was verified via the static-grep test rather than visually: surfacing a cluster requires ≥20 identical-signature sessions (`MIN_CLUSTER_INSTANCES`), impractical to seed for a screenshot. The cell change is identical in shape to the others.
- No change to `core/framing.py` derivation logic — this PR only *consumes* it (`compute_framing` / `plan_determination_mix` / `fmtFramedDollar`).
- Minor cosmetic note for reviewers: for subscription users the budget-projection line reads "X% of cycle/mo vs Y% of cycle/cycle" — the "/mo" and "/cycle" suffixes are slightly redundant with "of cycle" but honest and not raw `$`. This section only renders when a subscription user has also set an explicit `[budget.<provider>] usd` ceiling (uncommon). Left as a minimal change; a wording refinement can follow separately if desired.

Closes #191

🤖 Generated with [Claude Code](https://claude.com/claude-code)