### PR TITLE
Fix #262, #268: Analytics explorer spend framing + tool-dimension empty state

### DIFF
--- a/tests/unit/test_lens_ui_regression.py
+++ b/tests/unit/test_lens_ui_regression.py
@@ -429,7 +429,9 @@ def test_analytics_respects_plan_tier_framing(html):
     # spend metric switches to token volume for subscription/local (dollars
     # suppressed); never re-derives the suppression rule — reads framing.
     assert "framing.pricing_mode === 'subscription' || framing.pricing_mode === 'local'" in html
-    assert "fmtFramedDollar(kpis.spend, framing)" in html
+    # The Spend KPI tile reframes via spendTileDisplay (implied-value multiplier
+    # for subscription, #262) rather than fmtFramedDollar's "% of cycle".
+    assert "spendTileDisplay(kpis.spend, framing)" in html
 
 
 def test_analytics_leaderboard_has_inline_bars(html):
@@ -496,10 +498,11 @@ def test_kpi_series_is_server_computed_not_client_aggregated(html):
 
 def test_kpi_spend_tile_respects_framing(html):
     # The Spend tile reads the framed value from the server block (api → $,
-    # subscription → "% of cycle"), never raw $ for subscription. Its sparkline
-    # and delta track SPEND (cost_usd) — "% of cycle" is just spend rescaled, so
-    # the trend/shape match while the displayed number is never raw dollars.
-    assert "const spendVal = fmtFramedDollar(kpis.spend, framing)" in html
+    # subscription → implied-value multiplier "43.5× plan value", #262), never
+    # raw $ for subscription. Its sparkline and delta track SPEND (cost_usd) —
+    # the multiplier is just spend rescaled, so the trend/shape match while the
+    # displayed number is never raw dollars.
+    assert "const spend = spendTileDisplay(kpis.spend, framing)" in html
     assert "series: kpiSparkValues(resp, 'spend'), delta: deltas.spend" in html
 
 
@@ -628,11 +631,12 @@ def test_kpi_tiles_clickable_select_metric(html):
 
 
 def test_spend_tile_distinct_under_subscription(html):
-    # #247: the Spend tile no longer falls back to raw tokens (which duplicated
-    # the Tokens tile). It uses the framed value (% of cycle) and is dropped when
-    # no distinct value exists.
-    assert "const spendVal = fmtFramedDollar(kpis.spend, framing)" in html
-    assert "if (spendVal !== '—')" in html
+    # #247/#262: the Spend tile no longer falls back to raw tokens (which
+    # duplicated the Tokens tile). It uses spendTileDisplay (implied-value
+    # multiplier for subscription) and is dropped when no distinct value exists
+    # (local / a subscription with no declared fee → null).
+    assert "const spend = spendTileDisplay(kpis.spend, framing)" in html
+    assert "if (spend) {" in html
     assert "spendSuppressed ? (fmtTokens(kpis.tokens) + ' tok')" not in html  # old dup gone
 
 
@@ -837,3 +841,48 @@ def test_script_cluster_payload_token_total_is_server_side(html):
     # The cell consumes c.avg_tokens (server-provided per-cluster token total),
     # never re-aggregating in JS.
     assert "${fmtPerItemCost(c.avg_cost_usd, c.avg_tokens, framing)}" in html
+
+
+# --- #262: Analytics spend tile = implied-value multiplier, separators, soft delta -- #
+def test_analytics_spend_tile_uses_value_multiplier_for_subscription(html):
+    # The Spend tile shows an implied-value multiplier ("43.5× plan value") for
+    # subscription, never "% of cycle" and never raw $ — plan VALUE, not spend.
+    assert "function spendTileDisplay(spendUsd, framing)" in html
+    assert "+ '× plan value'" in html
+    # multiplier == (% of cycle) / 100 == spend / plan_monthly_usd
+    assert "(spendUsd || 0) / framing.plan_monthly_usd" in html
+    # the tile no longer renders fmtFramedDollar (the "% of cycle") for spend
+    assert "const spendVal = fmtFramedDollar(kpis.spend, framing);" not in html
+    assert "const spend = spendTileDisplay(kpis.spend, framing);" in html
+
+
+def test_analytics_count_tiles_have_thousand_separators(html):
+    # Sessions / Events tiles are exact counts with separators ("23,954"), not
+    # raw String() integers.
+    assert "function fmtCount(n)" in html
+    assert "toLocaleString('en-US')" in html
+    assert "value: fmtCount(kpis.sessions)" in html
+    assert "value: fmtCount(kpis.events)" in html
+    assert "value: String(kpis.sessions)" not in html
+    assert "value: String(kpis.events)" not in html
+
+
+def test_analytics_thin_prior_window_softens_delta(html):
+    # A near-empty prior window suppresses the alarming ▲% and annotates instead.
+    assert "const prevThin = !!resp.kpi_prev && (resp.kpi_prev.sessions || 0) < 2;" in html
+    assert "vs partial prior window" in html
+    # the flag is threaded through the tile into the delta chip
+    assert "prevThin=${prevThin}" in html
+    assert "function DeltaChip({ pct, cost, prevThin })" in html
+
+
+# --- #268: tool dimension + spend/tokens → helpful empty state, not zeros ----- #
+def test_analytics_tool_dim_no_cost_metric_empty_state(html):
+    # Grouping spend/tokens by tool(_category) is structurally all-zeros (tool
+    # spans carry no tokens/cost) — show an empty state with a one-click switch.
+    assert "const toolDimNoMetric = (groupBy === 'tool' || groupBy === 'tool_category')" in html
+    assert "&& (metric === 'spend' || metric === 'tokens');" in html
+    assert "Tools don't carry" in html
+    # one-click recovery actions
+    assert "onClick=${() => setFilter('metric', 'events')}>Switch to Events" in html
+    assert "setFilter('group_by', 'model')" in html

--- a/tokenjam/ui/index.html
+++ b/tokenjam/ui/index.html
@@ -1969,6 +1969,32 @@ function fmtPerItemCost(costUsd, tokenTotal, framing) {
   return fmtFramedDollar(costUsd, framing); // api / unknown → dollars
 }
 
+// Integer count with thousand separators (#262): "23954" → "23,954". For the
+// Sessions / Events KPI tiles, which are exact counts (not abbreviated like
+// fmtTokens "23.9k").
+function fmtCount(n) {
+  if (n == null) return '0';
+  return Math.round(n).toLocaleString('en-US');
+}
+
+// The Spend KPI tile under plan-tier framing (#262). For SUBSCRIPTION, the
+// confusing "% of cycle" is replaced by an honest implied-value MULTIPLIER —
+// "43.5× plan value" (implied API value ÷ the plan's monthly fee, which is just
+// the "% of cycle" number ÷ 100). It is plan VALUE, never "spent $X". api /
+// unknown keep dollars. LOCAL (no plan fee) and a subscription with no declared
+// monthly fee have no denominator, so the tile is dropped — the Tokens tile
+// already conveys volume. Returns {label, value} or null (drop the tile).
+function spendTileDisplay(spendUsd, framing) {
+  const mode = framing && framing.pricing_mode;
+  if (mode === 'subscription') {
+    if (!framing.plan_monthly_usd) return null;          // no fee → no multiplier
+    const mult = (spendUsd || 0) / framing.plan_monthly_usd;  // == (% of cycle) / 100
+    return { label: 'Implied value', value: mult.toFixed(1) + '× plan value' };
+  }
+  if (mode === 'local') return null;                     // no plan fee to multiply against
+  return { label: 'Spend', value: fmtCost(spendUsd) };   // api / unknown → dollars
+}
+
 // Positive plan-tier chip(s) from the server `framing` block (#110). Distinct from
 // the warning `qualifier` banner — confirms api / subscription / local mode.
 function PlanBadge({ framing }) {
@@ -1994,8 +2020,15 @@ function TrendChip({ pct }) {
 // Signed period-over-period delta chip for KPI tiles (#217). `cost`=true uses
 // the spend semantic (up = red/attention, down = green); volume metrics
 // (tokens/sessions/events) stay neutral — more isn't inherently "bad".
-function DeltaChip({ pct, cost }) {
+function DeltaChip({ pct, cost, prevThin }) {
   if (pct == null) return null;
+  // Soften a delta computed against a near-empty prior window (#262): a fresh
+  // backfill makes the prior period a sliver of data, so the % (e.g. ▲1682%) is
+  // arithmetic noise, not a trend. Suppress the alarming number and annotate.
+  if (prevThin) {
+    return html`<span class="delta-chip" style="color:var(--text-dim)"
+      title="The prior window has little data, so a percentage change would be misleading.">vs partial prior window</span>`;
+  }
   const up = pct > 0;
   const arrow = pct === 0 ? '·' : up ? '▲' : '▼';
   const color = cost
@@ -2030,7 +2063,7 @@ function Sparkline({ values, color = 'var(--accent)', width = 92, height = 26 })
 // `onSelect` makes the tile the metric selector (#247): the kpi-active border
 // already implied it was clickable; wiring onClick fulfills that. Falls back to
 // a static tile when no handler is given.
-function KpiTile({ label, value, active, series, delta, cost, onSelect }) {
+function KpiTile({ label, value, active, series, delta, cost, prevThin, onSelect }) {
   const cls = 'kpi-tile' + (active ? ' kpi-active' : '') + (onSelect ? ' kpi-clickable' : '');
   const props = onSelect
     ? { class: cls, role: 'button', tabindex: '0', 'aria-pressed': String(!!active),
@@ -2042,7 +2075,7 @@ function KpiTile({ label, value, active, series, delta, cost, onSelect }) {
       <div class="kpi-num"><div class="kpi-val">${value}</div><div class="kpi-lab">${label}</div></div>
       <${Sparkline} values=${series} />
     </div>
-    <${DeltaChip} pct=${delta} cost=${cost} />
+    <${DeltaChip} pct=${delta} cost=${cost} prevThin=${prevThin} />
   </div>`;
 }
 
@@ -3128,6 +3161,12 @@ function AnalyticsView({ params, route = 'analytics', embedded = false, kpiCapti
 
   const metricSuffix = isSpend ? (useTokens ? ' (tokens)' : '') : '';
 
+  // Tool spans carry no tokens/cost, so grouping spend/tokens BY tool (or tool
+  // category) is structurally all-zeros (#268). Rather than render a wall of
+  // zeros, show a helpful empty state with a one-click switch to Events.
+  const toolDimNoMetric = (groupBy === 'tool' || groupBy === 'tool_category')
+    && (metric === 'spend' || metric === 'tokens');
+
   return html`
     ${embedded ? null : html`<div class="page-title" style="display:flex;align-items:center;gap:10px;flex-wrap:wrap">
       Analytics <${PlanBadge} framing=${framing} />
@@ -3171,33 +3210,36 @@ function AnalyticsView({ params, route = 'analytics', embedded = false, kpiCapti
 
     ${!error && kpis ? (() => {
       // The Spend tile follows the server framing block (single source, never
-      // re-derived). Under suppression (subscription/local) it shows a DISTINCT
-      // subscription value — "% of cycle" via fmtFramedDollar — NOT raw tokens
-      // (which duplicated the Tokens tile, #247). Its sparkline/delta still
-      // track SPEND (cost_usd), since "% of cycle" is just spend rescaled by the
-      // plan fee — so the trend/shape are identical to spend, never raw $. When
-      // no distinct value is meaningful (fmtFramedDollar → "—": local, or a
-      // subscription with no declared monthly fee) the Spend tile is dropped
-      // rather than duplicate Tokens.
+      // re-derived). Under SUBSCRIPTION it shows an implied-value MULTIPLIER
+      // ("43.5× plan value", #262) — NOT "% of cycle" and NOT raw tokens (which
+      // duplicated the Tokens tile, #247). Its sparkline/delta still track SPEND
+      // (cost_usd), since the multiplier is just spend rescaled by the plan fee
+      // — so the trend/shape are identical to spend, never raw $. LOCAL / a
+      // subscription with no declared fee have no denominator → the tile is
+      // dropped rather than duplicate Tokens.
       const deltas = resp.kpi_deltas || {};
-      const spendVal = fmtFramedDollar(kpis.spend, framing);
+      const spend = spendTileDisplay(kpis.spend, framing);
+      // A prior window with almost no activity makes period-over-period % a
+      // misleading sliver (the ▲1682% on a fresh backfill, #262). Use the prior
+      // window's session count as the universal "did anything happen" proxy.
+      const prevThin = !!resp.kpi_prev && (resp.kpi_prev.sessions || 0) < 2;
       const onMetric = (k) => setFilter('metric', k);
       const tiles = [];
-      if (spendVal !== '—') {
-        tiles.push({ key: 'spend', label: 'Spend', cost: true, value: spendVal,
+      if (spend) {
+        tiles.push({ key: 'spend', label: spend.label, cost: true, value: spend.value,
           series: kpiSparkValues(resp, 'spend'), delta: deltas.spend });
       }
       tiles.push({ key: 'tokens', label: 'Tokens', cost: false, value: fmtTokens(kpis.tokens),
         series: kpiSparkValues(resp, 'tokens'), delta: deltas.tokens });
-      tiles.push({ key: 'sessions', label: 'Sessions', cost: false, value: String(kpis.sessions),
+      tiles.push({ key: 'sessions', label: 'Sessions', cost: false, value: fmtCount(kpis.sessions),
         series: kpiSparkValues(resp, 'sessions'), delta: deltas.sessions });
-      tiles.push({ key: 'events', label: 'Events', cost: false, value: String(kpis.events),
+      tiles.push({ key: 'events', label: 'Events', cost: false, value: fmtCount(kpis.events),
         series: kpiSparkValues(resp, 'events'), delta: deltas.events });
       return html`
         <div class="kpi-row">
           ${tiles.map(t => html`<${KpiTile} label=${t.label} value=${t.value} active=${t.key === metric}
               series=${t.series} delta=${t.delta == null ? null : t.delta} cost=${t.cost}
-              onSelect=${() => onMetric(t.key)} />`)}
+              prevThin=${prevThin} onSelect=${() => onMetric(t.key)} />`)}
         </div>
         ${kpiCaption ? html`<div class="kpi-caption">${kpiCaption}</div>` : null}`;
     })() : null}
@@ -3207,7 +3249,16 @@ function AnalyticsView({ params, route = 'analytics', embedded = false, kpiCapti
         <div class="chart-head">
           <div class="chart-title">${(ANALYTICS_METRICS.find(m => m[0] === metric) || [, metric])[1]} by ${(ANALYTICS_DIMENSIONS.find(d => d[0] === groupBy) || [, groupBy])[1]}${metricSuffix}</div>
         </div>
-        ${loading ? html`<div class="shimmer" style="height:200px"></div>`
+        ${toolDimNoMetric ? html`
+          <div class="empty" style="padding:32px 16px;text-align:center">
+            <div style="font-size:13px;margin-bottom:12px">Tools don't carry ${metric === 'spend' ? 'cost' : 'tokens'} — those live on the LLM-call spans, not tool spans.</div>
+            <div style="display:flex;gap:8px;justify-content:center;flex-wrap:wrap">
+              <button class="btn" onClick=${() => setFilter('metric', 'events')}>Switch to Events</button>
+              <button class="btn" onClick=${() => setFilter('group_by', 'model')}>Group by Model</button>
+              <button class="btn" onClick=${() => setFilter('group_by', 'agent')}>Group by Agent</button>
+            </div>
+          </div>`
+          : loading ? html`<div class="shimmer" style="height:200px"></div>`
           : chart === 'hbar'
             ? (board && board.length ? html`
               <div class="leaderboard">


### PR DESCRIPTION
Two fixes to `AnalyticsView` (used by both the standalone **Analytics** screen and the embedded **Dashboard** hero). All figures consume the server `framing` block — the suppression rules are never re-derived in JS, and subscription never sees raw `$`.

## #262 — KPI-tile fixes
**Spend tile → implied-value multiplier.** Under a subscription plan, "% of cycle" was an unintuitive read of spend. It's now an honest implied-value **multiplier** — "43.5× plan value" (implied API value ÷ the plan's monthly fee, which is exactly the "% of cycle" number ÷ 100, already in the framing block). It is plan **value**, clearly labelled, never "spent \$X" and never raw \$. api/unknown keep dollars; local / a subscription with no declared fee drop the tile (the Tokens tile already conveys volume). The sparkline + delta still track spend, since the multiplier is just spend linearly rescaled.

**Thousand separators on count tiles.** Sessions / Events render via `fmtCount` ("23,954") instead of raw `String()` integers.

**Softened thin-window deltas.** A fresh backfill makes the prior period a sliver of data, so period-over-period % became arithmetic noise (the alarming ▲1682%). When the prior window has <2 sessions, the misleading number is suppressed and annotated **"vs partial prior window"** instead.

## #268 — tool dimension + spend/tokens empty state
Grouping the spend/tokens metric **by tool** (or tool category) is structurally all-zeros — tool spans carry no tokens/cost (those live on the LLM-call spans). Instead of a wall of zeros, the chart area shows a helpful empty state ("Tools don't carry cost/tokens …") with **one-click switches** to Events, or to grouping by Model / Agent. The window-level KPI tiles (which aren't grouped by tool) stay meaningful and are unaffected.

## Tests / Verification
- New static-grep guards in `tests/unit/test_lens_ui_regression.py`: multiplier helper + formula, `fmtCount` separators on count tiles, thin-prior `prevThin` softening, and the tool-dimension empty state with its switch buttons. Updated the prior #247-era tests that pinned the now-superseded `fmtFramedDollar` spend tile.
- `tests/unit/test_ui_offline.py` green; `node --check` on the app module passes; full `pytest tests/unit/ tests/integration/` = 904 passed; `ruff` clean.
- **Visually verified** (subscription `max_5x`, \$100/mo fee + thin prior window + tool spans, headless Chrome):
  - Spend tile shows "44.0× plan value" (label "Implied value"), not "% of cycle".
  - With a 1-session prior window, all tiles show "vs partial prior window" instead of ▲879900%.
  - Grouping spend by Tool shows the empty state + "Switch to Events / Group by Model / Group by Agent" buttons.

## What's NOT in this PR
- **api/unknown plans** are unchanged on the Spend tile (raw \$ is correct there).
- The multiplier deliberately has no denominator for **local** plans (no monthly fee), so the Spend tile is dropped for local — same as today; the Tokens tile carries volume.
- The empty state is shown for the structural tool+spend/tokens combo (always all-zeros), not gated on inspecting the returned rows.

Closes #262
Closes #268

🤖 Generated with [Claude Code](https://claude.com/claude-code)