### PR TITLE
[Lens viz] Cost-annotated trace waterfall (#215)

### DIFF
--- a/tests/unit/test_lens_ui_regression.py
+++ b/tests/unit/test_lens_ui_regression.py
@@ -441,3 +441,33 @@ def test_analytics_leaderboard_has_inline_bars(html):
     assert "function buildLeaderboard" in html
     assert "lb-fill" in html
     assert ".lb-bar" in html
+
+
+# --- #215: cost-annotated trace waterfall ---------------------------------- #
+def test_trace_waterfall_cost_summary(html):
+    # A cost-first trace summary header (total cost + tokens + duration + spans).
+    assert "wf-summary" in html
+    assert "Total cost" in html
+    assert "wfTotalCostFramed" in html
+    # the total cost routes through the framing helper (not raw fmtCost)
+    assert "const wfTotalCostFramed = fmtFramedDollar(wfTotalCost, framing)" in html
+
+
+def test_trace_waterfall_per_span_cost_token_annotation(html):
+    # Per-span cost + tokens annotation column with a magnitude bar (not just the
+    # hover tooltip), so the timeline reads cost-first.
+    assert "wf-cost-bar" in html
+    assert "wf-cost-fill" in html
+    assert 'class="wf-cost-val"' in html
+    assert 'class="wf-cost-tok"' in html
+    # tokens summed per span and shown in the annotation
+    assert "const spanTokens = s =>" in html
+    assert "wf-cost-tok\">${sTok ? fmtTokens(sTok)" in html
+
+
+def test_trace_waterfall_magnitude_respects_framing(html):
+    # The magnitude bar (and summary) read on TOKEN volume when dollars are
+    # suppressed (subscription/local) — the suppression decision comes from the
+    # server framing block, never re-derived in JS.
+    assert "framing.pricing_mode === 'subscription' || framing.pricing_mode === 'local'" in html
+    assert "const wfMagOf = s => wfUseTokens ? spanTokens(s) : (s.cost_usd || 0)" in html

--- a/tokenjam/ui/index.html
+++ b/tokenjam/ui/index.html
@@ -439,6 +439,29 @@ tr.clickable:hover td.chevron { color: var(--accent); }
 .wf-bar.tool { background: var(--warn); color: var(--bg); }
 .wf-bar.other { background: var(--text-dim); }
 
+/* Cost-annotated waterfall (#215): trace cost summary + a per-span cost/token
+   annotation column with a magnitude bar so the timeline reads cost-first. */
+.wf-summary {
+  display: flex; gap: 18px; flex-wrap: wrap;
+  margin: 0 0 14px; padding: 10px 14px;
+  background: var(--surface); border: 1px solid var(--border); border-radius: 8px;
+  font-family: 'Geist Mono', monospace; font-size: 12px; color: var(--text-dim);
+}
+.wf-summary b { color: var(--text); font-weight: 600; }
+.wf-head { display: flex; align-items: center; font-size: 10px; color: var(--text-faint);
+  font-family: 'Geist Mono', monospace; text-transform: uppercase; letter-spacing: 0.04em;
+  margin-bottom: 4px; }
+.wf-head .wf-cost { color: var(--text-faint); }
+.wf-cost {
+  flex-shrink: 0; width: 156px; display: flex; align-items: center; gap: 8px;
+  padding-left: 12px; font-family: 'Geist Mono', monospace; font-size: 11px;
+}
+.wf-cost-bar { width: 34px; height: 8px; background: var(--border); border-radius: 2px;
+  overflow: hidden; flex-shrink: 0; }
+.wf-cost-fill { display: block; height: 100%; background: var(--accent); }
+.wf-cost-val { color: var(--text); min-width: 50px; text-align: right; }
+.wf-cost-tok { color: var(--text-dim); min-width: 46px; text-align: right; }
+
 /* Span detail */
 .span-detail {
   background: var(--surface);
@@ -1510,6 +1533,18 @@ function TraceDetailView({ traceId }) {
   const rows = flatten(roots, 0);
   const labelW = 100;
 
+  // Cost-first annotation (#215). Plan-tier framing: when dollars are suppressed
+  // (subscription/local), the magnitude bar + summary read on TOKEN volume, never
+  // raw spend — the suppression decision comes from the server framing block, not
+  // re-derived here. Tokens are never suppressed, so they always annotate.
+  const spanTokens = s => (s.input_tokens || 0) + (s.output_tokens || 0) + (s.cache_tokens || 0) + (s.cache_write_tokens || 0);
+  const wfUseTokens = !!framing && (framing.pricing_mode === 'subscription' || framing.pricing_mode === 'local');
+  const wfMagOf = s => wfUseTokens ? spanTokens(s) : (s.cost_usd || 0);
+  const wfMaxMag = Math.max(0, ...rows.map(r => wfMagOf(r.span)));
+  const wfTotalCost = spans.reduce((a, s) => a + (s.cost_usd || 0), 0);
+  const wfTotalTokens = spans.reduce((a, s) => a + spanTokens(s), 0);
+  const wfTotalCostFramed = fmtFramedDollar(wfTotalCost, framing);
+
   const sel = selected ? spans.find(s => s.span_id === selected) : null;
 
   // Determine agent name from root span
@@ -1520,6 +1555,17 @@ function TraceDetailView({ traceId }) {
     <button class="btn btn-back" onClick=${() => location.hash = '#/traces'}>\u2190 Back to traces</button>
     <div class="page-title">Trace details for ${agentName}</div>
     <div style="font-size:12px;color:var(--text-dim);margin:-14px 0 16px;font-family:'Geist Mono',monospace">Click a span for details</div>
+    <div class="wf-summary">
+      <span>Total cost <b>${wfTotalCostFramed}</b></span>
+      <span>Tokens <b>${fmtTokens(wfTotalTokens)}</b></span>
+      <span>Duration <b>${fmtDur(traceDur)}</b></span>
+      <span><b>${spans.length}</b> spans</span>
+    </div>
+    <div class="wf-head">
+      <div class="wf-label" style="width:${labelW}px;padding-left:8px">Span</div>
+      <div class="wf-track">Timeline</div>
+      <div class="wf-cost">Cost / tokens</div>
+    </div>
     <div class="waterfall">
       ${rows.map(({ span: s, depth }) => {
         const st = new Date(s.start_time).getTime() - traceStart;
@@ -1533,10 +1579,14 @@ function TraceDetailView({ traceId }) {
         // Plan-tier framed cost (#187): subscription \u2192 "% of cycle", local \u2192 "\u2014"
         // (suppressed; omitted from the compact bar label), api/unknown \u2192 "$X".
         const costFramed = fmtFramedDollar(s.cost_usd, framing);
-        const costStr = s.cost_usd != null && s.cost_usd > 0 && costFramed !== '\u2014' ? ' \u2014 ' + costFramed : '';
+        // Cost now lives in the dedicated annotation column (#215); the bar label
+        // stays focused on what/how-long so the two reads don't compete.
         const barLabel = isAgent
-          ? fmtDur(s.duration_ms) + costStr
-          : (detail ? detail + ' \u2014 ' : '') + fmtDur(s.duration_ms) + costStr;
+          ? fmtDur(s.duration_ms)
+          : (detail ? detail + ' \u2014 ' : '') + fmtDur(s.duration_ms);
+        const sTok = spanTokens(s);
+        const costShown = s.cost_usd != null && s.cost_usd > 0 && costFramed !== '\u2014';
+        const wfFrac = wfMaxMag > 0 ? (wfMagOf(s) / wfMaxMag * 100) : 0;
         const tipLines = [friendly];
         tipLines.push('Duration: ' + fmtDur(s.duration_ms));
         if (s.provider) tipLines.push('Provider: ' + s.provider);
@@ -1556,6 +1606,11 @@ function TraceDetailView({ traceId }) {
                 <div class="wf-bar ${kind}" style="width:100%">${barLabel}</div>
                 <div class="wf-tip">${tooltip}</div>
               </div>
+            </div>
+            <div class="wf-cost">
+              <div class="wf-cost-bar"><div class="wf-cost-fill" style="width:${wfFrac.toFixed(1)}%"></div></div>
+              <span class="wf-cost-val">${costShown ? costFramed : ''}</span>
+              <span class="wf-cost-tok">${sTok ? fmtTokens(sTok) : ''}</span>
             </div>
           </div>
         `;


### PR DESCRIPTION
A cost-first reading of the trace timeline. The trace-detail screen already drew a duration waterfall (each span positioned by start-time, sized by duration) with framed cost in the bar label and tokens only on hover; this makes it a **cost-first waterfall** — "where the time and the spend go". UI-only (the cost/token/timing fields were already on the trace spans), custom CSS, offline intact.

## Screenshot
Delivered to the reviewer to attach (no binaries committed, per the hard rule). It shows the cost summary header, the time-positioned bars, and the new **COST / TOKENS** annotation column with per-span magnitude bars (opus $0.0850 / 11.9k dominates; haiku $0.0040 / 1.4k; tool spans blank).

## Summary
- **Trace cost summary header** — total cost (framed) · total tokens · duration · span count.
- **Per-span COST / TOKENS annotation column** — always visible (not just the tooltip), each row with a **magnitude bar** so expensive spans pop against the timeline. Cost moves out of the bar label into this column so the two reads (what/how-long vs how-much) don't compete.

## Plan-tier framing (single compute path, Rule 14)
- Every dollar routes through the existing `fmtFramedDollar` against the trace response's framing block — subscription/local see token-share / suppressed dollars, never raw spend. The existing `const costFramed = fmtFramedDollar(s.cost_usd, framing)` is preserved.
- When dollars are suppressed, the **magnitude bar + summary read on token volume** (`wfMagOf = wfUseTokens ? spanTokens(s) : cost`) — the suppression decision comes from the server framing block, never re-derived in JS. Tokens are never suppressed, so they always annotate.

## Constraints honored
- Custom CSS for the timeline/annotation (no new chart lib); offline-first intact.
- No new endpoint — the data was already on the trace spans.

## Tests / Verification
- `tests/unit/test_lens_ui_regression.py` (+3): summary header + total-cost framing routing; per-span cost/token annotation column + magnitude bar + per-span token sum; magnitude basis switches to tokens under subscription/local framing.
- Existing trace-detail framing regression (`costFramed = fmtFramedDollar(...)`) still passes.
- `test_ui_offline.py` green; app module passes `node --check`.
- Full `pytest tests/unit tests/integration` → **843 passed**; `ruff check tokenjam/` + `mypy tokenjam/` clean.

Closes #215

🤖 Generated with [Claude Code](https://claude.com/claude-code)