### PR TITLE
Fix #251, #260: Optimize chart zero-segments + per-item cluster cost

### DIFF
--- a/tests/unit/test_lens_ui_regression.py
+++ b/tests/unit/test_lens_ui_regression.py
@@ -275,9 +275,12 @@ def test_optimize_budget_projection_routes_through_framing(html):
 
 
 def test_optimize_cluster_avg_cost_routes_through_framing(html):
-    # The script/reuse cluster table "Avg cost" cell must reframe, not raw $.
+    # The script cluster table "Avg cost" cell is per-item, so per #260 it routes
+    # through fmtPerItemCost (tokens for subscription/local), not the raw $ nor
+    # the window-aggregate fmtFramedDollar "% of cycle".
     assert "${fmtCost(c.avg_cost_usd)}" not in html
-    assert "${fmtFramedDollar(c.avg_cost_usd, framing)}" in html
+    assert "${fmtFramedDollar(c.avg_cost_usd, framing)}" not in html
+    assert "${fmtPerItemCost(c.avg_cost_usd, c.avg_tokens, framing)}" in html
 
 
 # --- Lens Visualizations Wave 1: cost charts (#211–#213) ------------------- #
@@ -697,3 +700,43 @@ def test_per_trace_token_totals_come_from_server_not_aggregated_in_js(html):
     # _costVal reads server-provided per-row input_tokens/output_tokens; the UI
     # never re-sums spans in JS for the list rows (single compute path, #249).
     assert "function _costVal(r, useTokens)" in html
+
+
+# --- #251: component-waste chart drops zero segments + positive empty state -- #
+def test_component_waste_chart_filters_zero_segments(html):
+    # The cumulative-overlap bar technique paints a zero-value segment as a
+    # full-height bar in its own color (cache-write=0 → full-height purple over
+    # the real stack). Zero-value segments must be filtered BEFORE building the
+    # cumulative bars, in both columns.
+    assert "const costSegsNZ = (costSegs || []).filter(s => (s.value || 0) > 0);" in html
+    assert "const recSegsNZ = (recSegs || []).filter(s => (s.value || 0) > 0);" in html
+    # the cumulative loops iterate the filtered lists, not the raw props
+    assert "costSegsNZ.forEach((s, i) =>" in html
+    assert "recSegsNZ.forEach((s, i) =>" in html
+    # color offset uses the filtered cost length so the palette stays aligned
+    assert "palette[(costSegsNZ.length + i) % palette.length]" in html
+
+
+def test_component_waste_empty_recoverable_is_positive_state(html):
+    # The empty "Recoverable (est.)" column shows a positive signal, not blank /
+    # dim space.
+    assert "Nothing recoverable in this window" in html
+    assert 'class="waste-none"' in html
+    # the old neutral/dim empty message is gone
+    assert "No recoverable waste estimated in this window." not in html
+
+
+def test_component_waste_dominant_split_label(html):
+    # Optional %-split note when one token component is ~all the spend (>95%),
+    # so the single-block bar is explained rather than mysterious.
+    assert "function dominantSplit(costSegs)" in html
+    assert "pct > 95 ?" in html
+    assert "const wasteDominant = waste ? dominantSplit(waste.costSegs) : null;" in html
+    assert 'class="waste-split"' in html
+
+
+# --- #260: script cluster avg cost carries a server-side token total --------- #
+def test_script_cluster_payload_token_total_is_server_side(html):
+    # The cell consumes c.avg_tokens (server-provided per-cluster token total),
+    # never re-aggregating in JS.
+    assert "${fmtPerItemCost(c.avg_cost_usd, c.avg_tokens, framing)}" in html

--- a/tests/unit/test_workflow_restructure.py
+++ b/tests/unit/test_workflow_restructure.py
@@ -121,6 +121,31 @@ def test_flags_cluster_at_or_above_threshold(db):
     ]
 
 
+def test_cluster_carries_avg_tokens_for_per_item_framing(db):
+    """Each cluster carries the per-instance mean of input+output tokens so the
+    UI can render the cell as TOKENS for subscription/local users (#260)."""
+    base = datetime(2026, 5, 10, tzinfo=timezone.utc)
+    # 20 sessions, each 1000 in + 200 out → avg_tokens should be 1200.
+    for i in range(MIN_CLUSTER_INSTANCES):
+        sid = f"tok-{i}"
+        sess = make_session(session_id=sid, plan_tier="api", duration_seconds=30.0,
+                            input_tokens=1000, output_tokens=200)
+        db.upsert_session(sess)
+        span = make_tool_span(tool_name="bash")
+        span.session_id = sid
+        span.start_time = base + timedelta(minutes=i)
+        span.attributes = {GenAIAttributes.TOOL_INPUT: {"command": "git pull"}}
+        db.insert_span(span)
+
+    config = _config(tool_inputs=True)
+    since = datetime(2026, 5, 1, tzinfo=timezone.utc)
+    until = datetime(2026, 5, 30, tzinfo=timezone.utc)
+    report = build_report(db=db, config=config, since=since, until=until,
+                          findings=["script"])
+    c = report.findings["script"].clusters[0]
+    assert c.avg_tokens == 1200
+
+
 def test_below_threshold_not_flagged(db):
     """Fewer than MIN_CLUSTER_INSTANCES sessions: no recommendation."""
     _seed_deterministic_cluster(

--- a/tokenjam/core/optimize/analyzers/workflow_restructure.py
+++ b/tokenjam/core/optimize/analyzers/workflow_restructure.py
@@ -91,6 +91,12 @@ class WorkflowCluster:
     avg_cost_usd:  float        # mean cost across the cluster
     avg_duration_seconds: float | None
     example_session_id: str | None
+    # Mean input+output tokens per instance, so the UI can render the per-cluster
+    # cost as TOKENS for subscription/local users (#260) — "% of cycle"/$ at this
+    # per-item granularity is the same category error fixed in #249/#259. Summed
+    # server-side (single compute path). Defaulted so older serialized reports
+    # round-trip through WorkflowCluster(**c).
+    avg_tokens:    int = 0
 
 
 @dataclass
@@ -183,7 +189,8 @@ def run(ctx: AnalyzerContext) -> None:
             f"COALESCE(AVG(total_cost_usd), 0.0), "
             f"COALESCE(AVG(EXTRACT(EPOCH FROM (ended_at - started_at))), 0.0), "
             f"COALESCE(SUM(total_cost_usd), 0.0), "
-            f"COALESCE(SUM(input_tokens + output_tokens + cache_tokens), 0) "
+            f"COALESCE(SUM(input_tokens + output_tokens + cache_tokens), 0), "
+            f"COALESCE(AVG(input_tokens + output_tokens), 0) "
             f"FROM sessions WHERE session_id IN ({placeholders})",
             members,
         ).fetchone()
@@ -191,6 +198,10 @@ def run(ctx: AnalyzerContext) -> None:
         avg_duration = float(agg[1] or 0.0) if agg else 0.0
         cluster_cost = float(agg[2] or 0.0) if agg else 0.0
         cluster_tokens = int(agg[3] or 0) if agg else 0
+        # Per-instance avg of input+output (the same basis the UI's _costVal uses
+        # for every other per-item token figure) so the cluster cell reads
+        # consistently with Traces/Status (#260).
+        avg_tokens = round(float(agg[4] or 0.0)) if agg else 0
         total_cluster_cost += cluster_cost
         total_cluster_tokens += cluster_tokens
 
@@ -207,6 +218,7 @@ def run(ctx: AnalyzerContext) -> None:
             avg_cost_usd=round(avg_cost, 6),
             avg_duration_seconds=round(avg_duration, 2) if avg_duration > 0 else None,
             example_session_id=members[0],
+            avg_tokens=avg_tokens,
         ))
 
     # Sort by instance count desc — the most common deterministic patterns

--- a/tokenjam/ui/index.html
+++ b/tokenjam/ui/index.html
@@ -631,6 +631,13 @@ a.chart-title:hover { color: var(--brand); text-decoration: underline; }
 .waste-name { font-family: 'Geist Mono', monospace; }
 .waste-rec { font-family: 'Geist Mono', monospace; font-weight: 600; color: var(--accent); display: inline-flex; align-items: center; gap: 6px; white-space: nowrap; }
 .waste-caveat { font-size: 11px; color: var(--text-faint); margin: 0 0 6px; max-width: 70ch; }
+/* Positive "nothing recoverable" state for the component chart's right column
+   (#251) — a clean signal, not blank space. */
+.waste-none { margin-top: 12px; border-top: 1px solid var(--border); padding-top: 8px;
+  font-size: 13px; color: var(--success); display: flex; align-items: center; gap: 6px; }
+.waste-none .check { font-weight: 700; }
+/* Optional dominant-component note when one token component is ~all the spend. */
+.waste-split { margin-top: 8px; font-size: 12px; color: var(--text-dim); }
 /* uPlot hover tooltip (#128). Positioned at the cursor; offset above-centered. */
 .u-tip {
   position: absolute; pointer-events: none; z-index: 5;
@@ -1344,22 +1351,30 @@ function ComponentWasteChart({ costSegs, recSegs, fmtY = fmtCost, height = 220 }
     const tick = cssVar('--text-dim') || '#a1a1a1';
     const width = ref.current.clientWidth || 600;
     const xs = [0, 1];                          // Cost | Recoverable (est.)
+    // Drop ZERO-value segments before building the cumulative bars (#251). The
+    // back-to-front stacking trick plots each segment's CUMULATIVE total as a
+    // full bar; a zero-value segment carries the running cumulative (unchanged
+    // by its 0) and so paints a full-height bar in its own color OVER the real
+    // stack (the cache-write=0 → full-height-purple bug). Filtering first keeps
+    // every plotted bar tied to a real, non-zero contribution.
+    const costSegsNZ = (costSegs || []).filter(s => (s.value || 0) > 0);
+    const recSegsNZ = (recSegs || []).filter(s => (s.value || 0) > 0);
     // Per-column cumulative (within-column) so the back-to-front bars stack
     // independently; 0 in the other column → invisible there.
     const series = [{}];
     const cols = [];                            // data columns (cumulative)
     const meta = [];                            // {label, color, raw, col}
     let accC = 0;
-    costSegs.forEach((s, i) => {
+    costSegsNZ.forEach((s, i) => {
       accC += (s.value || 0);
       cols.push([accC, 0]);
       meta.push({ label: s.label, color: s.color || palette[i % palette.length], raw: s.value || 0, col: 0 });
     });
     let accR = 0;
-    recSegs.forEach((s, i) => {
+    recSegsNZ.forEach((s, i) => {
       accR += (s.value || 0);
       cols.push([0, accR]);
-      meta.push({ label: s.title, color: palette[(costSegs.length + i) % palette.length], raw: s.value || 0, col: 1 });
+      meta.push({ label: s.title, color: palette[(costSegsNZ.length + i) % palette.length], raw: s.value || 0, col: 1 });
     });
     // Draw tallest cumulative first (within each column) so shorter bars paint
     // on top. Sort indices by cumulative descending; cross-column order is moot.
@@ -1441,6 +1456,19 @@ function buildComponentWaste(resp, useTokens) {
   const totalCost = costSegs.reduce((s, c) => s + c.value, 0);
   if (totalCost <= 0 && recSegs.length === 0) return null;
   return { costSegs, recSegs };
+}
+
+// When one token component is essentially all the measured spend (>95%), the
+// stacked "Cost" bar reads as a single block — so surface a small explanatory
+// split label rather than leaving the reader to guess (#251). Returns null when
+// no component dominates that strongly.
+function dominantSplit(costSegs) {
+  const segs = (costSegs || []).filter(s => (s.value || 0) > 0);
+  const total = segs.reduce((s, c) => s + (c.value || 0), 0);
+  if (total <= 0 || segs.length < 2) return null;
+  const top = segs.reduce((a, b) => (b.value > a.value ? b : a), segs[0]);
+  const pct = (100 * top.value) / total;
+  return pct > 95 ? { label: top.label, pct: pct.toFixed(1) } : null;
 }
 
 // ============================
@@ -2724,7 +2752,7 @@ function OptimizeFinding({ name, opt, framing }) {
       body = (fd.clusters || []).length ? html`
         <div class="opt-line">${fd.clusters.length} deterministic-pattern cluster(s).</div>
         <table class="opt-table"><thead><tr><th>Instances</th><th>Signature</th><th>Avg cost</th></tr></thead>
-          <tbody>${fd.clusters.map(c => html`<tr><td>${c.instances}×</td><td class="mono">${(c.signature || []).map(s => s.tool).join(' → ').slice(0, 60)}</td><td>${fmtFramedDollar(c.avg_cost_usd, framing)}</td></tr>`)}</tbody></table>
+          <tbody>${fd.clusters.map(c => html`<tr><td>${c.instances}×</td><td class="mono">${(c.signature || []).map(s => s.tool).join(' → ').slice(0, 60)}</td><td>${fmtPerItemCost(c.avg_cost_usd, c.avg_tokens, framing)}</td></tr>`)}</tbody></table>
         ${fd.caveat ? html`<div class="opt-caveat">! ${fd.caveat}</div>` : null}`
         : html`<div class="opt-line dim">No clusters above threshold (≥20 identical signatures).</div>`;
     } else if (name === 'trim') {
@@ -2788,6 +2816,7 @@ function OptimizeView({ params }) {
   const useTokens = !!compFraming && (compFraming.pricing_mode === 'subscription' || compFraming.pricing_mode === 'local');
   const waste = buildComponentWaste(st.comp, useTokens);
   const wasteFmtY = useTokens ? fmtTokens : fmtCost;
+  const wasteDominant = waste ? dominantSplit(waste.costSegs) : null;
 
   return html`
     <div class="page-title" style="display:flex;align-items:center;gap:10px;flex-wrap:wrap">
@@ -2835,7 +2864,8 @@ function OptimizeView({ params }) {
                 </div>
                 ${(r.caveat || r.basis) ? html`<div class="waste-caveat dim">${r.caveat || r.basis}</div>` : null}
               `)}
-            </div>` : html`<div class="chart-foot"><span class="dim">No recoverable waste estimated in this window.</span></div>`}
+            </div>` : html`<div class="waste-none"><span class="check">✓</span> Nothing recoverable in this window — no estimated waste from any analyzer.</div>`}
+          ${wasteDominant ? html`<div class="waste-split">${wasteDominant.label} is ${wasteDominant.pct}% of measured ${useTokens ? 'tokens' : 'spend'} this window.</div>` : null}
         </div>` : null}
       ${st.cmp ? html`<div class="chart-card"><div class="chart-title">Window comparison (${compare})</div>
         <div class="opt-line">Cost ${st.cmp.cost_delta_usd >= 0 ? '▲' : '▼'} ${fmtFramedDollar(Math.abs(st.cmp.cost_delta_usd), framing)} ${st.cmp.cost_delta_pct != null ? '(' + st.cmp.cost_delta_pct.toFixed(1) + '%)' : ''} · Tokens ${st.cmp.tokens_delta >= 0 ? '▲' : '▼'} ${fmtTokens(Math.abs(st.cmp.tokens_delta))}</div></div>` : null}


### PR DESCRIPTION
Two Optimize-screen rendering fixes.

## #251 — ComponentWasteChart rendered as a single full-height block
**Symptom:** the cost-by-component bar showed as one full-height block in a single color (e.g. a full-height purple bar) instead of a readable stack.

**Root cause:** the chart stacks segments with a back-to-front cumulative-bars trick — each segment plots its *cumulative* total as a full bar, tallest drawn first so shorter ones paint on top. A **zero-value segment** (commonly cache-write = 0) carries the running cumulative *unchanged* by its 0, so it sorts as a tall bar and paints a full-height block in its own color over the real stack.

**Fix:**
- Filter zero-value segments out of **both** columns *before* building the cumulative bars (`costSegsNZ` / `recSegsNZ`), so every plotted bar maps to a real, non-zero contribution. Palette offset uses the filtered length to stay aligned.
- Replace the blank/dim empty "Recoverable (est.)" column with a **positive state**: "✓ Nothing recoverable in this window — no estimated waste from any analyzer."
- Add a small **dominant-component split** note when one token component is >95% of measured spend, so the legitimately-single-block case is explained rather than mysterious.

## #260 — script cluster "Avg cost" cell showed per-item $
The cluster table's "Avg cost" cell still rendered a per-cluster dollar average at per-item granularity — the same category error #249/#259 fixed across Traces/Status. Now it routes through the existing `fmtPerItemCost(costUsd, tokenTotal, framing)` helper so subscription/local users see **tokens**, api/unknown keep dollars.

The per-cluster token total comes from the **server** (single compute path): `WorkflowCluster` gains `avg_tokens` (the per-instance mean of input+output — the same basis the UI's `_costVal` uses everywhere else), computed in the analyzer's aggregate query. Defaulted so older serialized reports round-trip through `WorkflowCluster(**c)`.

## Tests / Verification
- **New static-grep guards** (`tests/unit/test_lens_ui_regression.py`): zero-segment filter present in both columns; positive empty-recoverable state (old dim message gone); dominant-split helper; cluster cell uses `fmtPerItemCost(c.avg_cost_usd, c.avg_tokens, framing)`. Updated the prior `test_optimize_cluster_avg_cost_routes_through_framing` (which pinned the now-superseded `fmtFramedDollar`).
- **New analyzer test** (`tests/unit/test_workflow_restructure.py`): seeds a 20-session cluster at 1000 in + 200 out and asserts `c.avg_tokens == 1200`.
- `tests/unit/test_ui_offline.py` green; `node --check` on the app module passes; full `pytest tests/unit/ tests/synthetic/ tests/agents/ tests/integration/` = 977 passed; `ruff` + `mypy` clean.
- **Visually verified** against seeded data + headless Chrome:
  - Components with `cache-write = 0` now render a clean 3-segment cost stack (no full-height block).
  - An empty-recoverable window shows the green "✓ Nothing recoverable in this window" state.

## What's NOT in this PR
- The `reuse` finding has no per-cluster `$` cost cell (it deals in planning tokens / recoverable tokens already), so there was nothing to reframe there — only the `script` cell applied.
- The optional %-split label fires only above the >95% dominance threshold; balanced component mixes intentionally show no note.

Closes #251
Closes #260

🤖 Generated with [Claude Code](https://claude.com/claude-code)