### PR TITLE
[feature] tj proxy substrate (suggest mode) + pricing-mode gate + lifecycle (#219)

### DIFF
--- a/docs/proxy/overview.md
+++ b/docs/proxy/overview.md
@@ -1,0 +1,67 @@
+# tj proxy — the enforcement-plane substrate (suggest mode)
+
+`tj proxy` is an **optional, opt-in** in-process proxy that runs inside `tj serve`
+on a dedicated port (default **7392**), sitting between an agent and its LLM
+provider. It speaks the Anthropic (`/v1/messages`) and OpenAI
+(`/v1/chat/completions`) request shapes and forwards traffic to the real
+provider, streaming responses back.
+
+It ships in **suggest mode only**: it records what a policy *would* do and
+**enforces nothing**. Policy enforcement is a separate, later piece (#220); this
+is the open/MIT rails it will sit on. Off by default — you have to turn it on.
+
+## The pricing-mode gate (built-in invariant)
+
+The first step in the proxy's decision path resolves the session's pricing mode
+for the targeted provider, reusing the **existing** plan-tier logic
+(`core/framing.provider_pricing_mode` → `pricing_mode_for` →
+`SUBSCRIPTION_PLAN_TIERS`). The rule is never re-derived:
+
+- **Subscription** traffic, **`local`**, and **`unknown`** (a deliberate
+  fail-safe) → forwarded **unmodified**, observe-only, **never** a policy
+  decision. Intercepting subscription-plan traffic is outside provider terms of
+  service, so the proxy stays hands-off.
+- **`api` / usage-billed** traffic is the **only** traffic that reaches the
+  policy path (a no-op in suggest mode).
+
+The decision is a plain, inspectable value object (`tokenjam.proxy.gate.classify`
+→ `GateDecision`) and is unit-tested directly.
+
+## Safety doctrine
+
+- **Pass-through is sacred.** Any error in classification / recording forwards
+  the request unmodified.
+- **The proxy holds no keys.** The caller's credentials pass straight through;
+  the proxy never injects its own. Streaming responses are forwarded as streams.
+- **Absence is safe.** `tj proxy enable` wires the provider base-URLs at the
+  proxy (in `~/.claude/settings.json`) and turns it on; `disable` removes both.
+  `tj doctor` flags orphaned base-URL wiring (env points at the proxy but it's
+  off — traffic would hit a dead port).
+- **Kill switch.** `tj proxy killswitch` flips the proxy to
+  pass-through-everything while keeping the listener alive (`--off` to release).
+
+## Lifecycle
+
+```bash
+tj proxy enable       # turn on + wire provider base-URLs at the proxy
+tj proxy status       # show config, killswitch, and detected wiring (--json too)
+tj proxy killswitch   # pass-through-everything (--off to release)
+tj proxy disable      # turn off + remove the wiring
+```
+
+The proxy starts/stops with `tj serve`'s lifespan — it can never outlive the
+server. Restart `tj serve` after `enable`/`disable`/`killswitch` for the running
+listener to pick up the change.
+
+## Config (`[proxy]`)
+
+```toml
+[proxy]
+enabled = false          # off by default
+host = "127.0.0.1"
+port = 7392
+mode = "suggest"         # suggest only; enforce lands behind a later gate (#220)
+killswitch = false
+anthropic_base_url = "https://api.anthropic.com"
+openai_base_url = "https://api.openai.com"
+```

--- a/tests/integration/test_cmd_proxy.py
+++ b/tests/integration/test_cmd_proxy.py
@@ -1,0 +1,116 @@
+"""Lifecycle tests for `tj proxy` (#219) — enable/disable/status/killswitch.
+
+`proxy` is in `no_db_commands`, so these patch `open_db` with an
+`AssertionError` side effect to prove the command never opens the DB. Config and
+the Claude Code settings env are written under a tmp HOME so nothing touches the
+developer's real files.
+"""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+from click.testing import CliRunner
+
+from tokenjam.cli.main import cli
+from tokenjam.core.config import TjConfig, load_config
+
+
+@pytest.fixture
+def runner():
+    return CliRunner()
+
+
+@pytest.fixture
+def env(tmp_path, monkeypatch):
+    """Isolated HOME + a project config path the proxy commands write to."""
+    home = tmp_path / "home"
+    home.mkdir()
+    monkeypatch.setenv("HOME", str(home))
+    cfg_path = tmp_path / "tj.toml"
+    cfg_path.write_text('version = "1"\n')
+    return {"home": home, "cfg_path": cfg_path}
+
+
+def _invoke(runner, cfg_path, args):
+    config = load_config(str(cfg_path))
+    # proxy is a no_db_command — assert it never opens the DB.
+    with patch("tokenjam.cli.main.load_config", return_value=config), \
+         patch("tokenjam.cli.main.open_db",
+               side_effect=AssertionError("proxy must not open the DB")):
+        return runner.invoke(cli, args, obj=None)
+
+
+def _read_proxy(cfg_path) -> TjConfig:
+    return load_config(str(cfg_path)).proxy
+
+
+def test_enable_sets_config_and_wires_env(runner, env):
+    res = _invoke(runner, env["cfg_path"], ["proxy", "enable"])
+    assert res.exit_code == 0, res.output
+    proxy = _read_proxy(env["cfg_path"])
+    assert proxy.enabled is True
+    assert proxy.killswitch is False
+    # Base-URL env wired into ~/.claude/settings.json.
+    settings = json.loads((env["home"] / ".claude" / "settings.json").read_text())
+    base = f"http://{proxy.host}:{proxy.port}"
+    assert settings["env"]["ANTHROPIC_BASE_URL"] == base
+    assert settings["env"]["OPENAI_BASE_URL"] == base
+
+
+def test_disable_clears_config_and_unwires(runner, env):
+    _invoke(runner, env["cfg_path"], ["proxy", "enable"])
+    res = _invoke(runner, env["cfg_path"], ["proxy", "disable"])
+    assert res.exit_code == 0, res.output
+    assert _read_proxy(env["cfg_path"]).enabled is False
+    settings = json.loads((env["home"] / ".claude" / "settings.json").read_text())
+    assert "ANTHROPIC_BASE_URL" not in settings.get("env", {})
+    assert "OPENAI_BASE_URL" not in settings.get("env", {})
+
+
+def test_disable_leaves_user_custom_base_url_untouched(runner, env):
+    # A user's own ANTHROPIC_BASE_URL (not our proxy) must survive disable.
+    claude = env["home"] / ".claude"
+    claude.mkdir(parents=True)
+    (claude / "settings.json").write_text(json.dumps(
+        {"env": {"ANTHROPIC_BASE_URL": "https://my-gateway.example"}}))
+    _invoke(runner, env["cfg_path"], ["proxy", "disable"])
+    settings = json.loads((claude / "settings.json").read_text())
+    assert settings["env"]["ANTHROPIC_BASE_URL"] == "https://my-gateway.example"
+
+
+def test_killswitch_engage_and_release(runner, env):
+    _invoke(runner, env["cfg_path"], ["proxy", "enable"])
+    _invoke(runner, env["cfg_path"], ["proxy", "killswitch"])
+    assert _read_proxy(env["cfg_path"]).killswitch is True
+    _invoke(runner, env["cfg_path"], ["proxy", "killswitch", "--off"])
+    assert _read_proxy(env["cfg_path"]).killswitch is False
+
+
+def test_status_json_reports_state(runner, env):
+    _invoke(runner, env["cfg_path"], ["proxy", "enable"])
+    res = _invoke(runner, env["cfg_path"], ["--json", "proxy", "status"])
+    assert res.exit_code == 0, res.output
+    payload = json.loads(res.output)
+    assert payload["enabled"] is True
+    assert payload["port"] == 7392
+    assert payload["mode"] == "suggest"
+    assert "ANTHROPIC_BASE_URL" in payload["wiring"]
+    assert payload["orphaned_wiring"] == []
+
+
+def test_doctor_flags_orphaned_wiring(runner, env, tmp_path):
+    # Enable (wires env), then disable ONLY the config flag by hand so the env
+    # wiring is left orphaned — doctor must flag it.
+    _invoke(runner, env["cfg_path"], ["proxy", "enable"])
+    # Re-disable just the config (simulating a hand-edit), keep the env wiring.
+    from tokenjam.core.config import write_config
+    cfg = load_config(str(env["cfg_path"]))
+    cfg.proxy.enabled = False
+    write_config(cfg, env["cfg_path"])
+
+    from tokenjam.proxy.wiring import find_orphaned_wiring
+    reloaded = load_config(str(env["cfg_path"]))
+    assert find_orphaned_wiring(reloaded) == ["ANTHROPIC_BASE_URL", "OPENAI_BASE_URL"]

--- a/tests/integration/test_proxy_app.py
+++ b/tests/integration/test_proxy_app.py
@@ -1,0 +1,175 @@
+"""Integration tests for the proxy forwarding app (#219) — suggest mode.
+
+Uses ``httpx.MockTransport`` as the upstream provider (no real network) and
+``httpx.ASGITransport`` to drive the proxy app. Verifies:
+- subscription/unknown → forwarded UNMODIFIED + recorded observe-only,
+- api/usage → recorded on the policy path (still forwarded in suggest mode),
+- pass-through is sacred: a classification error still forwards,
+- the proxy holds no keys: the caller's credentials pass through untouched,
+- streaming responses are forwarded as streams.
+"""
+from __future__ import annotations
+
+import httpx
+import pytest
+
+from tokenjam.core.config import ProviderBudget, TjConfig
+from tokenjam.proxy import app as proxy_app_module
+from tokenjam.proxy.app import build_proxy_app
+from tokenjam.proxy.observer import ProxyObserver
+
+
+def _config(provider_plans: dict[str, str]) -> TjConfig:
+    return TjConfig(
+        version="1",
+        budgets={p: ProviderBudget(plan=plan) for p, plan in provider_plans.items()},
+    )
+
+
+class _Upstream:
+    """Records the last forwarded request and returns a canned response.
+
+    The handler is async and returns an async-streamed body so the full
+    forward path exercises streaming (``client.send(stream=True)`` →
+    ``aiter_raw()``), matching how a real provider responds.
+    """
+
+    def __init__(self, status: int = 200, body: bytes = b'{"ok":true}',
+                 headers: dict | None = None, chunks: list[bytes] | None = None):
+        self.last_request: httpx.Request | None = None
+        self.last_body: bytes | None = None
+        self._status = status
+        self._headers = headers or {"content-type": "application/json"}
+        self._chunks = chunks if chunks is not None else [body]
+
+    async def handler(self, request: httpx.Request) -> httpx.Response:
+        # Read the body so we can assert it was forwarded unmodified.
+        self.last_body = await request.aread()
+        self.last_request = request
+        chunks = list(self._chunks)
+
+        async def _agen():
+            for c in chunks:
+                yield c
+
+        return httpx.Response(self._status, headers=self._headers, content=_agen())
+
+
+def _make_client(upstream: _Upstream) -> httpx.AsyncClient:
+    return httpx.AsyncClient(transport=httpx.MockTransport(upstream.handler))
+
+
+async def _call(app, method, path, **kwargs) -> httpx.Response:
+    transport = httpx.ASGITransport(app=app)
+    async with httpx.AsyncClient(transport=transport, base_url="http://proxy") as client:
+        return await client.request(method, path, **kwargs)
+
+
+@pytest.mark.asyncio
+async def test_subscription_forwarded_unmodified_and_observed():
+    cfg = _config({"anthropic": "max_5x"})
+    upstream = _Upstream()
+    observer = ProxyObserver()
+    app = build_proxy_app(cfg, observer=observer, client=_make_client(upstream))
+
+    body = b'{"model":"claude-3","messages":[]}'
+    resp = await _call(app, "POST", "/v1/messages", content=body,
+                       headers={"x-api-key": "sk-caller", "anthropic-version": "2023-06-01"})
+
+    assert resp.status_code == 200
+    # Forwarded UNMODIFIED to the real provider.
+    assert upstream.last_request is not None
+    assert str(upstream.last_request.url) == "https://api.anthropic.com/v1/messages"
+    assert upstream.last_body == body
+    # Observed only — never a policy decision.
+    obs = observer.observations
+    assert len(obs) == 1
+    assert obs[0].provider == "anthropic"
+    assert obs[0].pricing_mode == "subscription"
+    assert obs[0].decision == "observe_only"
+    assert obs[0].forwarded is True
+
+
+@pytest.mark.asyncio
+async def test_api_reaches_policy_path_but_still_forwards():
+    cfg = _config({"openai": "api"})
+    upstream = _Upstream()
+    observer = ProxyObserver()
+    app = build_proxy_app(cfg, observer=observer, client=_make_client(upstream))
+
+    resp = await _call(app, "POST", "/v1/chat/completions", content=b"{}",
+                       headers={"authorization": "Bearer sk-caller"})
+
+    assert resp.status_code == 200
+    assert str(upstream.last_request.url) == "https://api.openai.com/v1/chat/completions"
+    # api/usage-billed is the ONLY traffic on the policy path; suggest mode still
+    # forwards it unmodified (enforces nothing).
+    assert observer.observations[0].decision == "policy"
+    assert observer.observations[0].forwarded is True
+
+
+@pytest.mark.asyncio
+async def test_holds_no_keys_client_credentials_pass_through():
+    cfg = _config({"anthropic": "api"})
+    upstream = _Upstream()
+    app = build_proxy_app(cfg, observer=ProxyObserver(), client=_make_client(upstream))
+
+    await _call(app, "POST", "/v1/messages", content=b"{}",
+                headers={"x-api-key": "sk-secret-caller-key"})
+
+    # The proxy holds no keys — the caller's credential reaches upstream as-is,
+    # and the proxy never injected one of its own.
+    assert upstream.last_request.headers.get("x-api-key") == "sk-secret-caller-key"
+
+
+@pytest.mark.asyncio
+async def test_pass_through_on_classification_error(monkeypatch):
+    cfg = _config({"anthropic": "api"})
+    upstream = _Upstream()
+    observer = ProxyObserver()
+
+    def _boom(*a, **k):
+        raise RuntimeError("classifier exploded")
+
+    # Pass-through is sacred: even if classification raises, the request must
+    # still be forwarded unmodified.
+    monkeypatch.setattr(proxy_app_module, "classify", _boom)
+    app = build_proxy_app(cfg, observer=observer, client=_make_client(upstream))
+
+    resp = await _call(app, "POST", "/v1/messages", content=b'{"x":1}')
+
+    assert resp.status_code == 200
+    assert upstream.last_request is not None            # forwarded despite the error
+    assert upstream.last_body == b'{"x":1}'
+    # A fail-safe observe-only record is still produced.
+    assert observer.observations[0].decision == "observe_only"
+    assert observer.observations[0].reason == "classification_error_failsafe"
+
+
+@pytest.mark.asyncio
+async def test_streaming_response_forwarded_as_stream():
+    cfg = _config({"anthropic": "api"})
+    # An SSE-style streamed upstream body, forwarded chunk-by-chunk.
+    chunks = [b"data: a\n\n", b"data: b\n\n", b"data: [DONE]\n\n"]
+    upstream = _Upstream(headers={"content-type": "text/event-stream"}, chunks=chunks)
+    app = build_proxy_app(cfg, observer=ProxyObserver(), client=_make_client(upstream))
+
+    transport = httpx.ASGITransport(app=app)
+    async with httpx.AsyncClient(transport=transport, base_url="http://proxy") as client:
+        async with client.stream("POST", "/v1/messages", content=b"{}") as resp:
+            assert resp.status_code == 200
+            assert resp.headers.get("content-type") == "text/event-stream"
+            received = b"".join([part async for part in resp.aiter_raw()])
+
+    assert received == b"".join(chunks)
+
+
+@pytest.mark.asyncio
+async def test_unrecognised_path_returns_404_no_forward():
+    cfg = _config({"anthropic": "api"})
+    upstream = _Upstream()
+    app = build_proxy_app(cfg, observer=ProxyObserver(), client=_make_client(upstream))
+
+    resp = await _call(app, "GET", "/v1/unknown-endpoint")
+    assert resp.status_code == 404
+    assert upstream.last_request is None  # nothing forwarded for an unknown upstream

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -199,6 +199,20 @@ class TestSerialise:
         assert restored.security.ingest_secret == "secret123"
         assert restored.capture.prompts is True
 
+    def test_proxy_roundtrip(self):
+        """[proxy] config round-trips through serialise/parse (#219)."""
+        config = TjConfig(version="1")
+        config.proxy.enabled = True
+        config.proxy.killswitch = True
+        config.proxy.port = 7392
+        restored = _parse(_serialise(config))
+        assert restored.proxy.enabled is True
+        assert restored.proxy.killswitch is True
+        assert restored.proxy.port == 7392
+        assert restored.proxy.mode == "suggest"
+        # Defaults when [proxy] is absent.
+        assert _parse({"version": "1"}).proxy.enabled is False
+
     def test_serialise_excludes_config_path(self):
         """Regression: config_path is a Path object which is not TOML
         serializable. _serialise() must exclude it. See v0.1.7 fix."""

--- a/tests/unit/test_proxy_gate.py
+++ b/tests/unit/test_proxy_gate.py
@@ -1,0 +1,82 @@
+"""Unit tests for the proxy pricing-mode gate — the substrate invariant (#219).
+
+The invariant: resolve pricing mode FIRST; subscription AND unknown (fail-safe)
+AND local are forwarded unmodified (observe-only); ONLY api/usage-billed reaches
+the policy path. The killswitch forces observe-only regardless.
+
+These configs declare a budget for an UNRELATED provider where the "no plan for
+this provider" case is exercised, so ``_declared_budget_plans`` does not fall
+back to reading the developer's real global ``~/.config/tj/config.toml`` (#106).
+"""
+from __future__ import annotations
+
+import pytest
+
+from tokenjam.core.config import ProviderBudget, TjConfig
+from tokenjam.proxy.gate import OBSERVE_ONLY, POLICY, classify
+
+
+def _config(provider_plans: dict[str, str | None]) -> TjConfig:
+    budgets = {p: ProviderBudget(plan=plan) for p, plan in provider_plans.items()}
+    return TjConfig(version="1", budgets=budgets)
+
+
+def test_api_plan_reaches_policy_path():
+    cfg = _config({"anthropic": "api"})
+    d = classify(cfg, "anthropic")
+    assert d.pricing_mode == "api"
+    assert d.path == POLICY
+    assert not d.observe_only
+
+
+@pytest.mark.parametrize("plan", ["pro", "max_5x", "max_20x", "plus", "team", "enterprise"])
+def test_subscription_plans_are_observe_only(plan):
+    cfg = _config({"anthropic": plan})
+    d = classify(cfg, "anthropic")
+    assert d.pricing_mode == "subscription"
+    assert d.path == OBSERVE_ONLY  # TOS: never a policy decision
+    assert d.observe_only
+
+
+def test_local_plan_is_observe_only():
+    cfg = _config({"anthropic": "local"})
+    d = classify(cfg, "anthropic")
+    assert d.pricing_mode == "local"
+    assert d.path == OBSERVE_ONLY
+
+
+def test_unknown_is_failsafe_observe_only():
+    # The config declares a plan for openai only — so anthropic has no declared
+    # plan and resolves to "unknown" WITHOUT hitting the global-config fallback
+    # (budgets is non-empty). Unknown must fail safe to observe-only.
+    cfg = _config({"openai": "api"})
+    d = classify(cfg, "anthropic")
+    assert d.plan_tier is None
+    assert d.pricing_mode == "unknown"
+    assert d.path == OBSERVE_ONLY
+
+
+def test_unrecognised_provider_is_observe_only():
+    cfg = _config({"anthropic": "api"})
+    d = classify(cfg, "some-other-provider")
+    assert d.pricing_mode == "unknown"
+    assert d.path == OBSERVE_ONLY
+
+
+def test_killswitch_forces_observe_only_even_for_api():
+    cfg = _config({"anthropic": "api"})
+    d = classify(cfg, "anthropic", killswitch=True)
+    assert d.pricing_mode == "api"          # mode is still resolved + inspectable
+    assert d.path == OBSERVE_ONLY           # but the path is forced to passthrough
+    assert d.killswitch is True
+    assert d.reason == "killswitch_passthrough"
+
+
+def test_decision_is_inspectable():
+    # The whole point: the invariant is a plain, inspectable value object.
+    cfg = _config({"openai": "api"})
+    d = classify(cfg, "openai")
+    assert d.provider == "openai"
+    assert d.plan_tier == "api"
+    assert d.path == POLICY
+    assert d.reason == "api_usage_billed"

--- a/tokenjam/cli/cmd_doctor.py
+++ b/tokenjam/cli/cmd_doctor.py
@@ -54,6 +54,9 @@ def cmd_doctor(ctx: click.Context, output_json: bool, repair: bool) -> None:
     # 10. Live-span staleness — flags a stalled OTLP connection (issue #179)
     checks.append(_check_span_staleness(ctx.obj["db"]))
 
+    # 11. Proxy base-URL wiring consistency (issue #219)
+    checks.append(_check_proxy_wiring(config))
+
     if output_json:
         click.echo(json.dumps(checks, default=str))
     else:
@@ -136,6 +139,35 @@ def _check_prometheus(config: object) -> dict:
                 "message": f"Enabled on port {config.export.prometheus.port}"}
     return {"name": "Prometheus", "level": "info",
             "message": "Prometheus export disabled."}
+
+
+def _check_proxy_wiring(config: object) -> dict:
+    """Flag orphaned proxy base-URL wiring (#219).
+
+    The dangerous state: an agent's provider base-URL points at the proxy port
+    but the proxy is disabled — traffic would hit a dead listener. Reuses the
+    proxy wiring helper so the check and `tj proxy` agree.
+    """
+    from tokenjam.proxy.wiring import find_orphaned_wiring, proxy_base_url
+    try:
+        orphaned = find_orphaned_wiring(config)
+    except Exception:  # noqa: BLE001 — best-effort; never fail doctor on this
+        orphaned = []
+    if orphaned:
+        return {
+            "name": "Proxy wiring", "level": "warning",
+            "message": (
+                f"{', '.join(orphaned)} point at the tj proxy "
+                f"({proxy_base_url(config)}) but the proxy is disabled. Agent "
+                "traffic would hit a dead port. Run `tj proxy enable` to start "
+                "the listener or `tj proxy disable` to remove the wiring."
+            ),
+        }
+    if getattr(config.proxy, "enabled", False):
+        return {"name": "Proxy wiring", "level": "ok",
+                "message": f"Proxy enabled on {proxy_base_url(config)} (suggest mode)."}
+    return {"name": "Proxy wiring", "level": "ok",
+            "message": "Proxy disabled; no orphaned base-URL wiring."}
 
 
 def _check_schema_vs_capture(config: object) -> dict:

--- a/tokenjam/cli/cmd_proxy.py
+++ b/tokenjam/cli/cmd_proxy.py
@@ -1,0 +1,134 @@
+"""``tj proxy`` — lifecycle for the optional enforcement-plane proxy (#219).
+
+Suggest mode only. Subcommands:
+
+- ``enable``     — turn the proxy on in config + wire provider base-URLs at it.
+- ``disable``    — turn it off + remove the base-URL wiring.
+- ``status``     — show config, killswitch, and detected base-URL wiring.
+- ``killswitch`` — flip to pass-through-everything (``--off`` to release).
+
+These read/write only config (+ Claude Code's settings env), so ``proxy`` is in
+``no_db_commands`` and never opens the DB.
+"""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import click
+
+from tokenjam.core.config import write_config
+from tokenjam.proxy.wiring import (
+    apply_env_wiring,
+    detect_wiring,
+    find_orphaned_wiring,
+    proxy_base_url,
+    remove_env_wiring,
+)
+from tokenjam.utils.formatting import console
+
+
+def _config_write_path(config) -> Path:
+    """Where to persist proxy config — the active file, else the global config."""
+    if getattr(config, "config_path", None):
+        return Path(config.config_path)
+    return Path.home() / ".config" / "tj" / "config.toml"
+
+
+@click.group("proxy")
+def cmd_proxy() -> None:
+    """Manage the optional enforcement-plane proxy (suggest mode)."""
+
+
+@cmd_proxy.command("enable")
+@click.pass_context
+def proxy_enable(ctx: click.Context) -> None:
+    """Enable the proxy and point provider base-URLs at it."""
+    config = ctx.obj["config"]
+    config.proxy.enabled = True
+    config.proxy.killswitch = False
+    path = _config_write_path(config)
+    write_config(config, path)
+    wired = apply_env_wiring(config)
+
+    url = proxy_base_url(config)
+    console.print(f"[green]Proxy enabled[/green] (suggest mode) — will listen on {url}")
+    console.print(f"  Config:  {path}")
+    console.print(f"  Wired:   {', '.join(wired)} → {url} (~/.claude/settings.json)")
+    console.print("[dim]Subscription/unknown traffic is forwarded unmodified "
+                  "(observe-only). Restart `tj serve` to start the listener.[/dim]")
+
+
+@cmd_proxy.command("disable")
+@click.pass_context
+def proxy_disable(ctx: click.Context) -> None:
+    """Disable the proxy and remove the base-URL wiring."""
+    config = ctx.obj["config"]
+    config.proxy.enabled = False
+    config.proxy.killswitch = False
+    path = _config_write_path(config)
+    write_config(config, path)
+    removed = remove_env_wiring(config)
+
+    console.print("[yellow]Proxy disabled[/yellow]")
+    console.print(f"  Config:  {path}")
+    if removed:
+        console.print(f"  Unwired: {', '.join(removed)} (~/.claude/settings.json)")
+    console.print("[dim]Restart `tj serve` to stop the listener.[/dim]")
+
+
+@cmd_proxy.command("killswitch")
+@click.option("--off", "release", is_flag=True, help="Release the killswitch.")
+@click.pass_context
+def proxy_killswitch(ctx: click.Context, release: bool) -> None:
+    """Flip the proxy to pass-through-everything (listener stays alive)."""
+    config = ctx.obj["config"]
+    config.proxy.killswitch = not release
+    path = _config_write_path(config)
+    write_config(config, path)
+    if release:
+        console.print("[green]Killswitch released[/green] — normal classification resumes.")
+    else:
+        console.print("[red]Killswitch engaged[/red] — ALL traffic forwarded "
+                      "unmodified (pass-through). Listener stays alive.")
+    console.print(f"  Config:  {path}")
+    console.print("[dim]Restart `tj serve` for the running listener to pick this up.[/dim]")
+
+
+@cmd_proxy.command("status")
+@click.pass_context
+def proxy_status(ctx: click.Context) -> None:
+    """Show proxy config + base-URL wiring state."""
+    config = ctx.obj["config"]
+    p = config.proxy
+    wiring = detect_wiring(config)
+    orphaned = find_orphaned_wiring(config)
+    payload = {
+        "enabled": p.enabled,
+        "host": p.host,
+        "port": p.port,
+        "mode": p.mode,
+        "killswitch": p.killswitch,
+        "base_url": proxy_base_url(config),
+        "anthropic_base_url": p.anthropic_base_url,
+        "openai_base_url": p.openai_base_url,
+        "wiring": wiring,
+        "orphaned_wiring": orphaned,
+    }
+    if ctx.obj.get("output_json"):
+        click.echo(json.dumps(payload, indent=2))
+        return
+
+    state = "[green]enabled[/green]" if p.enabled else "[dim]disabled[/dim]"
+    ks = " [red](killswitch engaged)[/red]" if p.killswitch else ""
+    console.print(f"tj proxy: {state}{ks}")
+    console.print(f"  Listen:    http://{p.host}:{p.port}  (mode: {p.mode})")
+    console.print(f"  Upstreams: anthropic={p.anthropic_base_url}  openai={p.openai_base_url}")
+    if wiring:
+        console.print(f"  Wiring:    {', '.join(wiring)} → {proxy_base_url(config)}")
+    else:
+        console.print("  Wiring:    none detected (~/.claude/settings.json)")
+    if orphaned:
+        console.print(f"  [yellow]Orphaned wiring:[/yellow] {', '.join(orphaned)} "
+                      "points at the proxy but it is disabled. "
+                      "Run `tj proxy enable` or `tj proxy disable`.")

--- a/tokenjam/cli/cmd_serve.py
+++ b/tokenjam/cli/cmd_serve.py
@@ -58,10 +58,20 @@ def cmd_serve(ctx: click.Context, host: str | None, port: int | None,
     import json as _json
     _state_path = Path.home() / ".local" / "share" / "tj" / "server.state"
 
+    # Optional enforcement-plane proxy (#219) — a second in-process listener on
+    # config.proxy.port, started/stopped with the server's lifespan. Suggest
+    # mode only; the pricing-mode gate forwards subscription/unknown unmodified.
+    proxy_runner = None
+    if config.proxy.enabled:
+        from tokenjam.proxy.server import ProxyRunner
+        proxy_runner = ProxyRunner(config)
+
     @asynccontextmanager
     async def _lifespan(_app: FastAPI) -> AsyncIterator[None]:
         # startup
         scheduler.start()
+        if proxy_runner is not None:
+            proxy_runner.start()
         # Stamp unknown sessions from declared [budget.*].plan on startup so
         # historical/backfilled rows match config without a separate onboard pass.
         from tokenjam.core.framing import apply_declared_plans_to_sessions
@@ -84,6 +94,8 @@ def cmd_serve(ctx: click.Context, host: str | None, port: int | None,
             yield
         finally:
             # shutdown
+            if proxy_runner is not None:
+                await proxy_runner.stop()
             scheduler.shutdown(wait=False)
 
     app = create_app(config, db, pipeline, lifespan=_lifespan)
@@ -92,6 +104,12 @@ def cmd_serve(ctx: click.Context, host: str | None, port: int | None,
     console.print(f"  API docs:    http://{bind_host}:{bind_port}/docs")
     if config.export.prometheus.enabled:
         console.print(f"  Metrics:     http://{bind_host}:{bind_port}/metrics")
+    if config.proxy.enabled:
+        _ks = " [yellow](killswitch: pass-through)[/yellow]" if config.proxy.killswitch else ""
+        console.print(
+            f"  Proxy:       http://{config.proxy.host}:{config.proxy.port} "
+            f"(suggest mode){_ks}"
+        )
     console.print()
 
     if reload:

--- a/tokenjam/cli/main.py
+++ b/tokenjam/cli/main.py
@@ -40,7 +40,7 @@ def cli(ctx: click.Context, config_path: str | None, output_json: bool,
         config.storage.path = db_path
 
     # Commands that don't need a database connection
-    no_db_commands = {"stop", "uninstall", "onboard", "mcp", "demo", "policy"}
+    no_db_commands = {"stop", "uninstall", "onboard", "mcp", "demo", "policy", "proxy"}
     invoked = ctx.invoked_subcommand
     if invoked in no_db_commands:
         ctx.obj["config"] = config
@@ -103,6 +103,7 @@ from tokenjam.cli.cmd_tokenmaxx import cmd_tokenmaxx  # noqa: E402
 from tokenjam.cli.cmd_backfill import cmd_backfill  # noqa: E402
 from tokenjam.cli.cmd_report import cmd_report  # noqa: E402
 from tokenjam.cli.cmd_policy import cmd_policy  # noqa: E402
+from tokenjam.cli.cmd_proxy import cmd_proxy  # noqa: E402
 
 cli.add_command(cmd_onboard, name="onboard")
 cli.add_command(cmd_status, name="status")
@@ -123,6 +124,7 @@ cli.add_command(cmd_tokenmaxx, name="tokenmaxx")
 cli.add_command(cmd_backfill, name="backfill")
 cli.add_command(cmd_report, name="report")
 cli.add_command(cmd_policy, name="policy")
+cli.add_command(cmd_proxy, name="proxy")
 
 # cmd_drift is provided by task 05 — register if available
 try:

--- a/tokenjam/core/config.py
+++ b/tokenjam/core/config.py
@@ -131,6 +131,30 @@ class ApiConfig:
 
 
 @dataclass
+class ProxyConfig:
+    """Optional in-process enforcement-plane proxy (#219), off by default.
+
+    When ``enabled``, ``tj serve`` runs a second listener on ``port`` that sits
+    between an agent and its LLM provider, speaking the Anthropic
+    (``/v1/messages``) and OpenAI (``/v1/chat/completions``) APIs. It ships in
+    SUGGEST MODE ONLY — it records what a policy *would* do and enforces nothing.
+
+    The pricing-mode gate is a built-in invariant (not a toggle): subscription
+    and ``unknown`` traffic is always forwarded unmodified (observe-only), and
+    only api/usage-billed traffic reaches the policy path. ``killswitch`` flips
+    the proxy to pass-through-everything while keeping the listener alive.
+    """
+    enabled:            bool = False
+    host:               str  = "127.0.0.1"
+    port:               int  = 7392
+    # "suggest" only for now; the enforce-mode path lands behind a later gate (#220).
+    mode:               str  = "suggest"
+    killswitch:         bool = False
+    anthropic_base_url: str  = "https://api.anthropic.com"
+    openai_base_url:    str  = "https://api.openai.com"
+
+
+@dataclass
 class CaptureConfig:
     prompts:      bool = False
     completions:  bool = False
@@ -173,6 +197,7 @@ class TjConfig:
     alerts:   AlertsConfig            = field(default_factory=AlertsConfig)
     security: SecurityConfig          = field(default_factory=SecurityConfig)
     api:      ApiConfig               = field(default_factory=ApiConfig)
+    proxy:    ProxyConfig             = field(default_factory=ProxyConfig)
     capture:  CaptureConfig           = field(default_factory=CaptureConfig)
     budgets:  dict[str, ProviderBudget] = field(default_factory=dict)
     # Path to the config file on disk; set by load_config() so that relative
@@ -378,6 +403,17 @@ def _parse(raw: dict) -> TjConfig:
         auth=api_auth,
     )
 
+    proxy_raw = raw.get("proxy", {})
+    proxy = ProxyConfig(
+        enabled=proxy_raw.get("enabled", False),
+        host=proxy_raw.get("host", ProxyConfig.host),
+        port=proxy_raw.get("port", ProxyConfig.port),
+        mode=proxy_raw.get("mode", ProxyConfig.mode),
+        killswitch=proxy_raw.get("killswitch", False),
+        anthropic_base_url=proxy_raw.get("anthropic_base_url", ProxyConfig.anthropic_base_url),
+        openai_base_url=proxy_raw.get("openai_base_url", ProxyConfig.openai_base_url),
+    )
+
     capture_raw = raw.get("capture", {})
     capture = CaptureConfig(
         prompts=capture_raw.get("prompts", False),
@@ -412,6 +448,7 @@ def _parse(raw: dict) -> TjConfig:
         alerts=alerts,
         security=security,
         api=api,
+        proxy=proxy,
         capture=capture,
         budgets=budgets,
     )

--- a/tokenjam/core/framing.py
+++ b/tokenjam/core/framing.py
@@ -153,6 +153,22 @@ def config_declared_plan_labels(config: Any) -> list[str]:
     return labels
 
 
+def provider_pricing_mode(config: Any, provider: str) -> tuple[str | None, str]:
+    """Resolve ``(plan_tier, pricing_mode)`` for a single provider's declared plan.
+
+    The proxy's pricing-mode gate (#219) needs the mode for the *specific*
+    provider a request targets (anthropic vs openai), not the dominant mix. This
+    reuses the existing declared-plan lookup (:func:`_declared_budget_plans`,
+    with the #106 global-config fallback) and :func:`pricing_mode_for` — the
+    pricing-mode rule is never re-derived. Returns ``(None, "unknown")`` when no
+    plan is declared for that provider, so the gate fails safe to observe-only.
+    """
+    for prov, tier in _declared_budget_plans(config):
+        if prov == provider:
+            return tier, pricing_mode_for(tier)
+    return None, "unknown"
+
+
 def config_declared_plan(config: Any) -> str | None:
     """Return the user's declared plan tier from config.
 

--- a/tokenjam/proxy/__init__.py
+++ b/tokenjam/proxy/__init__.py
@@ -1,0 +1,30 @@
+"""Optional enforcement-plane proxy (suggest mode only) — issue #219.
+
+An in-process listener inside ``tj serve`` (default port 7392) that sits between
+an agent and its LLM provider, speaking the Anthropic (``/v1/messages``) and
+OpenAI (``/v1/chat/completions``) APIs. It ships in SUGGEST MODE ONLY: it
+records what a policy *would* do and enforces nothing.
+
+The package is layered so the safety-critical decision logic carries no HTTP
+dependency and is trivially unit-testable:
+
+- :mod:`tokenjam.proxy.gate` — the pricing-mode gate invariant (pure).
+- :mod:`tokenjam.proxy.observer` — observe-only decision recorder.
+- :mod:`tokenjam.proxy.app` — the Starlette forwarding app (HTTP).
+- :mod:`tokenjam.proxy.server` — build/run the proxy listener inside ``tj serve``.
+- :mod:`tokenjam.proxy.wiring` — base-URL env wiring + orphan detection.
+
+Pass-through is sacred: any error in classification / policy / metering forwards
+the request unmodified. The proxy holds no keys — client credentials pass
+through from the caller.
+"""
+from __future__ import annotations
+
+from tokenjam.proxy.gate import (
+    OBSERVE_ONLY,
+    POLICY,
+    GateDecision,
+    classify,
+)
+
+__all__ = ["OBSERVE_ONLY", "POLICY", "GateDecision", "classify"]

--- a/tokenjam/proxy/app.py
+++ b/tokenjam/proxy/app.py
@@ -1,0 +1,176 @@
+"""The proxy's HTTP forwarding app (#219) — suggest mode only.
+
+A small Starlette app that speaks the Anthropic (``/v1/messages``) and OpenAI
+(``/v1/chat/completions``) request shapes, runs the pricing-mode gate, and
+forwards the request to the real provider **unmodified**, streaming the response
+back. It holds no keys — the caller's credentials pass straight through.
+
+Safety doctrine, enforced structurally:
+- The gate runs first, but in suggest mode the *action* is identical for both
+  paths (forward unmodified). The gate decision is only **recorded**.
+- Pass-through is sacred: any error in classification / recording is swallowed
+  and the request is forwarded anyway.
+"""
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+import httpx
+from starlette.applications import Starlette
+from starlette.background import BackgroundTask
+from starlette.requests import Request
+from starlette.responses import JSONResponse, StreamingResponse
+from starlette.routing import Route
+
+from tokenjam.proxy.gate import classify
+from tokenjam.proxy.observer import ProxyObserver
+
+logger = logging.getLogger("tokenjam.proxy")
+
+# Per-route provider mapping. The path itself identifies the provider's API
+# shape; the catch-all resolves to "unknown" → observe-only (fail-safe).
+_ROUTE_PROVIDER = {
+    "/v1/messages": "anthropic",
+    "/v1/chat/completions": "openai",
+}
+
+# Hop-by-hop headers must not be forwarded (RFC 7230 §6.1) plus host/length,
+# which httpx / the ASGI server recompute for the new connection.
+_HOP_BY_HOP = frozenset({
+    "host", "content-length", "connection", "keep-alive", "proxy-authenticate",
+    "proxy-authorization", "te", "trailer", "transfer-encoding", "upgrade",
+})
+
+
+def _provider_for(path: str) -> str:
+    return _ROUTE_PROVIDER.get(path, "unknown")
+
+
+def _base_url_for(config: Any, provider: str) -> str | None:
+    if provider == "anthropic":
+        return config.proxy.anthropic_base_url.rstrip("/")
+    if provider == "openai":
+        return config.proxy.openai_base_url.rstrip("/")
+    return None
+
+
+def _forward_headers(request: Request) -> list[tuple[bytes, bytes]]:
+    """Client headers minus hop-by-hop — credentials pass through untouched."""
+    return [
+        (k, v) for k, v in request.headers.raw
+        if k.decode("latin-1").lower() not in _HOP_BY_HOP
+    ]
+
+
+def _response_headers(upstream: httpx.Response) -> list[tuple[bytes, bytes]]:
+    return [
+        (k, v) for k, v in upstream.headers.raw
+        if k.decode("latin-1").lower() not in _HOP_BY_HOP
+    ]
+
+
+def build_proxy_app(config: Any, observer: ProxyObserver | None = None,
+                    client: httpx.AsyncClient | None = None) -> Starlette:
+    """Build the Starlette proxy app.
+
+    ``observer`` and ``client`` are injectable for testing — pass an
+    ``httpx.AsyncClient`` backed by ``httpx.MockTransport`` to avoid real
+    network calls. When ``client`` is None a real client is created on startup
+    and closed on shutdown.
+    """
+    observer = observer or ProxyObserver()
+    state: dict[str, Any] = {"client": client, "owns_client": client is None}
+
+    async def _get_client() -> httpx.AsyncClient:
+        if state["client"] is None:
+            state["client"] = httpx.AsyncClient(timeout=httpx.Timeout(600.0))
+        return state["client"]
+
+    async def _forward(request: Request, base_url: str) -> StreamingResponse:
+        client_ = await _get_client()
+        url = base_url + request.url.path
+        if request.url.query:
+            url += "?" + request.url.query
+        body = await request.body()
+        upstream_req = client_.build_request(
+            request.method, url, headers=_forward_headers(request), content=body,
+        )
+        upstream = await client_.send(upstream_req, stream=True)
+        return StreamingResponse(
+            upstream.aiter_raw(),
+            status_code=upstream.status_code,
+            headers={k.decode("latin-1"): v.decode("latin-1")
+                     for k, v in _response_headers(upstream)},
+            background=BackgroundTask(upstream.aclose),
+        )
+
+    async def _handle(request: Request) -> Any:
+        provider = _provider_for(request.url.path)
+        base_url = _base_url_for(config, provider)
+
+        # The pricing-mode gate runs FIRST. Pass-through is sacred: if anything
+        # in classification raises, we forward unmodified anyway.
+        decision = None
+        try:
+            decision = classify(
+                config, provider, killswitch=bool(config.proxy.killswitch),
+            )
+        except Exception:  # noqa: BLE001 — never let our logic break traffic
+            logger.exception("proxy gate classification failed; forwarding unmodified")
+
+        # No upstream known (unrecognised path) → nothing to forward to.
+        if base_url is None:
+            _safe_record(observer, request, decision, forwarded=False)
+            return JSONResponse(
+                {"error": "tj proxy: unrecognised path; no upstream configured",
+                 "path": request.url.path},
+                status_code=404,
+            )
+
+        # Forward UNMODIFIED (suggest mode enforces nothing on either path).
+        response = await _forward(request, base_url)
+        _safe_record(observer, request, decision, forwarded=True)
+        return response
+
+    routes = [
+        Route("/v1/messages", _handle, methods=["POST"]),
+        Route("/v1/chat/completions", _handle, methods=["POST"]),
+        Route("/{path:path}", _handle, methods=["GET", "POST", "PUT", "DELETE", "PATCH"]),
+    ]
+
+    from contextlib import asynccontextmanager
+
+    @asynccontextmanager
+    async def _lifespan(_app: Starlette):
+        try:
+            yield
+        finally:
+            if state["owns_client"] and state["client"] is not None:
+                await state["client"].aclose()
+
+    app = Starlette(routes=routes, lifespan=_lifespan)
+    app.state.observer = observer
+    app.state.tj_config = config
+    return app
+
+
+def _safe_record(observer: ProxyObserver, request: Request, decision: Any,
+                 *, forwarded: bool) -> None:
+    """Record the observation; recording must never break pass-through."""
+    try:
+        if decision is None:
+            # Classification failed — synthesise a fail-safe observe-only record
+            # so the gate failure is still visible without re-running classify.
+            from tokenjam.proxy.gate import OBSERVE_ONLY, GateDecision
+            decision = GateDecision(
+                provider=_provider_for(request.url.path), plan_tier=None,
+                pricing_mode="unknown", path=OBSERVE_ONLY,
+                reason="classification_error_failsafe",
+            )
+        observer.record(
+            method=request.method, path=request.url.path,
+            decision=decision, forwarded=forwarded,
+        )
+    except Exception:  # noqa: BLE001
+        logger.exception("proxy observation recording failed (ignored)")

--- a/tokenjam/proxy/gate.py
+++ b/tokenjam/proxy/gate.py
@@ -1,0 +1,82 @@
+"""The pricing-mode gate — the non-negotiable substrate invariant (#219).
+
+The FIRST step in the proxy's decision path resolves the session's pricing mode.
+**Subscription traffic — and ``unknown`` as a fail-safe — is forwarded
+UNMODIFIED (observe-only, never a policy decision)**, because intercepting
+subscription-plan traffic is outside provider terms of service. ``local`` is
+treated the same way (not usage-billed). ONLY ``api``/usage-billed traffic
+reaches the policy path.
+
+This module is intentionally pure — it imports only the existing pricing-mode
+logic (``core/framing.provider_pricing_mode`` → ``pricing_mode_for`` →
+``SUBSCRIPTION_PLAN_TIERS`` in ``otel/semconv``) and carries NO HTTP dependency,
+so the invariant stays inspectable and is unit-tested directly.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+from tokenjam.core.framing import provider_pricing_mode
+
+# The two decision paths a request can take.
+OBSERVE_ONLY = "observe_only"  # forward UNMODIFIED; never a policy decision
+POLICY = "policy"              # api/usage-billed → policy path (suggest-mode stub here)
+
+# Providers the proxy understands. Anything else resolves to "unknown" → observe.
+KNOWN_PROVIDERS = frozenset({"anthropic", "openai"})
+
+
+@dataclass(frozen=True)
+class GateDecision:
+    """The result of the pricing-mode gate for one request — fully inspectable.
+
+    ``path`` is the contract the rest of the proxy honors: ``OBSERVE_ONLY``
+    requests are forwarded unmodified and never reach policy evaluation;
+    ``POLICY`` requests reach the (suggest-mode, no-op) policy path. In suggest
+    mode BOTH are forwarded unmodified — the distinction is which requests are
+    *eligible* for enforcement once it lands (#220).
+    """
+    provider:     str
+    plan_tier:    str | None
+    pricing_mode: str          # api | subscription | local | unknown
+    path:         str          # OBSERVE_ONLY | POLICY
+    reason:       str
+    killswitch:   bool = False
+
+    @property
+    def observe_only(self) -> bool:
+        return self.path == OBSERVE_ONLY
+
+
+def classify(config: Any, provider: str, *, killswitch: bool = False) -> GateDecision:
+    """Resolve the pricing mode FIRST, then decide the path — the invariant.
+
+    - ``killswitch`` → always ``OBSERVE_ONLY`` (pass-through-everything).
+    - ``api`` (usage-billed) → ``POLICY`` (the ONLY path to policy evaluation).
+    - subscription / local / unknown → ``OBSERVE_ONLY`` (TOS + fail-safe).
+
+    The pricing mode is read from the existing declared-plan logic, never
+    re-derived here.
+    """
+    plan_tier, pricing_mode = provider_pricing_mode(config, provider)
+
+    if killswitch:
+        return GateDecision(
+            provider=provider, plan_tier=plan_tier, pricing_mode=pricing_mode,
+            path=OBSERVE_ONLY, reason="killswitch_passthrough", killswitch=True,
+        )
+
+    # api/usage-billed is the ONLY traffic that may reach the policy path.
+    if pricing_mode == "api":
+        return GateDecision(
+            provider=provider, plan_tier=plan_tier, pricing_mode=pricing_mode,
+            path=POLICY, reason="api_usage_billed",
+        )
+
+    # Subscription (TOS), local (not usage-billed), and unknown (fail-safe) are
+    # all forwarded unmodified and observed only — never a policy decision.
+    return GateDecision(
+        provider=provider, plan_tier=plan_tier, pricing_mode=pricing_mode,
+        path=OBSERVE_ONLY, reason=f"{pricing_mode}_passthrough",
+    )

--- a/tokenjam/proxy/observer.py
+++ b/tokenjam/proxy/observer.py
@@ -1,0 +1,72 @@
+"""Observe-only recorder for proxy gate decisions (#219).
+
+Every request through the proxy produces an inspectable record of what the gate
+decided (and, on the policy path, what a policy *would* do — nothing yet, this
+is suggest mode). Records are logged and kept in a small in-memory ring so the
+``tj proxy status`` command and tests can inspect recent decisions without any
+DB coupling. This is deliberately lightweight: the proxy never blocks on
+recording, and a recording failure must never affect pass-through.
+"""
+from __future__ import annotations
+
+import logging
+from collections import deque
+from dataclasses import asdict, dataclass
+from typing import Deque
+
+from tokenjam.proxy.gate import GateDecision
+from tokenjam.utils.time_parse import utcnow
+
+logger = logging.getLogger("tokenjam.proxy")
+
+
+@dataclass(frozen=True)
+class ProxyObservation:
+    """One observed request: the gate decision + request shape (no payload)."""
+    ts:           str
+    method:       str
+    path:         str          # request URL path, e.g. /v1/messages
+    provider:     str
+    pricing_mode: str
+    decision:     str          # observe_only | policy
+    reason:       str
+    forwarded:    bool         # always True in suggest mode
+    suggest_only: bool = True  # suggest mode enforces nothing
+
+
+class ProxyObserver:
+    """Keeps the last ``maxlen`` observations and logs each one."""
+
+    def __init__(self, maxlen: int = 256) -> None:
+        self._ring: Deque[ProxyObservation] = deque(maxlen=maxlen)
+
+    def record(self, *, method: str, path: str, decision: GateDecision,
+               forwarded: bool = True) -> ProxyObservation:
+        obs = ProxyObservation(
+            ts=utcnow().isoformat(),
+            method=method,
+            path=path,
+            provider=decision.provider,
+            pricing_mode=decision.pricing_mode,
+            decision=decision.path,
+            reason=decision.reason,
+            forwarded=forwarded,
+        )
+        self._ring.append(obs)
+        # Suggest mode: log what the gate decided; never raise out of recording.
+        try:
+            logger.info(
+                "proxy %s %s provider=%s mode=%s decision=%s reason=%s forwarded=%s",
+                method, path, obs.provider, obs.pricing_mode, obs.decision,
+                obs.reason, forwarded,
+            )
+        except Exception:  # noqa: BLE001 — recording must never break pass-through
+            pass
+        return obs
+
+    @property
+    def observations(self) -> list[ProxyObservation]:
+        return list(self._ring)
+
+    def as_dicts(self) -> list[dict]:
+        return [asdict(o) for o in self._ring]

--- a/tokenjam/proxy/server.py
+++ b/tokenjam/proxy/server.py
@@ -1,0 +1,67 @@
+"""Run the proxy listener in-process inside ``tj serve`` (#219).
+
+``tj serve`` binds the main API on ``api.port``; when ``proxy.enabled`` it also
+runs this second listener on ``proxy.port`` in the SAME event loop, started and
+stopped from the server's lifespan. Keeping it in-process (rather than a
+separate daemon) means the proxy shares the server's lifecycle exactly — it can
+never outlive ``tj serve`` or be orphaned.
+"""
+from __future__ import annotations
+
+import asyncio
+import contextlib
+import logging
+from typing import Any
+
+import uvicorn
+
+from tokenjam.proxy.app import build_proxy_app
+from tokenjam.proxy.observer import ProxyObserver
+
+logger = logging.getLogger("tokenjam.proxy")
+
+
+class ProxyRunner:
+    """Owns the proxy's uvicorn server + its lifecycle within an event loop."""
+
+    def __init__(self, config: Any, observer: ProxyObserver | None = None) -> None:
+        self.config = config
+        self.observer = observer or ProxyObserver()
+        self._server: uvicorn.Server | None = None
+        self._task: asyncio.Task | None = None
+
+    def start(self) -> None:
+        """Schedule the proxy server on the running event loop (non-blocking)."""
+        app = build_proxy_app(self.config, observer=self.observer)
+        uconfig = uvicorn.Config(
+            app,
+            host=self.config.proxy.host,
+            port=self.config.proxy.port,
+            log_level="warning",
+            # The parent tj-serve process already installs signal handlers; the
+            # embedded server must not steal them or it would race shutdown.
+            lifespan="on",
+        )
+        self._server = uvicorn.Server(uconfig)
+        # The parent `tj serve` process owns the process signal handlers. The
+        # embedded proxy server must NOT install or capture them, or it would
+        # override the parent's SIGINT/SIGTERM handling for the lifetime of the
+        # proxy task. Neutralise both the (older) method and the (current)
+        # capture_signals context manager so this stays version-robust.
+        self._server.install_signal_handlers = lambda: None  # type: ignore[assignment]
+        self._server.capture_signals = contextlib.nullcontext  # type: ignore[assignment]
+        self._task = asyncio.create_task(self._server.serve())
+        logger.info(
+            "tj proxy listening on http://%s:%d (mode=%s, killswitch=%s)",
+            self.config.proxy.host, self.config.proxy.port,
+            self.config.proxy.mode, self.config.proxy.killswitch,
+        )
+
+    async def stop(self) -> None:
+        if self._server is not None:
+            self._server.should_exit = True
+        if self._task is not None:
+            try:
+                await self._task
+            except Exception:  # noqa: BLE001
+                logger.exception("tj proxy server task ended with error")

--- a/tokenjam/proxy/wiring.py
+++ b/tokenjam/proxy/wiring.py
@@ -1,0 +1,102 @@
+"""Base-URL env wiring for the proxy (#219).
+
+``tj proxy enable`` points an agent's provider base-URLs at the local proxy so
+its traffic flows through it; ``disable`` removes that wiring. The wiring lives
+in Claude Code's global settings (``~/.claude/settings.json`` ``env`` block) —
+the same file ``tj onboard --claude-code`` already manages — so it survives
+restarts and is discoverable.
+
+"Absence is safe": we only ever set/remove the two base-URL keys, and we only
+remove a key whose value points at *our* proxy (never a user's custom base URL).
+``tj doctor`` uses :func:`find_orphaned_wiring` to flag the footgun where the
+env still points at the proxy but the proxy is disabled (traffic would hit a
+dead port).
+"""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+# Standard provider base-URL env vars honored by the Anthropic / OpenAI SDKs and
+# Claude Code. Mapping the proxy onto these routes that provider's traffic
+# through it. (Anthropic SDK / Claude Code: ANTHROPIC_BASE_URL; OpenAI: OPENAI_BASE_URL.)
+BASE_URL_ENV_VARS = ("ANTHROPIC_BASE_URL", "OPENAI_BASE_URL")
+
+
+def proxy_base_url(config: Any) -> str:
+    """The URL agents should target to route through the proxy."""
+    return f"http://{config.proxy.host}:{config.proxy.port}"
+
+
+def claude_settings_path() -> Path:
+    return Path.home() / ".claude" / "settings.json"
+
+
+def _load_settings(path: Path) -> dict:
+    if not path.exists():
+        return {}
+    try:
+        return json.loads(path.read_text() or "{}")
+    except (OSError, json.JSONDecodeError):
+        return {}
+
+
+def _write_settings(path: Path, data: dict) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(data, indent=2) + "\n")
+
+
+def apply_env_wiring(config: Any, *, settings_path: Path | None = None) -> list[str]:
+    """Point the provider base-URLs at the proxy in Claude Code's settings.
+
+    Returns the list of env vars wired. Idempotent.
+    """
+    path = settings_path or claude_settings_path()
+    settings = _load_settings(path)
+    env: dict = settings.get("env", {}) or {}
+    url = proxy_base_url(config)
+    for var in BASE_URL_ENV_VARS:
+        env[var] = url
+    settings["env"] = env
+    _write_settings(path, settings)
+    return list(BASE_URL_ENV_VARS)
+
+
+def remove_env_wiring(config: Any, *, settings_path: Path | None = None) -> list[str]:
+    """Remove ONLY the base-URL keys that point at our proxy. Idempotent.
+
+    A user's custom base URL (pointing elsewhere) is left untouched.
+    """
+    path = settings_path or claude_settings_path()
+    settings = _load_settings(path)
+    env: dict = settings.get("env", {}) or {}
+    url = proxy_base_url(config)
+    removed: list[str] = []
+    for var in BASE_URL_ENV_VARS:
+        if env.get(var) == url:
+            env.pop(var, None)
+            removed.append(var)
+    if removed:
+        settings["env"] = env
+        _write_settings(path, settings)
+    return removed
+
+
+def detect_wiring(config: Any, *, settings_path: Path | None = None) -> dict[str, str]:
+    """Base-URL env keys currently pointing at THIS proxy (host:port)."""
+    path = settings_path or claude_settings_path()
+    env = _load_settings(path).get("env", {}) or {}
+    url = proxy_base_url(config)
+    return {var: env[var] for var in BASE_URL_ENV_VARS if env.get(var) == url}
+
+
+def find_orphaned_wiring(config: Any, *, settings_path: Path | None = None) -> list[str]:
+    """Env vars that point at the proxy while the proxy is disabled (#219 doctor).
+
+    This is the dangerous state: an agent's traffic is being sent to a port with
+    no listener. Returns the offending env var names (empty when consistent).
+    """
+    if config.proxy.enabled:
+        return []
+    return list(detect_wiring(config, settings_path=settings_path).keys())


### PR DESCRIPTION
The OSS foundation of the Enforcement plane: an **optional, opt-in** in-process proxy inside `tj serve` (default port **7392**) that sits between an agent and its LLM provider, speaking the Anthropic (`/v1/messages`) and OpenAI (`/v1/chat/completions`) APIs. It ships in **suggest mode only** — it records what a policy *would* do and **enforces nothing**. MIT / open. Off by default.

## Summary
- New `tokenjam/proxy/` package, layered so the safety-critical decision logic carries no HTTP dependency: `gate.py` (the pricing-mode invariant, pure), `observer.py` (observe-only recorder), `app.py` (Starlette forwarding app), `server.py` (in-process listener), `wiring.py` (base-URL env wiring + orphan detection).
- `[proxy]` config block + `tj proxy enable|disable|status|killswitch` CLI (`cmd_proxy.py`, in `no_db_commands`).
- Proxy runs inside `tj serve`'s lifespan on `proxy.port`; `tj doctor` gains an orphaned-wiring check.

## The non-negotiable invariant (pricing-mode gate)
The **first** step in the decision path resolves the targeted provider's pricing mode, **reusing the existing logic** (`core/framing.provider_pricing_mode` → `pricing_mode_for` → `SUBSCRIPTION_PLAN_TIERS`) — never re-derived. **Subscription traffic — plus `local` and `unknown` as a fail-safe — is forwarded UNMODIFIED (observe-only, never a policy decision)**, because intercepting subscription-plan traffic is outside provider terms of service. **Only `api`/usage-billed traffic reaches the policy path** (a no-op in suggest mode). The decision is a plain, inspectable `GateDecision` value object, unit-tested directly. Wired in from the first commit.

## Safety doctrine (enforced structurally)
- **Pass-through is sacred:** any error in classification/recording forwards the request unmodified (a fail-safe observe-only record is still produced).
- **The proxy holds no keys:** the caller's credentials pass straight through; streaming responses are forwarded as streams.
- **Absence is safe:** `enable` wires the provider base-URLs at the proxy (`~/.claude/settings.json`) and turns it on; `disable` removes both (a user's *custom* base URL is left untouched); `tj doctor` flags orphaned wiring (env points at the proxy but it's off).
- **Kill switch:** `killswitch` flips to pass-through-everything while keeping the listener alive (`--off` to release).
- The proxy starts/stops with `tj serve`'s lifespan (same event loop) so it can never outlive the server, and it does not touch the parent's signal handlers.

## Tests / Verification
- **Gate invariant** (`tests/unit/test_proxy_gate.py`): subscription (all 6 tiers) / local / unknown / unrecognised-provider → observe-only; api → policy; killswitch → observe-only; decision is inspectable. Isolated from the real global config.
- **Forwarding** (`tests/integration/test_proxy_app.py`, httpx MockTransport + ASGITransport): unmodified pass-through, **holds-no-keys** credential pass-through, **streaming** forwarded as a stream, **pass-through-on-classification-error**, 404 on unknown upstream, observe vs policy recording.
- **Lifecycle** (`tests/integration/test_cmd_proxy.py`): enable/disable/status(`--json`)/killswitch, custom base-URL preserved on disable, doctor orphan flag; patches `open_db` with an `AssertionError` to prove `proxy` never opens the DB.
- `[proxy]` config round-trip test.
- Full suite **1030 passed**; `ruff` + `mypy` clean on all new code.
- **Live smoke** (`ProxyRunner` on a real event loop → local echo upstream): POST forwarded unmodified, caller's `x-api-key` reached the upstream untouched, subscription classified observe-only.

## What's NOT in this PR
- **Policy enforcement (#220)** — not built or referenced. The policy path is a suggest-mode no-op; in suggest mode BOTH paths forward unmodified, the gate only *records* eligibility.
- **Validation / certification** — a separate, private track; deliberately untouched.
- **Live config reload of the killswitch** — the flag is honored at proxy startup; restart `tj serve` to apply. Honest given suggest mode enforces nothing, so there is no live enforcement risk to interrupt. A live switch matters once enforcement lands (#220).
- **Codex/OpenAI base-URL wiring** beyond the standard `OPENAI_BASE_URL`/`ANTHROPIC_BASE_URL` keys in Claude Code's settings — the primary integration. Other agents can export those env vars manually.

Closes #219

🤖 Generated with [Claude Code](https://claude.com/claude-code)