### PR TITLE
Fix #249: render per-item cost as tokens, not "% of cycle"

### DIFF
--- a/tests/unit/test_lens_ui_regression.py
+++ b/tests/unit/test_lens_ui_regression.py
@@ -244,8 +244,10 @@ def test_cost_table_cells_route_through_framing(html):
 
 def test_traces_list_cost_routes_through_framing(html):
     # Traces list COST column must consume the framing block, not raw fmtCost.
+    # Per #249 it now goes through fmtPerItemCost (per-item → tokens for
+    # subscription/local), not the window-aggregate fmtFramedDollar "% of cycle".
     assert "<td>${fmtCost(t.cost_usd)}</td>" not in html
-    assert "${fmtFramedDollar(t.cost_usd, framing)}" in html
+    assert "${fmtPerItemCost(t.cost_usd, _costVal(t, true), framing)}" in html
     # The screen actually pulls the framing block off the /traces response.
     assert "setFraming(td.framing || null)" in html
 
@@ -256,7 +258,8 @@ def test_trace_detail_costs_route_through_framing(html):
     assert "fmtCost(s.cost_usd)" not in html
     assert "${fmtCost(sel.cost_usd)}" not in html
     assert "const costFramed = fmtFramedDollar(s.cost_usd, framing)" in html
-    assert "${fmtFramedDollar(sel.cost_usd, framing)}" in html
+    # The span-detail panel "Cost" is per-item → fmtPerItemCost (#249).
+    assert "${fmtPerItemCost(sel.cost_usd, _costVal(sel, true), framing)}" in html
     # Trace detail pulls the framing block off the /traces/{id} response.
     assert "setFraming(d.framing || null)" in html
 
@@ -264,9 +267,10 @@ def test_trace_detail_costs_route_through_framing(html):
 # --- #191: suppress raw $ on Status, Optimize & Reuse/script surfaces -------- #
 def test_status_card_cost_today_routes_through_framing(html):
     # Status agent cards' "Cost today" must consume the /status framing block,
-    # not render raw fmtCost(a.cost_today).
+    # not render raw fmtCost(a.cost_today). Per #249 it's per-item → tokens for
+    # subscription/local via fmtPerItemCost (not fmtFramedDollar "% of cycle").
     assert "${fmtCost(a.cost_today)}" not in html
-    assert "${fmtFramedDollar(a.cost_today, data.framing)}" in html
+    assert "${fmtPerItemCost(a.cost_today, _costVal(a, true), data.framing)}" in html
 
 
 def test_optimize_window_comparison_routes_through_framing(html):
@@ -449,8 +453,10 @@ def test_trace_waterfall_cost_summary(html):
     assert "wf-summary" in html
     assert "Total cost" in html
     assert "wfTotalCostFramed" in html
-    # the total cost routes through the framing helper (not raw fmtCost)
-    assert "const wfTotalCostFramed = fmtFramedDollar(wfTotalCost, framing)" in html
+    # A single trace's total is per-item, not a window aggregate — per #249 it
+    # routes through fmtPerItemCost (tokens for subscription/local), not the
+    # window-level fmtFramedDollar "% of cycle".
+    assert "const wfTotalCostFramed = fmtPerItemCost(wfTotalCost, wfTotalInOut, framing)" in html
 
 
 def test_trace_waterfall_per_span_cost_token_annotation(html):
@@ -617,6 +623,42 @@ def test_status_list_table_renderer_exists(html):
 
 
 def test_status_list_cost_column_respects_framing(html):
-    # The List view's Cost cell goes through fmtFramedDollar(framing) exactly
-    # like the cards — plan-tier framing is never re-derived in JS (#110/#241).
-    assert "<td>${fmtFramedDollar(a.cost_today, framing)}</td>" in html
+    # The List view's Cost cell goes through fmtPerItemCost exactly like the
+    # cards — per-item cost renders as tokens for subscription/local (#249),
+    # plan-tier framing is never re-derived in JS (#110/#241).
+    assert "<td>${fmtPerItemCost(a.cost_today, _costVal(a, true), framing)}</td>" in html
+
+
+# --- #249: "% of cycle" is window-level; per-item cost must render as tokens -- #
+def test_per_item_cost_helper_renders_tokens_for_subscription_local(html):
+    # The per-item formatter: subscription/local → token total (the in+out basis
+    # via _costVal), api/unknown → dollars. "% of cycle" (a window aggregate) is
+    # never produced at per-item granularity.
+    assert "function perItemUsesTokens(framing)" in html
+    assert "function fmtPerItemCost(costUsd, tokenTotal, framing)" in html
+    assert "if (perItemUsesTokens(framing)) return fmtTokens(tokenTotal || 0) + ' tok';" in html
+    # the only "% of cycle" string in the codebase lives in fmtFramedDollar, which
+    # per-item surfaces no longer call directly for the row value.
+    assert "return fmtFramedDollar(costUsd, framing); // api / unknown → dollars" in html
+
+
+def test_per_item_cost_surfaces_use_the_helper_not_framed_dollar(html):
+    # Every per-item dollar cell — Traces list, Status cards, StatusListTable,
+    # span-detail, and the per-trace total — uses fmtPerItemCost, not the
+    # window-aggregate fmtFramedDollar. Guards against a regression reintroducing
+    # "% of cycle" at per-row granularity (the #249 bug: "466.7% of cycle").
+    assert "${fmtPerItemCost(t.cost_usd, _costVal(t, true), framing)}" in html        # traces list
+    assert "${fmtPerItemCost(a.cost_today, _costVal(a, true), data.framing)}" in html  # status card
+    assert "<td>${fmtPerItemCost(a.cost_today, _costVal(a, true), framing)}</td>" in html  # status list
+    assert "${fmtPerItemCost(sel.cost_usd, _costVal(sel, true), framing)}" in html     # span detail
+    assert "fmtPerItemCost(wfTotalCost, wfTotalInOut, framing)" in html                # trace total
+    # these per-item surfaces must NOT call fmtFramedDollar on the row value
+    assert "${fmtFramedDollar(t.cost_usd, framing)}" not in html
+    assert "${fmtFramedDollar(a.cost_today, data.framing)}" not in html
+    assert "${fmtFramedDollar(sel.cost_usd, framing)}" not in html
+
+
+def test_per_trace_token_totals_come_from_server_not_aggregated_in_js(html):
+    # _costVal reads server-provided per-row input_tokens/output_tokens; the UI
+    # never re-sums spans in JS for the list rows (single compute path, #249).
+    assert "function _costVal(r, useTokens)" in html

--- a/tokenjam/api/routes/traces.py
+++ b/tokenjam/api/routes/traces.py
@@ -69,6 +69,10 @@ async def list_traces(
                 "cost_usd": t.cost_usd,
                 "status_code": t.status_code,
                 "span_count": t.span_count,
+                # Per-trace token totals — the UI renders per-row cost as TOKENS
+                # for subscription/local users (#249), never "% of cycle".
+                "input_tokens": t.input_tokens,
+                "output_tokens": t.output_tokens,
             }
             for t in traces
         ],

--- a/tokenjam/core/db.py
+++ b/tokenjam/core/db.py
@@ -608,7 +608,9 @@ class DuckDBBackend:
             f"CASE WHEN SUM(CASE WHEN status_code='error' THEN 1 ELSE 0 END) > 0 THEN 'error' "
             f"     WHEN SUM(CASE WHEN status_code='ok' THEN 1 ELSE 0 END) > 0 THEN 'ok' "
             f"     ELSE 'unset' END AS status_code, "
-            f"COUNT(*) AS span_count "
+            f"COUNT(*) AS span_count, "
+            f"SUM(input_tokens) AS input_tokens, "
+            f"SUM(output_tokens) AS output_tokens "
             f"FROM spans WHERE {where} "
             f"GROUP BY trace_id "
             f"ORDER BY start_time DESC "
@@ -621,6 +623,7 @@ class DuckDBBackend:
                 trace_id=r[0], agent_id=r[1], name=r[2], start_time=r[3],
                 duration_ms=r[4], cost_usd=r[5], status_code=r[6],
                 span_count=r[7],
+                input_tokens=int(r[8] or 0), output_tokens=int(r[9] or 0),
             )
             for r in rows
         ]

--- a/tokenjam/core/models.py
+++ b/tokenjam/core/models.py
@@ -220,6 +220,12 @@ class TraceRecord:
     cost_usd:   float | None  = None
     status_code: str          = "ok"
     span_count:  int          = 0
+    # Per-trace token totals so the UI can render per-row cost as TOKENS for
+    # subscription/local users (#249) — "% of cycle" is a window-level aggregate
+    # and is nonsensical at per-trace granularity. Summed server-side (single
+    # compute path) rather than re-aggregated in JS.
+    input_tokens:  int        = 0
+    output_tokens: int        = 0
 
 
 @dataclass

--- a/tokenjam/ui/index.html
+++ b/tokenjam/ui/index.html
@@ -1434,9 +1434,11 @@ function buildComponentWaste(resp, useTokens) {
 // ============================
 // The List alternative to the Status cards: one row per agent in a columned
 // table — Agent · Status · Cost today · Tokens · Tool calls · Elapsed · Actions.
-// The Cost cell goes through fmtFramedDollar(framing) exactly like the cards do,
-// so plan-tier framing (subscription → "% of cycle", local → "—") is respected
-// — never re-derived here. Reuses the existing .table-wrap/table CSS; no new lib.
+// The Cost cell goes through fmtPerItemCost(framing) exactly like the cards do:
+// per-item cost is rendered as TOKENS for subscription/local users (not "% of
+// cycle", which is a window-level aggregate — #249) and as dollars for api. The
+// suppression decision is never re-derived here. Reuses the existing
+// .table-wrap/table CSS; no new lib.
 function StatusListTable({ agents, framing }) {
   return html`
     <div class="table-wrap"><table>
@@ -1454,7 +1456,7 @@ function StatusListTable({ agents, framing }) {
           <tr>
             <td class="mono"><span class="status-dot ${a.status}" style="margin-right:7px"></span>${a.agent_id}</td>
             <td><span class="badge badge-${a.status}">${a.status}</span></td>
-            <td>${fmtFramedDollar(a.cost_today, framing)}</td>
+            <td>${fmtPerItemCost(a.cost_today, _costVal(a, true), framing)}</td>
             <td>${fmtTokens(a.input_tokens)} / ${fmtTokens(a.output_tokens)}</td>
             <td>${a.tool_call_count}${a.error_count ? ' (' + a.error_count + ' failed)' : ''}</td>
             <td>${a.duration_seconds != null ? fmtDurLong(a.duration_seconds * 1000) : '-'}</td>
@@ -1522,7 +1524,7 @@ function StatusView({ params }) {
             ${a.agent_id}
             <span class="badge badge-${a.status}" style="margin-left:auto">${a.status}</span>
           </div>
-          <div class="card-row"><span class="label">Cost today <span class="info-btn">i<span class="info-tip">Estimated from token usage. If you're on a subscription plan (e.g. Claude Max), your actual spend may differ.</span></span></span><span class="value">${fmtFramedDollar(a.cost_today, data.framing)}</span></div>
+          <div class="card-row"><span class="label">Cost today <span class="info-btn">i<span class="info-tip">Estimated from token usage. If you're on a subscription plan (e.g. Claude Max), your actual spend may differ.</span></span></span><span class="value">${fmtPerItemCost(a.cost_today, _costVal(a, true), data.framing)}</span></div>
           <div class="card-row"><span class="label">Tokens</span><span class="value">${fmtTokens(a.input_tokens)} in / ${fmtTokens(a.output_tokens)} out</span></div>
           <div class="card-row"><span class="label">Tool calls</span><span class="value">${a.tool_call_count}${a.error_count ? ' (' + a.error_count + ' failed)' : ''}</span></div>
           ${a.active_seconds != null ? html`<div class="card-row"><span class="label">Active <span class="info-btn">i<span class="info-tip">Compute time — the sum of this session's span durations. The work actually done.</span></span></span><span class="value">${fmtDur(a.active_seconds * 1000)}</span></div>` : null}
@@ -1612,7 +1614,7 @@ function TracesListView({ params }) {
               <td>${friendlySpanName(t.name)}</td>
               <td>${fmtAgo(t.start_time)}</td>
               <td>${fmtDur(t.duration_ms)}</td>
-              <td>${fmtFramedDollar(t.cost_usd, framing)}</td>
+              <td>${fmtPerItemCost(t.cost_usd, _costVal(t, true), framing)}</td>
               <td><span class="badge badge-${t.status_code}">${t.status_code}</span></td>
               <td>${st ? html`<span class="status-dot ${st}" style="margin-right:5px"></span><span class="badge badge-${st}">${st}</span>` : html`<span style="color:var(--text-dim)">-</span>`}</td>
               <td>${t.span_count}</td>
@@ -1688,7 +1690,11 @@ function TraceDetailView({ traceId }) {
   const wfMaxMag = Math.max(0, ...rows.map(r => wfMagOf(r.span)));
   const wfTotalCost = spans.reduce((a, s) => a + (s.cost_usd || 0), 0);
   const wfTotalTokens = spans.reduce((a, s) => a + spanTokens(s), 0);
-  const wfTotalCostFramed = fmtFramedDollar(wfTotalCost, framing);
+  // A single trace's total is per-item, not a window aggregate (#249) — render
+  // it as in+out TOKENS for subscription/local, dollars for api/unknown. ("% of
+  // cycle" for one trace is the same category error as the per-row cells.)
+  const wfTotalInOut = spans.reduce((a, s) => a + _costVal(s, true), 0);
+  const wfTotalCostFramed = fmtPerItemCost(wfTotalCost, wfTotalInOut, framing);
 
   const sel = selected ? spans.find(s => s.span_id === selected) : null;
 
@@ -1730,7 +1736,11 @@ function TraceDetailView({ traceId }) {
           ? fmtDur(s.duration_ms)
           : (detail ? detail + ' \u2014 ' : '') + fmtDur(s.duration_ms);
         const sTok = spanTokens(s);
-        const costShown = s.cost_usd != null && s.cost_usd > 0 && costFramed !== '\u2014';
+        // Per-SPAN cost is per-item: under subscription/local "% of cycle" is
+        // nonsensical at this granularity (#249), and the adjacent token column
+        // already conveys the per-span magnitude \u2014 so only show the $ value for
+        // api/unknown. (local was already suppressed via costFramed === '\u2014'.)
+        const costShown = !wfUseTokens && s.cost_usd != null && s.cost_usd > 0 && costFramed !== '\u2014';
         const wfFrac = wfMaxMag > 0 ? (wfMagOf(s) / wfMaxMag * 100) : 0;
         const tipLines = [friendly];
         tipLines.push('Duration: ' + fmtDur(s.duration_ms));
@@ -1741,7 +1751,7 @@ function TraceDetailView({ traceId }) {
         if (s.output_tokens != null) tipLines.push('Output tokens: ' + fmtTokens(s.output_tokens));
         if (s.cache_tokens) tipLines.push('Cache read: ' + fmtTokens(s.cache_tokens));
         if (s.cache_write_tokens) tipLines.push('Cache write: ' + fmtTokens(s.cache_write_tokens));
-        if (s.cost_usd != null && costFramed !== '—') tipLines.push('Cost: ' + costFramed);
+        if (!wfUseTokens && s.cost_usd != null && costFramed !== '—') tipLines.push('Cost: ' + costFramed);
         const tooltip = tipLines.join('\n');
         return html`
           <div class="wf-row ${selected === s.span_id ? 'selected' : ''}" onClick=${() => setSelected(s.span_id)}>
@@ -1776,7 +1786,7 @@ function TraceDetailView({ traceId }) {
           ${sel.output_tokens != null ? html`<span class="dk">Output tokens</span><span class="dv">${fmtTokens(sel.output_tokens)}</span>` : null}
           ${sel.cache_tokens ? html`<span class="dk">Cache read</span><span class="dv">${fmtTokens(sel.cache_tokens)}</span>` : null}
           ${sel.cache_write_tokens ? html`<span class="dk">Cache write</span><span class="dv">${fmtTokens(sel.cache_write_tokens)}</span>` : null}
-          ${sel.cost_usd != null ? html`<span class="dk">Cost</span><span class="dv">${fmtFramedDollar(sel.cost_usd, framing)}</span>` : null}
+          ${sel.cost_usd != null ? html`<span class="dk">Cost</span><span class="dv">${fmtPerItemCost(sel.cost_usd, _costVal(sel, true), framing)}</span>` : null}
           ${sel.agent_id ? html`<span class="dk">Agent</span><span class="dv">${sel.agent_id}</span>` : null}
           ${sel.conversation_id ? html`<span class="dk">Conversation</span><span class="dv">${sel.conversation_id}</span>` : null}
           ${sel.session_id ? html`<span class="dk">Session</span><span class="dv">${sel.session_id}</span>` : null}
@@ -1804,6 +1814,22 @@ function fmtFramedDollar(v, framing) {
     return framing.plan_monthly_usd ? (100 * v / framing.plan_monthly_usd).toFixed(1) + '% of cycle' : '—';
   }
   return fmtCost(v); // api / unknown
+}
+
+// Per-ITEM (per-row) cost rendering (#249). "% of cycle" is a WINDOW-LEVEL
+// aggregate concept — applying it to a single trace / agent / span produces
+// nonsense like "466.7% of cycle". So at per-item granularity, subscription /
+// local users see the row's TOKEN total (the same in+out basis as the Cost
+// table's "Cost (tokens)" column via _costVal), while api / unknown users keep
+// dollars unchanged. WINDOW-LEVEL totals + headlines still use fmtFramedDollar.
+// `tokenTotal` must be a server-provided per-row figure (single compute path) —
+// the /traces and /status payloads carry input_tokens/output_tokens per row.
+function perItemUsesTokens(framing) {
+  return !!framing && (framing.pricing_mode === 'subscription' || framing.pricing_mode === 'local');
+}
+function fmtPerItemCost(costUsd, tokenTotal, framing) {
+  if (perItemUsesTokens(framing)) return fmtTokens(tokenTotal || 0) + ' tok';
+  return fmtFramedDollar(costUsd, framing); // api / unknown → dollars
 }
 
 // Positive plan-tier chip(s) from the server `framing` block (#110). Distinct from


### PR DESCRIPTION
"% of cycle" is a **window-level** aggregate — it answers "how much of my monthly plan budget did this *window* consume." Applying it at **per-item** granularity (one trace, one agent, one span) is a category error that produces absurd figures like the Status card's **"466.7% of cycle"**: a single long-running session can exceed a whole month's implied API value, so "one item = >100% of your cycle" is meaningless.

## Summary
- Per-ITEM / per-row cost now renders as **TOKENS** for subscription/local users (mirroring the Cost table's existing "Cost (tokens)" treatment via `_costVal`), and as **dollars** for api/unknown (unchanged).
- WINDOW-LEVEL totals + headlines keep `fmtFramedDollar` ("% of cycle") — correct there, untouched.
- New shared helper `fmtPerItemCost(costUsd, tokenTotal, framing)` + `perItemUsesTokens(framing)` so the rule lives in one place and is consumed, never re-derived in JS.

## Surfaces fixed (every per-item dollar cell)
1. **Traces list** COST column — was "0.2% of cycle" per trace → tokens.
2. **Status** — both the cards' "Cost today" **and** the StatusListTable cost cell (the "466.7% of cycle" absurdity; StatusListTable added in #253).
3. **Audit of the rest of the UI** — trace detail: the per-trace **"Total cost"** headline, the per-span **waterfall $** (suppressed under subscription/local — the adjacent token column already conveys per-span magnitude), and the **span-detail panel "Cost"**.

## Data: per-row token totals come from the server (single compute path)
- `/status` already carried per-agent `input_tokens`/`output_tokens`.
- `/traces` did **not** — extended `TraceRecord` + `get_traces` SQL (`SUM(input_tokens)`, `SUM(output_tokens)`) + the route dict so each trace row carries its token total. The UI never re-aggregates per-item in JS.

## Honesty discipline
Consumes the server `framing` block; never re-derives the suppression rules; never shows raw `$` for subscription. For api-plan users, `$` at per-item granularity is fine and unchanged.

## Tests / Verification
- Updated the #187/#191/#241 regression tests that pinned the old per-item `fmtFramedDollar` behavior (now superseded), and added three new #249 guards in `tests/unit/test_lens_ui_regression.py`: the helper renders tokens for subscription/local, every per-item surface uses `fmtPerItemCost` (and **not** `fmtFramedDollar` on the row value), and per-row token totals are server-sourced.
- `tests/unit/test_ui_offline.py` green; `node --check` on the app module passes; full `pytest tests/unit/ tests/synthetic/ tests/agents/ tests/integration/` = 956 passed (pre-rebase); `ruff` + `mypy` clean on the touched Python files.
- Visually verified against a **subscription (max_5x)** seed + headless Chrome: Status cards, Status list, Traces list, and trace detail all show e.g. "150.0k tok" / "122.5k tok" — no "% of cycle" anywhere at per-item granularity.

## What's NOT in this PR
- **Analytics KPI tiles** — out of scope per the brief (#247 is handled inside Dashboard PR #252). Untouched.
- **Window-level totals/headlines** (Cost screen window total + projection, budget run-rate vs cycle ceiling, optimize compare delta) — these are genuine window/cycle aggregates and correctly keep "% of cycle".
- **Optimize `script`/reuse cluster avg-cost cell** — a per-cluster *average*, not a single item, and the cluster payload carries no per-cluster token total; left as-is to avoid expanding scope into analyzer payloads. Flagging it here for the master to decide if a follow-up is wanted.

Closes #249

🤖 Generated with [Claude Code](https://claude.com/claude-code)