### PR TITLE
docs: pipx-first install consistency across docs (part of #230)

### DIFF
--- a/docs/claude-code-integration.md
+++ b/docs/claude-code-integration.md
@@ -3,7 +3,7 @@
 Monitor every Claude Code session — costs, tool calls, API requests, errors — with two commands:
 
 ```bash
-pipx install 'tokenjam[mcp]'
+pipx install tokenjam
 tj onboard --claude-code
 # Restart Claude Code, then:
 tj status --agent claude-code-<project>
@@ -35,7 +35,7 @@ Claude Code emits OTLP log events which `tj serve` converts into spans — every
 
 ## MCP server
 
-The MCP server is included in the `[mcp]` extra and registered automatically by `tj onboard --claude-code`. It gives Claude Code direct access to your observability data inside the session itself. After restarting Claude Code you have 13 tools available in every session:
+The MCP server ships in the base install (`pipx install tokenjam` — no extra needed) and is registered automatically by `tj onboard --claude-code`. It gives Claude Code direct access to your observability data inside the session itself. After restarting Claude Code you have 13 tools available in every session:
 
 | Tool | What it does |
 |---|---|

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -52,8 +52,8 @@ TokenJam keeps heavyweight ML dependencies, framework adapters, and the MCP serv
 
 | Extra | What it pulls in | Why it's optional |
 |---|---|---|
-| `tokenjam[mcp]` | `fastmcp` | Only needed for the Claude Code / Codex MCP server (`tj mcp`). Pulled by `tj onboard --claude-code` automatically when invoked through the documented one-liner. |
-| `tokenjam[bloat]` | `llmlingua>=0.2`, transitively PyTorch + transformers (~2GB) | The Trim analyzer (`tj optimize trim`) scores token significance with LLMLingua-2. Most users don't run it; keeping torch out of the base install means `pip install tokenjam` stays small and fast on machines that don't have a GPU/CPU build of torch already. |
+| `tokenjam[mcp]` | nothing (no-op alias) | **No longer needed.** `fastmcp` moved into the base install in v0.3.5, so the Claude Code / Codex MCP server (`tj mcp`) works on a plain `pipx install tokenjam`. The extra is kept as an empty no-op so old `pipx install 'tokenjam[mcp]'` commands still succeed; it pulls nothing extra. |
+| `tokenjam[bloat]` | `llmlingua>=0.2`, transitively PyTorch + transformers (~2GB) | The Trim analyzer (`tj optimize trim`) scores token significance with LLMLingua-2. Most users don't run it; keeping torch out of the base install keeps it small and fast on machines that don't have a GPU/CPU build of torch already. |
 | `tokenjam[langchain]` | `langchain>=0.2` | Convenience pin for `patch_langchain()`; you can also install langchain yourself. |
 | `tokenjam[crewai]` | `crewai>=0.28` | Convenience pin for `patch_crewai()`. |
 | `tokenjam[autogen]` | `pyautogen>=0.2` | Convenience pin for `patch_autogen()`. |
@@ -63,7 +63,7 @@ TokenJam keeps heavyweight ML dependencies, framework adapters, and the MCP serv
 Combine multiple extras:
 
 ```bash
-pipx install 'tokenjam[mcp,bloat]'
+pipx install 'tokenjam[bloat,litellm]'
 ```
 
 ### Bloat extra details

--- a/docs/optimize/trim.md
+++ b/docs/optimize/trim.md
@@ -25,7 +25,7 @@ base install:
 pipx install 'tokenjam[bloat]'
 ```
 
-The base `pip install tokenjam` does NOT pull torch. Trim shows up in
+The base install (`pipx install tokenjam`) does NOT pull torch. Trim shows up in
 `tj optimize` analyzer choices regardless, but running it without the
 extra prints a clear install hint and exits.
 


### PR DESCRIPTION
README and `docs/installation.md` already lead with `pipx install tokenjam`, but several docs still showed bare `pip install tokenjam` or the `[mcp]` extra as the primary install path. This makes pipx the lead everywhere and corrects the now-stale `[mcp]`-extra framing.

## Summary
- Lead with `pipx install tokenjam` in every doc that shows a primary install command.
- Keep `pip install` only as the explicit "in a clean venv" fallback (mirroring README's framing).
- Correct the `[mcp]` extra docs: `fastmcp` moved into the base install in v0.3.5 (#101), so the extra is now an empty no-op kept only for back-compat — the MCP server works on a plain `pipx install tokenjam` and is wired automatically by `tj onboard --claude-code`.

## Changes
- **docs/claude-code-integration.md** — quickstart now `pipx install tokenjam` (was `'tokenjam[mcp]'`); the MCP-server section states it ships in the base install (no extra needed) and is registered automatically by `tj onboard --claude-code`.
- **docs/installation.md** — the `[mcp]` extras row now explains it's a no-op alias and why (old `'tokenjam[mcp]'` commands still succeed but pull nothing extra); the `[bloat]` row no longer casually references `pip install`; the combine-extras example uses a real combo (`bloat,litellm`) instead of the no-op `mcp`.
- **docs/optimize/trim.md** — the torch/base-install note now reads `pipx install tokenjam` instead of bare `pip install`.

## Intentionally left as-is
- **README.md:22** — its `pip install tokenjam` is the deliberate clean-venv fallback.
- **docs/installation.md** "Alternative: pip in a venv" block and the venv upgrade line — also deliberate `pip` fallbacks.

## Tests / Verification
- Docs-only; no code changes. Swept all of `docs/` — the only remaining bare `pip install tokenjam` is the venv-fallback block in installation.md. Other `pip`/`npm` hits are unrelated (TS SDK install, example bash commands).

## What's NOT in this PR (deferred)
- **Part 2 of #230 — documenting the new 0.5.0 Lens viz screens** (analytics explorer, cost-by-model breakdown, cache-savings series, recoverable-waste overlay, KPI sparklines). Deferred to a follow-up once the UI freezes post-0.5.0, so the docs describe a final surface. **This PR deliberately does NOT use `Closes #230`** — #230 stays open for Part 2.

Addresses the install-command-consistency portion of #230.

🤖 Generated with [Claude Code](https://claude.com/claude-code)