### PR TITLE
Bump version to 0.5.1

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "tokenjam"
-version = "0.5.0"
+version = "0.5.1"
 description = "TokenJam — local-first OTel-native observability for Autonomous AI agents"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/sdk-ts/package.json
+++ b/sdk-ts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tokenjam/sdk",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "description": "TypeScript SDK for TokenJam — local-first observability for AI agents",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",


### PR DESCRIPTION
Release-cut for **0.5.1** — the first-run-polish release.

## Summary
- Bump `pyproject.toml` + `sdk-ts/package.json` to `0.5.1`.

## What 0.5.1 ships (since 0.5.0)
- **Merged Dashboard** as the default view (Overview retired) + in-place triage drill-through (#247, #252)
- **Subscription framing** corrected everywhere — per-item cost as tokens (#249), the "× plan value" multiplier replacing "% of cycle" (#262)
- **Backfill fidelity** — session-level traces (#243), cache read/write split (#245), honest session counts (#238)
- **Three chart redesigns** — component-waste single-block fix (#251), cache-savings answer-first redesign (#246), cost-first trace waterfall (#244)
- **Onboarding** welcome banner + next-steps nudge + plan-first prompts (#240)
- **Polish** — KPI tiles (separators, softened deltas), Status List-default + horizontal scroll (#263), tool-dimension empty state (#268)
- **Docs** — contribution funnel + README/AGENTS accuracy (#239 tests, #257, #271)

## Tests / Verification
- Full CI green across the milestone (14 issues closed); no code changes here beyond the version strings.

## Next
On merge → `gh release create v0.5.1` fires publish-pypi + publish-npm.

🤖 Generated with [Claude Code](https://claude.com/claude-code)