### PR TITLE
[Lens viz] Cost-by-component + recoverable-waste overlay (#211)

### DIFF
--- a/tests/integration/test_cost_charts.py
+++ b/tests/integration/test_cost_charts.py
@@ -18,7 +18,7 @@ from tokenjam.core.config import ProviderBudget, TjConfig
 from tokenjam.core.db import InMemoryBackend
 from tokenjam.core.ingest import IngestPipeline
 from tokenjam.utils.time_parse import utcnow
-from tests.factories import make_llm_span, make_session
+from tests.factories import make_llm_span, make_session, make_tool_span
 
 
 def _app(db, config):
@@ -104,4 +104,95 @@ async def test_cost_cache_empty_window_is_safe():
         d = (await c.get("/api/v1/cost/cache?since=7d")).json()
     assert d["series"] == []
     assert d["total_captured_usd"] == 0
+    assert "framing" in d
+
+
+# --- #211: cost-by-component + recoverable-waste overlay ------------------- #
+def _seed_downsize_and_cache(db, plan_tier="api"):
+    """Small Opus sessions (downsize candidate) with cache tokens (cache
+    recoverable) + tool spans, so build_report yields multiple recoverables."""
+    now = utcnow()
+    for i in range(6):
+        s = make_session(session_id=f"s{i}", plan_tier=plan_tier, agent_id="cc")
+        db.upsert_session(s)
+        llm = make_llm_span(
+            session_id=f"s{i}", agent_id="cc", model="claude-opus-4-7",
+            provider="anthropic", input_tokens=1200, output_tokens=200,
+            cache_tokens=3000, cache_write_tokens=800, cost_usd=0.05,
+            start_time=now - timedelta(days=i),
+        )
+        db.insert_span(llm)
+        for _ in range(2):
+            t = make_tool_span(agent_id="cc", tool_name="Read", trace_id=llm.trace_id)
+            t.session_id = f"s{i}"
+            t.start_time = now - timedelta(days=i)
+            db.insert_span(t)
+
+
+@pytest.mark.asyncio
+async def test_components_split_priced_per_component():
+    db = InMemoryBackend()
+    cfg = TjConfig(version="1")
+    _seed_downsize_and_cache(db)
+    transport = httpx.ASGITransport(app=_app(db, cfg))
+    async with httpx.AsyncClient(transport=transport, base_url="http://t") as c:
+        d = (await c.get("/api/v1/cost/components?since=30d")).json()
+    keys = [c["key"] for c in d["components"]]
+    assert keys == ["input", "output", "cache_read", "cache_write"]
+    by = {c["key"]: c for c in d["components"]}
+    # Opus 4.7 input rate; 6 × 1200 = 7200 input tokens. Cost must be > 0 and
+    # token volume exact.
+    assert by["input"]["tokens"] == 7200
+    assert by["cache_read"]["tokens"] == 18000
+    assert by["input"]["cost_usd"] > 0
+    assert d["framing"]["pricing_mode"] == "api"
+
+
+@pytest.mark.asyncio
+async def test_components_recoverable_is_registry_driven_and_honest():
+    db = InMemoryBackend()
+    cfg = TjConfig(version="1")
+    _seed_downsize_and_cache(db)
+    transport = httpx.ASGITransport(app=_app(db, cfg))
+    async with httpx.AsyncClient(transport=transport, base_url="http://t") as c:
+        d = (await c.get("/api/v1/cost/components?since=30d")).json()
+    rec = {r["analyzer"]: r for r in d["recoverable"]}
+    # downsize is the typed slot; reuse comes from the findings dict — its
+    # presence proves the collector is registry-driven (not a hard-coded list).
+    assert "downsize" in rec
+    assert "reuse" in rec
+    # each carries a component attribution
+    assert rec["downsize"]["component"] == "call"
+    assert rec["cache"]["component"] == "input" if "cache" in rec else True
+    # downsize keeps its mandatory caveat verbatim (Rule 14)
+    from tokenjam.core.optimize.types import MODEL_DOWNGRADE_CAVEAT
+    assert rec["downsize"]["caveat"] == MODEL_DOWNGRADE_CAVEAT
+    # honesty: the payload never calls recoverable "saved"
+    import json
+    assert "saved" not in json.dumps(d).lower()
+    assert d["total_recoverable_usd"] > 0
+
+
+@pytest.mark.asyncio
+async def test_components_subscription_framing_suppresses_dollars():
+    db = InMemoryBackend()
+    cfg = TjConfig(version="1", budgets={"anthropic": ProviderBudget(plan="max_20x")})
+    _seed_downsize_and_cache(db, plan_tier="max_20x")
+    transport = httpx.ASGITransport(app=_app(db, cfg))
+    async with httpx.AsyncClient(transport=transport, base_url="http://t") as c:
+        d = (await c.get("/api/v1/cost/components?since=30d")).json()
+    assert d["framing"]["pricing_mode"] == "subscription"
+    # token volumes stay present so the UI can render the tokens framing
+    assert sum(c["tokens"] for c in d["components"]) > 0
+
+
+@pytest.mark.asyncio
+async def test_components_empty_window_is_safe():
+    db = InMemoryBackend()
+    cfg = TjConfig(version="1")
+    transport = httpx.ASGITransport(app=_app(db, cfg))
+    async with httpx.AsyncClient(transport=transport, base_url="http://t") as c:
+        d = (await c.get("/api/v1/cost/components?since=7d")).json()
+    assert d["total_cost_usd"] == 0
+    assert d["recoverable"] == []
     assert "framing" in d

--- a/tests/unit/test_lens_ui_regression.py
+++ b/tests/unit/test_lens_ui_regression.py
@@ -330,3 +330,56 @@ def test_cache_savings_chart_is_best_effort(html):
     # A failing /cost/cache must not blank the cost screen.
     assert "cacheResp = await api('/cost/cache'" in html
     assert "} catch (_) { cacheResp = null; }" in html
+
+
+# --- #211: cost-by-component + recoverable-waste overlay ------------------- #
+def _component_waste_card(html: str) -> str:
+    """Extract the #211 chart card markup so honesty asserts are scoped to it."""
+    start = html.index("Cost by component + recoverable waste")
+    return html[start:start + 1800]
+
+
+def test_component_waste_chart_present(html):
+    assert "function ComponentWasteChart" in html
+    assert "function buildComponentWaste" in html
+    assert "function componentWasteTooltip" in html
+    assert "${ComponentWasteChart}" in html
+    assert "uPlot.paths.bars" in html  # uPlot stacked bars, not a new lib
+
+
+def test_component_waste_fetches_dedicated_endpoint(html):
+    assert "/cost/components" in html
+    # best-effort: a failed fetch must not blank the Optimize screen
+    assert "api('/cost/components'" in html
+    assert ".catch(() => null)" in html
+
+
+def test_component_waste_is_registry_driven(html):
+    # The overlay is built from the response's `recoverable` list (server-side
+    # registry iteration), not a hard-coded analyzer array in the UI.
+    assert "resp.recoverable" in html
+    # no hard-coded per-analyzer overlay list like ['downsize','cache',...] in
+    # buildComponentWaste — it maps over whatever the server returned
+    card = html[html.index("function buildComponentWaste"):html.index("function buildComponentWaste") + 700]
+    assert "resp.recoverable" in card
+    assert "['downsize'" not in card
+
+
+def test_component_waste_honesty_estimated_not_saved(html):
+    card = _component_waste_card(html)
+    # Positive honesty language present…
+    assert "estimated recoverable" in card.lower()
+    assert "not a realized cost reduction" in card
+    # …and the word "saved" never appears on THIS surface (Rule 14).
+    assert "saved" not in card.lower()
+    assert "savings you got" not in card.lower()
+
+
+def test_component_waste_recoverable_routes_through_framing(html):
+    # Per-analyzer recoverable must reframe (subscription/local → token-share),
+    # mirroring the existing recoverable band — not raw fmtCost.
+    assert "fmtFramedSavings(r.usd, r.tokens, compFraming)" in html
+    # the measured-cost total uses the dollar framing helper, not raw fmtCost
+    assert "fmtFramedDollar(st.comp.total_cost_usd" in html
+    # plan-tier toggle drives tokens-vs-dollars for the whole surface
+    assert "compFraming.pricing_mode === 'subscription' || compFraming.pricing_mode === 'local'" in html

--- a/tokenjam/api/routes/cost.py
+++ b/tokenjam/api/routes/cost.py
@@ -194,6 +194,171 @@ def _cache_series(conn, agent_id, since_dt, until_dt) -> dict:
     return out
 
 
+# Component a given analyzer's recoverable savings primarily acts on. "call"
+# means whole-call (a model swap or call elimination), NOT a single token
+# component — used for analyzers whose savings can't be honestly pinned to one
+# component (downsize / script / reuse). New analyzers default to "call", so the
+# overlay stays registry-driven (#211).
+_ANALYZER_COMPONENT = {
+    "cache": "input",     # raising cache efficacy shrinks the input component
+    "trim": "input",      # trims low-significance input/prompt tokens
+    "downsize": "call",   # whole-call model swap
+    "script": "call",     # eliminates whole deterministic calls
+    "reuse": "call",      # eliminates whole repeated-planning calls
+}
+_ANALYZER_TITLE = {
+    "downsize": "Downsize", "cache": "Cache", "script": "Script",
+    "trim": "Trim", "reuse": "Reuse",
+}
+
+_COMPONENT_LABELS = [
+    ("input", "Input"),
+    ("output", "Output"),
+    ("cache_read", "Cache read"),
+    ("cache_write", "Cache write"),
+]
+
+
+def _component_costs(conn, agent_id, since_dt, until_dt) -> dict:
+    """Split the window's spend into the four token components (#211).
+
+    Computes each component's cost per (provider, model) via the pricing table
+    so the split is exact rather than apportioned from the aggregate cost_usd.
+    Returns the four components with both cost and token volume (the UI shows
+    tokens for subscription/local framing where dollars are suppressed).
+    """
+    from tokenjam.core.pricing import get_rates
+
+    comp = {k: {"cost_usd": 0.0, "tokens": 0} for k, _ in _COMPONENT_LABELS}
+    if conn is None:
+        return comp
+    clauses = ["model IS NOT NULL"]
+    params: list = []
+    if agent_id:
+        params.append(agent_id)
+        clauses.append("agent_id = $" + str(len(params)))
+    if since_dt is not None:
+        params.append(since_dt)
+        clauses.append("start_time >= $" + str(len(params)))
+    if until_dt is not None:
+        params.append(until_dt)
+        clauses.append("start_time <= $" + str(len(params)))
+    where = " AND ".join(clauses)
+    sql = (
+        "SELECT provider, model, COALESCE(SUM(input_tokens), 0), "
+        "COALESCE(SUM(output_tokens), 0), COALESCE(SUM(cache_tokens), 0), "
+        "COALESCE(SUM(cache_write_tokens), 0) "
+        "FROM spans WHERE " + where + " GROUP BY provider, model"
+    )
+    for provider, model, in_t, out_t, cr_t, cw_t in conn.execute(sql, params).fetchall():
+        in_t, out_t, cr_t, cw_t = int(in_t or 0), int(out_t or 0), int(cr_t or 0), int(cw_t or 0)
+        comp["input"]["tokens"] += in_t
+        comp["output"]["tokens"] += out_t
+        comp["cache_read"]["tokens"] += cr_t
+        comp["cache_write"]["tokens"] += cw_t
+        rates = get_rates(provider, model) if model else None
+        if rates is None:
+            continue
+        comp["input"]["cost_usd"] += in_t * rates.input_per_mtok / 1_000_000.0
+        comp["output"]["cost_usd"] += out_t * rates.output_per_mtok / 1_000_000.0
+        comp["cache_read"]["cost_usd"] += cr_t * rates.cache_read_per_mtok / 1_000_000.0
+        comp["cache_write"]["cost_usd"] += cw_t * rates.cache_write_per_mtok / 1_000_000.0
+    return comp
+
+
+def _collect_recoverable(report) -> list[dict]:
+    """Registry-driven per-analyzer recoverable list (#211 overlay).
+
+    Iterates the typed downgrade slot + every wave-2 finding carrying the #111
+    recoverable contract field, so a new analyzer appears with no code change
+    here. Each entry keeps the analyzer's own caveat + estimate_basis verbatim
+    (Rule 14) and the component its savings act on. Only positive estimates are
+    surfaced (a None/0 estimate is "nothing to recover", not an overlay bar)."""
+    out: list[dict] = []
+
+    def add(name: str, finding) -> None:
+        if finding is None:
+            return
+        usd = getattr(finding, "estimated_recoverable_usd", None)
+        tok = getattr(finding, "estimated_recoverable_tokens", None)
+        if not ((usd is not None and usd > 0) or (tok is not None and tok > 0)):
+            return
+        out.append({
+            "analyzer": name,
+            "title": _ANALYZER_TITLE.get(name, name.replace("-", " ").title()),
+            "component": _ANALYZER_COMPONENT.get(name, "call"),
+            "estimated_recoverable_usd": usd,
+            "estimated_recoverable_tokens": tok,
+            "estimate_basis": getattr(finding, "estimate_basis", "") or "",
+            "caveat": getattr(finding, "caveat", "") or "",
+        })
+
+    add("downsize", getattr(report, "downgrade", None))
+    for name, finding in (getattr(report, "findings", None) or {}).items():
+        if name == "downsize":
+            continue
+        if hasattr(finding, "estimated_recoverable_usd"):
+            add(name, finding)
+    return out
+
+
+@router.get("/cost/components")
+async def get_cost_components(
+    request: Request,
+    agent_id: str | None = None,
+    since: str | None = None,
+    until: str | None = None,
+) -> dict:
+    """Cost-by-component split + per-analyzer recoverable-waste overlay (#211).
+
+    The component bars are MEASURED spend split into input / output / cache-read
+    / cache-write. The overlay is each analyzer's *estimated recoverable* waste —
+    registry-driven, carrying the analyzer's own caveat verbatim. "Estimated
+    recoverable" is never conflated with the measured cost and never called
+    "saved" (Critical Rule 14). Every figure routes through the framing block so
+    subscription/local users see token-share, not raw dollars."""
+    db = request.app.state.db
+    config = request.app.state.config
+    since_dt = parse_since(since) if since else None
+    until_dt = parse_since(until) if until else None
+    conn = getattr(db, "conn", None)
+
+    comp = _component_costs(conn, agent_id, since_dt, until_dt)
+    components = [
+        {"key": key, "label": label,
+         "cost_usd": round(comp[key]["cost_usd"], 8), "tokens": comp[key]["tokens"]}
+        for key, label in _COMPONENT_LABELS
+    ]
+    total_cost = sum(c["cost_usd"] for c in components)
+    total_tokens = sum(c["tokens"] for c in components)
+
+    recoverable: list[dict] = []
+    if conn is not None:
+        try:
+            from tokenjam.core.optimize import build_report
+            report = build_report(
+                db=db, config=config,
+                since=since_dt or utcnow(), until=until_dt or utcnow(),
+                agent_id=agent_id,
+            )
+            recoverable = _collect_recoverable(report)
+        except Exception:
+            recoverable = []
+
+    total_rec_usd = sum(r["estimated_recoverable_usd"] or 0.0 for r in recoverable)
+    total_rec_tokens = sum(r["estimated_recoverable_tokens"] or 0 for r in recoverable)
+
+    return {
+        "components": components,
+        "total_cost_usd": round(total_cost, 8),
+        "total_tokens": total_tokens,
+        "recoverable": recoverable,
+        "total_recoverable_usd": round(total_rec_usd, 8),
+        "total_recoverable_tokens": total_rec_tokens,
+        "framing": _framing_block(db, config, agent_id, total_cost, total_tokens),
+    }
+
+
 @router.get("/cost/cache")
 async def get_cost_cache(
     request: Request,

--- a/tokenjam/ui/index.html
+++ b/tokenjam/ui/index.html
@@ -546,6 +546,12 @@ tr.clickable:hover td.chevron { color: var(--accent); }
 .trend-chip { font-family: 'Geist Mono', monospace; font-size: 12px; }
 .chart-foot { margin-top: 10px; font-family: 'Geist Mono', monospace; font-size: 11px; color: var(--text-dim); }
 .chart-foot .dim { color: var(--text-faint); }
+/* Per-analyzer recoverable-waste list under the #211 component chart. */
+.waste-list { margin-top: 12px; border-top: 1px solid var(--border); padding-top: 8px; }
+.waste-row { display: flex; align-items: baseline; justify-content: space-between; gap: 12px; font-size: 13px; padding: 4px 0; }
+.waste-name { font-family: 'Geist Mono', monospace; }
+.waste-rec { font-family: 'Geist Mono', monospace; font-weight: 600; color: var(--accent); display: inline-flex; align-items: center; gap: 6px; white-space: nowrap; }
+.waste-caveat { font-size: 11px; color: var(--text-faint); margin: 0 0 6px; max-width: 70ch; }
 .drill-link { font-family: 'Geist Mono', monospace; font-size: 12px; color: var(--brand); text-decoration: none; white-space: nowrap; }
 .drill-link:hover { text-decoration: underline; }
 /* uPlot hover tooltip (#128). Positioned at the cursor; offset above-centered. */
@@ -1172,6 +1178,122 @@ function CacheSavingsChart({ cache, hit, env, height = 200, fmtY = fmtCost, axis
     return () => { window.removeEventListener('resize', onResize); plot.destroy(); };
   }, [cache, hit, env, height, bucket]);
   return html`<div class="chart" ref=${ref}></div>`;
+}
+
+// Cost-by-component + recoverable-waste overlay (#211, the differentiator).
+// TWO ordinal columns: "Cost" stacked by the four token components (measured
+// spend) and "Recoverable (est.)" stacked by analyzer (estimated waste). They
+// are SEPARATE bars — recoverable is never subtracted from cost and never
+// called "saved" (Critical Rule 14). `costSegs` = [{label,value,color}],
+// `recSegs` = [{title,value,...}] already framed ($ or tokens) by the caller.
+// Stacking reuses the back-to-front cumulative-bars trick; each series is
+// non-zero in only ONE column, so per-column stacks stay independent.
+function ComponentWasteChart({ costSegs, recSegs, fmtY = fmtCost, height = 220 }) {
+  const ref = useRef(null);
+  useEffect(() => {
+    if (!ref.current || !window.uPlot) return;
+    const palette = [1, 2, 3, 4, 5].map(i => cssVar('--chart-' + i)).filter(Boolean);
+    const grid = cssVar('--border') || '#1f1f1f';
+    const tick = cssVar('--text-dim') || '#a1a1a1';
+    const width = ref.current.clientWidth || 600;
+    const xs = [0, 1];                          // Cost | Recoverable (est.)
+    // Per-column cumulative (within-column) so the back-to-front bars stack
+    // independently; 0 in the other column → invisible there.
+    const series = [{}];
+    const cols = [];                            // data columns (cumulative)
+    const meta = [];                            // {label, color, raw, col}
+    let accC = 0;
+    costSegs.forEach((s, i) => {
+      accC += (s.value || 0);
+      cols.push([accC, 0]);
+      meta.push({ label: s.label, color: s.color || palette[i % palette.length], raw: s.value || 0, col: 0 });
+    });
+    let accR = 0;
+    recSegs.forEach((s, i) => {
+      accR += (s.value || 0);
+      cols.push([0, accR]);
+      meta.push({ label: s.title, color: palette[(costSegs.length + i) % palette.length], raw: s.value || 0, col: 1 });
+    });
+    // Draw tallest cumulative first (within each column) so shorter bars paint
+    // on top. Sort indices by cumulative descending; cross-column order is moot.
+    const order = meta.map((_, i) => i).sort((a, b) => {
+      const ca = cols[a][meta[a].col], cb = cols[b][meta[b].col];
+      return cb - ca;
+    });
+    const barsPath = (window.uPlot.paths && window.uPlot.paths.bars)
+      ? window.uPlot.paths.bars({ size: [0.5, 80] }) : undefined;
+    const chartData = [xs, ...order.map(k => cols[k])];
+    order.forEach(k => {
+      series.push({ label: meta[k].label, stroke: meta[k].color, fill: meta[k].color,
+        width: 0, paths: barsPath, points: { show: false },
+        value: (u, v) => (v == null ? '-' : fmtY(v)) });
+    });
+    const opts = {
+      width, height, legend: { show: false },
+      cursor: { x: false, y: false, points: { show: false } },
+      plugins: [componentWasteTooltip(meta, fmtY)],
+      scales: { x: { time: false, range: [-0.5, 1.5] } },
+      axes: [
+        { stroke: tick, grid: { show: false }, ticks: { stroke: grid },
+          splits: [0, 1], values: () => ['Cost', 'Recoverable (est.)'] },
+        { stroke: tick, grid: { stroke: grid, width: 1 }, ticks: { stroke: grid },
+          size: 60, values: (u, vals) => vals.map(v => fmtY(v)) },
+      ],
+      series,
+    };
+    const plot = new window.uPlot(opts, chartData, ref.current);
+    const onResize = () => plot.setSize({ width: ref.current.clientWidth || width, height });
+    window.addEventListener('resize', onResize);
+    return () => { window.removeEventListener('resize', onResize); plot.destroy(); };
+  }, [costSegs, recSegs, height]);
+  return html`<div class="chart" ref=${ref}></div>`;
+}
+
+// Tooltip for the component-waste chart: lists the segments of the hovered
+// column with their raw (un-cumulated) framed values.
+function componentWasteTooltip(meta, fmtFn) {
+  let tip;
+  return { hooks: {
+    init: (u) => {
+      tip = document.createElement('div'); tip.className = 'u-tip'; tip.style.display = 'none';
+      u.over.appendChild(tip);
+      u.over.addEventListener('mouseleave', () => { tip.style.display = 'none'; });
+    },
+    setCursor: (u) => {
+      const idx = u.cursor.idx;
+      if (idx == null) { tip.style.display = 'none'; return; }
+      const col = u.data[0][idx];               // 0 = Cost, 1 = Recoverable
+      const title = col === 0 ? 'Cost by component' : 'Estimated recoverable';
+      let rows = '';
+      meta.forEach(m => {
+        if (m.col !== col || !m.raw) return;
+        rows += `<div class="u-tip-row"><span class="u-tip-dot" style="background:${m.color}"></span>${m.label}: ${fmtFn(m.raw)}</div>`;
+      });
+      tip.innerHTML = `<div class="u-tip-date">${title}</div>${rows || '<div class="u-tip-row">—</div>'}`;
+      tip.style.display = 'block';
+      tip.style.left = u.cursor.left + 'px'; tip.style.top = u.cursor.top + 'px';
+    },
+  } };
+}
+
+// Build the cost-by-component + recoverable overlay from a /cost/components
+// response. `useTokens` (subscription/local) swaps measured cost $ → token
+// volume and recoverable $ → recoverable tokens, so the whole surface respects
+// plan-tier framing. Returns null when there's nothing to show.
+function buildComponentWaste(resp, useTokens) {
+  if (!resp || !resp.components) return null;
+  const costSegs = resp.components.map(c => ({
+    label: c.label, value: useTokens ? (c.tokens || 0) : (c.cost_usd || 0),
+  }));
+  const recSegs = (resp.recoverable || []).map(r => ({
+    title: r.title, component: r.component,
+    value: useTokens ? (r.estimated_recoverable_tokens || 0) : (r.estimated_recoverable_usd || 0),
+    usd: r.estimated_recoverable_usd, tokens: r.estimated_recoverable_tokens,
+    basis: r.estimate_basis || '', caveat: r.caveat || '',
+  })).filter(r => r.value > 0);
+  const totalCost = costSegs.reduce((s, c) => s + c.value, 0);
+  if (totalCost <= 0 && recSegs.length === 0) return null;
+  return { costSegs, recSegs };
 }
 
 // ============================
@@ -2475,7 +2597,7 @@ function OptimizeView({ params }) {
   const focus = readParam(params, 'finding', DEFAULTS.finding);
   const setFilter = (k, v) => navigate('optimize', { since, agent_id: agentId, compare, finding: focus, [k]: v }, DEFAULTS);
 
-  const [st, setSt] = useState({ loading: true, error: null, opt: null, cmp: null });
+  const [st, setSt] = useState({ loading: true, error: null, opt: null, cmp: null, comp: null });
 
   const load = useCallback(async () => {
     setSt(s => ({ ...s, loading: !s.opt, error: null }));
@@ -2483,7 +2605,10 @@ function OptimizeView({ params }) {
       const opt = await api('/optimize', { since, agent_id: agentId || undefined });
       let cmp = null;
       if (compare) cmp = await api('/cost/compare', { since, compare, agent_id: agentId || undefined }).catch(() => null);
-      setSt({ loading: false, error: null, opt, cmp });
+      // Cost-by-component + recoverable-waste overlay (#211). Best-effort: a
+      // failure must not blank the Optimize screen.
+      const comp = await api('/cost/components', { since, agent_id: agentId || undefined }).catch(() => null);
+      setSt({ loading: false, error: null, opt, cmp, comp });
     } catch (e) { setSt(s => ({ ...s, loading: false, error: e.message || String(e) })); }
   }, [since, agentId, compare]);
 
@@ -2498,6 +2623,10 @@ function OptimizeView({ params }) {
 
   const framing = st.opt ? st.opt.framing : null;
   const order = ['downsize', 'cache', 'cache-recommend', 'script', 'trim'];
+  const compFraming = st.comp ? st.comp.framing : framing;
+  const useTokens = !!compFraming && (compFraming.pricing_mode === 'subscription' || compFraming.pricing_mode === 'local');
+  const waste = buildComponentWaste(st.comp, useTokens);
+  const wasteFmtY = useTokens ? fmtTokens : fmtCost;
 
   return html`
     <div class="page-title" style="display:flex;align-items:center;gap:10px;flex-wrap:wrap">
@@ -2524,6 +2653,29 @@ function OptimizeView({ params }) {
 
     ${!st.loading && st.opt ? html`
       ${framing && framing.qualifier_text ? html`<div class="qualifier">${framing.qualifier_text}</div>` : null}
+      ${waste ? html`
+        <div class="chart-card">
+          <div class="chart-head">
+            <div class="chart-title">Cost by component + recoverable waste ${useTokens ? '(tokens)' : ''}</div>
+            <div class="chart-meta">
+              <span class="chart-total">${useTokens ? (fmtTokens(st.comp.total_tokens || 0) + ' tokens') : fmtFramedDollar(st.comp.total_cost_usd || 0, compFraming)}</span>
+            </div>
+          </div>
+          <${ComponentWasteChart} costSegs=${waste.costSegs} recSegs=${waste.recSegs} fmtY=${wasteFmtY} height=${220} />
+          <div class="chart-foot">
+            <span class="dim">Left bar = measured spend split by token component. Right bar = <b>estimated recoverable</b> waste, stacked by analyzer — a heuristic estimate to review before acting, not a realized cost reduction.</span>
+          </div>
+          ${waste.recSegs.length ? html`
+            <div class="waste-list">
+              ${waste.recSegs.map(r => html`
+                <div class="waste-row">
+                  <span class="waste-name">${r.title} <span class="dim">→ ${r.component === 'call' ? 'whole-call' : r.component.replace('_', '-')}</span></span>
+                  <span class="waste-rec">${fmtFramedSavings(r.usd, r.tokens, compFraming)} <span class="estimated-tag" title=${r.caveat || r.basis}>estimated recoverable</span></span>
+                </div>
+                ${(r.caveat || r.basis) ? html`<div class="waste-caveat dim">${r.caveat || r.basis}</div>` : null}
+              `)}
+            </div>` : html`<div class="chart-foot"><span class="dim">No recoverable waste estimated in this window.</span></div>`}
+        </div>` : null}
       ${st.cmp ? html`<div class="chart-card"><div class="chart-title">Window comparison (${compare})</div>
         <div class="opt-line">Cost ${st.cmp.cost_delta_usd >= 0 ? '▲' : '▼'} ${fmtFramedDollar(Math.abs(st.cmp.cost_delta_usd), framing)} ${st.cmp.cost_delta_pct != null ? '(' + st.cmp.cost_delta_pct.toFixed(1) + '%)' : ''} · Tokens ${st.cmp.tokens_delta >= 0 ? '▲' : '▼'} ${fmtTokens(Math.abs(st.cmp.tokens_delta))}</div></div>` : null}
       ${order.map(n => html`<${OptimizeFinding} name=${n} opt=${st.opt} framing=${framing} />`)}


### PR DESCRIPTION
The differentiated Lens viz (milestone #3): split the window's spend into the four token components and overlay each optimize analyzer's **attributed recoverable waste** — the cost-WASTE view a generic activity dashboard can't produce, because it depends on our analyzers' attributed estimates. Data is shaped **server-side**; the UI renders from the response and consumes the `framing` block (never re-derives), uses **vendored uPlot** (offline intact), and respects plan-tier framing.

## Verification (screenshot)
Delivered to the reviewer to attach here (no binaries committed to the repo, per the hard rule). It shows: the left **Cost** bar stacked by the 4 token components; the right **Recoverable (est.)** bar stacked by analyzer; the honest caption ("…a heuristic estimate to review before acting, **not a realized cost reduction**"); and the per-analyzer list — `Downsize → whole-call`, `Cache → input`, `Reuse → whole-call`, each tagged **estimated recoverable** with its caveat verbatim. (Reuse appears straight from the findings dict — registry-driven.)

## Summary
- **New `GET /api/v1/cost/components`** — component cost split (input / output / cache-read / cache-write), priced **per (provider, model)** via the pricing table (exact, not apportioned from aggregate `cost_usd`) + a **registry-driven** per-analyzer recoverable list.
- **New `ComponentWasteChart`** (uPlot stacked bars) on the Optimize screen: measured **Cost** vs **Recoverable (est.)** as two separate columns, plus a per-analyzer recoverable list.

## Honesty discipline (Rule 14 — the reason #211 was split out)
- Recoverable is a **separate bar**, never subtracted from measured cost, and the word **"saved" never appears on this surface** — the caption says "*a heuristic estimate to review before acting, not a realized cost reduction*"; figures carry the **"estimated recoverable"** tag.
- Each analyzer keeps its **own caveat + estimate_basis verbatim** (downsize's `MODEL_DOWNGRADE_CAVEAT`, reuse's basis, etc.).
- Every figure routes through the framing helpers (`fmtFramedSavings` for recoverable — same as the existing recoverable band — `fmtFramedDollar` for measured cost), so **subscription/local see token-share**, and the bars themselves switch to token volume.

## Registry-driven
`_collect_recoverable` iterates the typed `downgrade` slot **plus every finding carrying the #111 `estimated_recoverable_usd` contract field** — a new analyzer surfaces with no code change. Component attribution defaults to `"call"` (whole-call) for analyzers that can't be honestly pinned to one token component (downsize / script / reuse); cache + trim → `input`. The test proves it by asserting `reuse` (a findings-dict analyzer, not a typed slot) appears automatically.

## Tests / Verification
- `tests/integration/test_cost_charts.py` (+4): per-component pricing + exact token volumes; registry-driven recoverable (reuse present) with the downsize caveat verbatim and **"saved" absent from the payload**; subscription framing suppresses dollars; empty-window safe.
- `tests/unit/test_lens_ui_regression.py` (+5): chart/helpers present (`uPlot.paths.bars`, no new lib); built from `resp.recoverable` (no hard-coded analyzer list); honesty caption + **"saved" absent from the #211 card**; recoverable routes through `fmtFramedSavings`, cost total through `fmtFramedDollar`.
- `test_ui_offline.py` green; extracted app module passes `node --check`.
- Full `pytest tests/unit tests/integration` → **823 passed**; `ruff check tokenjam/` + `mypy tokenjam/` clean (116 files).

## Notes
- Best-effort fetch: a `/cost/components` failure renders nothing extra rather than blanking Optimize.
- This completes the Lens Visualizations Wave (#211 was the deferred MEDIUM after #212/#213 shipped in #218).

Closes #211

🤖 Generated with [Claude Code](https://claude.com/claude-code)