### PR TITLE
Status: default to List view + fix list-table horizontal scroll (#263)

### DIFF
--- a/tests/unit/test_lens_ui_regression.py
+++ b/tests/unit/test_lens_ui_regression.py
@@ -644,9 +644,10 @@ def test_dashboard_triage_drills_in_place(html):
 # --- #241: Status screen Cards | List view toggle -------------------------- #
 def test_status_view_toggle_exists(html):
     # A segmented Cards | List control on the Status screen, driven by the URL
-    # view param (default 'cards', omitted from the URL via navigate defaults).
+    # view param. List is the default (#263), omitted from the URL via navigate
+    # defaults; Cards carries ?view=cards.
     assert ".view-toggle" in html  # segmented-control CSS
-    assert "const DEFAULTS = { view: 'cards', agent_id: '' };" in html
+    assert "const DEFAULTS = { view: 'list', agent_id: '' };" in html
     assert "readParam(params, 'view', DEFAULTS.view, v => ['cards', 'list'].includes(v))" in html
     assert "const setView = (v) => navigate('status', { agent_id: agentId, view: v }, DEFAULTS);" in html
     # both toggle buttons present
@@ -654,11 +655,26 @@ def test_status_view_toggle_exists(html):
     assert "onClick=${() => setView('list')}>List</button>" in html
 
 
+def test_status_list_is_default_view(html):
+    # #263: List is the default scan view (not Cards).
+    assert "const DEFAULTS = { view: 'list', agent_id: '' };" in html
+    assert "const DEFAULTS = { view: 'cards', agent_id: '' };" not in html
+
+
 def test_status_list_table_renderer_exists(html):
     # The List view is a dedicated columned-table renderer, gated behind the
-    # view mode. Cards remains the default render path.
+    # view mode (now the default render path).
     assert "function StatusListTable({ agents, framing })" in html
     assert "? StatusListTable({ agents, framing: data.framing })" in html
+
+
+def test_status_list_table_horizontally_scrolls(html):
+    # #263: the list table sits in the scrolling .table-wrap AND carries a
+    # min-width so it overflows (and scrolls) on narrow viewports instead of
+    # compressing columns and clipping the actions cell.
+    assert "<div class=\"table-wrap\"><table class=\"status-list\">" in html
+    assert ".table-wrap { overflow-x: auto; }" in html
+    assert ".table-wrap table.status-list { min-width: 760px; }" in html
 
 
 def test_status_list_cost_column_respects_framing(html):

--- a/tokenjam/ui/index.html
+++ b/tokenjam/ui/index.html
@@ -296,6 +296,10 @@ code, .mono {
 
 /* Tables */
 .table-wrap { overflow-x: auto; }
+/* Status List (#263): a min-width lets the table exceed a narrow container so
+   .table-wrap's overflow-x actually scrolls, instead of compressing columns and
+   clipping the actions cell (View cost / View traces) off the right edge. */
+.table-wrap table.status-list { min-width: 760px; }
 table {
   width: 100%;
   border-collapse: collapse;
@@ -1523,7 +1527,7 @@ function dominantSplit(costSegs) {
 // .table-wrap/table CSS; no new lib.
 function StatusListTable({ agents, framing }) {
   return html`
-    <div class="table-wrap"><table>
+    <div class="table-wrap"><table class="status-list">
       <thead><tr>
         <th>Agent</th>
         <th>Status</th>
@@ -1558,9 +1562,10 @@ function StatusListTable({ agents, framing }) {
 function StatusView({ params }) {
   // Optional single-agent filter via URL (#112). Filtered client-side since
   // /status returns every agent.
-  // View mode (Cards | List) also lives in the URL (#241): `#/status?view=list`.
-  // Cards is the default and is omitted from the URL so default links stay clean.
-  const DEFAULTS = { view: 'cards', agent_id: '' };
+  // View mode (Cards | List) also lives in the URL (#241): `#/status?view=cards`.
+  // List is the default (the more useful scan view, #263) and is omitted from
+  // the URL; choosing Cards carries `?view=cards`.
+  const DEFAULTS = { view: 'list', agent_id: '' };
   const agentId = readParam(params, 'agent_id', DEFAULTS.agent_id);
   const viewMode = readParam(params, 'view', DEFAULTS.view, v => ['cards', 'list'].includes(v));
   const setView = (v) => navigate('status', { agent_id: agentId, view: v }, DEFAULTS);


### PR DESCRIPTION
Two refinements to the Status Cards/List toggle (shipped in #241).

## 1. List is the default view
The columned **List** is the more useful default for scanning agents — flipped the default from `cards` to `list`. Cards stays available via the toggle and now carries `?view=cards` in the URL; the default (list) is omitted so default links stay clean.

## 2. List table was chopped off on the right
The actions column (`View cost → / View traces →`) was clipped at the right edge. The table already sat in a `.table-wrap` with `overflow-x: auto`, but `table { width: 100% }` with no `min-width` let the columns **compress to the container** and clip the nowrap actions cell instead of overflowing. Scoping a **`min-width: 760px`** to the list table (via a `status-list` class) lets it exceed a narrow container, so the wrapper actually **scrolls** and every column stays reachable.

## Verification (screenshots delivered to reviewer)
- Default `#/status` now renders **List** (toggle active, "Click on an agent row…").
- At a wide viewport both action links (`View cost →` / `View traces →`) render fully; the `min-width` inside `overflow-x: auto` guarantees horizontal scroll on narrow viewports rather than clipping.

## Constraints
UI-only, offline. The Cost column keeps its plan-tier framing via `fmtPerItemCost` (#259) — untouched.

## Tests
- `tests/unit/test_lens_ui_regression.py`: List is the default (`DEFAULTS = { view: 'list', … }`, old `'cards'` default gone); the list table sits in the scrolling `.table-wrap` with the `min-width`. The #241 toggle test updated for the new default.
- `test_ui_offline.py` green; app module passes `node --check`.
- Full `pytest tests/unit tests/integration` → **902 passed**; `ruff` + `mypy` clean.

Closes #263

🤖 Generated with [Claude Code](https://claude.com/claude-code)