### PR TITLE
[feature] Policy engine + envelope (data-driven, suggest mode) (#220)

### DIFF
--- a/docs/policy/overview.md
+++ b/docs/policy/overview.md
@@ -56,6 +56,50 @@ Rows are only emitted when something is actually configured. A bare config witho
 any per-agent overrides still produces the default `alerts` rows (every config
 ships with at least one channel) but nothing else.
 
+## Enforcement-plane policies (`[[policies]]`, #220)
+
+The proxy's policy engine (#220) loads **data-driven** policies from `[[policies]]`
+and evaluates *eligible* requests through the proxy substrate (#219). A policy is
+data, not code — it binds a registered `kind` (an evaluator) to a target with
+kind-specific `params`:
+
+```toml
+[[policies]]
+name = "demo-cap"
+kind = "noop"            # the reference example kind (ships); budget_cap is #222
+mode = "suggest"         # suggest only — enforce is gated off in the OSS rails
+target_provider = "openai"
+```
+
+**Suggest mode only.** The engine *evaluates and records* what each policy WOULD
+do, then the request is forwarded **unmodified** — nothing is enforced. The
+enforce-mode path is scaffolded but gated off behind the certification gate (a
+separate, private track).
+
+**API-only.** The engine only ever sees `api`/usage-billed traffic. Subscription /
+`unknown` traffic is observe-only at the gate (#219) and never reaches the engine —
+enforced belt-and-suspenders by an api-only guard inside the engine itself.
+
+**Unvalidated.** There is no certification engine in the open tree, so every policy
+decision carries an explicit `unvalidated` label. `tj policy list` and
+`tj policy decisions` surface it — a suggestion is never implied to be validated safe.
+
+```
+$ tj policy list
+POLICY            SETTING                                                  SOURCE
+policies.demo-cap kind=noop, mode=suggest, label=unvalidated, provider=openai  [[policies]][0]
+...
+Enforcement-plane policies ([[policies]]) run 'unvalidated' (suggest mode only — ...).
+
+$ tj policy decisions        # recent decisions from a running `tj serve` proxy
+TIME       PROVIDER  PATH                  WOULD-DO  POLICIES   LABEL
+2026-…     openai    /v1/chat/completions  noop      demo-cap   unvalidated
+```
+
+`tj policy decisions` reads the recent in-memory decisions from a running proxy
+(`tj proxy enable` + `tj serve`); without one it prints a hint. The
+`add | edit | apply` lifecycle remains out of scope this sprint.
+
 ## Why a preview?
 
 The unified policy framing is what the next sprint's `tj policy add | edit | apply`

--- a/tests/integration/test_proxy_policy.py
+++ b/tests/integration/test_proxy_policy.py
@@ -1,0 +1,130 @@
+"""Integration tests for the policy engine wired into the proxy app (#220).
+
+Verifies, through the real Starlette app (httpx MockTransport upstream):
+- the POLICY path runs the engine, records the envelope, and STILL forwards
+  the request UNMODIFIED (suggest mode enforces nothing),
+- the OBSERVE_ONLY path NEVER builds a policy envelope (the engine never runs),
+- the `/__tj/policy/decisions` + `/__tj/policy/policies` read surfaces,
+- the unvalidated label rides the recorded envelope.
+"""
+from __future__ import annotations
+
+import httpx
+import pytest
+
+from tokenjam.core.config import PolicyConfig, ProviderBudget, TjConfig
+from tokenjam.proxy.app import build_proxy_app
+from tokenjam.proxy.engine import ACTION_WOULD_BLOCK, UNVALIDATED_LABEL, PolicyOutcome, register_policy
+from tokenjam.proxy.observer import ProxyObserver
+
+
+@register_policy("itest_block")
+def _itest_block(policy, request):
+    return PolicyOutcome(would_action=ACTION_WOULD_BLOCK, reason="itest: would block")
+
+
+def _config(plans: dict[str, str], policies=None) -> TjConfig:
+    return TjConfig(
+        version="1",
+        budgets={p: ProviderBudget(plan=plan) for p, plan in plans.items()},
+        policies=policies or [],
+    )
+
+
+class _Upstream:
+    def __init__(self):
+        self.last_body: bytes | None = None
+        self.last_request: httpx.Request | None = None
+
+    async def handler(self, request: httpx.Request) -> httpx.Response:
+        self.last_body = await request.aread()
+        self.last_request = request
+
+        async def _agen():
+            yield b'{"ok":true}'
+        return httpx.Response(200, headers={"content-type": "application/json"}, content=_agen())
+
+
+def _client(upstream):
+    return httpx.AsyncClient(transport=httpx.MockTransport(upstream.handler))
+
+
+async def _post(app, path, body=b"{}", headers=None):
+    transport = httpx.ASGITransport(app=app)
+    async with httpx.AsyncClient(transport=transport, base_url="http://proxy") as c:
+        return await c.post(path, content=body, headers=headers or {})
+
+
+async def _get(app, path):
+    transport = httpx.ASGITransport(app=app)
+    async with httpx.AsyncClient(transport=transport, base_url="http://proxy") as c:
+        return await c.get(path)
+
+
+@pytest.mark.asyncio
+async def test_policy_path_evaluates_records_and_forwards_unmodified():
+    cfg = _config({"openai": "api"}, [PolicyConfig(name="blocker", kind="itest_block")])
+    upstream = _Upstream()
+    observer = ProxyObserver()
+    app = build_proxy_app(cfg, observer=observer, client=_client(upstream))
+
+    body = b'{"model":"gpt-4o","messages":[]}'
+    resp = await _post(app, "/v1/chat/completions", body=body,
+                       headers={"authorization": "Bearer sk-caller"})
+
+    assert resp.status_code == 200
+    # Suggest mode: the request was forwarded UNMODIFIED despite the would_block.
+    assert upstream.last_body == body
+    # The envelope was recorded with what the policy WOULD do + the label.
+    obs = observer.observations[0]
+    assert obs.decision == "policy"
+    assert obs.policy is not None
+    assert obs.policy["overall_action"] == ACTION_WOULD_BLOCK
+    assert obs.policy["enforced"] is False
+    assert obs.policy["label"] == UNVALIDATED_LABEL
+    assert obs.policy["evaluations"][0]["policy_name"] == "blocker"
+
+
+@pytest.mark.asyncio
+async def test_observe_only_path_never_builds_an_envelope():
+    # Subscription traffic is observe-only — the engine must never run, so no
+    # policy envelope is attached even though a policy is defined.
+    cfg = _config({"anthropic": "max_5x"}, [PolicyConfig(name="blocker", kind="itest_block")])
+    upstream = _Upstream()
+    observer = ProxyObserver()
+    app = build_proxy_app(cfg, observer=observer, client=_client(upstream))
+
+    await _post(app, "/v1/messages", body=b"{}", headers={"x-api-key": "sk"})
+
+    obs = observer.observations[0]
+    assert obs.decision == "observe_only"
+    assert obs.policy is None  # engine never evaluated observe-only traffic
+
+
+@pytest.mark.asyncio
+async def test_policies_read_endpoint_lists_defined_policies():
+    cfg = _config({"openai": "api"},
+                  [PolicyConfig(name="blocker", kind="itest_block", target_provider="openai")])
+    app = build_proxy_app(cfg, observer=ProxyObserver(), client=_client(_Upstream()))
+
+    resp = await _get(app, "/__tj/policy/policies")
+    data = resp.json()
+    assert data["label"] == "unvalidated"
+    assert data["policies"][0]["name"] == "blocker"
+    assert data["policies"][0]["target_provider"] == "openai"
+
+
+@pytest.mark.asyncio
+async def test_decisions_read_endpoint_returns_recorded_envelopes():
+    cfg = _config({"openai": "api"}, [PolicyConfig(name="blocker", kind="itest_block")])
+    observer = ProxyObserver()
+    app = build_proxy_app(cfg, observer=observer, client=_client(_Upstream()))
+
+    # Generate one policy decision + one observe-only (no envelope).
+    await _post(app, "/v1/chat/completions", body=b"{}")
+
+    resp = await _get(app, "/__tj/policy/decisions")
+    data = resp.json()
+    assert data["label"] == "unvalidated"
+    assert len(data["decisions"]) == 1  # only the POLICY-path one carries an envelope
+    assert data["decisions"][0]["policy"]["overall_action"] == ACTION_WOULD_BLOCK

--- a/tests/unit/test_cmd_policy.py
+++ b/tests/unit/test_cmd_policy.py
@@ -222,3 +222,86 @@ def test_policy_list_does_not_require_db(runner):
 def test_policyrow_to_dict_round_trips():
     row = PolicyRow(policy="a", setting="b", source="c")
     assert row.to_dict() == {"policy": "a", "setting": "b", "source": "c"}
+
+
+# --- #220: enforcement-plane [[policies]] + decisions surface ---
+
+def test_list_shows_engine_policies_with_unvalidated_label():
+    from tokenjam.core.config import PolicyConfig
+    from tokenjam.cli.cmd_policy import _policy_engine_rows
+
+    rows = _policy_engine_rows([
+        PolicyConfig(name="cap", kind="noop", mode="suggest", target_provider="openai"),
+    ])
+    assert len(rows) == 1
+    assert rows[0].policy == "policies.cap"
+    assert "kind=noop" in rows[0].setting
+    assert "label=unvalidated" in rows[0].setting       # honesty: never implied validated
+    assert rows[0].source == "[[policies]][0]"
+
+
+def test_list_command_renders_engine_policies_and_note(runner):
+    from tokenjam.core.config import PolicyConfig
+    cfg = TjConfig(version="1",
+                   policies=[PolicyConfig(name="cap", kind="noop", mode="suggest")])
+    result = _invoke(runner, cfg, ["policy", "list"])
+    assert result.exit_code == 0, result.output
+    assert "policies.cap" in result.output
+    assert "unvalidated" in result.output
+
+
+def test_list_json_includes_unvalidated_note_when_policies_present(runner):
+    from tokenjam.core.config import PolicyConfig
+    cfg = TjConfig(version="1", policies=[PolicyConfig(name="cap", kind="noop")])
+    result = _invoke(runner, cfg, ["--json", "policy", "list"])
+    assert result.exit_code == 0, result.output
+    payload = json.loads(result.output)
+    assert "unvalidated" in payload["unvalidated_note"]
+    assert any(r["policy"] == "policies.cap" for r in payload["policies"])
+
+
+_SAMPLE_DECISIONS = {"decisions": [{
+    "ts": "2026-06-24T00:00:00+00:00", "provider": "openai",
+    "path": "/v1/chat/completions",
+    "policy": {"overall_action": "would_block", "label": "unvalidated",
+               "evaluations": [{"policy_name": "blocker"}]},
+}], "label": "unvalidated"}
+
+
+def test_decisions_json_surfaces_envelope_and_label(runner):
+    cfg = TjConfig(version="1")
+    with patch("tokenjam.cli.cmd_policy._fetch_proxy_json", return_value=_SAMPLE_DECISIONS):
+        result = _invoke(runner, cfg, ["--json", "policy", "decisions"])
+    assert result.exit_code == 0, result.output
+    payload = json.loads(result.output)
+    assert payload["label"] == "unvalidated"
+    assert payload["reachable"] is True
+    assert payload["decisions"][0]["policy"]["overall_action"] == "would_block"
+
+
+def test_decisions_renders_recent_envelopes(runner):
+    # The human table renders without error; width-robust assertions only (Rich
+    # truncates cells under the narrow CliRunner terminal).
+    cfg = TjConfig(version="1")
+    with patch("tokenjam.cli.cmd_policy._fetch_proxy_json", return_value=_SAMPLE_DECISIONS):
+        result = _invoke(runner, cfg, ["policy", "decisions"])
+    assert result.exit_code == 0, result.output
+    assert "openai" in result.output
+    assert "unvalidated" in result.output
+
+
+def test_decisions_graceful_when_proxy_unreachable(runner):
+    cfg = TjConfig(version="1")
+    with patch("tokenjam.cli.cmd_policy._fetch_proxy_json", return_value=None):
+        result = _invoke(runner, cfg, ["policy", "decisions"])
+    assert result.exit_code == 0, result.output
+    assert "No running proxy reachable" in result.output
+
+
+def test_decisions_does_not_open_db(runner):
+    cfg = TjConfig(version="1")
+    with patch("tokenjam.cli.main.load_config", return_value=cfg), \
+         patch("tokenjam.cli.main.open_db", side_effect=AssertionError("must not open db")), \
+         patch("tokenjam.cli.cmd_policy._fetch_proxy_json", return_value=None):
+        result = runner.invoke(cli, ["policy", "decisions"])
+    assert result.exit_code == 0, result.output

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -213,6 +213,25 @@ class TestSerialise:
         # Defaults when [proxy] is absent.
         assert _parse({"version": "1"}).proxy.enabled is False
 
+    def test_policies_roundtrip(self):
+        """[[policies]] enforcement-plane policies round-trip (#220)."""
+        from tokenjam.core.config import PolicyConfig
+        config = TjConfig(version="1", policies=[
+            PolicyConfig(name="cap", kind="noop", mode="enforce",
+                         target_provider="openai", params={"limit": 5}),
+        ])
+        restored = _parse(_serialise(config))
+        assert len(restored.policies) == 1
+        p = restored.policies[0]
+        assert p.name == "cap"
+        assert p.kind == "noop"
+        assert p.mode == "enforce"
+        assert p.target_provider == "openai"
+        assert p.params == {"limit": 5}
+        # Defaults when [[policies]] absent / malformed entries skipped.
+        assert _parse({"version": "1"}).policies == []
+        assert _parse({"version": "1", "policies": [{"name": "x"}]}).policies == []  # no kind
+
     def test_serialise_excludes_config_path(self):
         """Regression: config_path is a Path object which is not TOML
         serializable. _serialise() must exclude it. See v0.1.7 fix."""

--- a/tests/unit/test_policy_engine.py
+++ b/tests/unit/test_policy_engine.py
@@ -1,0 +1,160 @@
+"""Unit tests for the policy engine + envelope (#220) — HTTP-free.
+
+Covers: the engine evaluates a registered policy; the api-only guard (observe-
+only traffic never reaches the engine); suggest-mode records but enforces
+nothing; the `unvalidated` label is always present; the enforce path is
+scaffolded but gated off; and the envelope round-trips.
+"""
+from __future__ import annotations
+
+import pytest
+
+from tokenjam.core.config import PolicyConfig, ProviderBudget, TjConfig
+from tokenjam.proxy.engine import (
+    ACTION_NOOP,
+    ACTION_WOULD_BLOCK,
+    ENFORCE_GATE_OPEN,
+    UNVALIDATED_LABEL,
+    PolicyEngine,
+    PolicyEnvelope,
+    PolicyEvaluation,
+    PolicyGuardError,
+    PolicyOutcome,
+    PolicyRequest,
+    register_policy,
+)
+from tokenjam.proxy.gate import OBSERVE_ONLY, POLICY, GateDecision, classify
+
+
+# --- a stub policy kind the tests register (no concrete logic ships) ---
+@register_policy("test_block")
+def _test_block(policy, request):
+    return PolicyOutcome(
+        would_action=ACTION_WOULD_BLOCK,
+        reason="stub: would block",
+        details={"seen_provider": request.provider},
+    )
+
+
+def _api_config(policies):
+    return TjConfig(
+        version="1",
+        budgets={"openai": ProviderBudget(plan="api"),
+                 "anthropic": ProviderBudget(plan="api")},
+        policies=policies,
+    )
+
+
+def _api_gate(config, provider="openai") -> GateDecision:
+    gd = classify(config, provider)
+    assert gd.path == POLICY  # precondition: api/usage-billed
+    return gd
+
+
+def test_engine_evaluates_registered_policy():
+    cfg = _api_config([PolicyConfig(name="blocker", kind="test_block")])
+    engine = PolicyEngine.from_config(cfg)
+    env = engine.evaluate(_api_gate(cfg), PolicyRequest(provider="openai", path="/v1/chat/completions"))
+
+    assert len(env.evaluations) == 1
+    ev = env.evaluations[0]
+    assert ev.policy_name == "blocker"
+    assert ev.kind == "test_block"
+    assert ev.would_action == ACTION_WOULD_BLOCK
+    assert ev.details["seen_provider"] == "openai"
+    # Overall action summarises to the strongest would-action.
+    assert env.overall_action == ACTION_WOULD_BLOCK
+
+
+def test_api_only_guard_rejects_observe_only():
+    # The engine must NEVER evaluate observe-only traffic (#219 invariant,
+    # belt-and-suspenders with the gate).
+    sub_cfg = TjConfig(version="1", budgets={"anthropic": ProviderBudget(plan="max_5x")})
+    observe_gd = classify(sub_cfg, "anthropic")
+    assert observe_gd.path == OBSERVE_ONLY
+
+    engine = PolicyEngine.from_config(_api_config([PolicyConfig(name="b", kind="test_block")]))
+    with pytest.raises(PolicyGuardError):
+        engine.evaluate(observe_gd, PolicyRequest(provider="anthropic", path="/v1/messages"))
+
+
+def test_api_only_guard_rejects_any_non_policy_path():
+    # Even a hand-built decision with a bogus path is refused.
+    engine = PolicyEngine.from_config(_api_config([]))
+    bogus = GateDecision(provider="openai", plan_tier="api", pricing_mode="api",
+                         path="something_else", reason="x")
+    with pytest.raises(PolicyGuardError):
+        engine.evaluate(bogus, PolicyRequest(provider="openai", path="/v1/chat/completions"))
+
+
+def test_suggest_mode_never_enforces():
+    cfg = _api_config([PolicyConfig(name="blocker", kind="test_block", mode="suggest")])
+    env = PolicyEngine.from_config(cfg).evaluate(
+        _api_gate(cfg), PolicyRequest(provider="openai", path="/v1/chat/completions"))
+    # Records what it WOULD do, but enforces nothing.
+    assert env.overall_action == ACTION_WOULD_BLOCK
+    assert env.enforced is False
+    assert env.suggest_only is True
+
+
+def test_enforce_mode_is_scaffolded_but_gated_off():
+    # A mode=enforce policy is recorded as enforcement-eligible but NEVER acts in
+    # the OSS rails (the cert gate is closed).
+    assert ENFORCE_GATE_OPEN is False
+    cfg = _api_config([PolicyConfig(name="blocker", kind="test_block", mode="enforce")])
+    env = PolicyEngine.from_config(cfg).evaluate(
+        _api_gate(cfg), PolicyRequest(provider="openai", path="/v1/chat/completions"))
+    assert env.enforced is False
+    assert env.enforcement_gated is True
+    assert env.evaluations[0].enforcement_gated is True
+
+
+def test_unvalidated_label_always_present():
+    cfg = _api_config([PolicyConfig(name="b", kind="test_block")])
+    env = PolicyEngine.from_config(cfg).evaluate(
+        _api_gate(cfg), PolicyRequest(provider="openai", path="/v1/chat/completions"))
+    assert env.label == UNVALIDATED_LABEL
+    assert env.validated is False
+
+
+def test_target_provider_filters_applicable_policies():
+    # A policy targeting anthropic does not apply to an openai request.
+    cfg = _api_config([PolicyConfig(name="anthro-only", kind="test_block",
+                                    target_provider="anthropic")])
+    env = PolicyEngine.from_config(cfg).evaluate(
+        _api_gate(cfg, "openai"), PolicyRequest(provider="openai", path="/v1/chat/completions"))
+    assert env.evaluations == []
+    assert env.overall_action == ACTION_NOOP
+
+
+def test_disabled_policy_is_skipped():
+    cfg = _api_config([PolicyConfig(name="off", kind="test_block", enabled=False)])
+    engine = PolicyEngine.from_config(cfg)
+    assert engine.policies == []  # filtered at load
+
+
+def test_unknown_kind_is_reported_not_raised():
+    cfg = _api_config([PolicyConfig(name="mystery", kind="does_not_exist")])
+    env = PolicyEngine.from_config(cfg).evaluate(
+        _api_gate(cfg), PolicyRequest(provider="openai", path="/v1/chat/completions"))
+    assert env.evaluations[0].would_action == "error"
+    assert "unknown policy kind" in env.evaluations[0].reason
+
+
+def test_envelope_round_trip():
+    cfg = _api_config([PolicyConfig(name="blocker", kind="test_block", mode="enforce")])
+    env = PolicyEngine.from_config(cfg).evaluate(
+        _api_gate(cfg), PolicyRequest(provider="openai", path="/v1/chat/completions"))
+    restored = PolicyEnvelope.from_dict(env.to_dict())
+    assert restored.to_dict() == env.to_dict()
+    assert isinstance(restored.evaluations[0], PolicyEvaluation)
+    assert restored.label == UNVALIDATED_LABEL
+
+
+def test_noop_example_kind_ships_and_evaluates():
+    # The built-in `noop` reference kind works without tests registering anything.
+    cfg = _api_config([PolicyConfig(name="ex", kind="noop")])
+    env = PolicyEngine.from_config(cfg).evaluate(
+        _api_gate(cfg), PolicyRequest(provider="openai", path="/v1/chat/completions"))
+    assert env.evaluations[0].would_action == ACTION_NOOP
+    assert env.overall_action == ACTION_NOOP

--- a/tokenjam/cli/cmd_policy.py
+++ b/tokenjam/cli/cmd_policy.py
@@ -1,12 +1,15 @@
 """
-`tj policy` — read-only preview of the unified policy surface.
+`tj policy` — read-only view of the unified + enforcement-plane policy surface.
 
-This sprint ships `tj policy list` only: a consolidated view of existing
-alerts / drift / schema / budget / sensitive-actions configuration under
-the unified "policy" framing. The underlying config structure is NOT
-migrated — each row points back to the TOML section it was read from.
+`tj policy list` consolidates existing alerts / drift / schema / budget /
+sensitive-actions configuration under the unified "policy" framing AND the
+data-driven `[[policies]]` enforcement-plane policies (#220) the proxy engine
+loads. Each row points back to the TOML section it was read from.
 
-`tj policy add | edit | apply | remove | test` land next sprint.
+`tj policy decisions` shows recent policy decisions (what each policy WOULD do)
+from a running `tj serve` proxy.
+
+`tj policy add | edit | apply | remove | test` remain out of scope this sprint.
 """
 from __future__ import annotations
 
@@ -15,6 +18,7 @@ from dataclasses import dataclass
 from typing import Any
 
 import click
+from rich.markup import escape
 
 from tokenjam.core.config import (
     AgentConfig,
@@ -23,15 +27,24 @@ from tokenjam.core.config import (
     BudgetConfig,
     CaptureConfig,
     DriftConfig,
+    PolicyConfig,
     ProviderBudget,
     TjConfig,
 )
+from tokenjam.proxy.engine import UNVALIDATED_LABEL
 from tokenjam.utils.formatting import console
 
 
 PREVIEW_NOTE = (
     "Note: this is a read-only preview. The unified "
     "`tj policy add|edit|apply` surface lands next sprint."
+)
+
+# Every OSS enforcement-plane policy runs unvalidated — there is no certification
+# engine in the open tree, so a suggestion is never implied to be validated safe.
+UNVALIDATED_NOTE = (
+    f"Enforcement-plane policies ([[policies]]) run '{UNVALIDATED_LABEL}' "
+    "(suggest mode only — they record what they WOULD do; nothing is enforced)."
 )
 
 
@@ -62,12 +75,15 @@ def cmd_policy_list(ctx: click.Context, output_json_flag: bool) -> None:
     output_json: bool = output_json_flag or ctx.obj.get("output_json", False)
 
     rows = _collect_rows(config)
+    has_engine_policies = bool(config.policies)
 
     if output_json:
-        payload = {
+        payload: dict[str, Any] = {
             "policies": [r.to_dict() for r in rows],
             "note": PREVIEW_NOTE,
         }
+        if has_engine_policies:
+            payload["unvalidated_note"] = UNVALIDATED_NOTE
         click.echo(json.dumps(payload, indent=2))
         return
 
@@ -77,7 +93,6 @@ def cmd_policy_list(ctx: click.Context, output_json_flag: bool) -> None:
         console.print(f"[dim]{PREVIEW_NOTE}[/dim]")
         return
 
-    from rich.markup import escape
     from rich.table import Table
 
     table = Table(show_header=True, header_style="bold", box=None, padding=(0, 2))
@@ -90,18 +105,120 @@ def cmd_policy_list(ctx: click.Context, output_json_flag: bool) -> None:
 
     console.print(table)
     console.print()
+    if has_engine_policies:
+        console.print(f"[yellow]{escape(UNVALIDATED_NOTE)}[/yellow]")
     console.print(f"[dim]{PREVIEW_NOTE}[/dim]")
+
+
+def _fetch_proxy_json(config: TjConfig, path: str) -> dict | None:
+    """GET a tj-internal read endpoint from the running proxy (None if down).
+
+    The proxy keeps recent decisions in memory, so `tj policy decisions` reads
+    them from the live `tj serve` proxy. Best-effort: any failure (proxy not
+    running, connection refused) returns None and the caller renders a hint.
+    """
+    import httpx
+    url = f"http://{config.proxy.host}:{config.proxy.port}{path}"
+    try:
+        resp = httpx.get(url, timeout=2.0)
+        if resp.status_code == 200:
+            return resp.json()
+    except Exception:  # noqa: BLE001 — proxy may simply be down
+        return None
+    return None
+
+
+@cmd_policy.command("decisions")
+@click.option("--json", "output_json_flag", is_flag=True,
+              help="Emit machine-readable JSON.")
+@click.option("--limit", default=20, show_default=True,
+              help="Max number of recent decisions to show.")
+@click.pass_context
+def cmd_policy_decisions(ctx: click.Context, output_json_flag: bool, limit: int) -> None:
+    """Show recent policy decisions (what each policy WOULD do) from the proxy."""
+    config: TjConfig = ctx.obj["config"]
+    output_json: bool = output_json_flag or ctx.obj.get("output_json", False)
+
+    payload = _fetch_proxy_json(config, "/__tj/policy/decisions")
+    decisions = (payload or {}).get("decisions", [])
+    decisions = decisions[-limit:] if limit and len(decisions) > limit else decisions
+
+    if output_json:
+        click.echo(json.dumps({
+            "decisions": decisions,
+            "label": UNVALIDATED_LABEL,
+            "reachable": payload is not None,
+        }, indent=2))
+        return
+
+    if payload is None:
+        console.print(
+            "[dim]No running proxy reachable at "
+            f"http://{config.proxy.host}:{config.proxy.port}. "
+            "Start it with `tj proxy enable` + `tj serve`.[/dim]"
+        )
+        return
+    if not decisions:
+        console.print("[dim]No policy decisions recorded yet "
+                      "(suggest mode — eligible api traffic only).[/dim]")
+        console.print()
+        console.print(f"[yellow]{escape(UNVALIDATED_NOTE)}[/yellow]")
+        return
+
+    from rich.table import Table
+
+    table = Table(show_header=True, header_style="bold", box=None, padding=(0, 2))
+    for col in ("TIME", "PROVIDER", "PATH", "WOULD-DO", "POLICIES", "LABEL"):
+        table.add_column(col, style="dim" if col in ("TIME", "LABEL") else None)
+    for d in decisions:
+        pol = d.get("policy") or {}
+        evals = pol.get("evaluations", [])
+        table.add_row(
+            escape(str(d.get("ts", ""))[:19]),
+            escape(str(d.get("provider", ""))),
+            escape(str(d.get("path", ""))),
+            escape(str(pol.get("overall_action", "-"))),
+            escape(", ".join(e.get("policy_name", "") for e in evals) or "-"),
+            escape(str(pol.get("label", UNVALIDATED_LABEL))),
+        )
+    console.print(table)
+    console.print()
+    console.print(f"[yellow]{escape(UNVALIDATED_NOTE)}[/yellow]")
 
 
 def _collect_rows(config: TjConfig) -> list[PolicyRow]:
     rows: list[PolicyRow] = []
 
+    rows.extend(_policy_engine_rows(config.policies))
     rows.extend(_alerts_rows(config.alerts))
     rows.extend(_defaults_budget_rows(config.defaults.budget))
     rows.extend(_provider_budget_rows(config.budgets))
     rows.extend(_agents_rows(config.agents))
     rows.extend(_capture_rows(config.capture))
 
+    return rows
+
+
+def _policy_engine_rows(policies: list[PolicyConfig]) -> list[PolicyRow]:
+    """Rows for the data-driven `[[policies]]` enforcement-plane policies (#220).
+
+    Each carries the explicit `unvalidated` label so the surface never implies a
+    policy has been certified safe.
+    """
+    rows: list[PolicyRow] = []
+    for idx, p in enumerate(policies):
+        parts = [f"kind={p.kind}", f"mode={p.mode}", f"label={UNVALIDATED_LABEL}"]
+        if not p.enabled:
+            parts.append("enabled=false")
+        if p.target_provider:
+            parts.append(f"provider={p.target_provider}")
+        if p.target_agent:
+            parts.append(f"agent={p.target_agent}")
+        rows.append(PolicyRow(
+            f"policies.{p.name}",
+            ", ".join(parts),
+            f"[[policies]][{idx}]",
+        ))
     return rows
 
 

--- a/tokenjam/core/config.py
+++ b/tokenjam/core/config.py
@@ -155,6 +155,29 @@ class ProxyConfig:
 
 
 @dataclass
+class PolicyConfig:
+    """A data-driven enforcement-plane policy (#220), defined in `[[policies]]`.
+
+    A policy is DATA, not code: it binds a ``kind`` (a registered evaluator) to
+    a target (provider / agent) with kind-specific ``params``. The proxy's
+    policy engine loads these and evaluates eligible (api/usage-billed) requests.
+
+    ``mode`` is ``suggest`` (evaluate + record what it WOULD do, enforce nothing)
+    or ``enforce`` (gated OFF in the OSS rails — scaffolded, never acts). All
+    OSS policies are user-authored and run **unvalidated** — there is no
+    certification engine in the open tree, so no policy decision is ever implied
+    to have been validated as safe.
+    """
+    name:            str
+    kind:            str
+    enabled:         bool = True
+    mode:            str  = "suggest"          # suggest | enforce (enforce gated off)
+    target_provider: str | None = None          # anthropic | openai | None (any)
+    target_agent:    str | None = None          # agent id | None (any)
+    params:          dict = field(default_factory=dict)
+
+
+@dataclass
 class CaptureConfig:
     prompts:      bool = False
     completions:  bool = False
@@ -200,6 +223,7 @@ class TjConfig:
     proxy:    ProxyConfig             = field(default_factory=ProxyConfig)
     capture:  CaptureConfig           = field(default_factory=CaptureConfig)
     budgets:  dict[str, ProviderBudget] = field(default_factory=dict)
+    policies: list[PolicyConfig]      = field(default_factory=list)
     # Path to the config file on disk; set by load_config() so that relative
     # paths in the config (e.g. output_schema) can be resolved correctly.
     config_path: Path | None          = field(default=None, repr=False, compare=False)
@@ -439,6 +463,22 @@ def _parse(raw: dict) -> TjConfig:
             plan=prov_raw.get("plan"),
         )
 
+    # [[policies]] — data-driven enforcement-plane policies (#220). Each binds a
+    # registered evaluator `kind` to a target with kind-specific params.
+    policies: list[PolicyConfig] = []
+    for pol_raw in raw.get("policies", []):
+        if not isinstance(pol_raw, dict) or "name" not in pol_raw or "kind" not in pol_raw:
+            continue
+        policies.append(PolicyConfig(
+            name=str(pol_raw["name"]),
+            kind=str(pol_raw["kind"]),
+            enabled=bool(pol_raw.get("enabled", True)),
+            mode=str(pol_raw.get("mode", PolicyConfig.mode)),
+            target_provider=pol_raw.get("target_provider"),
+            target_agent=pol_raw.get("target_agent"),
+            params=dict(pol_raw.get("params", {})),
+        ))
+
     return TjConfig(
         version=raw.get("version", "1"),
         defaults=defaults,
@@ -451,6 +491,7 @@ def _parse(raw: dict) -> TjConfig:
         proxy=proxy,
         capture=capture,
         budgets=budgets,
+        policies=policies,
     )
 
 

--- a/tokenjam/proxy/__init__.py
+++ b/tokenjam/proxy/__init__.py
@@ -20,6 +20,15 @@ through from the caller.
 """
 from __future__ import annotations
 
+from tokenjam.proxy.engine import (
+    UNVALIDATED_LABEL,
+    PolicyEngine,
+    PolicyEnvelope,
+    PolicyEvaluation,
+    PolicyGuardError,
+    PolicyRequest,
+    register_policy,
+)
 from tokenjam.proxy.gate import (
     OBSERVE_ONLY,
     POLICY,
@@ -27,4 +36,8 @@ from tokenjam.proxy.gate import (
     classify,
 )
 
-__all__ = ["OBSERVE_ONLY", "POLICY", "GateDecision", "classify"]
+__all__ = [
+    "OBSERVE_ONLY", "POLICY", "GateDecision", "classify",
+    "PolicyEngine", "PolicyEnvelope", "PolicyEvaluation", "PolicyRequest",
+    "PolicyGuardError", "register_policy", "UNVALIDATED_LABEL",
+]

--- a/tokenjam/proxy/app.py
+++ b/tokenjam/proxy/app.py
@@ -23,6 +23,7 @@ from starlette.requests import Request
 from starlette.responses import JSONResponse, StreamingResponse
 from starlette.routing import Route
 
+from tokenjam.proxy.engine import POLICY, PolicyEngine, PolicyRequest
 from tokenjam.proxy.gate import classify
 from tokenjam.proxy.observer import ProxyObserver
 
@@ -45,6 +46,28 @@ _HOP_BY_HOP = frozenset({
 
 def _provider_for(path: str) -> str:
     return _ROUTE_PROVIDER.get(path, "unknown")
+
+
+def _policy_request(request: Request, body: bytes) -> PolicyRequest:
+    """Build the pure (HTTP-free) policy-evaluation context from a request.
+
+    The body is parsed best-effort for kind-specific evaluators to read (e.g. a
+    future budget_cap reading the model); a malformed body is simply None.
+    """
+    import json
+    parsed: dict | None = None
+    try:
+        loaded = json.loads(body or b"{}")
+        if isinstance(loaded, dict):
+            parsed = loaded
+    except Exception:  # noqa: BLE001 — body parsing never breaks the request
+        parsed = None
+    return PolicyRequest(
+        provider=_provider_for(request.url.path),
+        path=request.url.path,
+        agent=None,  # the proxy does not resolve the agent at request time (MVP)
+        body=parsed,
+    )
 
 
 def _base_url_for(config: Any, provider: str) -> str | None:
@@ -71,15 +94,17 @@ def _response_headers(upstream: httpx.Response) -> list[tuple[bytes, bytes]]:
 
 
 def build_proxy_app(config: Any, observer: ProxyObserver | None = None,
-                    client: httpx.AsyncClient | None = None) -> Starlette:
+                    client: httpx.AsyncClient | None = None,
+                    engine: PolicyEngine | None = None) -> Starlette:
     """Build the Starlette proxy app.
 
-    ``observer`` and ``client`` are injectable for testing — pass an
+    ``observer``, ``client`` and ``engine`` are injectable for testing — pass an
     ``httpx.AsyncClient`` backed by ``httpx.MockTransport`` to avoid real
     network calls. When ``client`` is None a real client is created on startup
-    and closed on shutdown.
+    and closed on shutdown; when ``engine`` is None it is built from ``config``.
     """
     observer = observer or ProxyObserver()
+    engine = engine or PolicyEngine.from_config(config)
     state: dict[str, Any] = {"client": client, "owns_client": client is None}
 
     async def _get_client() -> httpx.AsyncClient:
@@ -87,12 +112,11 @@ def build_proxy_app(config: Any, observer: ProxyObserver | None = None,
             state["client"] = httpx.AsyncClient(timeout=httpx.Timeout(600.0))
         return state["client"]
 
-    async def _forward(request: Request, base_url: str) -> StreamingResponse:
+    async def _forward(request: Request, base_url: str, body: bytes) -> StreamingResponse:
         client_ = await _get_client()
         url = base_url + request.url.path
         if request.url.query:
             url += "?" + request.url.query
-        body = await request.body()
         upstream_req = client_.build_request(
             request.method, url, headers=_forward_headers(request), content=body,
         )
@@ -119,23 +143,63 @@ def build_proxy_app(config: Any, observer: ProxyObserver | None = None,
         except Exception:  # noqa: BLE001 — never let our logic break traffic
             logger.exception("proxy gate classification failed; forwarding unmodified")
 
+        # Read the body once — needed both for forwarding and for policy context.
+        body = await request.body()
+
+        # POLICY-path branch (#220): ONLY api/usage-billed traffic reaches the
+        # engine — the api-only guard inside the engine is belt-and-suspenders
+        # with this check. Observe-only traffic NEVER builds an envelope. Pass-
+        # through is sacred: any engine error forwards unmodified anyway.
+        envelope = None
+        if decision is not None and decision.path == POLICY:
+            try:
+                envelope = engine.evaluate(decision, _policy_request(request, body))
+            except Exception:  # noqa: BLE001 — engine never breaks traffic
+                logger.exception("policy engine failed; forwarding unmodified")
+
         # No upstream known (unrecognised path) → nothing to forward to.
         if base_url is None:
-            _safe_record(observer, request, decision, forwarded=False)
+            _safe_record(observer, request, decision, forwarded=False, envelope=envelope)
             return JSONResponse(
                 {"error": "tj proxy: unrecognised path; no upstream configured",
                  "path": request.url.path},
                 status_code=404,
             )
 
-        # Forward UNMODIFIED (suggest mode enforces nothing on either path).
-        response = await _forward(request, base_url)
-        _safe_record(observer, request, decision, forwarded=True)
+        # Forward UNMODIFIED. Suggest mode enforces nothing on EITHER path — the
+        # envelope only records what a policy WOULD do; the request is untouched.
+        response = await _forward(request, base_url, body)
+        _safe_record(observer, request, decision, forwarded=True, envelope=envelope)
         return response
+
+    async def _policies(_request: Request) -> JSONResponse:
+        """Read-only: the defined policies the engine loaded (#220 tj policy)."""
+        return JSONResponse({
+            "policies": [
+                {"name": getattr(p, "name", ""), "kind": getattr(p, "kind", ""),
+                 "mode": getattr(p, "mode", "suggest"),
+                 "target_provider": getattr(p, "target_provider", None),
+                 "target_agent": getattr(p, "target_agent", None),
+                 "enabled": getattr(p, "enabled", True)}
+                for p in engine.policies
+            ],
+            "label": "unvalidated",
+            "note": "Suggest mode only — policies record what they WOULD do; "
+                    "nothing is enforced. OSS policies run unvalidated.",
+        })
+
+    async def _decisions(_request: Request) -> JSONResponse:
+        """Read-only: recent policy decisions from the observer ring (#220)."""
+        policy_obs = [o for o in observer.as_dicts() if o.get("policy") is not None]
+        return JSONResponse({"decisions": policy_obs, "label": "unvalidated"})
 
     routes = [
         Route("/v1/messages", _handle, methods=["POST"]),
         Route("/v1/chat/completions", _handle, methods=["POST"]),
+        # tj-internal read surfaces (namespaced so they never collide with a
+        # provider path). Consumed by `tj policy policies|decisions`.
+        Route("/__tj/policy/policies", _policies, methods=["GET"]),
+        Route("/__tj/policy/decisions", _decisions, methods=["GET"]),
         Route("/{path:path}", _handle, methods=["GET", "POST", "PUT", "DELETE", "PATCH"]),
     ]
 
@@ -156,7 +220,7 @@ def build_proxy_app(config: Any, observer: ProxyObserver | None = None,
 
 
 def _safe_record(observer: ProxyObserver, request: Request, decision: Any,
-                 *, forwarded: bool) -> None:
+                 *, forwarded: bool, envelope: Any = None) -> None:
     """Record the observation; recording must never break pass-through."""
     try:
         if decision is None:
@@ -170,7 +234,7 @@ def _safe_record(observer: ProxyObserver, request: Request, decision: Any,
             )
         observer.record(
             method=request.method, path=request.url.path,
-            decision=decision, forwarded=forwarded,
+            decision=decision, forwarded=forwarded, envelope=envelope,
         )
     except Exception:  # noqa: BLE001
         logger.exception("proxy observation recording failed (ignored)")

--- a/tokenjam/proxy/engine.py
+++ b/tokenjam/proxy/engine.py
@@ -1,0 +1,261 @@
+"""The data-driven policy engine + envelope (#220) — suggest mode only.
+
+A policy is **data, not code**: `[[policies]]` in config bind a registered
+``kind`` (an evaluator) to a target with kind-specific ``params``. This module
+loads them and, for **eligible** requests, evaluates each applicable policy and
+produces a :class:`PolicyEnvelope` — an inspectable, round-trippable record of
+what every policy *would* do.
+
+Two invariants are enforced here, belt-and-suspenders with the gate (#219):
+
+1. **API-only guard.** :meth:`PolicyEngine.evaluate` REFUSES to run on anything
+   but a ``GateDecision.path == POLICY`` request (api/usage-billed). Observe-only
+   traffic (subscription / local / unknown) never reaches the engine; calling it
+   with such a decision raises :class:`PolicyGuardError`.
+2. **Suggest mode only.** The engine evaluates and RECORDS; it never modifies a
+   request. The enforce-mode path is scaffolded but GATED OFF behind
+   ``ENFORCE_GATE_OPEN`` (False) — actual request modification lands later behind
+   the certification gate (a separate, private track), NOT here.
+
+Honesty: there is no certification engine in the open tree, so every envelope
+carries the explicit ``unvalidated`` label. A suggestion is never implied to
+have been validated as safe.
+
+This module is intentionally HTTP-free (like the gate) so the safety-critical
+logic stays inspectable and is unit-tested directly.
+"""
+from __future__ import annotations
+
+from dataclasses import asdict, dataclass, field
+from typing import Any, Callable
+
+from tokenjam.proxy.gate import POLICY, GateDecision
+from tokenjam.utils.time_parse import utcnow
+
+# The cert gate. ENFORCE never acts in the OSS rails — request modification is a
+# separate, private track. This stays False here; do not flip it in OSS.
+ENFORCE_GATE_OPEN = False
+
+# Every OSS policy decision is unvalidated — there is no certification engine in
+# the open tree. Surfaced on every envelope and in `tj policy` output.
+UNVALIDATED_LABEL = "unvalidated"
+
+# would_action vocabulary (suggest mode — these are what a policy WOULD do).
+ACTION_NOOP = "noop"
+ACTION_ALLOW = "allow"
+ACTION_WOULD_MODIFY = "would_modify"
+ACTION_WOULD_BLOCK = "would_block"
+ACTION_ERROR = "error"
+
+# Strength ordering for summarising an envelope's overall would-action.
+_ACTION_STRENGTH = {
+    ACTION_NOOP: 0, ACTION_ALLOW: 0, ACTION_ERROR: 1,
+    ACTION_WOULD_MODIFY: 2, ACTION_WOULD_BLOCK: 3,
+}
+
+
+class PolicyGuardError(RuntimeError):
+    """Raised when the engine is asked to evaluate non-POLICY (observe-only) traffic."""
+
+
+@dataclass(frozen=True)
+class PolicyRequest:
+    """The pure evaluation context for one request (no HTTP types)."""
+    provider: str
+    path:     str
+    agent:    str | None = None
+    body:     dict | None = None
+
+
+@dataclass(frozen=True)
+class PolicyOutcome:
+    """What a single evaluator decided — the minimal return from a `kind`."""
+    would_action: str = ACTION_NOOP
+    reason:       str = ""
+    details:      dict = field(default_factory=dict)
+
+
+# A policy `kind` evaluator: pure function of (policy config, request) → outcome.
+PolicyEvaluator = Callable[[Any, PolicyRequest], PolicyOutcome]
+
+POLICY_REGISTRY: dict[str, PolicyEvaluator] = {}
+
+
+def register_policy(kind: str) -> Callable[[PolicyEvaluator], PolicyEvaluator]:
+    """Register an evaluator for a policy ``kind`` (mirrors the analyzer registry)."""
+    def _decorator(fn: PolicyEvaluator) -> PolicyEvaluator:
+        POLICY_REGISTRY[kind] = fn
+        return fn
+    return _decorator
+
+
+@register_policy("noop")
+def _noop_policy(policy: Any, request: PolicyRequest) -> PolicyOutcome:
+    """The reference example `kind`: applies to eligible traffic, does nothing.
+
+    Ships so the engine has a working built-in and `[[policies]]` round-trips
+    end-to-end. It is deliberately NOT concrete policy logic (budget_cap is
+    #222) — it only records that it observed the request.
+    """
+    return PolicyOutcome(
+        would_action=ACTION_NOOP,
+        reason="noop example policy: observed, no action",
+        details={"name": getattr(policy, "name", "")},
+    )
+
+
+@dataclass(frozen=True)
+class PolicyEvaluation:
+    """What ONE policy decided for a request — a row in the envelope."""
+    policy_name:       str
+    kind:              str
+    mode:              str          # suggest | enforce
+    would_action:      str
+    reason:            str
+    enforcement_gated: bool         # True when mode=enforce (gated off in OSS)
+    details:           dict = field(default_factory=dict)
+
+    def to_dict(self) -> dict:
+        return asdict(self)
+
+    @classmethod
+    def from_dict(cls, d: dict) -> "PolicyEvaluation":
+        return cls(
+            policy_name=d["policy_name"], kind=d["kind"], mode=d["mode"],
+            would_action=d["would_action"], reason=d.get("reason", ""),
+            enforcement_gated=bool(d.get("enforcement_gated", False)),
+            details=dict(d.get("details", {})),
+        )
+
+
+@dataclass(frozen=True)
+class PolicyEnvelope:
+    """The inspectable, round-trippable record of a request's policy evaluation.
+
+    Records what each policy WOULD do in suggest vs enforce mode. ``enforced`` is
+    always False in the OSS rails (the enforce path is gated off); ``validated``
+    is always False (no certification engine) and ``label`` is ``unvalidated``.
+    """
+    ts:                 str
+    provider:           str
+    path:               str
+    agent:              str | None
+    gate_path:          str          # always "policy" — the api-only guard holds
+    evaluations:        list[PolicyEvaluation]
+    overall_action:     str
+    enforced:           bool = False       # OSS: never enforces
+    enforcement_gated:  bool = False       # True if any enforce-mode policy applied
+    validated:          bool = False       # OSS: no certification engine
+    label:              str = UNVALIDATED_LABEL
+    suggest_only:       bool = True
+
+    def to_dict(self) -> dict:
+        d = asdict(self)
+        d["evaluations"] = [e.to_dict() for e in self.evaluations]
+        return d
+
+    @classmethod
+    def from_dict(cls, d: dict) -> "PolicyEnvelope":
+        return cls(
+            ts=d["ts"], provider=d["provider"], path=d["path"], agent=d.get("agent"),
+            gate_path=d.get("gate_path", POLICY),
+            evaluations=[PolicyEvaluation.from_dict(e) for e in d.get("evaluations", [])],
+            overall_action=d.get("overall_action", ACTION_NOOP),
+            enforced=bool(d.get("enforced", False)),
+            enforcement_gated=bool(d.get("enforcement_gated", False)),
+            validated=bool(d.get("validated", False)),
+            label=d.get("label", UNVALIDATED_LABEL),
+            suggest_only=bool(d.get("suggest_only", True)),
+        )
+
+
+def _policy_applies(policy: Any, request: PolicyRequest) -> bool:
+    """A policy applies when its target filters match the request."""
+    tp = getattr(policy, "target_provider", None)
+    ta = getattr(policy, "target_agent", None)
+    if tp is not None and tp != request.provider:
+        return False
+    if ta is not None and ta != request.agent:
+        return False
+    return True
+
+
+class PolicyEngine:
+    """Loads `[[policies]]` and evaluates eligible requests into envelopes."""
+
+    def __init__(self, policies: list[Any]):
+        # Only enabled policies participate.
+        self.policies = [p for p in (policies or []) if getattr(p, "enabled", True)]
+
+    @classmethod
+    def from_config(cls, config: Any) -> "PolicyEngine":
+        return cls(list(getattr(config, "policies", []) or []))
+
+    def evaluate(self, gate_decision: GateDecision, request: PolicyRequest) -> PolicyEnvelope:
+        """Evaluate all applicable policies for an eligible request.
+
+        The API-ONLY GUARD is the first line: this refuses to run on anything but
+        a POLICY-path (api/usage-billed) decision — belt-and-suspenders with the
+        gate. Observe-only traffic must NEVER reach the engine.
+        """
+        if gate_decision.path != POLICY:
+            raise PolicyGuardError(
+                f"policy engine refused non-POLICY traffic (path={gate_decision.path!r}); "
+                "observe-only traffic is never evaluated"
+            )
+
+        evaluations: list[PolicyEvaluation] = []
+        enforcement_gated = False
+        for policy in self.policies:
+            if not _policy_applies(policy, request):
+                continue
+            evaluations.append(self._evaluate_one(policy, request))
+            if getattr(policy, "mode", "suggest") == "enforce":
+                enforcement_gated = True
+
+        overall = ACTION_NOOP
+        for ev in evaluations:
+            if _ACTION_STRENGTH.get(ev.would_action, 0) > _ACTION_STRENGTH.get(overall, 0):
+                overall = ev.would_action
+
+        return PolicyEnvelope(
+            ts=utcnow().isoformat(),
+            provider=request.provider,
+            path=request.path,
+            agent=request.agent,
+            gate_path=gate_decision.path,
+            evaluations=evaluations,
+            overall_action=overall,
+            # Suggest mode only: nothing is ever enforced in the OSS rails. Even a
+            # mode=enforce policy is gated off behind ENFORCE_GATE_OPEN.
+            enforced=False,
+            enforcement_gated=enforcement_gated and not ENFORCE_GATE_OPEN,
+            validated=False,
+            label=UNVALIDATED_LABEL,
+        )
+
+    def _evaluate_one(self, policy: Any, request: PolicyRequest) -> PolicyEvaluation:
+        kind = getattr(policy, "kind", "")
+        mode = getattr(policy, "mode", "suggest")
+        name = getattr(policy, "name", "")
+        gated = mode == "enforce"  # enforce is scaffolded but never acts (OSS)
+
+        evaluator = POLICY_REGISTRY.get(kind)
+        if evaluator is None:
+            return PolicyEvaluation(
+                policy_name=name, kind=kind, mode=mode, would_action=ACTION_ERROR,
+                reason=f"unknown policy kind {kind!r} (no registered evaluator)",
+                enforcement_gated=gated, details={},
+            )
+        try:
+            outcome = evaluator(policy, request)
+        except Exception as exc:  # noqa: BLE001 — one bad policy never breaks the rest
+            return PolicyEvaluation(
+                policy_name=name, kind=kind, mode=mode, would_action=ACTION_ERROR,
+                reason=f"evaluator raised: {exc}", enforcement_gated=gated, details={},
+            )
+        return PolicyEvaluation(
+            policy_name=name, kind=kind, mode=mode,
+            would_action=outcome.would_action, reason=outcome.reason,
+            enforcement_gated=gated, details=dict(outcome.details),
+        )

--- a/tokenjam/proxy/observer.py
+++ b/tokenjam/proxy/observer.py
@@ -12,7 +12,7 @@ from __future__ import annotations
 import logging
 from collections import deque
 from dataclasses import asdict, dataclass
-from typing import Deque
+from typing import Any, Deque
 
 from tokenjam.proxy.gate import GateDecision
 from tokenjam.utils.time_parse import utcnow
@@ -32,6 +32,9 @@ class ProxyObservation:
     reason:       str
     forwarded:    bool         # always True in suggest mode
     suggest_only: bool = True  # suggest mode enforces nothing
+    # On the POLICY path, the round-trippable policy envelope (#220) — what each
+    # policy WOULD do. None on the observe-only path (the engine never runs).
+    policy:       dict | None = None
 
 
 class ProxyObserver:
@@ -41,7 +44,9 @@ class ProxyObserver:
         self._ring: Deque[ProxyObservation] = deque(maxlen=maxlen)
 
     def record(self, *, method: str, path: str, decision: GateDecision,
-               forwarded: bool = True) -> ProxyObservation:
+               forwarded: bool = True, envelope: Any = None) -> ProxyObservation:
+        # `envelope` is a PolicyEnvelope (POLICY path) or None (observe-only) —
+        # typed as Any to keep the observer free of an engine import cycle.
         obs = ProxyObservation(
             ts=utcnow().isoformat(),
             method=method,
@@ -51,14 +56,17 @@ class ProxyObserver:
             decision=decision.path,
             reason=decision.reason,
             forwarded=forwarded,
+            policy=envelope.to_dict() if envelope is not None else None,
         )
         self._ring.append(obs)
         # Suggest mode: log what the gate decided; never raise out of recording.
         try:
             logger.info(
-                "proxy %s %s provider=%s mode=%s decision=%s reason=%s forwarded=%s",
+                "proxy %s %s provider=%s mode=%s decision=%s reason=%s "
+                "forwarded=%s policy_action=%s",
                 method, path, obs.provider, obs.pricing_mode, obs.decision,
                 obs.reason, forwarded,
+                (obs.policy or {}).get("overall_action"),
             )
         except Exception:  # noqa: BLE001 — recording must never break pass-through
             pass


### PR DESCRIPTION
Plugs the policy engine into the proxy substrate (#219): the previously-no-op POLICY-path branch now evaluates **data-driven** policies and records an inspectable **envelope** of what each policy *would* do. **Suggest mode only — nothing is enforced.**

## Summary
- New `tokenjam/proxy/engine.py` (HTTP-free, like the gate): a policy-`kind` registry, `PolicyEngine`, `PolicyRequest`, `PolicyEvaluation`, and the round-trippable `PolicyEnvelope`.
- `[[policies]]` config block (`PolicyConfig` in `core/config.py`) — policies are **data, not code**: a `kind` (evaluator) bound to a target (provider/agent) with kind-specific `params`.
- Wired into the proxy app's POLICY-path branch; envelopes recorded via the observer (`ProxyObservation` gains an optional `policy` field).
- `tj policy` extended (not forked): `list` shows defined `[[policies]]` + their `unvalidated` label; new `tj policy decisions` reads recent decisions from a running proxy via tj-internal read endpoints.

## Invariants (belt-and-suspenders with the gate)
- **API-only guard.** `PolicyEngine.evaluate` REFUSES anything but `GateDecision.path == POLICY` (api/usage-billed), raising `PolicyGuardError`. Observe-only traffic (subscription/local/unknown) never reaches the engine — the app only calls it on the POLICY path **and** the engine re-checks. Tested both ways.
- **Suggest mode only.** The engine evaluates + records; it never modifies a request. The enforce-mode path is scaffolded but **gated OFF** behind `ENFORCE_GATE_OPEN = False` — actual request modification lands later behind the certification gate (a separate, private track), not here.
- **Unsigned-runs-labeled-unvalidated.** No certification engine exists in the open tree, so every envelope carries an explicit `unvalidated` label (`validated=False`). `tj policy list`/`decisions` surface it — a suggestion is never implied to be validated safe.

## No concrete policy logic
A `noop` reference `kind` ships so the engine works end-to-end; budget_cap is #222. Tests register their own stub kind to prove evaluation.

## Tests / Verification
- `tests/unit/test_policy_engine.py`: engine evaluates a registered policy; api-only guard (observe-only raises, any non-POLICY path raises); suggest-mode never enforces; enforce scaffolded-but-gated; unvalidated label always present; target filtering; unknown-kind reported not raised; **envelope round-trip**.
- `tests/integration/test_proxy_policy.py`: POLICY path evaluates + records + forwards **unmodified**; OBSERVE_ONLY path never builds an envelope; `/__tj/policy/policies` + `/__tj/policy/decisions` endpoints.
- `tests/unit/test_cmd_policy.py`: `list` shows engine policies + unvalidated note (table + `--json`); `decisions` renders + JSON + graceful-when-down + never opens the DB.
- `[[policies]]` config round-trip (`tests/unit/test_config.py`).
- Full suite **1053 passed**; `ruff` + `mypy` clean on new code.
- **Live smoke**: real `ProxyRunner` + a `[[policies]]` config + an api request → forwarded unmodified, envelope recorded (`decision: policy`, `gate_path: policy`), read endpoints + `tj policy decisions` (proxy on a separate thread) surface it with the `unvalidated` label.

## What's NOT in this PR
- **`tj policy add | edit | apply | remove | test`** — out of scope this sprint per the brief (the surface stays read-only).
- **Concrete policy logic** (e.g. `budget_cap`) — #222. Only the `noop` reference kind ships.
- **Enforce-mode request modification** — scaffolded + gated off; lands behind the cert gate (separate private track).
- **DB persistence of decisions / append-only migration** — decisions live in the proxy's in-memory observer ring this sprint (read via the endpoint); durable storage can follow.
- **Signature production / certification** — not in the open tree by design.

Closes #220

🤖 Generated with [Claude Code](https://claude.com/claude-code)