### PR TITLE
feat(lens): deep-link Overview tiles + spend headline into Analytics (#229)

### DIFF
--- a/tests/unit/test_lens_ui_regression.py
+++ b/tests/unit/test_lens_ui_regression.py
@@ -560,3 +560,37 @@ def test_chart_palette_defines_twelve_hues_both_themes(html):
 def test_colorfor_neutral_bucket_not_a_palette_hue(html):
     # 'other'/'(none)'/'' still map to the neutral grey, never a palette color.
     assert "if (s === 'other' || s === '(none)' || s === '') return cssVar('--text-dim')" in html
+
+
+# --- #229: Overview tiles/headline deep-link into Analytics (pre-filtered) --- #
+def test_overview_recoverable_tiles_deeplink_into_analytics(html):
+    # Each recoverable-waste analyzer maps to an Analytics slice, and the tiles
+    # render that deep-link via analyzerSliceHref (not the old Optimize finding
+    # link). The route honors metric/group_by/chart/since, so these are just
+    # well-formed Analytics URLs — no new state machine.
+    assert "const ANALYZER_ANALYTICS_SLICE = {" in html
+    for analyzer in ("downsize", "cache", "script", "reuse", "trim"):
+        assert f"{analyzer}:" in html  # each analyzer has a slice mapping
+    assert "function analyzerSliceHref(name, since)" in html
+    assert "const href = analyzerSliceHref(t.name, since);" in html
+    # the tiles no longer point at the Optimize finding screen
+    assert "'#/optimize?finding=' + t.name" not in html
+
+
+def test_overview_spend_headline_deeplinks_into_analytics(html):
+    # The spend headline is an <a> deep-linking into Analytics spend-over-time.
+    assert "<a class=\"chart-title\" href=${analyticsHref({ metric: 'spend', group_by: 'day', chart: 'bar', since })}" in html
+
+
+def test_analytics_deeplink_helper_exists_and_builds_hash_urls(html):
+    # The deep-link helper builds #/analytics?... URLs (offline hash links, no
+    # fetch) from a query object, dropping empty values.
+    assert "function analyticsHref(q)" in html
+    assert "return '#/analytics' + (s ? '?' + s : '');" in html
+
+
+def test_overview_remains_default_landing_no_render_time_redirect(html):
+    # #132 guard must hold: empty hash → Overview via getRoute, and there is no
+    # render-time location.hash assignment that would race the first render.
+    assert "(qIdx >= 0 ? raw.slice(0, qIdx) : raw) || 'overview'" in html
+    assert "location.hash = '#/overview'" not in html

--- a/tokenjam/ui/index.html
+++ b/tokenjam/ui/index.html
@@ -598,6 +598,10 @@ tr.clickable:hover td.chevron { color: var(--accent); }
   color: var(--text-dim);
   margin-bottom: 10px;
 }
+/* The spend headline deep-links into Analytics (#229); keep the heading look,
+   add a clickable affordance. */
+a.chart-title { text-decoration: none; cursor: pointer; }
+a.chart-title:hover { color: var(--brand); text-decoration: underline; }
 .chart { width: 100%; }
 .u-tooltip, .uplot { font-family: 'Geist Mono', monospace; }
 .chart-head { display: flex; align-items: baseline; justify-content: space-between; margin-bottom: 10px; gap: 12px; }
@@ -911,6 +915,21 @@ function navigate(view, filters, defaults, param) {
   }
   const q = qs.toString();
   location.hash = '#/' + view + (param ? '/' + param : '') + (q ? '?' + q : '');
+}
+
+// Build an Analytics deep-link URL from a query object (#229). Overview tiles
+// and the spend headline flow INTO the Analytics explorer pre-filtered to the
+// relevant slice — these are just well-formed Analytics URLs, no new state
+// machine. The Analytics route already honors every param used here (metric,
+// group_by, stack, chart, since, and the agent_id/provider/model/tool dimension
+// filters — see AnalyticsView). Empty values are dropped so URLs stay clean.
+function analyticsHref(q) {
+  const sp = new URLSearchParams();
+  for (const [k, v] of Object.entries(q || {})) {
+    if (v != null && v !== '') sp.set(k, v);
+  }
+  const s = sp.toString();
+  return '#/analytics' + (s ? '?' + s : '');
 }
 
 // --- Charts (uPlot, issue #112) ---
@@ -2422,6 +2441,23 @@ const ANALYZER_META = {
   'budget-projection': { title: 'Budget projection', hint: 'Projected cycle spend vs ceiling' },
 };
 
+// The Analytics slice each recoverable-waste analyzer opens into (#229). A
+// leaderboard (hbar) on the dimension the analyzer reasons over — so a Downsize
+// tile lands on "spend by model", Reuse/Trim on the per-agent view, Script on
+// per-tool. Unknown analyzers fall back to spend-by-model. Values are validated
+// by the Analytics route against ANALYTICS_METRICS / ANALYTICS_DIMENSIONS.
+const ANALYZER_ANALYTICS_SLICE = {
+  downsize: { metric: 'spend',    group_by: 'model', chart: 'hbar' },
+  cache:    { metric: 'tokens',   group_by: 'model', chart: 'hbar' },
+  script:   { metric: 'events',   group_by: 'tool',  chart: 'hbar' },
+  reuse:    { metric: 'sessions', group_by: 'agent', chart: 'hbar' },
+  trim:     { metric: 'tokens',   group_by: 'agent', chart: 'hbar' },
+};
+function analyzerSliceHref(name, since) {
+  const slice = ANALYZER_ANALYTICS_SLICE[name] || { metric: 'spend', group_by: 'model', chart: 'hbar' };
+  return analyticsHref({ ...slice, since });
+}
+
 // Title-case a registry key for display. Centralizes capitalization so a tile
 // for a not-yet-known analyzer still renders title-case instead of the raw
 // lowercase key (#162) — registry keys are lowercase by convention.
@@ -2659,7 +2695,8 @@ function OverviewView({ params }) {
          the tooltip, #128); drill-through is an explicit link in the header. -->
     <div class="chart-card">
       <div class="chart-head">
-        <div class="chart-title">Spend ${useTokens ? '(tokens) ' : ''}· last ${since}</div>
+        <a class="chart-title" href=${analyticsHref({ metric: 'spend', group_by: 'day', chart: 'bar', since })}
+           title="Explore spend over time in Analytics">Spend ${useTokens ? '(tokens) ' : ''}· last ${since} →</a>
         <div class="chart-meta">
           <span class="chart-total">${totalDisplay}</span>
           <${TrendChip} pct=${trendPct} />
@@ -2678,7 +2715,9 @@ function OverviewView({ params }) {
       ${tiles.length === 0 ? html`<div class="empty">No recoverable candidates in this window.</div>`
         : tiles.map(t => {
           const meta = ANALYZER_META[t.name] || { title: capitalize(t.name), hint: '' };
-          const href = '#/optimize?finding=' + t.name + '&since=' + since;
+          // Deep-link into the Analytics explorer on this analyzer's slice (#229),
+          // carrying the Overview's current window. The route honors every param.
+          const href = analyzerSliceHref(t.name, since);
           // Four honest states (#127): actionable / at_ceiling / no_findings / not_ready.
           if (t.state === 'actionable') return html`
             <a class="rec-tile" href=${href}>
@@ -2698,13 +2737,14 @@ function OverviewView({ params }) {
               <div class="rec-amount dim">No candidates</div>
               <div class="rec-hint">Nothing actionable in the last ${since}.</div>
             </a>`;
-          // not_ready — the only state that uses the "not ready" framing + hint.
+          // not_ready — the analyzer hasn't run, but its underlying data slice is
+          // still explorable, so the tile stays a deep-link for consistency.
           return html`
-            <div class="rec-tile muted">
+            <a class="rec-tile muted" href=${href}>
               <div class="rec-name">${meta.title}</div>
               <div class="rec-amount dim">Not ready</div>
               <div class="rec-hint">${t.hint || meta.hint}</div>
-            </div>`;
+            </a>`;
         })}
     </div>
 


### PR DESCRIPTION
Overview is the glanceable triage front door (#132 default landing) and Analytics is the open-ended explorer — the two should *flow into* each other, not merge. This makes Overview's tiles and the spend headline clickable, deep-linking into the Analytics explorer pre-filtered to the relevant slice. That removes the redundant-feeling overlap and makes Analytics discoverable, without losing the triage landing page.

## Summary
- **Recoverable-waste tiles** (Downsize / Cache / Script / Reuse / Trim) now deep-link into Analytics on that analyzer's slice — a leaderboard on the dimension the analyzer reasons over.
- **Spend headline** deep-links into Analytics on spend-over-time.
- A small `analyticsHref()` helper + an `ANALYZER_ANALYTICS_SLICE` map; no new endpoint, no new state machine.

## How
Deep-links are just well-formed Analytics URLs over the existing URL-as-state model. `navigate()` / `getRoute()` stay the source of truth. **The Analytics route already honors every param a deep-link sets** — `metric`, `group_by`, `stack`, `chart`, `since`, and the `agent_id` / `provider` / `model` / `tool` dimension filters (`AnalyticsView`, `tokenjam/ui/index.html`) — so **no route-parser change was needed**.

Slice mapping (leaderboard `hbar` on the analyzer's dimension, carrying the Overview window):

| tile | Analytics slice |
|---|---|
| Downsize | `metric=spend, group_by=model, chart=hbar` |
| Cache | `metric=tokens, group_by=model, chart=hbar` |
| Script | `metric=events, group_by=tool, chart=hbar` |
| Reuse | `metric=sessions, group_by=agent, chart=hbar` |
| Trim | `metric=tokens, group_by=agent, chart=hbar` |
| Spend headline | `metric=spend, group_by=day, chart=bar` (spend over time — mirrors the shipped `tokens-over-time` preset) |

## Constraints honored
- **UI-only, single-file SPA, offline.** Links are internal `#/analytics?...` hash URLs (no fetch); `test_ui_offline.py` stays green.
- **No new endpoint** — Analytics already serves these slices.
- **Default landing intact (#132).** Empty hash → Overview via `getRoute()`; no render-time `location.hash` redirect (a regression test pins this).
- **Static-grep regression** in `tests/unit/test_lens_ui_regression.py` asserts the tiles carry Analytics deep-link targets (`analyzerSliceHref`, the slice map, the headline `<a>`), and that the old `#/optimize?finding=` tile link is gone.

## Tests / Verification
- `pytest tests/unit/` → **661 passed** (incl. `test_lens_ui_regression.py` + `test_ui_offline.py`).
- `node --check` clean on the extracted app `<script type="module">` block.
- **Visual** (seeded `create_app` + headless Chrome): Overview renders with a clickable "Spend · last 7d →" headline and all five tiles; a Downsize tile lands on Analytics **Spend / Model / Leaderboard / 7d**; the spend headline lands on Analytics **Spend / Day / Bars / 7d** (clean one-bar-per-day). Default landing (empty hash → Overview) unchanged.

## What's NOT in this PR
- **The "model/agent surfaced in a band → filtered to it" deep-link** is satisfied at the routing level — the Analytics route honors `agent_id`/`provider`/`model`/`tool` filters, and the analyzer tiles already open Analytics on the model/agent *dimension* — but the Overview currently surfaces **no specific model/agent name** in any band to filter-link from. Adding such a surface (e.g. a top-spender row) is out of scope (the issue scope excludes the leaderboard). The plumbing is ready for it.
- **Tile destination change:** tiles previously linked to the Optimize finding screen (`#/optimize?finding=…`); per the issue they now flow into Analytics. The Optimize detail remains reachable via the Optimize nav item. Flagging in case a dual link (Analytics + Optimize) is preferred.
- Leaderboard coloring and sparklines (#217) — explicitly out of scope.

Closes #229

🤖 Generated with [Claude Code](https://claude.com/claude-code)