### PR TITLE
Bump version to 0.5.0

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -376,7 +376,7 @@ Key runtime dependency: `pytz` is required by DuckDB for `TIMESTAMPTZ` column ha
 - `tokenjam[bloat]` — `llmlingua>=0.2`, used by the Trim analyzer. Pulls PyTorch + transformers (~2GB). Kept out of base install. The analyzer self-registers without the extra installed; the deferred `import llmlingua` inside the analysis function body raises a typed message pointing the user at the install command.
 - Framework extras `[langchain]`, `[crewai]`, `[autogen]`, `[litellm]` for SDK patches.
 - `[dev]` for local development (`pytest`, `ruff`, `mypy`, `httpx`).
-- `[mcp]` for the FastMCP stdio server.
+- `[mcp]` — empty no-op alias. `fastmcp` moved into the base install in v0.3.5 (#101), so the FastMCP stdio server (`tj mcp`) works on a plain `pipx install tokenjam`. The extra is kept so old `tokenjam[mcp]` install commands still succeed; it pulls nothing extra.
 
 ## Further Reading
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "tokenjam"
-version = "0.4.2"
+version = "0.5.0"
 description = "TokenJam — local-first OTel-native observability for Autonomous AI agents"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/sdk-ts/package.json
+++ b/sdk-ts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tokenjam/sdk",
-  "version": "0.4.2",
+  "version": "0.5.0",
   "description": "TypeScript SDK for TokenJam — local-first observability for AI agents",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",


### PR DESCRIPTION
Release-cut for **0.5.0** — ships the complete **Lens Visualizations** milestone.

## Summary
- Bump `pyproject.toml` + `sdk-ts/package.json` to `0.5.0`.
- Correct the CLAUDE.md packaging note: `[mcp]` is a no-op alias (fastmcp moved into the base install in v0.3.5 / #101).

## What 0.5.0 ships
- **Analytics pivot explorer** — new screen: metric × dimension × stack × chart-type, presets, CSV export, URL-driven state (#210)
- **Cost** — stacked cost-by-model/agent breakdown + cache-savings time-series (#212, #213)
- **Optimize** — cost-by-component + recoverable-waste overlay (#211)
- **KPI sparklines + period-over-period deltas** on the Analytics tiles (#217)
- **Cost-annotated trace waterfall** (#215)
- **Consistent series coloring** — one shared 12-hue `colorFor` map across every chart + the time-dimension color fix (#227, #228, #234)
- **Overview → Analytics deep-links** — tiles + spend headline flow into the explorer pre-filtered (#229)
- **Docs** — pipx-first install consistency (#232)

## Tests / Verification
- Full CI set green on the merge base: **950 tests pass**, `node --check` clean on the UI app block, all Lens UI offline + regression guards present.
- No code changes here beyond the version + doc strings.

## Next
On merge → `gh release create v0.5.0` fires the publish-pypi + publish-npm workflows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)