### PR TITLE
Bump version to 0.4.2

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "tokenjam"
-version = "0.4.1"
+version = "0.4.2"
 description = "TokenJam — local-first OTel-native observability for Autonomous AI agents"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/sdk-ts/package.json
+++ b/sdk-ts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tokenjam/sdk",
-  "version": "0.4.1",
+  "version": "0.4.2",
   "description": "TypeScript SDK for TokenJam — local-first observability for AI agents",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",


### PR DESCRIPTION
Release-cut for **v0.4.2**. Bumps `pyproject.toml` + `sdk-ts/package.json` to `0.4.2` (Rule 15). A maintenance release closing a full pass of plan-tier-framing and cost-accuracy bugs found by validating TokenJam against real usage, plus first-class user pricing.

## What's in 0.4.2 (since 0.4.1)
- **Honest plan-tier framing everywhere** — no raw dollars to subscription/local users across CLI (#175/#176) and Lens (Cost table / Traces / trace-detail / Status / Optimize: #187/#191); chart framing consistent across windows (#177); CLI↔Lens parity (#197); local-timezone axis (#178) + coherent daily labels (#188).
- **Cost accuracy** — LiteLLM provider attribution fixed (was "litellm" → ~42% undercount + NULL billing/plan); LiteLLM now captures content + cache tokens (#194/#195); imported sessions inherit plan tier (#183).
- **First-class user pricing** — per-model rate overrides keyed by bare model name (attribution-proof) + docs (#200/#201).
- **SDK & onboarding** — SDK honors `TJ_CONFIG` (#196); onboard/`tj doctor` surface Claude Code restart staleness (#179).

## Pre-release validation: GO
871 tests + ruff/mypy clean + CI green; live Aider re-run confirmed correct provider/cost/content + TJ_CONFIG isolation; subscription framing parity CLI↔Lens; attribution-proof pricing override. Full report in the session notes.

## After merge
Create the GitHub Release `v0.4.2` (`gh release create v0.4.2 --generate-notes`) → fires PyPI + npm publishes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)