### PR TITLE
docs: fix stale .claude/-committed claim, refresh roadmap, top star CTA

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,6 +1,6 @@
 # Contributing to TokenJam
 
-TokenJam is MIT licensed and welcomes contributions. The codebase was built using parallel Claude Code agents — the `.claude/` task files are intentionally committed so contributors can use the same workflow.
+TokenJam is MIT licensed and welcomes contributions. It's built by AI coding agents, and contributing with one is first-class — see [Using coding agents](#using-coding-agents) below.
 
 ## Good first contributions
 
@@ -58,12 +58,12 @@ tests/factories.py     Span factory — use this in all synthetic tests, never
                        construct NormalizedSpan directly
 ```
 
-## Using Claude Code
+## Using coding agents
 
-This project was built using parallel Claude Code agents. The `.claude/` directory contains the original task files. If you're using Claude Code to contribute:
+TokenJam is built by AI coding agents, and contributing with one is first-class:
 
-- Read `AGENTS.md` at the repo root before starting — it contains the critical rules (DuckDB not SQLite, TOML not YAML, no CLI imports in `tokenjam/core/`, etc.)
-- The task files in `.claude/` show how the codebase was structured and are useful context for larger contributions
+- **Claude Code** — it reads [`CLAUDE.md`](CLAUDE.md) automatically; run `/init` to bring your agent up to speed on the architecture and conventions.
+- **Codex / Gemini / other agents** — read [`AGENTS.md`](AGENTS.md): the critical rules (DuckDB not SQLite, TOML not YAML, no CLI imports in `tokenjam/core/`, etc.) plus a pointer to CLAUDE.md for the full guide.
 
 ## Pricing table contributions
 

--- a/README.md
+++ b/README.md
@@ -24,6 +24,8 @@ pipx install tokenjam
 
 **No cloud · No signup · No vendor lock-in**
 
+<sub>⭐ If TokenJam saves you tokens, **star it** · 👁 **Watch for releases** — we ship often</sub>
+
 </div>
 
 ---
@@ -223,7 +225,13 @@ tj serve               # start Lens + REST API
 - [x] **Daemon DB concurrency** — per-thread DuckDB cursors so the Overview's fan-out doesn't block on a single shared connection (v0.4.1)
 - [x] **Cache cost transparency** — `cache_read` + `cache_write` token columns surfaced in CLI + UI + API (the previously-hidden ~91% cost driver on cache-heavy workloads)
 
-**Up next:**
+**Shipped in 0.5.x:**
+- [x] **Lens Visualizations** — an Analytics pivot explorer (metric × dimension × chart, presets, CSV), stacked cost-by-model, a cache-savings chart, KPI sparklines, a cost-annotated trace waterfall, and consistent series coloring
+- [x] **Merged Dashboard** — the explorer and the triage front-door unified into one default screen, with in-place drill-through from recoverable-waste tiles
+- [x] **First-run polish** — backfill fidelity (session-level traces, cache read/write split, honest session counts), plan-tier-aware framing throughout (subscription users see token-share, never raw spend), an onboarding welcome banner + next-steps guidance, and a contribution funnel
+
+**Up next** (roughly):
+- [ ] Continued Lens polish + per-product visual branding
 - [ ] `tj policy add | edit | apply` — unified rule surface
 - [ ] `tj replay` — replay captured sessions against new model versions
 - [ ] TypeScript framework patches (LangChain JS, OpenAI Agents SDK)
@@ -240,7 +248,7 @@ TokenJam is MIT, and contributions are welcome — from a one-line pricing fix t
 - 🟢 **[Good first issues →](https://github.com/Metabuilder-Labs/tokenjam/labels/good%20first%20issue)** — scoped, newcomer-friendly tasks, ready to pick up.
 - 💸 **Model pricing** — `tokenjam/pricing/models.toml` is community-maintained. Fix a rate or add a model in a single PR — no issue needed.
 - 🔌 **Framework integrations** — provider/framework patches follow one clear pattern (`tokenjam/sdk/integrations/anthropic.py` is the reference). Open an issue first to align on approach.
-- 🤖 **Built with Claude Code** — TokenJam was built by parallel Claude Code agents, and the `.claude/` task files are committed, so you can contribute the same way. [AGENTS.md](AGENTS.md) has the critical rules.
+- 🤖 **Built with coding agents** — TokenJam is built by AI coding agents, and contributing with one is first-class. **Claude Code:** read [CLAUDE.md](CLAUDE.md) and run `/init` to bring your agent up to speed. **Codex / other agents:** [AGENTS.md](AGENTS.md) has the critical rules.
 
 Setup and the full dev workflow are in **[CONTRIBUTING.md](CONTRIBUTING.md)**.
 


### PR DESCRIPTION
Small README/CONTRIBUTING accuracy fixes (from a review of the merged contribution-funnel docs).

## Summary
- **Fix the stale `.claude/`-committed claim** (README Contributing bullet + CONTRIBUTING.md, in two places). Those task files were checked in on the first commit but have since been removed and gitignored, so "the `.claude/` task files are committed, so you can contribute the same way" is false. Replaced with the accurate guidance: **Claude Code** → read [CLAUDE.md](CLAUDE.md) + run `/init`; **Codex / other agents** → [AGENTS.md](AGENTS.md) (which already exists and carries the critical rules).
- **Roadmap**: added a **Shipped in 0.5.x** block (Lens Visualizations, merged Dashboard, first-run polish), keeping the 0.3.x/0.4.x history; lightly refreshed "Up next."
- **Top star CTA**: repeated the "⭐ star · 👁 watch for releases" line in the header (it was only at the bottom).

## Notes
- AGENTS.md needed no changes — it already points agents at CLAUDE.md, lists the critical rules, and names Codex/Gemini explicitly.
- Docs-only; no competitor names; no over-claims.

🤖 Generated with [Claude Code](https://claude.com/claude-code)