### PR TITLE
Fix #197: CLI and Lens render identical plan-tier framing (window-independent mix)

### DIFF
--- a/tests/integration/test_cli_api_framing_parity.py
+++ b/tests/integration/test_cli_api_framing_parity.py
@@ -1,0 +1,118 @@
+"""#197 — `tj cost` (CLI) and `/api/v1/cost` (Lens) must render IDENTICAL
+plan-tier framing for the same DB / window / plan state.
+
+Both surfaces consume ``core/framing``, but the CLI direct-conn path framed off
+a window-SCOPED session mix while the API moved to a window-INDEPENDENT mix
+(#177). When the in-window mix differed from full history (daemon-off), they
+disagreed — the CLI suppressed dollars while Lens showed them, or vice-versa.
+
+These tests seed sessions that STARTED outside a 24h window but have recent
+spans, so the window-scoped mix is empty while full history carries the real
+plan — the exact divergence. They then assert the CLI's ``_cost_framing`` and
+the live ``/api/v1/cost`` framing block agree across api / subscription /
+unknown. (Pre-fix, the subscription and unknown cases fail.)
+"""
+from __future__ import annotations
+
+import dataclasses
+from datetime import timedelta
+from types import SimpleNamespace
+
+import httpx
+import pytest
+
+from tokenjam.api.app import create_app
+from tokenjam.cli.cmd_cost import _cost_framing
+from tokenjam.core.config import ProviderBudget, StorageConfig, TjConfig
+from tokenjam.core.db import DuckDBBackend
+from tokenjam.core.ingest import IngestPipeline
+from tokenjam.utils.time_parse import utcnow
+from tests.factories import make_llm_span, make_session
+
+# The framing fields that express "units + qualifier" (AC #1) — the decision,
+# not the window-scoped dollar totals carried alongside it.
+_DECISION_FIELDS = (
+    "pricing_mode",
+    "plan_tier",
+    "plan_label",
+    "plan_labels",
+    "display_rule",
+    "qualifier_text",
+    "subscription_share_pct",
+    "api_share_pct",
+)
+
+
+@pytest.fixture(autouse=True)
+def _isolate_home(monkeypatch, tmp_path):
+    """Point Path.home() at an empty dir so config_declared_plan's global
+    fallback never reads the dev machine's ~/.config/tj/config.toml."""
+    monkeypatch.setattr("pathlib.Path.home", lambda: tmp_path)
+
+
+def _seed_out_of_window(db, plan_tier: str) -> None:
+    """20 sessions that STARTED 5 days ago (outside a 24h window) but each have
+    a span in the last hour. Window-scoped session mix → empty; full-history
+    mix → {plan_tier: 20}. That gap is exactly what made the CLI and API
+    disagree daemon-off (#197)."""
+    now = utcnow()
+    for i in range(20):
+        s = make_session(session_id=f"s-{i}", plan_tier=plan_tier)
+        s = dataclasses.replace(s, started_at=now - timedelta(days=5))
+        db.upsert_session(s)
+        db.insert_span(make_llm_span(
+            session_id=f"s-{i}", billing_account="anthropic",
+            start_time=now - timedelta(minutes=10 + i),
+            input_tokens=1000, output_tokens=200, cost_usd=5.0,
+        ))
+
+
+def _decision(framing_dict: dict) -> dict:
+    return {k: framing_dict.get(k) for k in _DECISION_FIELDS}
+
+
+async def _api_framing(db, config) -> dict:
+    pipeline = IngestPipeline(db=db, config=config)
+    app = create_app(config=config, db=db, ingest_pipeline=pipeline)
+    transport = httpx.ASGITransport(app=app)
+    async with httpx.AsyncClient(transport=transport, base_url="http://t") as c:
+        resp = await c.get("/api/v1/cost?since=24h")
+    return resp.json()["framing"]
+
+
+def _cli_framing(db, config) -> dict:
+    now = utcnow()
+    ctx = SimpleNamespace(obj={"config": config})
+    framing = _cost_framing(
+        ctx, db,
+        since="24h",
+        since_dt=now - timedelta(hours=24),
+        until_dt=now,
+        agent=None,
+        total_cost=0.0,
+        total_tokens=0,
+    )
+    assert framing is not None  # direct-conn path: config + conn both present
+    return framing.to_dict()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("plan_tier,budgets,expected_mode", [
+    ("api", {"anthropic": ProviderBudget(plan="api")}, "api"),
+    ("max_5x", {"anthropic": ProviderBudget(plan="max_5x")}, "subscription"),
+    ("unknown", {}, "unknown"),
+])
+async def test_cli_and_api_framing_agree(tmp_path, plan_tier, budgets, expected_mode):
+    db = DuckDBBackend(StorageConfig(path=str(tmp_path / "t.duckdb")))
+    config = TjConfig(version="1", budgets=budgets)
+    _seed_out_of_window(db, plan_tier=plan_tier)
+
+    api = _decision(await _api_framing(db, config))
+    cli = _decision(_cli_framing(db, config))
+
+    # Both must reach the same units + qualifier for the same DB/window/plan.
+    assert cli == api, f"CLI {cli} != API {api}"
+    # And the shared decision must be the expected plan-driven mode (not the
+    # empty-window "api" default the CLI used to collapse to).
+    assert api["pricing_mode"] == expected_mode, api
+    db.close()

--- a/tokenjam/cli/cmd_cost.py
+++ b/tokenjam/cli/cmd_cost.py
@@ -160,8 +160,17 @@ def _cost_framing(ctx, db, since, since_dt, until_dt, agent, total_cost, total_t
     config = ctx.obj.get("config") if ctx.obj else None
     conn = getattr(db, "conn", None)
     if config is not None and conn is not None:
-        from tokenjam.core.framing import WindowSummary, compute_framing, plan_tier_mix
-        mix = plan_tier_mix(conn, since_dt, until_dt, agent)
+        from tokenjam.core.framing import (
+            WindowSummary,
+            compute_framing,
+            plan_determination_mix,
+        )
+        # Window-INDEPENDENT mix for the framing DECISION — matching the API
+        # (`api/routes/cost.py`) so the CLI direct-conn path and Lens render
+        # identical units + qualifier for the same DB (#197). The pricing mode
+        # is a property of the user's plan, not the selected window; only the
+        # totals below stay window-scoped.
+        mix = plan_determination_mix(conn, agent)
         return compute_framing(config, WindowSummary(
             total_cost_usd=total_cost,
             total_tokens=total_tokens,
@@ -221,8 +230,15 @@ def _compare_framing(ctx, db, since_dt, until_dt, agent, diff):
     conn = getattr(db, "conn", None)
     if config is None or conn is None:
         return None
-    from tokenjam.core.framing import WindowSummary, compute_framing, plan_tier_mix
-    mix = plan_tier_mix(conn, since_dt, until_dt, agent)
+    from tokenjam.core.framing import (
+        WindowSummary,
+        compute_framing,
+        plan_determination_mix,
+    )
+    # Window-INDEPENDENT mix for the framing DECISION (#197) — same basis as the
+    # bare `tj cost` table and the API. The compare window's totals/deltas stay
+    # window-scoped; only the tokens-vs-dollars framing decision is plan-wide.
+    mix = plan_determination_mix(conn, agent)
     return compute_framing(config, WindowSummary(
         total_cost_usd=diff.current.total_cost_usd,
         total_tokens=diff.current.total_tokens,


### PR DESCRIPTION
For the same local DuckDB, `tj cost` (CLI) could suppress dollar figures while the Lens web UI showed "API billing" + dollars — two surfaces, one dataset, opposite framing. Confirmed (issue comment, 2026-06-22) as an independent framing-consumption divergence, not gated on #194.

## Summary
- `_cost_framing` and `_compare_framing` (`tokenjam/cli/cmd_cost.py`) now decide framing from the **window-independent** `plan_determination_mix(conn, agent)` — the same basis as `api/routes/cost.py` — instead of the window-scoped `plan_tier_mix(conn, since_dt, until_dt, agent)`.
- Window totals (cost / tokens / `--compare` deltas) stay window-scoped; only the tokens-vs-dollars unit + qualifier are plan-wide.
- New integration test pins CLI framing to the live `/api/v1/cost` framing across api / subscription / unknown.

## Symptom → root cause → fix
- **Symptom:** CLI suppressed dollars (unknown/subscription framing) while Lens showed dollars, for the same DB.
- **Root cause:** the pricing mode is a property of the user's **plan**, not the selected window. `/api/v1/cost` moved to a window-independent mix in #177/#186/#187; the CLI's direct-conn path was left on the old **window-scoped** mix. When the in-window session mix differed from full history (e.g. a 24h window whose sessions all *started* earlier but have recent spans), the two computed a different `pricing_mode`/suppression. Daemon-off only — with `tj serve` up, the CLI shims to the API's `framing` block and they already agreed.
- **Fix:** use `plan_determination_mix` for the framing **decision** in both CLI functions, mirroring the API construction exactly (`sessions = sum(mix.values())`, totals window-scoped). Both surfaces consume `core/framing`; neither re-derives the suppression rules.

## Scope note (left as-is, flagged for awareness)
`tj optimize` / `tj report` also use the window-scoped `plan_tier_mix`, **but so does `/api/v1/optimize`** — so the CLI and Lens *agree* on the optimize surface; it is not a CLI-vs-Lens divergence and is out of scope for #197. Whether the optimize surface should also adopt window-independent framing (for cost/optimize internal consistency) is a separate design question for triage, not a bug fix here.

## Tests / Verification
New `tests/integration/test_cli_api_framing_parity.py`: seeds 20 sessions started 5 days ago (outside a 24h window) with spans in the last hour, so the window-scoped mix is empty while full history carries the real plan — the exact divergence. It asserts the CLI `_cost_framing` decision fields (`pricing_mode`, `plan_tier`, `plan_label(s)`, `display_rule`, `qualifier_text`, share pcts) equal the live `/api/v1/cost` `framing` block across **api / subscription / unknown**.

- Verified the test **fails on pre-fix code** (CLI collapses to the empty-window "api" default — wrong mode/labels/share-pcts) and passes after.
- `pytest tests/unit tests/synthetic tests/agents tests/integration` → **854 passed**. `ruff` + `mypy` clean on touched files.

## What's NOT in this PR
- `tj optimize` / `tj report` framing basis (see scope note — not a CLI-vs-Lens divergence; deferred to triage).
- `litellm.py` (#195, owned by a parallel agent).

Closes #197

🤖 Generated with [Claude Code](https://claude.com/claude-code)