### PR TITLE
[feature] Add Cards | List view toggle to the Status screen (#241)

### DIFF
--- a/tests/unit/test_lens_ui_regression.py
+++ b/tests/unit/test_lens_ui_regression.py
@@ -594,3 +594,29 @@ def test_overview_remains_default_landing_no_render_time_redirect(html):
     # render-time location.hash assignment that would race the first render.
     assert "(qIdx >= 0 ? raw.slice(0, qIdx) : raw) || 'overview'" in html
     assert "location.hash = '#/overview'" not in html
+
+
+# --- #241: Status screen Cards | List view toggle -------------------------- #
+def test_status_view_toggle_exists(html):
+    # A segmented Cards | List control on the Status screen, driven by the URL
+    # view param (default 'cards', omitted from the URL via navigate defaults).
+    assert ".view-toggle" in html  # segmented-control CSS
+    assert "const DEFAULTS = { view: 'cards', agent_id: '' };" in html
+    assert "readParam(params, 'view', DEFAULTS.view, v => ['cards', 'list'].includes(v))" in html
+    assert "const setView = (v) => navigate('status', { agent_id: agentId, view: v }, DEFAULTS);" in html
+    # both toggle buttons present
+    assert "onClick=${() => setView('cards')}>Cards</button>" in html
+    assert "onClick=${() => setView('list')}>List</button>" in html
+
+
+def test_status_list_table_renderer_exists(html):
+    # The List view is a dedicated columned-table renderer, gated behind the
+    # view mode. Cards remains the default render path.
+    assert "function StatusListTable({ agents, framing })" in html
+    assert "? StatusListTable({ agents, framing: data.framing })" in html
+
+
+def test_status_list_cost_column_respects_framing(html):
+    # The List view's Cost cell goes through fmtFramedDollar(framing) exactly
+    # like the cards — plan-tier framing is never re-derived in JS (#110/#241).
+    assert "<td>${fmtFramedDollar(a.cost_today, framing)}</td>" in html

--- a/tokenjam/ui/index.html
+++ b/tokenjam/ui/index.html
@@ -393,6 +393,17 @@ tr.clickable:hover td.chevron { color: var(--accent); }
 .btn:hover { border-color: var(--accent); color: var(--accent); }
 .btn-back { margin-bottom: 16px; }
 
+/* Segmented view toggle (Cards | List), e.g. the Status screen (#241). */
+.view-toggle { display: inline-flex; border: 1px solid var(--border); border-radius: 6px; overflow: hidden; }
+.view-toggle button {
+  background: var(--surface); border: none; color: var(--text-dim);
+  padding: 5px 12px; cursor: pointer;
+  font-family: 'Geist Mono', monospace; font-size: 12px;
+}
+.view-toggle button + button { border-left: 1px solid var(--border); }
+.view-toggle button:hover:not(.active) { color: var(--text); }
+.view-toggle button.active { background: rgba(var(--accent-rgb),0.10); color: var(--accent); }
+
 /* Waterfall */
 .waterfall { margin: 16px 0; }
 .wf-row {
@@ -1419,12 +1430,56 @@ function buildComponentWaste(resp, useTokens) {
 }
 
 // ============================
+// Status List Table (#241)
+// ============================
+// The List alternative to the Status cards: one row per agent in a columned
+// table — Agent · Status · Cost today · Tokens · Tool calls · Elapsed · Actions.
+// The Cost cell goes through fmtFramedDollar(framing) exactly like the cards do,
+// so plan-tier framing (subscription → "% of cycle", local → "—") is respected
+// — never re-derived here. Reuses the existing .table-wrap/table CSS; no new lib.
+function StatusListTable({ agents, framing }) {
+  return html`
+    <div class="table-wrap"><table>
+      <thead><tr>
+        <th>Agent</th>
+        <th>Status</th>
+        <th>Cost today <span class="info-btn">i<span class="info-tip">Estimated from token usage. If you're on a subscription plan (e.g. Claude Max), your actual spend may differ.</span></span></th>
+        <th>Tokens (in / out)</th>
+        <th>Tool calls</th>
+        <th>Elapsed <span class="info-btn">i<span class="info-tip">Wall-clock from session start to last activity. Resumed Claude Code sessions span days.</span></span></th>
+        <th></th>
+      </tr></thead>
+      <tbody>
+        ${agents.map(a => html`
+          <tr>
+            <td class="mono"><span class="status-dot ${a.status}" style="margin-right:7px"></span>${a.agent_id}</td>
+            <td><span class="badge badge-${a.status}">${a.status}</span></td>
+            <td>${fmtFramedDollar(a.cost_today, framing)}</td>
+            <td>${fmtTokens(a.input_tokens)} / ${fmtTokens(a.output_tokens)}</td>
+            <td>${a.tool_call_count}${a.error_count ? ' (' + a.error_count + ' failed)' : ''}</td>
+            <td>${a.duration_seconds != null ? fmtDurLong(a.duration_seconds * 1000) : '-'}</td>
+            <td style="white-space:nowrap">
+              <a href=${'#/cost?agent_id=' + encodeURIComponent(a.agent_id)}>View cost →</a>
+              <a href=${'#/traces?agent_id=' + encodeURIComponent(a.agent_id)} style="margin-left:10px">View traces →</a>
+            </td>
+          </tr>
+        `)}
+      </tbody>
+    </table></div>`;
+}
+
+// ============================
 // Status View
 // ============================
 function StatusView({ params }) {
   // Optional single-agent filter via URL (#112). Filtered client-side since
   // /status returns every agent.
-  const agentId = readParam(params, 'agent_id', '');
+  // View mode (Cards | List) also lives in the URL (#241): `#/status?view=list`.
+  // Cards is the default and is omitted from the URL so default links stay clean.
+  const DEFAULTS = { view: 'cards', agent_id: '' };
+  const agentId = readParam(params, 'agent_id', DEFAULTS.agent_id);
+  const viewMode = readParam(params, 'view', DEFAULTS.view, v => ['cards', 'list'].includes(v));
+  const setView = (v) => navigate('status', { agent_id: agentId, view: v }, DEFAULTS);
   const [data, setData] = useState(null);
   const [alerts, setAlerts] = useState([]);
 
@@ -1446,12 +1501,20 @@ function StatusView({ params }) {
 
   return html`
     <div class="page-title">Status</div>
-    <div style="font-size:12px;color:var(--text-dim);margin:-14px 0 16px;font-family:'Geist Mono',monospace">
-      ${agentId
-        ? html`Filtered to <span class="mono">${agentId}</span> · <a href="#/status" style="color:var(--brand)">show all</a>`
-        : 'Click on an agent tile for details'}
+    <div style="display:flex;align-items:center;gap:12px;margin:-14px 0 16px">
+      <div style="font-size:12px;color:var(--text-dim);font-family:'Geist Mono',monospace">
+        ${agentId
+          ? html`Filtered to <span class="mono">${agentId}</span> · <a href="#/status" style="color:var(--brand)">show all</a>`
+          : (viewMode === 'list' ? 'Click on an agent row for details' : 'Click on an agent tile for details')}
+      </div>
+      <div class="view-toggle" style="margin-left:auto" role="tablist" aria-label="Status view mode">
+        <button class=${viewMode === 'cards' ? 'active' : ''} aria-pressed=${viewMode === 'cards'} onClick=${() => setView('cards')}>Cards</button>
+        <button class=${viewMode === 'list' ? 'active' : ''} aria-pressed=${viewMode === 'list'} onClick=${() => setView('list')}>List</button>
+      </div>
     </div>
-    <div class="cards">
+    ${viewMode === 'list'
+      ? StatusListTable({ agents, framing: data.framing })
+      : html`<div class="cards">
       ${agents.map(a => html`
         <div class="card">
           <div class="card-header">
@@ -1472,7 +1535,7 @@ function StatusView({ params }) {
           </div>
         </div>
       `)}
-    </div>
+    </div>`}
     ${alerts.length > 0 ? html`
       <div class="page-title" style="font-size:14px;margin-top:8px">Recent Alerts</div>
       <div class="table-wrap"><table>


### PR DESCRIPTION
The Status screen only offered a card grid. Cards are great for a handful of agents but get unwieldy as the agent count grows. This adds a compact, columned **List** alternative for at-a-glance comparison, while keeping **Cards** as the unchanged default.

## Summary
- Small segmented **Cards | List** toggle on the Status screen (top-right).
- **List view** = a columned table: Agent · Status · Cost today · Tokens (in / out) · Tool calls · Elapsed · actions (View cost → / View traces →).
- View mode lives in the URL: `#/status?view=list` (default `cards`, omitted from the URL) via the existing `getRoute()`/`navigate()` pattern — round-trips through reload + back/forward like every other filter.
- Reuses the data the Status screen already fetches (`/api/v1/status`) — **no new endpoint**, no new vendored lib, just the existing `.table-wrap`/`table` CSS plus a tiny `.view-toggle` segmented-control style.

## Plan-tier framing (honesty discipline)
The List view's Cost column goes through `fmtFramedDollar(a.cost_today, framing)` — **exactly** what the cards do. Plan-tier rules (subscription → "% of cycle", local → "—", api/unknown → dollars) are consumed from the server `framing` block and **never re-derived in JS** (single compute path).

## Tests / Verification
- Added three static-grep regression tests in `tests/unit/test_lens_ui_regression.py`:
  - `test_status_view_toggle_exists` — toggle markup + URL `view` param wiring (default `cards`).
  - `test_status_list_table_renderer_exists` — the dedicated `StatusListTable` renderer is gated behind the view mode.
  - `test_status_list_cost_column_respects_framing` — Cost cell uses `fmtFramedDollar(..., framing)`.
- `tests/unit/test_ui_offline.py` stays green (no new external URLs).
- `node --check` on the extracted app `<script type="module">` block passes.
- Visually verified against a seeded `create_app` + headless Chrome: Cards view (default) and `#/status?view=list` both render correctly; toggle active-state and plan-tier-framed Cost column confirmed.

## What's NOT in this PR
- No List/Cards toggle on other screens — scoped to Status per the issue. If it's wanted on Traces/Cost it can be a follow-up.
- List rows are not click-to-navigate (cards aren't either); per-row actions are the explicit View cost → / View traces → links.

Closes #241

🤖 Generated with [Claude Code](https://claude.com/claude-code)