### PR TITLE
Group backfilled spans into session-level traces (#243)

### DIFF
--- a/tests/unit/test_backfill.py
+++ b/tests/unit/test_backfill.py
@@ -213,6 +213,79 @@ def test_backfill_plan_tier_unknown_when_config_has_no_plan(tmp_path):
         db.close()
 
 
+# --- #243: backfilled spans group into one session-level trace ------------- #
+
+def test_backfill_groups_session_into_one_trace(tmp_path):
+    # A conversation with two assistant turns; the first issues two tool calls.
+    # All four spans (2 LLM + 2 tool) should land in ONE trace, with the tool
+    # spans as children of their assistant message (not per-message fragments).
+    _make_session_file(
+        tmp_path, session_id="sess-trace", cwd="/Users/me/proj",
+        records=[
+            _assistant_record(
+                "msg-1", "claude-opus-4-7", 1000, 200,
+                "2026-04-01T10:00:00.000Z", "sess-trace", "/Users/me/proj",
+                tool_uses=[("tu-1", "Bash"), ("tu-2", "Read")],
+            ),
+            _assistant_record(
+                "msg-2", "claude-opus-4-7", 500, 100,
+                "2026-04-01T10:00:05.000Z", "sess-trace", "/Users/me/proj",
+            ),
+        ],
+    )
+    db = InMemoryBackend()
+    try:
+        from tokenjam.core.models import TraceFilters
+
+        ingest_claude_code(db, root=tmp_path)
+
+        # Exactly one trace for the whole session.
+        trace_ids = [
+            r[0] for r in db.conn.execute(
+                "SELECT DISTINCT trace_id FROM spans"
+            ).fetchall()
+        ]
+        assert len(trace_ids) == 1
+
+        traces = db.get_traces(TraceFilters())
+        assert len(traces) == 1
+        assert traces[0].span_count == 4  # 2 LLM + 2 tool
+
+        # The trace holds both LLM calls and both tool calls, and every tool
+        # span is parented to an LLM span in the same trace.
+        spans = db.get_trace_spans(trace_ids[0])
+        llm = [s for s in spans if s.name == "gen_ai.llm.call"]
+        tools = [s for s in spans if s.name == "gen_ai.tool.call"]
+        assert len(llm) == 2
+        assert len(tools) == 2
+        llm_ids = {s.span_id for s in llm}
+        assert all(t.parent_span_id in llm_ids for t in tools)
+        assert {t.tool_name for t in tools} == {"Bash", "Read"}
+    finally:
+        db.close()
+
+
+def test_backfill_separate_sessions_get_separate_traces(tmp_path):
+    # Two distinct sessions must NOT collapse into one trace.
+    for sid in ("sess-x", "sess-y"):
+        _make_session_file(
+            tmp_path, session_id=sid, cwd="/Users/me/proj",
+            records=[_assistant_record(
+                f"m-{sid}", "claude-haiku-4-5", 100, 50,
+                "2026-04-01T10:00:00.000Z", sid, "/Users/me/proj",
+            )],
+        )
+    db = InMemoryBackend()
+    try:
+        ingest_claude_code(db, root=tmp_path)
+        n_traces = db.conn.execute(
+            "SELECT COUNT(DISTINCT trace_id) FROM spans"
+        ).fetchone()[0]
+        assert n_traces == 2
+    finally:
+        db.close()
+
+
 # --- #245: backfill persists the cache read/write split -------------------- #
 
 def test_backfill_persists_cache_read_write_split(tmp_path):

--- a/tokenjam/core/backfill.py
+++ b/tokenjam/core/backfill.py
@@ -130,8 +130,17 @@ def _det_id(*parts: str, length: int = 16) -> str:
     return h[:length]
 
 
-def _trace_id_for(session_id: str, message_uuid: str) -> str:
-    return _det_id("trace", session_id, message_uuid, length=32)
+def _trace_id_for(session_id: str) -> str:
+    """One trace per session/conversation.
+
+    Keyed on the session id alone (NOT per assistant message) so a whole
+    conversation is a single trace with its LLM calls and tool calls as
+    children — the Traces view then shows real session-level waterfalls
+    instead of ~1.5-span per-message fragments (#243). This matches the live
+    Claude Code log path (`routes/logs.py._trace_id_from_session`), which
+    already groups by session.
+    """
+    return _det_id("trace", session_id, length=32)
 
 
 def _span_id_for_assistant(session_id: str, message_uuid: str) -> str:
@@ -254,7 +263,10 @@ def parse_claude_code_session(path: Path) -> ParsedSession | None:
 
         message_uuid = record.get("uuid") or msg.get("id") or f"{line_no}"
         sid_str = session_id or path.stem
-        trace_id = _trace_id_for(sid_str, message_uuid)
+        # One trace per session (#243): all assistant turns + their tool calls
+        # in this conversation share a trace_id. span_id stays per-message so
+        # idempotency (deterministic span IDs) is unaffected.
+        trace_id = _trace_id_for(sid_str)
         span_id = _span_id_for_assistant(sid_str, message_uuid)
 
         provider = _provider_for_model(model)


### PR DESCRIPTION
Backfilled Claude Code traces were fragmented per-message, so the Traces view showed every row as "LLM Call", buried tool calls, and produced thousands of ~1.5-span traces instead of coherent conversation waterfalls. This keys the backfill `trace_id` on the session so a conversation becomes one trace.

> **Stacked on #254.** This branch is cut on top of `fix/backfill-fidelity`, so the diff against `main` contains #254's commit *plus* this one — **review the second commit (`Group backfilled spans into session-level traces`) for the #243 change**, and merge #254 first. Base is `main` so CI runs (the workflow only triggers on `main`-targeted PRs).

## Summary
- Key the backfill `trace_id` on the session/conversation alone (was `(session_id, message_uuid)`), so all LLM + tool spans in a conversation share one trace with tool calls as children.
- `span_id` stays per-message/per-tool → idempotency (deterministic span IDs) is unaffected; only the grouping changes.

## #243 — per-message trace fragmentation
**Symptom.** Every backfilled Traces row was type "LLM Call" with blank duration; tool calls (shell 3.1k, file 2.5k in Analytics) were invisible in the list, only showing on drill-in. ~16k traces averaging ~1.5 spans.

**Root cause.** `_trace_id_for(session_id, message_uuid)` rooted each trace on a single assistant message. `get_traces` derives the list TYPE from the first span name (`FIRST(name ORDER BY start_time)`), which was always the lone LLM call; tool spans inherited the parent message's trace_id as nested children.

**Fix.** `_trace_id_for(session_id)` — one trace per conversation. All assistant turns and their tool calls now group under a single session-level trace, so the Traces view shows real waterfalls including tool calls.

## Verified against the live path
The Claude Code / Codex OTLP-log receiver (`routes/logs.py._trace_id_from_session`) **already** keys `trace_id` on the session, so live telemetry was never fragmented — only backfill was. This change makes the two paths agree rather than inventing a new scheme.

**Migration note:** already-ingested spans keep their old per-message trace_ids until re-backfilled (`span_id` is the PK, so a re-run skips them). The grouping is forward-only — acceptable, and a re-backfill regroups.

## Tests / Verification
`tests/unit/test_backfill.py`:
- `test_backfill_groups_session_into_one_trace` — a session with two assistant turns (one issuing two tool calls) collapses to a single trace with the expected 2 LLM + 2 tool child spans; every tool span is parented to an LLM span in the same trace; `get_traces` returns one trace with `span_count == 4`.
- `test_backfill_separate_sessions_get_separate_traces` — two distinct sessions stay as two traces.
- Full suite: **957 passed**; `ruff` + `mypy` clean on touched files.

## What's NOT in this PR (deliberately out of scope)
- **Duration / waterfall UI (#244)** — backfill has no per-call latency, so `duration_ms` stays `None`. Sizing bars by cost/tokens, the fixed span-name column, timestamps, status icons, etc. are the UI's job, tracked in #244.
- **Surfacing tool-call *type* in the Traces list label** — the list TYPE still comes from the first span name; relabeling is a UI concern (#244). This PR fixes the underlying trace *structure*, which is the prerequisite.

Closes #243

🤖 Generated with [Claude Code](https://claude.com/claude-code)
