### PR TITLE
[Lens viz] KPI tiles → sparkline + period-over-period delta (#217)

### DIFF
--- a/tests/integration/test_analytics.py
+++ b/tests/integration/test_analytics.py
@@ -148,3 +148,44 @@ async def test_empty_window_is_safe():
     assert d["rows"] == [] and d["groups"] == []
     assert d["kpis"]["spend"] == 0
     assert "framing" in d
+    # #217: the sparkline/delta fields are always present. With a window set,
+    # the delta keys exist but are null (no prior data → no divide-by-zero).
+    assert d["kpi_series"] == []
+    assert set(d["kpi_deltas"]) == {"spend", "tokens", "events", "sessions"}
+    assert all(v is None for v in d["kpi_deltas"].values())
+
+
+@pytest.mark.asyncio
+async def test_kpi_series_and_deltas_for_sparklines():
+    """#217: the explorer returns a per-bucket `kpi_series` (all four metrics)
+    and a period-over-period `kpi_deltas` vs the prior equal-length window —
+    both computed server-side so the UI never aggregates per-bucket in JS."""
+    db = InMemoryBackend()
+    cfg = TjConfig(version="1")
+    _seed(db)  # 4 days of data, two models/day
+    d = await _get(db, cfg, "metric=spend&group_by=model&since=30d")
+    # Per-bucket series carries every KPI metric for each bucket.
+    assert d["kpi_series"], "expected a non-empty kpi_series"
+    for b in d["kpi_series"]:
+        assert {"bucket", "spend", "tokens", "events", "sessions"} <= set(b)
+    # Series spend reconciles with the window KPI total.
+    assert sum(b["spend"] for b in d["kpi_series"]) == pytest.approx(d["kpis"]["spend"])
+    # Prior window had no data (seed is the most recent 4 days) → prev=0 → null
+    # delta, never a divide-by-zero.
+    assert set(d["kpi_deltas"]) == {"spend", "tokens", "events", "sessions"}
+    assert d["kpi_deltas"]["spend"] is None
+    assert d["kpi_prev"]["spend"] == 0
+
+
+@pytest.mark.asyncio
+async def test_kpi_delta_non_null_when_prior_window_has_data():
+    """#217: a real period-over-period % when both the current and prior
+    equal-length windows carry data (the seed spans 4 consecutive days, so a
+    2-day window's prior 2 days are non-empty)."""
+    db = InMemoryBackend()
+    cfg = TjConfig(version="1")
+    _seed(db)
+    d = await _get(db, cfg, "metric=spend&group_by=model&since=2d")
+    assert d["kpi_prev"]["spend"] > 0, "prior window should have seeded data"
+    assert d["kpi_deltas"]["spend"] is not None
+    assert isinstance(d["kpi_deltas"]["spend"], float)

--- a/tests/unit/test_lens_ui_regression.py
+++ b/tests/unit/test_lens_ui_regression.py
@@ -471,3 +471,35 @@ def test_trace_waterfall_magnitude_respects_framing(html):
     # server framing block, never re-derived in JS.
     assert "framing.pricing_mode === 'subscription' || framing.pricing_mode === 'local'" in html
     assert "const wfMagOf = s => wfUseTokens ? spanTokens(s) : (s.cost_usd || 0)" in html
+
+
+# --- #217: KPI tiles → sparkline + period-over-period delta ----------------- #
+def test_kpi_tiles_have_sparkline_and_delta(html):
+    # KPI tiles gain a trend sparkline + a signed period-over-period delta chip.
+    assert "function Sparkline(" in html
+    assert "function DeltaChip(" in html
+    assert "function KpiTile(" in html
+
+
+def test_kpi_sparkline_is_inline_svg_not_uplot(html):
+    # The sparkline is a lightweight inline SVG (offline, no per-tile uPlot
+    # instance) — so #218's offline guarantee + render cost both hold.
+    assert '<svg class="spark"' in html
+    assert "<polyline points=" in html
+
+
+def test_kpi_series_is_server_computed_not_client_aggregated(html):
+    # Single compute path: the sparkline reads the server's `kpi_series` through
+    # the shared window grid; the UI never buckets/aggregates per-span in JS.
+    assert "function kpiSparkValues(" in html
+    assert "_windowGrid({ ...resp, series: resp.kpi_series })" in html
+    assert "resp.kpi_deltas" in html
+
+
+def test_kpi_spend_tile_respects_framing(html):
+    # The Spend tile's value, sparkline, AND delta read on TOKEN volume when
+    # dollars are suppressed (subscription/local) — decided once from the server
+    # framing block, never re-derived. Volume tiles stay plan-independent.
+    assert "const spendSuppressed = !!framing && (framing.pricing_mode === 'subscription' || framing.pricing_mode === 'local')" in html
+    assert "kpiSparkValues(resp, spendSuppressed ? 'tokens' : 'spend')" in html
+    assert "delta: spendSuppressed ? deltas.tokens : deltas.spend" in html

--- a/tokenjam/api/routes/analytics.py
+++ b/tokenjam/api/routes/analytics.py
@@ -137,6 +137,7 @@ async def get_analytics(
     empty = {
         **meta, "rows": [], "groups": [], "stacks": [], "totals_by_group": {},
         "kpis": {"spend": 0.0, "tokens": 0, "events": 0, "sessions": 0},
+        "kpi_series": [], "kpi_prev": None, "kpi_deltas": {},
         "framing": _framing_block(db, config, agent_id, 0.0, 0),
     }
     if conn is None:
@@ -164,22 +165,31 @@ async def get_analytics(
         subtype.append("model IS NOT NULL")
     if dims & {"tool", "tool_category"}:
         subtype.append("tool_name IS NOT NULL")
-    # User filters + time window (shared param list across grouped + KPI queries).
-    user_clauses: list[str] = []
-    params: list = []
-    for pname, value in (("agent_id", agent_id), ("provider", provider),
-                         ("model", model), ("tool", tool)):
-        if value:
-            params.append(value)
-            user_clauses.append(_FILTER_COLUMN[pname] + " = $" + str(len(params)))
-    if since_dt is not None:
-        params.append(since_dt)
-        user_clauses.append("start_time >= $" + str(len(params)))
-    if until_dt is not None:
-        params.append(until_dt)
-        user_clauses.append("start_time <= $" + str(len(params)))
-    where = " AND ".join(subtype + user_clauses) if (subtype or user_clauses) else "1=1"
-    kpi_where = " AND ".join(user_clauses) if user_clauses else "1=1"
+    # The non-time equality filters (agent/provider/model/tool), reused to build
+    # the current window, the per-bucket KPI series, and the prior-period window.
+    filter_pairs = [(_FILTER_COLUMN[p], v) for p, v in
+                    (("agent_id", agent_id), ("provider", provider),
+                     ("model", model), ("tool", tool)) if v]
+
+    def where_and_params(*, with_subtype: bool, lo, hi) -> tuple[str, list]:
+        """Build a (where, params) over the filters + a [lo, hi) time window.
+        `with_subtype` adds the breakdown's span-subtype gate (no params)."""
+        cl: list[str] = list(subtype) if with_subtype else []
+        ps: list = []
+        for col, val in filter_pairs:
+            ps.append(val)
+            cl.append(col + " = $" + str(len(ps)))
+        if lo is not None:
+            ps.append(lo)
+            cl.append("start_time >= $" + str(len(ps)))
+        if hi is not None:
+            ps.append(hi)
+            cl.append("start_time < $" + str(len(ps)))
+        return (" AND ".join(cl) if cl else "1=1", ps)
+
+    end_dt = until_dt or utcnow()
+    where, params = where_and_params(with_subtype=True, lo=since_dt, hi=end_dt)
+    kpi_where, kpi_params = where_and_params(with_subtype=False, lo=since_dt, hi=end_dt)
 
     g1 = resolve(group_by)
     g2 = resolve(stack_by) if stack_by else None
@@ -222,19 +232,48 @@ async def get_analytics(
     stack_keys = sorted(stacks, key=lambda k: stacks[k], reverse=True)
 
     # KPI totals over the window (independent of group_by). DISTINCT for sessions
-    # so a session spanning models/buckets is counted once.
-    kpi_sql = (
-        "SELECT COALESCE(SUM(cost_usd),0.0), "
-        + _TOKENS_EXPR + ", COUNT(*), COUNT(DISTINCT session_id) "
-        "FROM spans WHERE " + kpi_where
+    # so a session spanning models/buckets is counted once. The four-metric
+    # SELECT is reused for the prior window too.
+    _kpi_cols = ("COALESCE(SUM(cost_usd),0.0), " + _TOKENS_EXPR
+                 + ", COUNT(*), COUNT(DISTINCT session_id)")
+
+    def _kpi_totals(where_sql: str, ps: list) -> dict:
+        row = conn.execute("SELECT " + _kpi_cols + " FROM spans WHERE " + where_sql, ps).fetchone()
+        return {
+            "spend": float(row[0] or 0.0) if row else 0.0,
+            "tokens": int(row[1] or 0) if row else 0,
+            "events": int(row[2] or 0) if row else 0,
+            "sessions": int(row[3] or 0) if row else 0,
+        }
+
+    kpis = _kpi_totals(kpi_where, kpi_params)
+
+    # Per-bucket series for ALL FOUR KPI metrics (the sparklines, #217). One
+    # query, server-side — the UI zero-fills across the window and never
+    # aggregates per-bucket in JS (single compute path).
+    kpi_series_sql = (
+        "SELECT " + _bucket_expr(bucket) + " AS b, " + _kpi_cols
+        + " FROM spans WHERE " + kpi_where + " GROUP BY b ORDER BY b"
     )
-    krow = conn.execute(kpi_sql, params).fetchone()
-    kpis = {
-        "spend": float(krow[0] or 0.0) if krow else 0.0,
-        "tokens": int(krow[1] or 0) if krow else 0,
-        "events": int(krow[2] or 0) if krow else 0,
-        "sessions": int(krow[3] or 0) if krow else 0,
-    }
+    kpi_series = [
+        {"bucket": int(r[0]), "spend": float(r[1] or 0.0), "tokens": int(r[2] or 0),
+         "events": int(r[3] or 0), "sessions": int(r[4] or 0)}
+        for r in conn.execute(kpi_series_sql, kpi_params).fetchall()
+    ]
+
+    # Period-over-period delta vs the prior equal-length window (#217), same
+    # convention as the Cost/Overview --compare headline. Computed server-side.
+    kpi_prev: dict | None = None
+    kpi_deltas: dict = {}
+    if since_dt is not None:
+        prev_since = since_dt - (end_dt - since_dt)
+        pwhere, pparams = where_and_params(with_subtype=False, lo=prev_since, hi=since_dt)
+        kpi_prev = _kpi_totals(pwhere, pparams)
+        for m in ("spend", "tokens", "events", "sessions"):
+            prev_v = kpi_prev[m]
+            cur_v = kpis[m]
+            kpi_deltas[m] = (round((cur_v - prev_v) / prev_v * 100.0, 1)
+                             if prev_v else None)
 
     return {
         **meta,
@@ -243,5 +282,8 @@ async def get_analytics(
         "stacks": stack_keys,
         "totals_by_group": {k: round(v, 8) for k, v in totals.items()},
         "kpis": kpis,
+        "kpi_series": kpi_series,
+        "kpi_prev": kpi_prev,
+        "kpi_deltas": kpi_deltas,
         "framing": _framing_block(db, config, agent_id, kpis["spend"], kpis["tokens"]),
     }

--- a/tokenjam/ui/index.html
+++ b/tokenjam/ui/index.html
@@ -348,8 +348,13 @@ tr.clickable:hover td.chevron { color: var(--accent); }
 .preset-row { margin-top: -6px; }
 .preset-btn { font-size: 11px; padding: 4px 9px; }
 .kpi-row { display: flex; gap: 12px; margin-bottom: 16px; flex-wrap: wrap; }
-.kpi-tile { flex: 1 1 120px; background: var(--surface); border: 1px solid var(--border); border-radius: 8px; padding: 12px 14px; }
+.kpi-tile { flex: 1 1 140px; background: var(--surface); border: 1px solid var(--border); border-radius: 8px; padding: 12px 14px; }
 .kpi-tile.kpi-active { border-color: var(--accent); }
+.kpi-top { display: flex; align-items: flex-start; justify-content: space-between; gap: 10px; }
+.kpi-num { min-width: 0; }
+.spark { display: block; flex-shrink: 0; }
+.spark-empty { flex-shrink: 0; }
+.kpi-tile .delta-chip { font-family: 'Geist Mono', monospace; font-size: 11px; margin-top: 6px; display: inline-block; }
 .kpi-val { font-family: 'Geist Mono', monospace; font-size: 20px; font-weight: 600; }
 .kpi-lab { font-size: 11px; color: var(--text-dim); margin-top: 2px; }
 .leaderboard { display: flex; flex-direction: column; gap: 6px; padding: 6px 0; }
@@ -1683,6 +1688,68 @@ function TrendChip({ pct }) {
   return html`<span class="trend-chip" style="color:${color}">${arrow} ${Math.abs(pct).toFixed(1)}% vs prev</span>`;
 }
 
+// Signed period-over-period delta chip for KPI tiles (#217). `cost`=true uses
+// the spend semantic (up = red/attention, down = green); volume metrics
+// (tokens/sessions/events) stay neutral — more isn't inherently "bad".
+function DeltaChip({ pct, cost }) {
+  if (pct == null) return null;
+  const up = pct > 0;
+  const arrow = pct === 0 ? '·' : up ? '▲' : '▼';
+  const color = cost
+    ? (pct === 0 ? 'var(--text-dim)' : up ? 'var(--error)' : 'var(--success)')
+    : 'var(--text-dim)';
+  return html`<span class="delta-chip" style="color:${color}">${arrow} ${Math.abs(pct).toFixed(1)}% vs prev</span>`;
+}
+
+// Inline-SVG sparkline (#217) — lightweight + offline; avoids spinning up a
+// uPlot instance per KPI tile. `values` is a numeric series (already in the
+// plan-tier-appropriate unit chosen by the caller). Draws a normalized polyline
+// over a faint area fill.
+function Sparkline({ values, color = 'var(--accent)', width = 92, height = 26 }) {
+  const vs = (values || []).filter(v => typeof v === 'number' && !isNaN(v));
+  if (vs.length < 2) return html`<div class="spark-empty" style=${'width:' + width + 'px;height:' + height + 'px'}></div>`;
+  const max = Math.max(...vs), min = Math.min(...vs);
+  const span = (max - min) || 1;
+  const n = vs.length;
+  const px = i => (i / (n - 1)) * width;
+  const py = v => height - ((v - min) / span) * (height - 4) - 2;
+  const line = vs.map((v, i) => px(i).toFixed(1) + ',' + py(v).toFixed(1)).join(' ');
+  const area = 'M0,' + height + ' L' + vs.map((v, i) => px(i).toFixed(1) + ',' + py(v).toFixed(1)).join(' L') + ' L' + width.toFixed(1) + ',' + height + ' Z';
+  return html`<svg class="spark" width=${width} height=${height} viewBox=${'0 0 ' + width + ' ' + height} preserveAspectRatio="none">
+    <path d=${area} fill=${color} opacity="0.13"></path>
+    <polyline points=${line} fill="none" stroke=${color} stroke-width="1.5"></polyline>
+  </svg>`;
+}
+
+// A trend-aware KPI tile (#217): value + sparkline + signed delta. The caller
+// passes series/delta already in the right unit (token-share for a suppressed
+// Spend tile), so framing is decided once upstream — never re-derived here.
+function KpiTile({ label, value, active, series, delta, cost }) {
+  return html`<div class=${'kpi-tile' + (active ? ' kpi-active' : '')}>
+    <div class="kpi-top">
+      <div class="kpi-num"><div class="kpi-val">${value}</div><div class="kpi-lab">${label}</div></div>
+      <${Sparkline} values=${series} />
+    </div>
+    <${DeltaChip} pct=${delta} cost=${cost} />
+  </div>`;
+}
+
+// Zero-filled per-bucket values for one KPI metric from the analytics
+// `kpi_series` (server-computed; the UI never aggregates per-bucket — single
+// compute path). Spans the full window via the shared grid so the sparkline
+// shape matches the chart's window.
+function kpiSparkValues(resp, metric) {
+  const grid = _windowGrid({ ...resp, series: resp.kpi_series });
+  if (!grid) return (resp.kpi_series || []).map(b => b[metric] || 0);
+  const { xs, idx, step } = grid;
+  const ys = xs.map(() => 0);
+  (resp.kpi_series || []).forEach(b => {
+    const t = Math.floor(b.bucket / step) * step;
+    if (t in idx) ys[idx[t]] += (b[metric] || 0);
+  });
+  return ys;
+}
+
 // Build a uPlot [xs, ys...] series from day-grouped cost rows. `mode` is
 // total | model | agent; `useTokens` swaps cost for token volume (subscription
 // / local framing where dollars are suppressed). Splits keep the top-5 keys
@@ -2931,16 +2998,30 @@ function AnalyticsView({ params }) {
 
     ${!error && framing && framing.qualifier_text ? html`<div class="qualifier">${framing.qualifier_text}</div>` : null}
 
-    ${!error && kpis ? html`
-      <div class="kpi-row">
-        ${[['spend', 'Spend', valueIsDollars || !isSpend ? fmtFramedDollar(kpis.spend, framing) : fmtTokens(kpis.tokens) + ' tok'],
-           ['tokens', 'Tokens', fmtTokens(kpis.tokens)],
-           ['sessions', 'Sessions', String(kpis.sessions)],
-           ['events', 'Events', String(kpis.events)]].map(([k, lab, val]) => html`
-          <div class=${'kpi-tile' + (k === metric ? ' kpi-active' : '')}>
-            <div class="kpi-val">${val}</div><div class="kpi-lab">${lab}</div>
-          </div>`)}
-      </div>` : null}
+    ${!error && kpis ? (() => {
+      // The Spend tile follows the server framing block: subscription/local
+      // suppress dollars, so its value + sparkline + delta read on TOKEN volume,
+      // never raw $ — decided here once, not re-derived per render path. Token /
+      // session / event tiles are plan-independent counts.
+      const spendSuppressed = !!framing && (framing.pricing_mode === 'subscription' || framing.pricing_mode === 'local');
+      const deltas = resp.kpi_deltas || {};
+      const tiles = [
+        { key: 'spend', label: 'Spend', cost: true,
+          value: spendSuppressed ? (fmtTokens(kpis.tokens) + ' tok') : fmtFramedDollar(kpis.spend, framing),
+          series: kpiSparkValues(resp, spendSuppressed ? 'tokens' : 'spend'),
+          delta: spendSuppressed ? deltas.tokens : deltas.spend },
+        { key: 'tokens', label: 'Tokens', cost: false, value: fmtTokens(kpis.tokens),
+          series: kpiSparkValues(resp, 'tokens'), delta: deltas.tokens },
+        { key: 'sessions', label: 'Sessions', cost: false, value: String(kpis.sessions),
+          series: kpiSparkValues(resp, 'sessions'), delta: deltas.sessions },
+        { key: 'events', label: 'Events', cost: false, value: String(kpis.events),
+          series: kpiSparkValues(resp, 'events'), delta: deltas.events },
+      ];
+      return html`<div class="kpi-row">
+        ${tiles.map(t => html`<${KpiTile} label=${t.label} value=${t.value} active=${t.key === metric}
+            series=${t.series} delta=${t.delta == null ? null : t.delta} cost=${t.cost} />`)}
+      </div>`;
+    })() : null}
 
     ${!error ? html`
       <div class="chart-card">


### PR DESCRIPTION
Adds a trend sparkline + a signed period-over-period delta to each Analytics KPI tile, so the headline metrics (Spend / Tokens / Sessions / Events) convey direction at a glance instead of a single point value.

## Summary
- **Server-side** (`/api/v1/analytics`): new `kpi_series` (per-bucket values for all four metrics), `kpi_prev`, and `kpi_deltas` (% vs the prior equal-length window). Computed in one pass alongside the existing KPI totals — the UI consumes them through the shared window grid and never aggregates per-bucket in JS (single compute path).
- **UI**: `Sparkline` (lightweight inline SVG — no per-tile uPlot, stays offline), `DeltaChip` (signed; cost-semantic colors for Spend, neutral for volume metrics), and `KpiTile` wiring them onto the existing tiles.

## Plan-tier framing
The Spend tile's value, sparkline, **and** delta read on **token volume** when dollars are suppressed (subscription/local). The suppression decision comes from the server `framing` block and is decided once in the view, never re-derived per render path. Token / Session / Event tiles are plan-independent counts.

## Tests / Verification
- `tests/unit/test_lens_ui_regression.py` — 4 new static-grep guards: sparkline + delta + tile helpers present; sparkline is inline-SVG (not uPlot); series is server-computed via the shared window grid; the Spend tile respects framing.
- `tests/integration/test_analytics.py` — 3 new endpoint tests: `kpi_series` carries all four metrics and reconciles with the KPI totals; null-safe delta when the prior window is empty; a real % when the prior window has data.
- `node --check` on the app module block, `test_ui_offline.py` green, `ruff` + `mypy` clean. Full local run: 79 unit/offline + 12 analytics tests pass.

## What's NOT in this PR
- Leaderboard color-coding (#228), Overview→Analytics deep-linking (#229), and the time-dimension epoch-color bug (#227) are tracked separately — out of scope here.

Closes #217

🤖 Generated with [Claude Code](https://claude.com/claude-code)