### PR TITLE
[Lens viz] Analytics pivot explorer — one chart, every slice (#210, #214, #216)

### DIFF
--- a/tests/integration/test_analytics.py
+++ b/tests/integration/test_analytics.py
@@ -1,0 +1,150 @@
+"""Endpoint tests for the Analytics pivot explorer (#210).
+
+Covers the generalized group-by: metric × group_by × stack_by × filters → a
+grouped series + KPI totals + the plan-tier framing block. The explorer's
+line / bar / hbar views are all client-side pivots of this one `rows` shape.
+"""
+from __future__ import annotations
+
+from datetime import timedelta
+
+import httpx
+import pytest
+
+from tokenjam.api.app import create_app
+from tokenjam.core.config import ProviderBudget, TjConfig
+from tokenjam.core.db import InMemoryBackend
+from tokenjam.core.ingest import IngestPipeline
+from tokenjam.utils.time_parse import utcnow
+from tests.factories import make_llm_span, make_session, make_tool_span
+
+
+def _app(db, config):
+    return create_app(config=config, db=db, ingest_pipeline=IngestPipeline(db=db, config=config))
+
+
+def _seed(db, plan="api"):
+    now = utcnow()
+    for d in range(4):
+        for model, provider, cost in [("claude-opus-4-7", "anthropic", 0.06),
+                                       ("gpt-4o", "openai", 0.03)]:
+            sid = f"s{d}-{model}"
+            db.upsert_session(make_session(session_id=sid, plan_tier=plan, agent_id="cc"))
+            llm = make_llm_span(
+                session_id=sid, agent_id="cc", model=model, provider=provider,
+                input_tokens=2000, output_tokens=300, cost_usd=cost,
+                start_time=now - timedelta(days=d),
+            )
+            db.insert_span(llm)
+            for tool in ["Read", "Bash", "Grep"]:
+                t = make_tool_span(agent_id="cc", tool_name=tool, trace_id=llm.trace_id)
+                t.session_id = sid
+                t.start_time = now - timedelta(days=d)
+                db.insert_span(t)
+
+
+async def _get(db, cfg, qs):
+    transport = httpx.ASGITransport(app=_app(db, cfg))
+    async with httpx.AsyncClient(transport=transport, base_url="http://t") as c:
+        return (await c.get("/api/v1/analytics?" + qs)).json()
+
+
+@pytest.mark.asyncio
+async def test_spend_by_model_grouped_series_and_kpis():
+    db = InMemoryBackend()
+    cfg = TjConfig(version="1")
+    _seed(db)
+    d = await _get(db, cfg, "metric=spend&group_by=model&since=30d")
+    assert d["metric"] == "spend" and d["value_unit"] == "usd"
+    # groups sorted by total desc; opus (0.06×4) > gpt (0.03×4)
+    assert d["groups"] == ["claude-opus-4-7", "gpt-4o"]
+    assert d["rows"], "expected grouped rows"
+    for r in d["rows"]:
+        assert {"bucket", "group", "stack", "value", "tokens"} <= set(r)
+    # KPIs are window totals, independent of group_by
+    assert d["kpis"]["spend"] == pytest.approx(0.36)
+    assert d["kpis"]["sessions"] == 8
+    assert d["framing"]["pricing_mode"] == "api"
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("metric,unit", [
+    ("tokens", "tokens"), ("sessions", "count"), ("events", "count"),
+])
+async def test_metric_dimension_matrix(metric, unit):
+    db = InMemoryBackend()
+    cfg = TjConfig(version="1")
+    _seed(db)
+    d = await _get(db, cfg, f"metric={metric}&group_by=agent&since=30d")
+    assert d["value_unit"] == unit
+    assert d["groups"] == ["cc"]
+    assert d["rows"]
+
+
+@pytest.mark.asyncio
+async def test_tool_category_dimension_includes_tool_spans():
+    """tool / tool_category breakdowns must see tool spans (NULL model), which
+    the LLM-cost `model IS NOT NULL` gate would otherwise hide."""
+    db = InMemoryBackend()
+    cfg = TjConfig(version="1")
+    _seed(db)
+    d = await _get(db, cfg, "metric=events&group_by=tool_category&since=30d")
+    assert set(d["groups"]) == {"file", "shell", "search"}  # Read/Edit, Bash, Grep
+    assert "(none)" not in d["groups"]
+    # KPI totals reflect the FULL window (LLM spend included), not the tool-only
+    # subtype gate the breakdown applies — so "events by tool" never zeroes Spend.
+    assert d["kpis"]["spend"] > 0
+    assert d["kpis"]["tokens"] > 0
+
+
+@pytest.mark.asyncio
+async def test_stack_by_returns_second_dimension():
+    db = InMemoryBackend()
+    cfg = TjConfig(version="1")
+    _seed(db)
+    d = await _get(db, cfg, "metric=spend&group_by=provider&stack_by=model&since=30d")
+    assert d["stack_by"] == "model"
+    assert set(d["groups"]) == {"anthropic", "openai"}
+    assert set(d["stacks"]) == {"claude-opus-4-7", "gpt-4o"}
+    assert any(r["stack"] for r in d["rows"])
+
+
+@pytest.mark.asyncio
+async def test_filters_scope_the_window():
+    db = InMemoryBackend()
+    cfg = TjConfig(version="1")
+    _seed(db)
+    d = await _get(db, cfg, "metric=spend&group_by=model&provider=anthropic&since=30d")
+    assert d["groups"] == ["claude-opus-4-7"]
+    assert "gpt-4o" not in d["groups"]
+
+
+@pytest.mark.asyncio
+async def test_subscription_framing_suppresses_dollars():
+    db = InMemoryBackend()
+    cfg = TjConfig(version="1", budgets={"anthropic": ProviderBudget(plan="max_20x")})
+    _seed(db, plan="max_20x")
+    d = await _get(db, cfg, "metric=spend&group_by=model&since=30d")
+    assert d["framing"]["pricing_mode"] == "subscription"
+    # token volume is present per row so the UI renders token-share, not $
+    assert all("tokens" in r for r in d["rows"])
+
+
+@pytest.mark.asyncio
+async def test_unknown_metric_and_dimension_rejected():
+    db = InMemoryBackend()
+    cfg = TjConfig(version="1")
+    transport = httpx.ASGITransport(app=_app(db, cfg))
+    async with httpx.AsyncClient(transport=transport, base_url="http://t") as c:
+        assert (await c.get("/api/v1/analytics?metric=bogus")).status_code == 400
+        assert (await c.get("/api/v1/analytics?group_by=bogus")).status_code == 400
+
+
+@pytest.mark.asyncio
+async def test_empty_window_is_safe():
+    db = InMemoryBackend()
+    cfg = TjConfig(version="1")
+    d = await _get(db, cfg, "metric=spend&group_by=model&since=7d")
+    assert d["rows"] == [] and d["groups"] == []
+    assert d["kpis"]["spend"] == 0
+    assert "framing" in d

--- a/tests/unit/test_lens_ui_regression.py
+++ b/tests/unit/test_lens_ui_regression.py
@@ -383,3 +383,61 @@ def test_component_waste_recoverable_routes_through_framing(html):
     assert "fmtFramedDollar(st.comp.total_cost_usd" in html
     # plan-tier toggle drives tokens-vs-dollars for the whole surface
     assert "compFraming.pricing_mode === 'subscription' || compFraming.pricing_mode === 'local'" in html
+
+
+# --- #210: Analytics pivot explorer (subsumes #214 leaderboard + #216) ----- #
+def test_analytics_screen_registered(html):
+    assert "function AnalyticsView" in html
+    assert "case 'analytics': return html`<${AnalyticsView}" in html
+    assert 'href="#/analytics"' in html  # sidebar nav link
+
+
+def test_analytics_metric_dimension_chart_controls(html):
+    # metric × group_by × stack × chart-type controls, driven off shared vocab.
+    assert "const ANALYTICS_METRICS" in html
+    assert "const ANALYTICS_DIMENSIONS" in html
+    assert "const ANALYTICS_CHARTS" in html
+    for ctl in ("'metric'", "'group_by'", "'stack'", "'chart'"):
+        assert ctl in html, f"missing control {ctl}"
+    # the three uPlot/leaderboard chart types
+    for ch in ("'bar'", "'line'", "'hbar'"):
+        assert ch in html
+
+
+def test_analytics_presets_and_csv_export(html):
+    assert "const ANALYTICS_PRESETS" in html
+    assert "function analyticsCsv" in html
+    assert "function downloadCsv" in html
+    assert "Export CSV" in html
+    # the leaderboard preset closes #214; spend-by-model line closes #216
+    assert "'leaderboard'" in html
+    assert "'spend-by-model'" in html
+
+
+def test_analytics_url_is_source_of_truth(html):
+    # state read from URL params with validators, written back via navigate()
+    assert "navigate('analytics'" in html
+    assert "readParam(params, 'metric'" in html
+    assert "readParam(params, 'group_by'" in html
+    assert "readParam(params, 'chart'" in html
+
+
+def test_analytics_consumes_endpoint_not_reimplements(html):
+    # single compute path: fetches /analytics and renders from the response
+    assert "api('/analytics'" in html
+    assert "resp.groups" in html
+    assert "resp.rows" in html
+
+
+def test_analytics_respects_plan_tier_framing(html):
+    # spend metric switches to token volume for subscription/local (dollars
+    # suppressed); never re-derives the suppression rule — reads framing.
+    assert "framing.pricing_mode === 'subscription' || framing.pricing_mode === 'local'" in html
+    assert "fmtFramedDollar(kpis.spend, framing)" in html
+
+
+def test_analytics_leaderboard_has_inline_bars(html):
+    # #214: sorted leaderboard with inline magnitude bars (CSS, no chart lib).
+    assert "function buildLeaderboard" in html
+    assert "lb-fill" in html
+    assert ".lb-bar" in html

--- a/tokenjam/api/app.py
+++ b/tokenjam/api/app.py
@@ -76,6 +76,7 @@ def create_app(
     from tokenjam.api.routes.optimize import router as optimize_router
     from tokenjam.api.routes.reuse import router as reuse_router
     from tokenjam.api.routes.cost_compare import router as cost_compare_router
+    from tokenjam.api.routes.analytics import router as analytics_router
     from tokenjam.api.routes.version import router as version_router, health_router
 
     app.include_router(spans_router, prefix="/api/v1")
@@ -90,6 +91,7 @@ def create_app(
     app.include_router(optimize_router, prefix="/api/v1")
     app.include_router(reuse_router, prefix="/api/v1")
     app.include_router(cost_compare_router, prefix="/api/v1")
+    app.include_router(analytics_router, prefix="/api/v1")
     app.include_router(version_router, prefix="/api/v1")
     app.include_router(health_router)  # /health — no prefix, for uptime probes
     app.include_router(metrics_router)  # /metrics — no prefix

--- a/tokenjam/api/routes/analytics.py
+++ b/tokenjam/api/routes/analytics.py
@@ -1,0 +1,247 @@
+"""
+GET /api/v1/analytics — the generalized group-by behind the Analytics explorer
+(#210).
+
+One pivot endpoint: (metric × group_by × optional stack_by × filters × window)
+-> a time-bucketed grouped series + KPI totals + the plan-tier framing block.
+It generalizes the Wave-1 `/cost` group-by (which carried provider + the token
+split): the explorer's line / bar / hbar views are all client-side pivots of
+the single `rows` shape this returns, so there is one server compute path.
+
+Honesty / framing: the `spend` metric is dollar-bearing, so the response always
+carries the framing block (single source, #110) AND a `tokens` value per row,
+letting the UI render token-share for subscription/local users without
+re-deriving the suppression rules (Critical Rule 14). Token / session / event
+metrics are plan-independent counts.
+"""
+from __future__ import annotations
+
+from fastapi import APIRouter, Depends, HTTPException, Request
+
+from tokenjam.api.deps import require_api_key
+from tokenjam.api.routes.cost import _framing_block
+from tokenjam.utils.time_parse import parse_since, utcnow
+
+router = APIRouter(dependencies=[Depends(require_api_key)])
+
+# tool_name -> coarse category. Centralized here so "tool_category" is a real
+# explorer dimension without a stored column. Unknown tools fall to 'other'.
+_TOOL_CATEGORY_CASE = (
+    "CASE "
+    "WHEN tool_name IN ('Read','Write','Edit','MultiEdit','NotebookEdit') THEN 'file' "
+    "WHEN tool_name IN ('Bash','BashOutput','KillShell') THEN 'shell' "
+    "WHEN tool_name IN ('Grep','Glob','LS') THEN 'search' "
+    "WHEN tool_name IN ('WebFetch','WebSearch') THEN 'web' "
+    "WHEN tool_name IN ('Task','Agent') THEN 'agent' "
+    "WHEN tool_name IN ('TodoWrite') THEN 'planning' "
+    "WHEN tool_name IS NULL THEN NULL "
+    "ELSE 'other' END"
+)
+
+# Dimension name -> a SAFE SQL expression (never user input; whitelisted so no
+# injection is possible — Rule 7). "day" is the time bucket, handled specially.
+_DIMENSION_EXPR: dict[str, str] = {
+    "agent": "agent_id",
+    "provider": "provider",
+    "model": "model",
+    "tool": "tool_name",
+    "tool_category": _TOOL_CATEGORY_CASE,
+    "kind": "kind",
+    "request_type": "request_type",
+    "day": "__bucket__",  # sentinel: resolved to the time-bucket expression
+}
+
+# Metric name -> (SQL aggregate, value unit). spend is the only dollar-bearing
+# (framing-sensitive) metric.
+_METRIC_EXPR: dict[str, tuple[str, str]] = {
+    "spend": ("COALESCE(SUM(cost_usd), 0.0)", "usd"),
+    "tokens": ("COALESCE(SUM(COALESCE(input_tokens,0)+COALESCE(output_tokens,0)), 0)", "tokens"),
+    "events": ("COUNT(*)", "count"),
+    "sessions": ("COUNT(DISTINCT session_id)", "count"),
+}
+
+_METRIC_LABEL = {
+    "spend": "Spend", "tokens": "Tokens", "events": "Events", "sessions": "Sessions",
+}
+
+# Equality filters the explorer exposes (param name -> span column).
+_FILTER_COLUMN = {
+    "agent_id": "agent_id",
+    "provider": "provider",
+    "model": "model",
+    "tool": "tool_name",
+}
+
+_TOKENS_EXPR = "COALESCE(SUM(COALESCE(input_tokens,0)+COALESCE(output_tokens,0)), 0)"
+
+
+def _bucket_unit(since_dt, until_dt) -> str:
+    start = since_dt
+    end = until_dt or utcnow()
+    span_days = ((end - start).total_seconds() / 86400.0) if start is not None else None
+    return "hour" if (span_days is not None and span_days <= 2) else "day"
+
+
+def _bucket_expr(unit: str) -> str:
+    # `unit` is a provably-internal literal ('hour'/'day' from _bucket_unit),
+    # never user input, so inlining it keeps a single shared param list across
+    # the grouped + KPI queries (still no f-string SQL on any user value, Rule 7).
+    assert unit in ("hour", "day")
+    return f"CAST(epoch(date_trunc('{unit}', start_time AT TIME ZONE 'UTC')) AS BIGINT)"
+
+
+@router.get("/analytics")
+async def get_analytics(
+    request: Request,
+    metric: str = "spend",
+    group_by: str = "model",
+    stack_by: str | None = None,
+    since: str | None = None,
+    until: str | None = None,
+    agent_id: str | None = None,
+    provider: str | None = None,
+    model: str | None = None,
+    tool: str | None = None,
+) -> dict:
+    """Return a grouped series for (metric, group_by, optional stack_by, filters)."""
+    if metric not in _METRIC_EXPR:
+        raise HTTPException(400, f"Unknown metric: {metric}")
+    if group_by not in _DIMENSION_EXPR:
+        raise HTTPException(400, f"Unknown group_by: {group_by}")
+    if stack_by in ("", "none"):
+        stack_by = None
+    if stack_by is not None and stack_by not in _DIMENSION_EXPR:
+        raise HTTPException(400, f"Unknown stack_by: {stack_by}")
+
+    db = request.app.state.db
+    config = request.app.state.config
+    since_dt = parse_since(since) if since else None
+    until_dt = parse_since(until) if until else None
+    conn = getattr(db, "conn", None)
+
+    bucket = _bucket_unit(since_dt, until_dt)
+    metric_expr, value_unit = _METRIC_EXPR[metric]
+
+    meta = {
+        "metric": metric,
+        "metric_label": _METRIC_LABEL[metric],
+        "value_unit": value_unit,
+        "group_by": group_by,
+        "stack_by": stack_by,
+        "series_bucket": bucket,
+        "window_start": int(since_dt.timestamp()) if since_dt is not None else None,
+        "window_end": int((until_dt or utcnow()).timestamp()),
+        "available_metrics": list(_METRIC_EXPR.keys()),
+        "available_dimensions": list(_DIMENSION_EXPR.keys()),
+    }
+    empty = {
+        **meta, "rows": [], "groups": [], "stacks": [], "totals_by_group": {},
+        "kpis": {"spend": 0.0, "tokens": 0, "events": 0, "sessions": 0},
+        "framing": _framing_block(db, config, agent_id, 0.0, 0),
+    }
+    if conn is None:
+        return empty
+
+    def resolve(dim: str) -> str:
+        expr = _DIMENSION_EXPR[dim]
+        return _bucket_expr(bucket) if expr == "__bucket__" else expr
+
+    # WHERE — every user value bound via $N; filters/since/until only (the bucket
+    # unit is inlined as a validated literal). One shared param list serves both
+    # the grouped query and the KPI query.
+    #
+    # Span-subtype gate, dimension-aware: a model/provider breakdown should only
+    # see LLM spans (tool spans have NULL model and would add a noisy '(none)'
+    # group), while a tool/tool_category breakdown should only see tool spans.
+    # Other dimensions (agent / day / kind) span all rows. A model+tool pivot is
+    # incoherent and correctly yields nothing.
+    dims = {group_by} | ({stack_by} if stack_by else set())
+    # Subtype gate (no params) cleans the BREAKDOWN; it is NOT applied to the KPI
+    # totals, which reflect the true window scoped only by the user's filters +
+    # time — so "events by tool" doesn't zero out the Spend KPI.
+    subtype: list[str] = []
+    if dims & {"model", "provider"}:
+        subtype.append("model IS NOT NULL")
+    if dims & {"tool", "tool_category"}:
+        subtype.append("tool_name IS NOT NULL")
+    # User filters + time window (shared param list across grouped + KPI queries).
+    user_clauses: list[str] = []
+    params: list = []
+    for pname, value in (("agent_id", agent_id), ("provider", provider),
+                         ("model", model), ("tool", tool)):
+        if value:
+            params.append(value)
+            user_clauses.append(_FILTER_COLUMN[pname] + " = $" + str(len(params)))
+    if since_dt is not None:
+        params.append(since_dt)
+        user_clauses.append("start_time >= $" + str(len(params)))
+    if until_dt is not None:
+        params.append(until_dt)
+        user_clauses.append("start_time <= $" + str(len(params)))
+    where = " AND ".join(subtype + user_clauses) if (subtype or user_clauses) else "1=1"
+    kpi_where = " AND ".join(user_clauses) if user_clauses else "1=1"
+
+    g1 = resolve(group_by)
+    g2 = resolve(stack_by) if stack_by else None
+    select_cols = [_bucket_expr(bucket) + " AS b", g1 + " AS g1"]
+    group_cols = ["b", "g1"]
+    if g2 is not None:
+        select_cols.append(g2 + " AS g2")
+        group_cols.append("g2")
+    select_cols.append(metric_expr + " AS val")
+    select_cols.append(_TOKENS_EXPR + " AS toks")
+
+    sql = (
+        "SELECT " + ", ".join(select_cols) + " FROM spans WHERE " + where
+        + " GROUP BY " + ", ".join(group_cols) + " ORDER BY b"
+    )
+    raw = conn.execute(sql, params).fetchall()
+
+    rows: list[dict] = []
+    totals: dict[str, float] = {}
+    stacks: dict[str, float] = {}
+    for r in raw:
+        b = int(r[0])
+        g1v = r[1] if r[1] is not None else "(none)"
+        if g2 is not None:
+            g2v = r[2] if r[2] is not None else "(none)"
+            val = float(r[3] or 0.0)
+            toks = int(r[4] or 0)
+        else:
+            g2v = None
+            val = float(r[2] or 0.0)
+            toks = int(r[3] or 0)
+        rows.append({"bucket": b, "group": str(g1v),
+                     "stack": (str(g2v) if g2v is not None else None),
+                     "value": val, "tokens": toks})
+        totals[str(g1v)] = totals.get(str(g1v), 0.0) + val
+        if g2v is not None:
+            stacks[str(g2v)] = stacks.get(str(g2v), 0.0) + val
+
+    groups = sorted(totals, key=lambda k: totals[k], reverse=True)
+    stack_keys = sorted(stacks, key=lambda k: stacks[k], reverse=True)
+
+    # KPI totals over the window (independent of group_by). DISTINCT for sessions
+    # so a session spanning models/buckets is counted once.
+    kpi_sql = (
+        "SELECT COALESCE(SUM(cost_usd),0.0), "
+        + _TOKENS_EXPR + ", COUNT(*), COUNT(DISTINCT session_id) "
+        "FROM spans WHERE " + kpi_where
+    )
+    krow = conn.execute(kpi_sql, params).fetchone()
+    kpis = {
+        "spend": float(krow[0] or 0.0) if krow else 0.0,
+        "tokens": int(krow[1] or 0) if krow else 0,
+        "events": int(krow[2] or 0) if krow else 0,
+        "sessions": int(krow[3] or 0) if krow else 0,
+    }
+
+    return {
+        **meta,
+        "rows": rows,
+        "groups": groups,
+        "stacks": stack_keys,
+        "totals_by_group": {k: round(v, 8) for k, v in totals.items()},
+        "kpis": kpis,
+        "framing": _framing_block(db, config, agent_id, kpis["spend"], kpis["tokens"]),
+    }

--- a/tokenjam/ui/index.html
+++ b/tokenjam/ui/index.html
@@ -343,6 +343,22 @@ tr.clickable:hover td.chevron { color: var(--accent); }
   font-size: 12px;
 }
 .filters select:focus, .filters input:focus { outline: none; border-color: var(--accent); }
+/* Analytics explorer (#210) — labelled controls, KPI tiles, leaderboard. */
+.ctl { display: inline-flex; align-items: center; gap: 6px; font-size: 11px; color: var(--text-dim); font-family: 'Geist Mono', monospace; }
+.preset-row { margin-top: -6px; }
+.preset-btn { font-size: 11px; padding: 4px 9px; }
+.kpi-row { display: flex; gap: 12px; margin-bottom: 16px; flex-wrap: wrap; }
+.kpi-tile { flex: 1 1 120px; background: var(--surface); border: 1px solid var(--border); border-radius: 8px; padding: 12px 14px; }
+.kpi-tile.kpi-active { border-color: var(--accent); }
+.kpi-val { font-family: 'Geist Mono', monospace; font-size: 20px; font-weight: 600; }
+.kpi-lab { font-size: 11px; color: var(--text-dim); margin-top: 2px; }
+.leaderboard { display: flex; flex-direction: column; gap: 6px; padding: 6px 0; }
+.lb-row { display: grid; grid-template-columns: 24px minmax(80px, 160px) 1fr auto; align-items: center; gap: 10px; font-size: 13px; }
+.lb-rank { color: var(--text-faint); font-family: 'Geist Mono', monospace; text-align: right; }
+.lb-name { font-family: 'Geist Mono', monospace; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.lb-bar { height: 14px; background: var(--border); border-radius: 3px; overflow: hidden; }
+.lb-fill { display: block; height: 100%; background: var(--accent); }
+.lb-val { font-family: 'Geist Mono', monospace; font-weight: 600; white-space: nowrap; }
 .btn {
   background: var(--surface);
   border: 1px solid var(--border);
@@ -672,6 +688,7 @@ a.health-tile.attn { border-color: var(--warn); }
   <a href="#/status" class="nav-link" data-view="status"><span class="icon">&bull;</span> Status</a>
   <a href="#/traces" class="nav-link" data-view="traces"><span class="icon">&diamond;</span> Traces</a>
   <a href="#/cost" class="nav-link" data-view="cost"><span class="icon">$</span> Cost</a>
+  <a href="#/analytics" class="nav-link" data-view="analytics"><span class="icon">&#9636;</span> Analytics</a>
   <a href="#/alerts" class="nav-link" data-view="alerts"><span class="icon">!</span> Alerts</a>
   <a href="#/drift" class="nav-link" data-view="drift"><span class="icon">~</span> Drift</a>
   <a href="#/optimize" class="nav-link" data-view="optimize"><span class="icon">&#9889;</span> Optimize</a>
@@ -2687,6 +2704,217 @@ function OptimizeView({ params }) {
 }
 
 // ============================
+// Analytics explorer (#210)
+// ============================
+// The single explorable pivot: metric × group_by × optional stack × chart-type,
+// filters, KPI tiles, presets, URL state, CSV export. Renders entirely from the
+// /api/v1/analytics response + its framing block (single compute path — the UI
+// never re-derives plan-tier rules). Subsumes the cost-by-model / spend-over-
+// time / leaderboard charts as presets (#214/#216).
+const ANALYTICS_METRICS = [
+  ['spend', 'Spend'], ['tokens', 'Tokens'], ['sessions', 'Sessions'], ['events', 'Events'],
+];
+const ANALYTICS_DIMENSIONS = [
+  ['model', 'Model'], ['agent', 'Agent'], ['provider', 'Provider'], ['tool', 'Tool'],
+  ['tool_category', 'Tool category'], ['kind', 'Span kind'], ['request_type', 'Request type'],
+  ['day', 'Day'],
+];
+const ANALYTICS_CHARTS = [['bar', 'Bars'], ['line', 'Lines'], ['hbar', 'Leaderboard']];
+// Built-in presets (close #214 leaderboard + #216 multi-series as preset views).
+const ANALYTICS_PRESETS = [
+  { id: 'spend-by-model', label: 'Spend by model', q: { metric: 'spend', group_by: 'model', chart: 'line', stack: '' } },
+  { id: 'leaderboard', label: 'Cost leaderboard', q: { metric: 'spend', group_by: 'model', chart: 'hbar', stack: '' } },
+  { id: 'tokens-over-time', label: 'Tokens over time', q: { metric: 'tokens', group_by: 'day', chart: 'bar', stack: '' } },
+  { id: 'tool-usage', label: 'Tool usage', q: { metric: 'events', group_by: 'tool_category', chart: 'hbar', stack: '' } },
+];
+
+// Pivot the analytics rows into a uPlot [xs, ...ys] time-series, one ys per
+// top-N group (+ "other"), zero-filled across the window (reuses _windowGrid so
+// the x-axis spans the full selected window, #133). `valueOf` picks cost vs
+// tokens per plan-tier framing.
+function buildAnalyticsSeries(resp, useTokens) {
+  if (!resp || !resp.rows) return null;
+  const grid = _windowGrid({ ...resp, series: resp.rows });
+  if (!grid) return null;
+  const { xs, idx, step, bucket, coarsened } = grid;
+  const valueOf = r => (useTokens ? (r.tokens || 0) : (r.value || 0));
+  const top = (resp.groups || []).slice(0, 5);
+  const topSet = new Set(top);
+  const hasOther = (resp.groups || []).length > top.length;
+  const labels = hasOther ? [...top, 'other'] : [...top];
+  const yss = labels.map(() => xs.map(() => 0));
+  resp.rows.forEach(r => {
+    const b = Math.floor(r.bucket / step) * step; if (!(b in idx)) return;
+    const li = topSet.has(r.group) ? labels.indexOf(r.group) : (hasOther ? labels.length - 1 : -1);
+    if (li >= 0) yss[li][idx[b]] += valueOf(r);
+  });
+  return { data: [xs, ...yss], labels, bucket, coarsened, requestedBucket: grid.reqBucket };
+}
+
+// Collapse the time dimension into per-group totals for the leaderboard (#214):
+// sorted desc, each with a fraction-of-max for the inline magnitude bar.
+function buildLeaderboard(resp, useTokens) {
+  if (!resp || !resp.rows) return null;
+  const totals = {};
+  resp.rows.forEach(r => { totals[r.group] = (totals[r.group] || 0) + (useTokens ? (r.tokens || 0) : (r.value || 0)); });
+  const entries = Object.keys(totals).map(g => ({ group: g, value: totals[g] }))
+    .sort((a, b) => b.value - a.value);
+  const max = entries.length ? Math.max(...entries.map(e => e.value), 0) : 0;
+  entries.forEach(e => { e.frac = max > 0 ? e.value / max : 0; });
+  return entries;
+}
+
+// CSV from the current pivot — built client-side from the response (offline,
+// no server round-trip), downloaded via a Blob object URL.
+function analyticsCsv(resp) {
+  const head = ['bucket_epoch', 'bucket_iso', resp.group_by, resp.stack_by || 'stack', resp.metric, 'tokens'];
+  const lines = [head.join(',')];
+  (resp.rows || []).forEach(r => {
+    const iso = new Date(r.bucket * 1000).toISOString();
+    const cell = v => { const s = String(v == null ? '' : v); return /[",\n]/.test(s) ? '"' + s.replace(/"/g, '""') + '"' : s; };
+    lines.push([r.bucket, iso, cell(r.group), cell(r.stack), r.value, r.tokens].join(','));
+  });
+  return lines.join('\n');
+}
+
+function downloadCsv(filename, text) {
+  const blob = new Blob([text], { type: 'text/csv' });
+  const url = URL.createObjectURL(blob);
+  const a = document.createElement('a');
+  a.href = url; a.download = filename; document.body.appendChild(a); a.click();
+  document.body.removeChild(a); URL.revokeObjectURL(url);
+}
+
+function AnalyticsView({ params }) {
+  const DEFAULTS = { since: '30d', metric: 'spend', group_by: 'model', stack: '', chart: 'bar',
+    agent_id: '', provider: '', model: '', tool: '' };
+  const since = readParam(params, 'since', DEFAULTS.since, validSince);
+  const metric = readParam(params, 'metric', DEFAULTS.metric, v => ANALYTICS_METRICS.some(m => m[0] === v));
+  const groupBy = readParam(params, 'group_by', DEFAULTS.group_by, v => ANALYTICS_DIMENSIONS.some(d => d[0] === v));
+  const stack = readParam(params, 'stack', DEFAULTS.stack, v => v === '' || ANALYTICS_DIMENSIONS.some(d => d[0] === v));
+  const chart = readParam(params, 'chart', DEFAULTS.chart, v => ANALYTICS_CHARTS.some(c => c[0] === v));
+  const fAgent = readParam(params, 'agent_id', '');
+  const fProvider = readParam(params, 'provider', '');
+  const fModel = readParam(params, 'model', '');
+  const fTool = readParam(params, 'tool', '');
+  const cur = { since, metric, group_by: groupBy, stack, chart, agent_id: fAgent, provider: fProvider, model: fModel, tool: fTool };
+  const setFilter = (k, v) => navigate('analytics', { ...cur, [k]: v }, DEFAULTS);
+  const applyPreset = (q) => navigate('analytics', { ...cur, ...q }, DEFAULTS);
+
+  const [st, setSt] = useState({ loading: true, error: null, resp: null });
+
+  const load = useCallback(async () => {
+    setSt(s => ({ ...s, loading: !s.resp, error: null }));
+    try {
+      const resp = await api('/analytics', {
+        metric, group_by: groupBy, stack_by: stack || undefined, since,
+        agent_id: fAgent || undefined, provider: fProvider || undefined,
+        model: fModel || undefined, tool: fTool || undefined,
+      });
+      setSt({ loading: false, error: null, resp });
+    } catch (e) { setSt(s => ({ ...s, loading: false, error: e.message || String(e) })); }
+  }, [metric, groupBy, stack, chart, since, fAgent, fProvider, fModel, fTool]);
+
+  useEffect(() => { load(); }, [load]);
+
+  const { loading, error, resp } = st;
+  const framing = resp ? resp.framing : null;
+  // Plan-tier framing: the spend metric switches to token volume for
+  // subscription/local (dollars suppressed) — single source, never re-derived.
+  const isSpend = metric === 'spend';
+  const useTokens = isSpend && !!framing && (framing.pricing_mode === 'subscription' || framing.pricing_mode === 'local');
+  const valueIsDollars = isSpend && !useTokens;
+  const fmtV = valueIsDollars ? fmtCost : fmtTokens;
+  const fmtVal = v => (metric === 'sessions' || metric === 'events') ? fmtTokens(v).replace(/ tokens$/, '') : fmtV(v);
+  const axisFmt = valueIsDollars ? fmtAxisUsd : fmtTokens;
+
+  const series = (chart === 'line' || chart === 'bar') ? buildAnalyticsSeries(resp, useTokens) : null;
+  const board = chart === 'hbar' ? buildLeaderboard(resp, useTokens) : null;
+  const kpis = resp ? resp.kpis : null;
+  const filterChips = [['agent_id', fAgent], ['provider', fProvider], ['model', fModel], ['tool', fTool]].filter(x => x[1]);
+
+  const metricSuffix = isSpend ? (useTokens ? ' (tokens)' : '') : '';
+
+  return html`
+    <div class="page-title" style="display:flex;align-items:center;gap:10px;flex-wrap:wrap">
+      Analytics <${PlanBadge} framing=${framing} />
+    </div>
+
+    <div class="filters">
+      <label class="ctl">Metric
+        <select value=${metric} onChange=${e => setFilter('metric', e.target.value)}>
+          ${ANALYTICS_METRICS.map(([v, l]) => html`<option value=${v}>${l}</option>`)}
+        </select></label>
+      <label class="ctl">By
+        <select value=${groupBy} onChange=${e => setFilter('group_by', e.target.value)}>
+          ${ANALYTICS_DIMENSIONS.map(([v, l]) => html`<option value=${v}>${l}</option>`)}
+        </select></label>
+      <label class="ctl">Stack
+        <select value=${stack} onChange=${e => setFilter('stack', e.target.value)}>
+          <option value="">none</option>
+          ${ANALYTICS_DIMENSIONS.filter(d => d[0] !== groupBy).map(([v, l]) => html`<option value=${v}>${l}</option>`)}
+        </select></label>
+      <label class="ctl">Chart
+        <select value=${chart} onChange=${e => setFilter('chart', e.target.value)}>
+          ${ANALYTICS_CHARTS.map(([v, l]) => html`<option value=${v}>${l}</option>`)}
+        </select></label>
+      <select value=${since} onChange=${e => setFilter('since', e.target.value)}>
+        <option value="24h">Last 24h</option><option value="7d">Last 7d</option>
+        <option value="30d">Last 30d</option><option value="90d">Last 90d</option>
+      </select>
+      <button class="btn" onClick=${load}>Refresh</button>
+      <button class="btn" onClick=${() => resp && downloadCsv('tokenjam-analytics.csv', analyticsCsv(resp))}>Export CSV</button>
+    </div>
+
+    <div class="filters preset-row">
+      <span class="dim" style="font-size:12px">Presets:</span>
+      ${ANALYTICS_PRESETS.map(p => html`<button class="btn preset-btn" onClick=${() => applyPreset(p.q)}>${p.label}</button>`)}
+      ${filterChips.map(([k, v]) => html`<button class="btn" onClick=${() => setFilter(k, '')}>${k.replace('_id', '')}: ${v} ✕</button>`)}
+    </div>
+
+    ${error ? html`<div class="chart-card" style="border-color:var(--error)"><div style="color:var(--error);font-size:13px;margin-bottom:10px">Couldn't load analytics: ${error}</div><button class="btn" onClick=${load}>Retry</button></div>` : null}
+
+    ${!error && framing && framing.qualifier_text ? html`<div class="qualifier">${framing.qualifier_text}</div>` : null}
+
+    ${!error && kpis ? html`
+      <div class="kpi-row">
+        ${[['spend', 'Spend', valueIsDollars || !isSpend ? fmtFramedDollar(kpis.spend, framing) : fmtTokens(kpis.tokens) + ' tok'],
+           ['tokens', 'Tokens', fmtTokens(kpis.tokens)],
+           ['sessions', 'Sessions', String(kpis.sessions)],
+           ['events', 'Events', String(kpis.events)]].map(([k, lab, val]) => html`
+          <div class=${'kpi-tile' + (k === metric ? ' kpi-active' : '')}>
+            <div class="kpi-val">${val}</div><div class="kpi-lab">${lab}</div>
+          </div>`)}
+      </div>` : null}
+
+    ${!error ? html`
+      <div class="chart-card">
+        <div class="chart-head">
+          <div class="chart-title">${(ANALYTICS_METRICS.find(m => m[0] === metric) || [, metric])[1]} by ${(ANALYTICS_DIMENSIONS.find(d => d[0] === groupBy) || [, groupBy])[1]}${metricSuffix}</div>
+        </div>
+        ${loading ? html`<div class="shimmer" style="height:200px"></div>`
+          : chart === 'hbar'
+            ? (board && board.length ? html`
+              <div class="leaderboard">
+                ${board.map((e, i) => html`
+                  <div class="lb-row">
+                    <span class="lb-rank">${i + 1}</span>
+                    <span class="lb-name" title=${e.group}>${e.group}</span>
+                    <span class="lb-bar"><span class="lb-fill" style=${'width:' + (e.frac * 100).toFixed(1) + '%'}></span></span>
+                    <span class="lb-val">${fmtVal(e.value)}</span>
+                  </div>`)}
+              </div>` : html`<div class="empty" style="padding:32px 0">No data in this window.</div>`)
+            : (series ? html`
+              ${chart === 'line'
+                ? html`<${SpendChart} data=${series.data} labels=${series.labels} height=${220} fmtY=${fmtV} axisFmtY=${axisFmt} showLegend=${series.labels.length > 1} bucket=${series.bucket} />`
+                : html`<${StackedBarChart} data=${series.data} labels=${series.labels} height=${220} fmtY=${fmtV} axisFmtY=${axisFmt} bucket=${series.bucket} />`}
+              ${series.coarsened ? html`<div class="chart-foot"><span class="dim">Showing ${series.bucket} buckets — this range is too long for ${series.requestedBucket}ly detail.</span></div>` : null}
+            ` : html`<div class="empty" style="padding:32px 0">No data in this window.</div>`)}
+      </div>` : null}
+  `;
+}
+
+// ============================
 // App Router
 // ============================
 function App() {
@@ -2723,6 +2951,7 @@ function App() {
       if (route.param) return html`<${TraceDetailView} traceId=${route.param} />`;
       return html`<${TracesListView} params=${p} />`;
     case 'cost': return html`<${CostView} params=${p} />`;
+    case 'analytics': return html`<${AnalyticsView} params=${p} />`;
     case 'alerts': return html`<${AlertsView} params=${p} />`;
     case 'drift': return html`<${DriftView} params=${p} />`;
     case 'optimize': return html`<${OptimizeView} params=${p} />`;


### PR DESCRIPTION
The Wave-2 headliner of the Lens Visualizations milestone (#210): a single explorable pivot that generalizes the lone `SpendChart` into a full analytics surface. All data shaping is **server-side** (single compute path); the UI renders from the response and consumes the `framing` block (never re-derives), uses **vendored uPlot** + a CSS leaderboard (offline intact), and keeps **all state in the URL**.

## Screenshots
Delivered to the reviewer to attach (no binaries committed, per the hard rule):
- **Spend × model × stacked bars over time** — metric / break-down / stack / chart controls, presets, KPI tiles, Export CSV.
- **Cost leaderboard** preset — spend by model, sorted hbar with inline magnitude bars (**#214**).
- **Tool usage** preset — events by tool-category leaderboard (KPI tiles still show true window totals).

## Summary
- **New `GET /api/v1/analytics`** — the single generalized group-by: `(metric, group_by, stack_by, filters, since)` → time-bucketed grouped series + KPI totals + framing block. Generalizes the Wave-1 `/cost` group-by.
- **New Analytics screen** — `metric × break-down × optional stack × chart-type`, filters, KPI tiles, presets, URL state, CSV export.
- **Closes #214** (cost leaderboard) and **#216** (multi-series spend) as built-in presets.

## Endpoint
- **metrics**: spend / tokens / sessions / events. **dimensions**: agent / provider / model / tool / tool_category / kind / request_type / day. `tool_category` is derived server-side from `tool_name` (real dimension, no stored column).
- **Dimension-aware subtype gate** cleans the breakdown (model breakdown → LLM spans; tool breakdown → tool spans) **without** scoping the KPI totals, which stay true window figures — so "events by tool" never zeroes the Spend tile.
- **Plan-tier framing (Rule 14):** the `spend` metric carries the framing block **and** a per-row `tokens` value, so subscription/local render token-share without re-deriving suppression. Token/session/event metrics are plan-independent counts.
- **SQL safety (Rule 7):** every user value bound via `$N`; the bucket unit is a validated internal literal (`hour`/`day`), dimensions/metrics are whitelisted (no injection).

## UI
- **bar** = stacked bars over time, **line** = multi-series over time (reuses `SpendChart`/`StackedBarChart`), **hbar** = a sorted CSS leaderboard with inline magnitude bars (cheap, no chart lib — closes #214).
- **URL is source of truth** (`metric/group_by/stack/chart/filters/since`), via `readParam`/`navigate`, matching Lens's convention. Presets are one-click URL navigations.
- **CSV** built client-side from the response, downloaded via a Blob (offline-safe).

## Tests / Verification
- `tests/integration/test_analytics.py` (10): spend-by-model series + KPIs; metric×dimension matrix (tokens/sessions/events); tool_category includes tool spans **and** KPI independence; `stack_by`; filters; subscription framing; 400 on bad metric/dimension; empty-window safe.
- `tests/unit/test_lens_ui_regression.py` (+7): screen registered + nav link; metric/dimension/stack/chart controls; presets + CSV; URL-state; single-compute-path consumption (`api('/analytics')`, `resp.groups`/`resp.rows`); plan-tier framing routing; leaderboard inline bars.
- `test_ui_offline.py` green; app module passes `node --check`.
- Full `pytest tests/unit tests/integration` → **840 passed**; `ruff check tokenjam/` + `mypy tokenjam/` clean (117 files).

## Scope notes
- The new endpoint is the generalized group-by path; the existing Wave-1 `/cost` charts still use their own endpoints — migrating them onto `/analytics` is a safe follow-up (not done here to keep the diff focused and avoid regressing shipped charts). Noted per the "land the explorer core + endpoint" guidance.
- **#214**: delivered as the explorer's "Cost leaderboard" preset (sorted hbar + inline bars across model/agent/tool, framing-respected). This is the leaderboard surface, not an in-place edit of the existing Cost table — flagging so the reviewer can decide whether the in-place table polish is still wanted (acceptance criteria are met by the preset).
- Treemap/pie deferred per the issue.

Closes #210
Closes #214
Closes #216

🤖 Generated with [Claude Code](https://claude.com/claude-code)