### PR TITLE
Fix Analytics coloring: shared color map + no color-by-time-dimension (#227, #228)

### DIFF
--- a/tests/unit/test_lens_ui_regression.py
+++ b/tests/unit/test_lens_ui_regression.py
@@ -503,3 +503,41 @@ def test_kpi_spend_tile_respects_framing(html):
     assert "const spendSuppressed = !!framing && (framing.pricing_mode === 'subscription' || framing.pricing_mode === 'local')" in html
     assert "kpiSparkValues(resp, spendSuppressed ? 'tokens' : 'spend')" in html
     assert "delta: spendSuppressed ? deltas.tokens : deltas.spend" in html
+
+
+# --- #228: shared series→color map + colored leaderboard ------------------- #
+def test_shared_colorfor_helper_exists(html):
+    # ONE name-keyed color map, hashed into the shared --chart-1..5 palette, so a
+    # series is the same hue everywhere (not a per-chart positional palette).
+    assert "function colorFor(name)" in html
+    assert "h = (h * 31 + s.charCodeAt(i))" in html
+
+
+def test_leaderboard_bars_use_shared_colorfor(html):
+    # Leaderboard .lb-fill colored by the shared map, keyed by the group name.
+    assert "background:' + colorFor(e.group)" in html
+
+
+def test_dimension_charts_color_by_name(html):
+    # SpendChart + StackedBarChart color multi-series via colorFor(name), not by
+    # draw-order index — same map the leaderboard uses (ComponentWasteChart keeps
+    # its own component palette; different namespace, out of scope).
+    assert html.count("single ? (palette[0] || '#3d8eff') : colorFor(lab)") >= 2
+    # the stacked-bar tooltip dots match the bars (also via the shared map)
+    assert "colorFor(labels[k] || ('s' + k))" in html
+
+
+# --- #227: don't color by the time dimension ------------------------------- #
+def test_time_dimension_renders_single_series(html):
+    # group_by=Day with no stack must be ONE series (tokens/day, one color), not
+    # one-per-day-bucket → no raw-epoch rainbow legend.
+    assert "const timeGroup = resp.group_by === 'day'" in html
+    assert "return { data: [xs, ys], labels: ['Total']" in html
+    # the time dimension feeds the x-axis; series come from stack_by instead
+    assert "const seriesKeys = timeGroup ? (resp.stacks || []) : (resp.groups || [])" in html
+
+
+def test_time_dimension_labels_formatted_as_dates(html):
+    # A time-dimension group key renders as a date, never a raw epoch second.
+    assert "function formatGroupLabel" in html
+    assert "formatGroupLabel(e.group, groupBy)" in html

--- a/tokenjam/ui/index.html
+++ b/tokenjam/ui/index.html
@@ -902,6 +902,36 @@ function cssVar(name) {
   return getComputedStyle(document.documentElement).getPropertyValue(name).trim();
 }
 
+// Shared series→color map (#228). ONE place that turns a series NAME (model /
+// agent / tool-category / …) into a stable hue from the --chart-1..5 palette,
+// so a given series is the SAME color on every chart and screen — never a
+// per-chart palette indexed by draw order. Every colored surface (leaderboard,
+// stacked bars, multi-series spend) must route through this; do not introduce a
+// second palette. 'other'/'(none)' buckets read as a neutral grey so the
+// catch-all never masquerades as a real series.
+function colorFor(name) {
+  const s = String(name == null ? '' : name);
+  if (s === 'other' || s === '(none)' || s === '') return cssVar('--text-dim') || '#a1a1a1';
+  const palette = [1, 2, 3, 4, 5].map(i => cssVar('--chart-' + i)).filter(Boolean);
+  if (!palette.length) return '#3d8eff';
+  let h = 0;
+  for (let i = 0; i < s.length; i++) h = (h * 31 + s.charCodeAt(i)) >>> 0;
+  return palette[h % palette.length];
+}
+
+// Format a group/series key for display. A TIME dimension (Day) carries raw
+// epoch-second keys; render them as dates, never the raw integer (#227). Other
+// dimensions pass through unchanged.
+function formatGroupLabel(name, dim) {
+  if (dim === 'day') {
+    const n = Number(name);
+    if (Number.isFinite(n) && n > 1e9) {
+      return new Date(n * 1000).toLocaleDateString(undefined, { month: 'short', day: 'numeric', timeZone: 'UTC' });
+    }
+  }
+  return name;
+}
+
 // Minimal time-series line/area chart over the vendored uPlot global. `data`
 // is uPlot's [xs, ys] tuple (xs in unix seconds). Reads CSS custom properties
 // so it matches the active light/dark theme at creation.
@@ -1034,7 +1064,10 @@ function SpendChart({ data, labels = ['Total'], height = 160, fmtY = fmtCost, ax
     const axisFmt = axisFmtY || fmtY;
     const series = [{}];
     labels.forEach((lab, i) => {
-      const c = palette[i % palette.length] || '#3d8eff';
+      // Single-series charts (e.g. a "Total" line) keep the primary chart hue;
+      // multi-series color by NAME via the shared map (#228) so a model is the
+      // same color here and on every other chart.
+      const c = single ? (palette[0] || '#3d8eff') : colorFor(lab);
       series.push({
         label: lab, stroke: c, width: 2,
         points: { show: data[0].length < 30 },
@@ -1101,11 +1134,14 @@ function stackedTooltip(segs, labels, fmtFn) {
       const d = new Date(u.data[0][idx] * 1000);
       const dateStr = d.toLocaleDateString(undefined, { month: 'short', day: 'numeric', timeZone: 'UTC' });
       const palette = [1, 2, 3, 4, 5].map(i => cssVar('--chart-' + i)).filter(Boolean);
+      const single = labels.length === 1;
       let rows = '';
       for (let k = 0; k < segs.length; k++) {
         const val = segs[k][idx];
         if (!val) continue;
-        const c = palette[k % palette.length] || '#3d8eff';
+        // Match the bar color exactly: shared color map by name (#228), primary
+        // hue for a lone series.
+        const c = single ? (palette[0] || '#3d8eff') : colorFor(labels[k] || ('s' + k));
         rows += `<div class="u-tip-row"><span class="u-tip-dot" style="background:${c}"></span>${labels[k] || ('s' + k)}: ${fmtFn(val)}</div>`;
       }
       tip.innerHTML = `<div class="u-tip-date">${dateStr}</div>${rows || '<div class="u-tip-row">—</div>'}`;
@@ -1142,10 +1178,14 @@ function StackedBarChart({ data, labels = [], height = 200, fmtY = fmtCost, axis
     const barsPath = (window.uPlot.paths && window.uPlot.paths.bars)
       ? window.uPlot.paths.bars({ size: [0.86, Infinity] }) : undefined;
     const chartData = [xs, ...order.map(k => cum[k])];
+    const single = labels.length === 1;
     const series = [{}];
     order.forEach(k => {
-      const c = palette[k % palette.length] || '#3d8eff';
-      series.push({ label: labels[k] || ('s' + k), stroke: c, fill: c, width: 0,
+      const lab = labels[k] || ('s' + k);
+      // Color by series NAME via the shared map (#228); a lone series keeps the
+      // primary hue. Same map the spend line + leaderboard use.
+      const c = single ? (palette[0] || '#3d8eff') : colorFor(lab);
+      series.push({ label: lab, stroke: c, fill: c, width: 0,
         paths: barsPath, points: { show: false }, value: (u, v) => (v == null ? '-' : fmtY(v)) });
     });
     const opts = {
@@ -2860,14 +2900,30 @@ function buildAnalyticsSeries(resp, useTokens) {
   if (!grid) return null;
   const { xs, idx, step, bucket, coarsened } = grid;
   const valueOf = r => (useTokens ? (r.tokens || 0) : (r.value || 0));
-  const top = (resp.groups || []).slice(0, 5);
+  // When group_by IS the time dimension (Day), time is already the x-axis, so
+  // coloring by the day-bucket key produces a meaningless rainbow with raw epoch
+  // legend labels (#227). The colored SERIES then come from stack_by (g2) if
+  // present, otherwise a SINGLE series — never one-per-day-bucket.
+  const timeGroup = resp.group_by === 'day';
+  const keyOf = timeGroup ? (r => r.stack) : (r => r.group);
+  const seriesKeys = timeGroup ? (resp.stacks || []) : (resp.groups || []);
+  if (!seriesKeys.length) {
+    const ys = xs.map(() => 0);
+    resp.rows.forEach(r => {
+      const b = Math.floor(r.bucket / step) * step;
+      if (b in idx) ys[idx[b]] += valueOf(r);
+    });
+    return { data: [xs, ys], labels: ['Total'], bucket, coarsened, requestedBucket: grid.reqBucket };
+  }
+  const top = seriesKeys.slice(0, 5);
   const topSet = new Set(top);
-  const hasOther = (resp.groups || []).length > top.length;
+  const hasOther = seriesKeys.length > top.length;
   const labels = hasOther ? [...top, 'other'] : [...top];
   const yss = labels.map(() => xs.map(() => 0));
   resp.rows.forEach(r => {
     const b = Math.floor(r.bucket / step) * step; if (!(b in idx)) return;
-    const li = topSet.has(r.group) ? labels.indexOf(r.group) : (hasOther ? labels.length - 1 : -1);
+    const k = keyOf(r);
+    const li = topSet.has(k) ? labels.indexOf(k) : (hasOther ? labels.length - 1 : -1);
     if (li >= 0) yss[li][idx[b]] += valueOf(r);
   });
   return { data: [xs, ...yss], labels, bucket, coarsened, requestedBucket: grid.reqBucket };
@@ -3032,13 +3088,16 @@ function AnalyticsView({ params }) {
           : chart === 'hbar'
             ? (board && board.length ? html`
               <div class="leaderboard">
-                ${board.map((e, i) => html`
+                ${board.map((e, i) => {
+                  const label = formatGroupLabel(e.group, groupBy);
+                  return html`
                   <div class="lb-row">
                     <span class="lb-rank">${i + 1}</span>
-                    <span class="lb-name" title=${e.group}>${e.group}</span>
-                    <span class="lb-bar"><span class="lb-fill" style=${'width:' + (e.frac * 100).toFixed(1) + '%'}></span></span>
+                    <span class="lb-name" title=${label}>${label}</span>
+                    <span class="lb-bar"><span class="lb-fill" style=${'width:' + (e.frac * 100).toFixed(1) + '%;background:' + colorFor(e.group)}></span></span>
                     <span class="lb-val">${fmtVal(e.value)}</span>
-                  </div>`)}
+                  </div>`;
+                })}
               </div>` : html`<div class="empty" style="padding:32px 0">No data in this window.</div>`)
             : (series ? html`
               ${chart === 'line'


### PR DESCRIPTION
Two related coloring fixes on the Analytics screen of the Lens SPA. UI-only, offline, pure CSS + the existing `--chart-1..5` custom properties — no new lib. Color treatment only; plan-tier framing / honesty logic untouched.

## #228 — one shared series→color map + colored leaderboard
The charts colored series by **draw-order position** (`palette[i % len]`), so a model could be a different hue on different charts; the leaderboard was monochrome grey. Introduced a single **`colorFor(name)`** helper that hashes a series **name** into the shared `--chart-1..5` palette, so a model / agent / tool-category is the **same color on every chart and screen** (`other`/`(none)` read as a neutral grey).
- Leaderboard bars now color via `colorFor(group)`.
- The multi-series spend line, the stacked bars, and the stacked-bar tooltip dots all route through the **same** map (a lone series keeps the primary hue).
- The #211 component chart keeps its own component palette (input/output/cache/analyzers) — a different namespace, explicitly out of scope.

## #227 — don't color by the time dimension
With `group_by=Day` (the x-axis is already time) and `Stack=none`, the explorer treated each day-bucket as its own series → a rainbow with **raw epoch-second** legend labels (`1781913600`, …). `buildAnalyticsSeries` now renders a **single `Total` series** in that case; when a time dimension is grouped, the colored series come from `stack_by` instead, and any time-dimension key shown as a label (e.g. a Day leaderboard) is formatted as a **date** via `formatGroupLabel`, never a raw epoch.

## Verification (screenshots in this PR)
- **Tokens × Day × Bars × Stack=none** — now a single blue series, legend reads `TOTAL`, x-axis shows dates (was a per-day rainbow with epoch labels).
- **Spend × Model × Leaderboard** — bars colored by model (opus / gpt / sonnet / haiku), consistent with the stacked/line charts since all hash the same name.

## Tests
- `tests/unit/test_lens_ui_regression.py` (+5): shared `colorFor` exists (name-hashed into the palette); leaderboard + dimension charts route through it (incl. tooltip dots); time dimension renders a single series; time-dimension labels formatted as dates.
- `test_ui_offline.py` green; app module passes `node --check`.
- Full `pytest tests/unit tests/integration` → **854 passed**; `ruff` + `mypy` clean (no Python changed).

Closes #227
Closes #228

🤖 Generated with [Claude Code](https://claude.com/claude-code)