### PR TITLE
Fix #195: capture prompt/completion content + cache tokens on LiteLLM spans

### DIFF
--- a/tests/integration/test_litellm_enrichment.py
+++ b/tests/integration/test_litellm_enrichment.py
@@ -1,0 +1,126 @@
+"""End-to-end: the LiteLLM integration enriches spans with content + cache
+tokens (#195).
+
+Wires the real LiteLLM integration through a local TracerProvider →
+TjSpanExporter → IngestPipeline → InMemoryBackend, so the genuine path is
+exercised: `span.set_attribute` → `convert_otel_span` → `strip_captured_content`
+gate → `NormalizedSpan` field mapping → the `cache` analyzer. A local provider
+(passed explicitly to `install()`) avoids the process-global TracerProvider, so
+the test is deterministic regardless of order.
+"""
+from __future__ import annotations
+
+import json
+import sys
+import types
+from datetime import datetime, timezone
+
+import pytest
+from opentelemetry.sdk.trace import TracerProvider
+from opentelemetry.sdk.trace.export import SimpleSpanProcessor
+
+from tokenjam.core.config import CaptureConfig, TjConfig
+from tokenjam.core.db import InMemoryBackend
+from tokenjam.core.ingest import IngestPipeline
+from tokenjam.core.optimize.analyzers.cache_efficacy import _compute_rows
+from tokenjam.otel.provider import TjSpanExporter
+from tokenjam.otel.semconv import GenAIAttributes
+
+
+def _fake_litellm_module():
+    """A litellm whose completion returns Anthropic-style usage with cache reads
+    + creation tokens and a real assistant message."""
+    mod = types.ModuleType("litellm")
+
+    def completion(*args, **kwargs):
+        return types.SimpleNamespace(
+            choices=[types.SimpleNamespace(
+                message=types.SimpleNamespace(content="the cached answer"))],
+            usage=types.SimpleNamespace(
+                prompt_tokens=10_000, completion_tokens=200,
+                cache_read_input_tokens=8_000,
+                cache_creation_input_tokens=1_500,
+            ),
+            _hidden_params={"custom_llm_provider": "anthropic"},
+            model="claude-sonnet-4-6",
+        )
+
+    async def acompletion(*args, **kwargs):
+        return completion()
+
+    mod.completion = completion
+    mod.acompletion = acompletion
+    return mod
+
+
+@pytest.fixture
+def fake_litellm():
+    fake = _fake_litellm_module()
+    sys.modules["litellm"] = fake
+    yield fake
+    from tokenjam.sdk.integrations.litellm import LiteLLMIntegration
+    LiteLLMIntegration.installed = False
+    del sys.modules["litellm"]
+
+
+def _run_litellm_call(db, capture):
+    """Install the integration against a local provider feeding `db`, make one
+    (fake) litellm.completion call, return the stored span as a column dict
+    (``attributes`` parsed from JSON)."""
+    config = TjConfig(version="1", capture=capture)
+    pipeline = IngestPipeline(db=db, config=config)
+    provider = TracerProvider()
+    provider.add_span_processor(SimpleSpanProcessor(TjSpanExporter(pipeline)))
+
+    from tokenjam.sdk.integrations.litellm import LiteLLMIntegration
+    import litellm
+    LiteLLMIntegration().install(provider.get_tracer("test-195"))
+    litellm.completion(
+        model="anthropic/claude-sonnet-4-6",
+        messages=[{"role": "user", "content": "summarize the doc"}],
+    )
+    provider.force_flush()
+
+    cur = db.conn.execute("SELECT * FROM spans ORDER BY start_time DESC LIMIT 1")
+    row = dict(zip([d[0] for d in cur.description], cur.fetchone()))
+    row["attributes"] = json.loads(row["attributes"]) if row.get("attributes") else {}
+    return row
+
+
+def test_content_kept_when_capture_on(fake_litellm):
+    db = InMemoryBackend()
+    row = _run_litellm_call(db, CaptureConfig(prompts=True, completions=True))
+    assert "summarize the doc" in row["attributes"][GenAIAttributes.PROMPT_CONTENT]
+    assert row["attributes"][GenAIAttributes.COMPLETION_CONTENT] == "the cached answer"
+
+
+def test_content_stripped_when_capture_off(fake_litellm):
+    db = InMemoryBackend()
+    row = _run_litellm_call(db, CaptureConfig(prompts=False, completions=False))
+    assert GenAIAttributes.PROMPT_CONTENT not in row["attributes"]
+    assert GenAIAttributes.COMPLETION_CONTENT not in row["attributes"]
+    # Cache tokens are NOT content — they survive regardless of capture toggles.
+    assert row["cache_tokens"] == 8_000
+    assert row["cache_write_tokens"] == 1_500
+
+
+def test_cache_tokens_populate_normalized_span(fake_litellm):
+    db = InMemoryBackend()
+    row = _run_litellm_call(db, CaptureConfig())
+    assert row["cache_tokens"] == 8_000
+    assert row["cache_write_tokens"] == 1_500
+
+
+def test_cache_tokens_drive_cache_efficacy(fake_litellm):
+    """The cache analyzer now sees real cache reads on LiteLLM spans, so efficacy
+    is non-zero — it always read 0% before #195 (no cache tokens captured)."""
+    db = InMemoryBackend()
+    _run_litellm_call(db, CaptureConfig())
+    since = datetime(2020, 1, 1, tzinfo=timezone.utc)
+    until = datetime(2100, 1, 1, tzinfo=timezone.utc)
+    rows = _compute_rows(db.conn, since, until, agent_id=None)
+    assert len(rows) == 1
+    row = rows[0]
+    assert row.provider == "anthropic"
+    assert row.cache_tokens == 8_000
+    assert row.efficacy > 0  # 8000 / (10000 + 8000) ≈ 0.44

--- a/tests/unit/test_litellm_integration.py
+++ b/tests/unit/test_litellm_integration.py
@@ -318,3 +318,143 @@ class TestLiteLLMIntegration:
             _tj_litellm_active.reset(token)
 
         assert _tj_litellm_active.get(False) is False
+
+    # -- content + cache-token capture (#195) ------------------------------- #
+
+    def test_captures_prompt_and_completion_content(self, tracer_and_spans):
+        """Prompt (from request messages) + completion (from response) land on
+        the span as PROMPT_CONTENT / COMPLETION_CONTENT (#195). The ingest gate
+        strips them later when [capture] is off — capture is unconditional here."""
+        tracer, spans = tracer_and_spans
+        import litellm
+
+        def fake(*a, **kw):
+            return types.SimpleNamespace(
+                choices=[types.SimpleNamespace(
+                    message=types.SimpleNamespace(content="the answer"))],
+                usage=types.SimpleNamespace(prompt_tokens=100, completion_tokens=50),
+                _hidden_params={"custom_llm_provider": "openai"},
+                model="gpt-4o-mini",
+            )
+        litellm.completion = fake
+
+        from tokenjam.sdk.integrations.litellm import LiteLLMIntegration
+        LiteLLMIntegration().install(tracer)
+
+        litellm.completion(
+            model="openai/gpt-4o-mini",
+            messages=[{"role": "user", "content": "what is 2+2?"}],
+        )
+
+        attrs = spans[0].attributes
+        assert "what is 2+2?" in attrs[GenAIAttributes.PROMPT_CONTENT]
+        assert attrs[GenAIAttributes.COMPLETION_CONTENT] == "the answer"
+
+    def test_captures_cache_tokens_anthropic_style(self, tracer_and_spans):
+        """Anthropic-style usage exposes cache_read/creation_input_tokens directly."""
+        tracer, spans = tracer_and_spans
+        import litellm
+
+        def fake(*a, **kw):
+            return types.SimpleNamespace(
+                choices=[types.SimpleNamespace(
+                    message=types.SimpleNamespace(content="ok"))],
+                usage=types.SimpleNamespace(
+                    prompt_tokens=100, completion_tokens=50,
+                    cache_read_input_tokens=300,
+                    cache_creation_input_tokens=120,
+                ),
+                _hidden_params={"custom_llm_provider": "anthropic"},
+                model="claude-haiku-4-5",
+            )
+        litellm.completion = fake
+
+        from tokenjam.sdk.integrations.litellm import LiteLLMIntegration
+        LiteLLMIntegration().install(tracer)
+        litellm.completion(model="anthropic/claude-haiku-4-5", messages=[])
+
+        attrs = spans[0].attributes
+        assert attrs[GenAIAttributes.CACHE_READ_TOKENS] == 300
+        assert attrs[GenAIAttributes.CACHE_CREATE_TOKENS] == 120
+
+    def test_captures_cache_tokens_openai_style(self, tracer_and_spans):
+        """OpenAI-style usage nests the cached read count under
+        prompt_tokens_details.cached_tokens (no creation count)."""
+        tracer, spans = tracer_and_spans
+        import litellm
+
+        def fake(*a, **kw):
+            return types.SimpleNamespace(
+                choices=[types.SimpleNamespace(
+                    message=types.SimpleNamespace(content="ok"))],
+                usage=types.SimpleNamespace(
+                    prompt_tokens=100, completion_tokens=50,
+                    prompt_tokens_details=types.SimpleNamespace(cached_tokens=200),
+                ),
+                _hidden_params={"custom_llm_provider": "openai"},
+                model="gpt-4o-mini",
+            )
+        litellm.completion = fake
+
+        from tokenjam.sdk.integrations.litellm import LiteLLMIntegration
+        LiteLLMIntegration().install(tracer)
+        litellm.completion(model="openai/gpt-4o-mini", messages=[])
+
+        attrs = spans[0].attributes
+        assert attrs[GenAIAttributes.CACHE_READ_TOKENS] == 200
+        assert GenAIAttributes.CACHE_CREATE_TOKENS not in attrs
+
+    def test_no_cache_fields_means_no_cache_attrs(self, tracer_and_spans):
+        """A usage object with no cache fields leaves cache attributes unset, so
+        no-cache spans stay clean (and don't carry MagicMock-truthy garbage)."""
+        tracer, spans = tracer_and_spans
+        import litellm
+
+        def fake(*a, **kw):
+            return types.SimpleNamespace(
+                choices=[types.SimpleNamespace(
+                    message=types.SimpleNamespace(content="ok"))],
+                usage=types.SimpleNamespace(prompt_tokens=100, completion_tokens=50),
+                _hidden_params={"custom_llm_provider": "openai"},
+                model="gpt-4o-mini",
+            )
+        litellm.completion = fake
+
+        from tokenjam.sdk.integrations.litellm import LiteLLMIntegration
+        LiteLLMIntegration().install(tracer)
+        litellm.completion(model="openai/gpt-4o-mini", messages=[])
+
+        attrs = spans[0].attributes
+        assert GenAIAttributes.CACHE_READ_TOKENS not in attrs
+        assert GenAIAttributes.CACHE_CREATE_TOKENS not in attrs
+
+    def test_streaming_captures_completion_content_and_cache(self, tracer_and_spans):
+        """Sync streaming accumulates delta content + reads cache from the final
+        usage chunk."""
+        tracer, spans = tracer_and_spans
+        import litellm
+
+        def _chunk(text=None, usage=None):
+            delta = types.SimpleNamespace(content=text)
+            return types.SimpleNamespace(
+                choices=[types.SimpleNamespace(delta=delta)], usage=usage,
+            )
+        chunks = [
+            _chunk("Hel"),
+            _chunk("lo!"),
+            _chunk(None, types.SimpleNamespace(
+                prompt_tokens=50, completion_tokens=25,
+                cache_read_input_tokens=10)),
+        ]
+        litellm.completion = lambda *a, **kw: iter(chunks)
+
+        from tokenjam.sdk.integrations.litellm import LiteLLMIntegration
+        LiteLLMIntegration().install(tracer)
+        list(litellm.completion(
+            model="openai/gpt-4o-mini", messages=[], stream=True,
+        ))
+
+        attrs = spans[0].attributes
+        assert attrs[GenAIAttributes.COMPLETION_CONTENT] == "Hello!"
+        assert attrs[GenAIAttributes.CACHE_READ_TOKENS] == 10
+        assert attrs[GenAIAttributes.INPUT_TOKENS] == 50

--- a/tokenjam/sdk/integrations/litellm.py
+++ b/tokenjam/sdk/integrations/litellm.py
@@ -15,6 +15,7 @@ from __future__ import annotations
 
 import contextvars
 import functools
+import json
 import logging
 
 from opentelemetry import trace
@@ -68,6 +69,115 @@ def _strip_provider_prefix(model: str) -> str:
     return model
 
 
+# --- content + cache-token enrichment (#195) ------------------------------- #
+# These set attributes unconditionally; the IngestPipeline's
+# strip_captured_content() gate drops prompt/completion content when the
+# matching [capture] toggle is off, so there is no behavior change when content
+# capture is disabled. Without them, cache-recommend / Reuse text / trim get no
+# content and the cache analyzer always reads 0% efficacy for LiteLLM spans.
+
+def _serialize_prompt(args: tuple, kwargs: dict) -> str | None:
+    """Serialize a completion call's request messages/prompt to a string.
+
+    OTel attributes can't hold a list-of-dicts, so chat ``messages`` are
+    JSON-encoded; the analyzers' ``_stringify_prompt`` accepts a string. Falls
+    back to a text-completion ``prompt`` kwarg.
+    """
+    messages = kwargs.get("messages")
+    if messages is None and len(args) > 1:
+        messages = args[1]
+    if messages is not None:
+        try:
+            return json.dumps(messages, default=str)
+        except Exception:
+            return str(messages)
+    prompt = kwargs.get("prompt")
+    if prompt is not None:
+        return prompt if isinstance(prompt, str) else str(prompt)
+    return None
+
+
+def _record_prompt_content(span, args: tuple, kwargs: dict) -> None:
+    """Set PROMPT_CONTENT on the span (stripped at ingest if capture is off)."""
+    content = _serialize_prompt(args, kwargs)
+    if content is not None:
+        span.set_attribute(GenAIAttributes.PROMPT_CONTENT, content)
+
+
+def _extract_completion_text(response: object) -> str | None:
+    """Pull the assistant text from a non-streaming ModelResponse."""
+    choices = getattr(response, "choices", None)
+    if not choices:
+        return None
+    try:
+        choice = choices[0]
+    except (IndexError, TypeError):
+        return None
+    message = getattr(choice, "message", None)
+    if message is not None:
+        content = getattr(message, "content", None)
+        if content is not None:
+            return content if isinstance(content, str) else str(content)
+    text = getattr(choice, "text", None)
+    if text is not None:
+        return str(text)
+    return None
+
+
+def _chunk_delta_text(chunk: object) -> str | None:
+    """Extract the incremental assistant text from one streaming chunk."""
+    choices = getattr(chunk, "choices", None)
+    if not choices:
+        return None
+    try:
+        delta = getattr(choices[0], "delta", None)
+    except (IndexError, TypeError):
+        return None
+    if delta is None:
+        return None
+    content = getattr(delta, "content", None)
+    return content if isinstance(content, str) else None
+
+
+def _extract_cache_tokens(usage: object) -> tuple[int | None, int | None]:
+    """Return ``(cache_read, cache_write)`` from a LiteLLM Usage object.
+
+    LiteLLM normalizes provider usage inconsistently: Anthropic-style prompt
+    caching surfaces ``cache_read_input_tokens`` / ``cache_creation_input_tokens``
+    directly on the usage object, while OpenAI-style caching nests the read
+    count under ``prompt_tokens_details.cached_tokens``. Check both shapes.
+    """
+    cache_read = getattr(usage, "cache_read_input_tokens", None)
+    if not cache_read:
+        details = getattr(usage, "prompt_tokens_details", None)
+        if isinstance(details, dict):
+            cache_read = details.get("cached_tokens")
+        elif details is not None:
+            cache_read = getattr(details, "cached_tokens", None)
+    cache_write = getattr(usage, "cache_creation_input_tokens", None)
+    return cache_read, cache_write
+
+
+def _set_usage_attributes(usage: object, span) -> None:
+    """Set input/output + cache-read/write token attributes from a Usage object.
+
+    Cache fields (#195) were previously dropped, so the ``cache`` analyzer
+    always read 0% efficacy for LiteLLM spans. Mirrors patch_anthropic: only
+    set cache attributes when non-zero so no-cache spans stay clean.
+    """
+    prompt_tokens = getattr(usage, "prompt_tokens", None)
+    if prompt_tokens is not None:
+        span.set_attribute(GenAIAttributes.INPUT_TOKENS, prompt_tokens)
+    completion_tokens = getattr(usage, "completion_tokens", None)
+    if completion_tokens is not None:
+        span.set_attribute(GenAIAttributes.OUTPUT_TOKENS, completion_tokens)
+    cache_read, cache_write = _extract_cache_tokens(usage)
+    if cache_read:
+        span.set_attribute(GenAIAttributes.CACHE_READ_TOKENS, cache_read)
+    if cache_write:
+        span.set_attribute(GenAIAttributes.CACHE_CREATE_TOKENS, cache_write)
+
+
 class LiteLLMIntegration:
     name = "litellm"
     installed = False
@@ -115,6 +225,8 @@ class LiteLLMIntegration:
                         GenAIAttributes.CONVERSATION_ID, conv_id,
                     )
 
+            _record_prompt_content(span, args, kwargs)
+
             token = _tj_litellm_active.set(True)
             try:
                 response = integration._original_completion(*args, **kwargs)
@@ -156,6 +268,8 @@ class LiteLLMIntegration:
                     span.set_attribute(
                         GenAIAttributes.CONVERSATION_ID, conv_id,
                     )
+
+            _record_prompt_content(span, args, kwargs)
 
             token = _tj_litellm_active.set(True)
             try:
@@ -205,14 +319,11 @@ def _record_usage(response: object, span, model: str) -> None:
 
     usage = getattr(response, "usage", None)
     if usage:
-        prompt_tokens = getattr(usage, "prompt_tokens", None)
-        if prompt_tokens is not None:
-            span.set_attribute(GenAIAttributes.INPUT_TOKENS, prompt_tokens)
-        completion_tokens = getattr(usage, "completion_tokens", None)
-        if completion_tokens is not None:
-            span.set_attribute(
-                GenAIAttributes.OUTPUT_TOKENS, completion_tokens,
-            )
+        _set_usage_attributes(usage, span)
+
+    completion = _extract_completion_text(response)
+    if completion is not None:
+        span.set_attribute(GenAIAttributes.COMPLETION_CONTENT, completion)
 
 
 class _SyncStreamWrapper:
@@ -225,6 +336,7 @@ class _SyncStreamWrapper:
         self._token = token
         self._usage = None
         self._last_chunk = None
+        self._completion_parts: list[str] = []
 
     def __iter__(self):
         _ok = False
@@ -233,6 +345,9 @@ class _SyncStreamWrapper:
                 usage = getattr(chunk, "usage", None)
                 if usage:
                     self._usage = usage
+                delta = _chunk_delta_text(chunk)
+                if delta:
+                    self._completion_parts.append(delta)
                 self._last_chunk = chunk
                 yield chunk
             _ok = True
@@ -249,20 +364,12 @@ class _SyncStreamWrapper:
                 _strip_provider_prefix(self._model),
             )
             if self._usage:
-                prompt_tokens = getattr(
-                    self._usage, "prompt_tokens", None,
+                _set_usage_attributes(self._usage, self._span)
+            if self._completion_parts:
+                self._span.set_attribute(
+                    GenAIAttributes.COMPLETION_CONTENT,
+                    "".join(self._completion_parts),
                 )
-                if prompt_tokens is not None:
-                    self._span.set_attribute(
-                        GenAIAttributes.INPUT_TOKENS, prompt_tokens,
-                    )
-                completion_tokens = getattr(
-                    self._usage, "completion_tokens", None,
-                )
-                if completion_tokens is not None:
-                    self._span.set_attribute(
-                        GenAIAttributes.OUTPUT_TOKENS, completion_tokens,
-                    )
             if _ok:
                 self._span.set_status(trace.Status(trace.StatusCode.OK))
             self._span.end()
@@ -282,6 +389,7 @@ class _AsyncStreamWrapper:
         self._token = token
         self._usage = None
         self._last_chunk = None
+        self._completion_parts: list[str] = []
 
     def __aiter__(self):
         return self._iterate()
@@ -293,6 +401,9 @@ class _AsyncStreamWrapper:
                 usage = getattr(chunk, "usage", None)
                 if usage:
                     self._usage = usage
+                delta = _chunk_delta_text(chunk)
+                if delta:
+                    self._completion_parts.append(delta)
                 self._last_chunk = chunk
                 yield chunk
             _ok = True
@@ -309,20 +420,12 @@ class _AsyncStreamWrapper:
                 _strip_provider_prefix(self._model),
             )
             if self._usage:
-                prompt_tokens = getattr(
-                    self._usage, "prompt_tokens", None,
+                _set_usage_attributes(self._usage, self._span)
+            if self._completion_parts:
+                self._span.set_attribute(
+                    GenAIAttributes.COMPLETION_CONTENT,
+                    "".join(self._completion_parts),
                 )
-                if prompt_tokens is not None:
-                    self._span.set_attribute(
-                        GenAIAttributes.INPUT_TOKENS, prompt_tokens,
-                    )
-                completion_tokens = getattr(
-                    self._usage, "completion_tokens", None,
-                )
-                if completion_tokens is not None:
-                    self._span.set_attribute(
-                        GenAIAttributes.OUTPUT_TOKENS, completion_tokens,
-                    )
             if _ok:
                 self._span.set_status(trace.Status(trace.StatusCode.OK))
             self._span.end()


### PR DESCRIPTION
The LiteLLM integration recorded only `prompt_tokens` / `completion_tokens` — no prompt/completion content (even with `[capture]` on) and no cache token counts. That silently starved three analyzers that need text (`cache-recommend`, Reuse's per-cluster rendering, `trim`) and made the `cache` analyzer always read 0% efficacy for LiteLLM-sourced spans.

## Summary
- Capture **prompt + completion content** on LiteLLM spans, set unconditionally and stripped at ingest by the existing `strip_captured_content()` gate (the four `[capture]` toggles are honored — no change when capture is off).
- Extract **cache-read + cache-write tokens** from the LiteLLM `Usage` object into `CACHE_READ_TOKENS` / `CACHE_CREATE_TOKENS`, which `convert_otel_span` already maps to `NormalizedSpan.cache_tokens` / `cache_write_tokens`.
- Applied on the non-streaming path **and** both sync/async streaming wrappers.
- Provider attribution (#194) untouched.

## Root cause
`_record_usage()` and the stream wrappers in `tokenjam/sdk/integrations/litellm.py` read only `usage.prompt_tokens` / `usage.completion_tokens`. No message/response content extraction; no cache-token extraction.

## Fix
- **Prompt content** (`_serialize_prompt` → `_record_prompt_content`): request `messages` JSON-encoded (OTel attributes can't hold a list-of-dicts; the analyzers' `_stringify_prompt` accepts a string), with a text-completion `prompt` fallback. Set as `PROMPT_CONTENT`.
- **Completion content** (`_extract_completion_text`, `_chunk_delta_text`): assistant message text, accumulated across delta chunks when streaming. Set as `COMPLETION_CONTENT`.
- **Cache tokens** (`_extract_cache_tokens`): LiteLLM normalizes inconsistently — Anthropic-style caching exposes `cache_read_input_tokens` / `cache_creation_input_tokens` directly; OpenAI-style nests the read under `prompt_tokens_details.cached_tokens`. Both shapes are checked. A shared `_set_usage_attributes()` now sets input/output **and** cache tokens across all three paths (previously duplicated, token-only). Cache attrs are set only when non-zero (mirrors `patch_anthropic`) so no-cache spans stay clean.

Honesty discipline: content travels through the same ingest gate every other surface uses, so disabling `[capture].prompts` / `.completions` removes it before DB write — no behavior change when off.

## Tests / Verification
- `tests/unit/test_litellm_integration.py` (+5): prompt+completion content capture; Anthropic-style cache tokens; OpenAI-style nested `cached_tokens`; the no-cache case (no stray cache attrs); streaming completion accumulation + cache.
- `tests/integration/test_litellm_enrichment.py` (new, +4): wires the **real** integration through a local `TracerProvider` → `TjSpanExporter` → `IngestPipeline` → `InMemoryBackend` and asserts (a) content kept when `[capture]` on, (b) content stripped when off while cache tokens survive (cache ≠ content), (c) cache tokens populate the `NormalizedSpan` fields, (d) the `cache` analyzer's efficacy is now non-zero (8000/(10000+8000) ≈ 0.44 — it read 0% before).
- Verified **all six new tests fail without the fix** and pass with it.
- Full suite: `pytest tests/unit/ tests/synthetic/ tests/agents/ tests/integration/` → **860 passed**. `ruff check tokenjam/` + `mypy tokenjam/sdk/integrations/litellm.py` clean.

## What's NOT in this PR
- **Provider attribution** (#194, just merged) — `_parse_provider` / `provider_for_model` / `_strip_provider_prefix` untouched.
- Content for the other provider patches (anthropic/openai) — out of scope; this issue is the LiteLLM path. (Those patches also don't capture content today; a follow-up could unify, but not here.)
- No change to `strip_captured_content` / the `[capture]` toggle semantics — the fix reuses the existing gate.

Closes #195

🤖 Generated with [Claude Code](https://claude.com/claude-code)