### PR TITLE
feat(proxy): budget_cap policy — first concrete policy on the engine (#222)

### DIFF
--- a/tests/unit/test_budget_cap_policy.py
+++ b/tests/unit/test_budget_cap_policy.py
@@ -1,0 +1,216 @@
+"""Unit tests for the budget_cap policy (#222) — the first concrete policy on
+the #220 engine. HTTP-free.
+
+Covers: fires would_block when current-cycle spend is over the per-provider
+ceiling and no-ops under; the soft "approaching ceiling" warn; reads the RIGHT
+``[budget.<provider>] usd`` ceiling (provider-scoped); the real DuckDB cycle-
+spend path (cycle bounds + provider scoping); graceful no-op when no ceiling /
+no spend data; the api-only guard means budget_cap never runs on observe-only
+traffic; and the envelope carries the unvalidated label + a would-do action
+(never "blocked" — suggest mode).
+"""
+from __future__ import annotations
+
+from datetime import timedelta
+
+import pytest
+
+from tokenjam.core.config import PolicyConfig, ProviderBudget, TjConfig
+from tokenjam.core.db import InMemoryBackend
+from tokenjam.proxy.engine import (
+    ACTION_NOOP,
+    ACTION_WOULD_BLOCK,
+    UNVALIDATED_LABEL,
+    PolicyContext,
+    PolicyEngine,
+    PolicyGuardError,
+    PolicyRequest,
+)
+from tokenjam.proxy.gate import OBSERVE_ONLY, POLICY, GateDecision, classify
+from tokenjam.utils.time_parse import utcnow
+from tests.factories import make_llm_span, make_session
+
+
+def _cfg(*, ceilings: dict[str, float | None], policy_params: dict | None = None) -> TjConfig:
+    budgets = {p: ProviderBudget(plan="api", usd=usd) for p, usd in ceilings.items()}
+    return TjConfig(
+        version="1",
+        budgets=budgets,
+        policies=[PolicyConfig(name="cap", kind="budget_cap", params=policy_params or {})],
+    )
+
+
+def _engine(cfg: TjConfig, *, spend, db=None) -> PolicyEngine:
+    # `spend` is a {provider: usd} map (or a single float) injected as the
+    # cycle-spend source so the evaluator is testable without a DB.
+    if callable(spend):
+        spend_fn = spend
+    elif isinstance(spend, dict):
+        spend_fn = lambda p: spend.get(p)  # noqa: E731
+    else:
+        spend_fn = lambda p: spend  # noqa: E731
+    ctx = PolicyContext(config=cfg, db=db, spend_fn=(None if db is not None else spend_fn))
+    return PolicyEngine(list(cfg.policies), context=ctx)
+
+
+def _api_gate(cfg: TjConfig, provider="openai") -> GateDecision:
+    gd = classify(cfg, provider)
+    assert gd.path == POLICY  # precondition: api/usage-billed
+    return gd
+
+
+def _req(provider="openai") -> PolicyRequest:
+    path = "/v1/messages" if provider == "anthropic" else "/v1/chat/completions"
+    return PolicyRequest(provider=provider, path=path)
+
+
+def test_fires_would_block_when_over_ceiling():
+    cfg = _cfg(ceilings={"openai": 100.0})
+    env = _engine(cfg, spend=150.0).evaluate(_api_gate(cfg), _req("openai"))
+    ev = env.evaluations[0]
+    assert ev.would_action == ACTION_WOULD_BLOCK
+    assert env.overall_action == ACTION_WOULD_BLOCK
+    assert ev.details["over_by_usd"] == pytest.approx(50.0)
+    assert ev.details["would_do"]  # carries the WOULD-do action
+    # Suggest mode: never claims it acted.
+    assert "would block" in ev.reason.lower()
+    assert "blocked" not in ev.reason.lower()
+
+
+def test_noop_when_under_ceiling():
+    cfg = _cfg(ceilings={"openai": 100.0})
+    env = _engine(cfg, spend=30.0).evaluate(_api_gate(cfg), _req("openai"))
+    ev = env.evaluations[0]
+    assert ev.would_action == ACTION_NOOP
+    assert ev.details["near_ceiling"] is False
+    assert env.overall_action == ACTION_NOOP
+
+
+def test_warns_near_ceiling():
+    cfg = _cfg(ceilings={"openai": 100.0})  # default warn_at = 0.8
+    env = _engine(cfg, spend=90.0).evaluate(_api_gate(cfg), _req("openai"))
+    ev = env.evaluations[0]
+    assert ev.would_action == ACTION_NOOP            # a warn is not a block
+    assert ev.details["near_ceiling"] is True
+    assert ev.details["pct_of_ceiling"] == pytest.approx(90.0)
+    assert "approaching" in ev.reason.lower()
+
+
+def test_warn_at_is_configurable_via_params():
+    cfg = _cfg(ceilings={"openai": 100.0}, policy_params={"warn_at": 0.5})
+    env = _engine(cfg, spend=60.0).evaluate(_api_gate(cfg), _req("openai"))
+    assert env.evaluations[0].details["near_ceiling"] is True  # 60% ≥ 50%
+
+
+def test_noop_when_no_ceiling_configured():
+    # No [budget.<provider>] usd → nothing to cap, even with huge spend.
+    cfg = _cfg(ceilings={"openai": None})
+    env = _engine(cfg, spend=9999.0).evaluate(_api_gate(cfg), _req("openai"))
+    ev = env.evaluations[0]
+    assert ev.would_action == ACTION_NOOP
+    assert "no [budget.openai] usd ceiling" in ev.reason
+    assert ev.details["ceiling_usd"] is None
+
+
+def test_reads_the_right_provider_ceiling():
+    # anthropic has a tight $10 ceiling, openai a loose $1000. The same $50 spend
+    # blocks on anthropic but is fine on openai — proving provider-scoped reads.
+    cfg = _cfg(ceilings={"anthropic": 10.0, "openai": 1000.0})
+    spend = {"anthropic": 50.0, "openai": 50.0}
+    anthro = _engine(cfg, spend=spend).evaluate(_api_gate(cfg, "anthropic"), _req("anthropic"))
+    openai = _engine(cfg, spend=spend).evaluate(_api_gate(cfg, "openai"), _req("openai"))
+    assert anthro.evaluations[0].would_action == ACTION_WOULD_BLOCK
+    assert anthro.evaluations[0].details["ceiling_usd"] == pytest.approx(10.0)
+    assert openai.evaluations[0].would_action == ACTION_NOOP
+    assert openai.evaluations[0].details["ceiling_usd"] == pytest.approx(1000.0)
+
+
+def test_cycle_spend_read_from_duckdb():
+    # The real path: cycle spend summed from the telemetry DB, scoped to the
+    # provider + the current billing cycle. Seed current-cycle spans via factory.
+    db = InMemoryBackend()
+    now = utcnow()
+    db.upsert_session(make_session(session_id="s1", plan_tier="api", agent_id="cc"))
+    # $7 of anthropic spend this cycle; an openai span must NOT count toward it.
+    for i in range(7):
+        db.insert_span(make_llm_span(session_id="s1", agent_id="cc", provider="anthropic",
+                                     model="claude-opus-4-7", cost_usd=1.0,
+                                     start_time=now - timedelta(hours=i + 1)))
+    db.insert_span(make_llm_span(session_id="s1", agent_id="cc", provider="openai",
+                                 model="gpt-4o", cost_usd=100.0, start_time=now - timedelta(hours=1)))
+
+    over = _cfg(ceilings={"anthropic": 5.0})   # $7 spend > $5 ceiling
+    env = _engine(over, spend=None, db=db).evaluate(_api_gate(over, "anthropic"), _req("anthropic"))
+    ev = env.evaluations[0]
+    assert ev.would_action == ACTION_WOULD_BLOCK
+    assert ev.details["cycle_spend_usd"] == pytest.approx(7.0)  # openai's $100 excluded
+
+    under = _cfg(ceilings={"anthropic": 20.0})  # $7 spend < $20 ceiling
+    env2 = _engine(under, spend=None, db=db).evaluate(_api_gate(under, "anthropic"), _req("anthropic"))
+    assert env2.evaluations[0].would_action == ACTION_NOOP
+    db.close()
+
+
+def test_old_spend_outside_cycle_is_excluded():
+    # Spend from before the current cycle must not count (deterministic ceiling).
+    db = InMemoryBackend()
+    now = utcnow()
+    db.upsert_session(make_session(session_id="s1", plan_tier="api", agent_id="cc"))
+    db.insert_span(make_llm_span(session_id="s1", agent_id="cc", provider="anthropic",
+                                 model="claude-opus-4-7", cost_usd=500.0,
+                                 start_time=now - timedelta(days=45)))  # last cycle
+    cfg = _cfg(ceilings={"anthropic": 5.0})
+    env = _engine(cfg, spend=None, db=db).evaluate(_api_gate(cfg, "anthropic"), _req("anthropic"))
+    assert env.evaluations[0].would_action == ACTION_NOOP  # 0 this cycle, under $5
+    assert env.evaluations[0].details["cycle_spend_usd"] == pytest.approx(0.0)
+    db.close()
+
+
+def test_noop_when_spend_unavailable():
+    # No DB and no injected spend → can't evaluate → graceful no-op (not a guess).
+    cfg = _cfg(ceilings={"openai": 100.0})
+    ctx = PolicyContext(config=cfg)  # no db, no spend_fn
+    env = PolicyEngine(list(cfg.policies), context=ctx).evaluate(_api_gate(cfg), _req("openai"))
+    ev = env.evaluations[0]
+    assert ev.would_action == ACTION_NOOP
+    assert "unavailable" in ev.reason
+    assert ev.details["cycle_spend_usd"] is None
+
+
+def test_only_evaluated_on_policy_path_traffic():
+    # budget_cap can never run on observe-only traffic — the engine's api-only
+    # guard refuses it before any evaluator is called.
+    sub_cfg = TjConfig(
+        version="1", budgets={"anthropic": ProviderBudget(plan="max_5x", usd=10.0)},
+        policies=[PolicyConfig(name="cap", kind="budget_cap")],
+    )
+    observe_gd = classify(sub_cfg, "anthropic")
+    assert observe_gd.path == OBSERVE_ONLY
+    engine = PolicyEngine(list(sub_cfg.policies),
+                          context=PolicyContext(config=sub_cfg, spend_fn=lambda p: 9999.0))
+    with pytest.raises(PolicyGuardError):
+        engine.evaluate(observe_gd, _req("anthropic"))
+
+
+def test_envelope_unvalidated_and_suggest_only_when_blocking():
+    cfg = _cfg(ceilings={"openai": 100.0})
+    env = _engine(cfg, spend=150.0).evaluate(_api_gate(cfg), _req("openai"))
+    assert env.label == UNVALIDATED_LABEL
+    assert env.validated is False
+    assert env.enforced is False          # suggest mode: never acts
+    assert env.suggest_only is True
+
+
+def test_from_config_threads_db_into_context():
+    # PolicyEngine.from_config(config, db=...) wires the DB so budget_cap can
+    # read cycle spend through the engine the proxy actually builds.
+    db = InMemoryBackend()
+    now = utcnow()
+    db.upsert_session(make_session(session_id="s1", plan_tier="api", agent_id="cc"))
+    db.insert_span(make_llm_span(session_id="s1", agent_id="cc", provider="openai",
+                                 model="gpt-4o", cost_usd=200.0, start_time=now))
+    cfg = _cfg(ceilings={"openai": 50.0})
+    engine = PolicyEngine.from_config(cfg, db=db)
+    env = engine.evaluate(_api_gate(cfg), _req("openai"))
+    assert env.evaluations[0].would_action == ACTION_WOULD_BLOCK
+    db.close()

--- a/tokenjam/cli/cmd_serve.py
+++ b/tokenjam/cli/cmd_serve.py
@@ -64,7 +64,9 @@ def cmd_serve(ctx: click.Context, host: str | None, port: int | None,
     proxy_runner = None
     if config.proxy.enabled:
         from tokenjam.proxy.server import ProxyRunner
-        proxy_runner = ProxyRunner(config)
+        # Pass the serve DB so in-process policies (budget_cap, #222) can read
+        # current-cycle spend from the same connection (per-thread cursors, #124).
+        proxy_runner = ProxyRunner(config, db=db)
 
     @asynccontextmanager
     async def _lifespan(_app: FastAPI) -> AsyncIterator[None]:

--- a/tokenjam/proxy/__init__.py
+++ b/tokenjam/proxy/__init__.py
@@ -22,6 +22,7 @@ from __future__ import annotations
 
 from tokenjam.proxy.engine import (
     UNVALIDATED_LABEL,
+    PolicyContext,
     PolicyEngine,
     PolicyEnvelope,
     PolicyEvaluation,
@@ -38,6 +39,6 @@ from tokenjam.proxy.gate import (
 
 __all__ = [
     "OBSERVE_ONLY", "POLICY", "GateDecision", "classify",
-    "PolicyEngine", "PolicyEnvelope", "PolicyEvaluation", "PolicyRequest",
-    "PolicyGuardError", "register_policy", "UNVALIDATED_LABEL",
+    "PolicyContext", "PolicyEngine", "PolicyEnvelope", "PolicyEvaluation",
+    "PolicyRequest", "PolicyGuardError", "register_policy", "UNVALIDATED_LABEL",
 ]

--- a/tokenjam/proxy/app.py
+++ b/tokenjam/proxy/app.py
@@ -95,16 +95,19 @@ def _response_headers(upstream: httpx.Response) -> list[tuple[bytes, bytes]]:
 
 def build_proxy_app(config: Any, observer: ProxyObserver | None = None,
                     client: httpx.AsyncClient | None = None,
-                    engine: PolicyEngine | None = None) -> Starlette:
+                    engine: PolicyEngine | None = None,
+                    db: Any = None) -> Starlette:
     """Build the Starlette proxy app.
 
-    ``observer``, ``client`` and ``engine`` are injectable for testing — pass an
-    ``httpx.AsyncClient`` backed by ``httpx.MockTransport`` to avoid real
+    ``observer``, ``client``, ``engine`` and ``db`` are injectable for testing —
+    pass an ``httpx.AsyncClient`` backed by ``httpx.MockTransport`` to avoid real
     network calls. When ``client`` is None a real client is created on startup
-    and closed on shutdown; when ``engine`` is None it is built from ``config``.
+    and closed on shutdown; when ``engine`` is None it is built from ``config``,
+    threading ``db`` (the shared tj-serve DuckDB) so in-process policies like
+    budget_cap (#222) can read current-cycle spend.
     """
     observer = observer or ProxyObserver()
-    engine = engine or PolicyEngine.from_config(config)
+    engine = engine or PolicyEngine.from_config(config, db=db)
     state: dict[str, Any] = {"client": client, "owns_client": client is None}
 
     async def _get_client() -> httpx.AsyncClient:

--- a/tokenjam/proxy/engine.py
+++ b/tokenjam/proxy/engine.py
@@ -26,6 +26,7 @@ logic stays inspectable and is unit-tested directly.
 """
 from __future__ import annotations
 
+import inspect
 from dataclasses import asdict, dataclass, field
 from typing import Any, Callable
 
@@ -75,8 +76,11 @@ class PolicyOutcome:
     details:      dict = field(default_factory=dict)
 
 
-# A policy `kind` evaluator: pure function of (policy config, request) → outcome.
-PolicyEvaluator = Callable[[Any, PolicyRequest], PolicyOutcome]
+# A policy `kind` evaluator. Pure function of (policy config, request) → outcome,
+# or (policy, request, context) for kinds that need shared state — the engine
+# inspects the arity and passes `context` only when the evaluator accepts it, so
+# stateless kinds (noop) keep the 2-arg form.
+PolicyEvaluator = Callable[..., PolicyOutcome]
 
 POLICY_REGISTRY: dict[str, PolicyEvaluator] = {}
 
@@ -87,6 +91,61 @@ def register_policy(kind: str) -> Callable[[PolicyEvaluator], PolicyEvaluator]:
         POLICY_REGISTRY[kind] = fn
         return fn
     return _decorator
+
+
+@dataclass(frozen=True)
+class PolicyContext:
+    """Shared, engine-level state an evaluator may need beyond the request.
+
+    Stateless kinds (``noop``) ignore it; stateful kinds (``budget_cap``) read
+    the per-provider ceiling from ``config.budgets`` and current-cycle spend from
+    the telemetry DB. HTTP-free: ``db`` is the shared ``tj serve`` DuckDB backend
+    (the proxy runs in-process, so it reuses that connection — per-thread cursors
+    make this concurrency-safe, #124). ``spend_fn`` is an injectable override so
+    evaluators are unit-testable without a DB; ``now_fn`` injects the clock for
+    deterministic cycle bounds in tests.
+    """
+    config:   Any = None
+    db:       Any = None
+    spend_fn: Callable[[str], float | None] | None = None
+    now_fn:   Callable[[], Any] | None = None
+
+    def provider_budget(self, provider: str) -> Any:
+        budgets = getattr(self.config, "budgets", None) or {}
+        return budgets.get(provider)
+
+    def cycle_spend_usd(self, provider: str) -> float | None:
+        """Current billing-cycle USD spend for ``provider`` (None if unavailable).
+
+        Honors the provider's ``cycle_start_day`` + ``applies_to_services`` from
+        config, mirroring the budget-projection analyzer's window so the proxy
+        and `tj optimize` agree on what counts. Best-effort: returns None when no
+        spend source is wired (a budget_cap with no data is a no-op, not a guess).
+        """
+        if self.spend_fn is not None:
+            return self.spend_fn(provider)
+        conn = getattr(self.db, "conn", None) if self.db is not None else None
+        if conn is None:
+            return None
+        from tokenjam.core.cycle import cycle_bounds
+        budget = self.provider_budget(provider)
+        start_day = getattr(budget, "cycle_start_day", 1) if budget is not None else 1
+        services = list(getattr(budget, "applies_to_services", None) or []) if budget else []
+        now = self.now_fn() if self.now_fn is not None else utcnow()
+        cs, ce = cycle_bounds(now, start_day)
+        # Parameterised SQL only (Rule 7); provider/cost_usd/start_time per semconv.
+        clauses = ["start_time >= $1", "start_time < $2", "provider = $3"]
+        params: list = [cs, ce, provider]
+        if services:
+            ph = ",".join("$" + str(len(params) + i + 1) for i in range(len(services)))
+            clauses.append(f"agent_id IN ({ph})")  # agent_id holds service.name in tj's model
+            params.extend(services)
+        sql = "SELECT COALESCE(SUM(cost_usd), 0.0) FROM spans WHERE " + " AND ".join(clauses)
+        try:
+            row = conn.execute(sql, params).fetchone()
+        except Exception:  # noqa: BLE001 — a spend-query failure must not break eval
+            return None
+        return float(row[0] or 0.0) if row else 0.0
 
 
 @register_policy("noop")
@@ -101,6 +160,85 @@ def _noop_policy(policy: Any, request: PolicyRequest) -> PolicyOutcome:
         would_action=ACTION_NOOP,
         reason="noop example policy: observed, no action",
         details={"name": getattr(policy, "name", "")},
+    )
+
+
+# Default fraction of the ceiling at which budget_cap raises a soft "approaching
+# ceiling" warning (still a no-op action). Overridable per policy via params.
+_BUDGET_CAP_DEFAULT_WARN_AT = 0.8
+
+
+@register_policy("budget_cap")
+def _budget_cap_policy(policy: Any, request: PolicyRequest, context: PolicyContext) -> PolicyOutcome:
+    """The first concrete policy (#222): per-provider cycle-spend ceiling.
+
+    Reads the existing ``[budget.<provider>] usd`` ceiling (``ProviderBudget.usd``)
+    and compares it to the provider's current-cycle spend:
+
+    - spend **over** the ceiling → ``would_block`` (it says it WOULD block further
+      requests; SUGGEST MODE — it does not act).
+    - spend at/above ``warn_at`` × ceiling (default 0.8) but under → a no-op that
+      flags ``near_ceiling`` (a soft warning).
+    - under → ``noop``.
+
+    A ceiling is deterministic, so budget_cap has NO validation/certification
+    dependency — that's why it's first, and why it's the policy that can graduate
+    to enforce-mode first when that gate opens (NOT built here; ENFORCE stays
+    closed). The envelope's ``unvalidated`` label + suggest-only framing are
+    applied by the engine; this evaluator never says "blocked", only "would
+    block".
+    """
+    provider = request.provider
+    budget = context.provider_budget(provider) if context is not None else None
+    ceiling = getattr(budget, "usd", None) if budget is not None else None
+    if not ceiling or ceiling <= 0:
+        return PolicyOutcome(
+            would_action=ACTION_NOOP,
+            reason=f"no [budget.{provider}] usd ceiling configured — nothing to cap",
+            details={"provider": provider, "ceiling_usd": None},
+        )
+
+    spend = context.cycle_spend_usd(provider) if context is not None else None
+    if spend is None:
+        return PolicyOutcome(
+            would_action=ACTION_NOOP,
+            reason=f"current-cycle spend for {provider} unavailable — no evaluation",
+            details={"provider": provider, "ceiling_usd": ceiling, "cycle_spend_usd": None},
+        )
+
+    try:
+        warn_at = float((getattr(policy, "params", None) or {}).get("warn_at", _BUDGET_CAP_DEFAULT_WARN_AT))
+    except (TypeError, ValueError):
+        warn_at = _BUDGET_CAP_DEFAULT_WARN_AT
+    pct = (spend / ceiling) if ceiling else 0.0
+    base = {
+        "provider": provider,
+        "ceiling_usd": round(float(ceiling), 6),
+        "cycle_spend_usd": round(float(spend), 6),
+        "pct_of_ceiling": round(pct * 100, 1),
+    }
+
+    if spend > ceiling:
+        # SUGGEST MODE: report what it WOULD do, never "blocked".
+        return PolicyOutcome(
+            would_action=ACTION_WOULD_BLOCK,
+            reason=(f"{provider} cycle spend ${spend:.2f} is over the "
+                    f"${ceiling:.2f} ceiling — would block until cycle reset "
+                    "(suggest mode: not enforced)"),
+            details={**base, "over_by_usd": round(float(spend - ceiling), 6),
+                     "would_do": "block further requests until the budget cycle resets"},
+        )
+    if pct >= warn_at:
+        return PolicyOutcome(
+            would_action=ACTION_NOOP,
+            reason=(f"{provider} cycle spend ${spend:.2f} is approaching the "
+                    f"${ceiling:.2f} ceiling ({base['pct_of_ceiling']}%)"),
+            details={**base, "near_ceiling": True, "warn_at_pct": round(warn_at * 100, 1)},
+        )
+    return PolicyOutcome(
+        would_action=ACTION_NOOP,
+        reason=f"{provider} cycle spend ${spend:.2f} is under the ${ceiling:.2f} ceiling",
+        details={**base, "near_ceiling": False},
     )
 
 
@@ -180,16 +318,45 @@ def _policy_applies(policy: Any, request: PolicyRequest) -> bool:
     return True
 
 
+def _accepts_context(fn: PolicyEvaluator) -> bool:
+    """True if an evaluator takes a 3rd (context) positional arg."""
+    try:
+        params = list(inspect.signature(fn).parameters.values())
+    except (TypeError, ValueError):
+        return False
+    if any(p.kind == p.VAR_POSITIONAL for p in params):
+        return True
+    positional = [p for p in params
+                  if p.kind in (p.POSITIONAL_ONLY, p.POSITIONAL_OR_KEYWORD)]
+    return len(positional) >= 3
+
+
+def _call_evaluator(fn: PolicyEvaluator, policy: Any, request: PolicyRequest,
+                    context: PolicyContext) -> PolicyOutcome:
+    """Call an evaluator, passing ``context`` only to kinds that accept it."""
+    if _accepts_context(fn):
+        return fn(policy, request, context)
+    return fn(policy, request)
+
+
 class PolicyEngine:
     """Loads `[[policies]]` and evaluates eligible requests into envelopes."""
 
-    def __init__(self, policies: list[Any]):
+    def __init__(self, policies: list[Any], context: PolicyContext | None = None):
         # Only enabled policies participate.
         self.policies = [p for p in (policies or []) if getattr(p, "enabled", True)]
+        # Shared state for stateful kinds (budget_cap). Empty by default so the
+        # engine works with no config/DB (stateful kinds then no-op gracefully).
+        self.context = context or PolicyContext()
 
     @classmethod
-    def from_config(cls, config: Any) -> "PolicyEngine":
-        return cls(list(getattr(config, "policies", []) or []))
+    def from_config(cls, config: Any, *, db: Any = None) -> "PolicyEngine":
+        # `db` is the shared tj-serve DuckDB backend, threaded through so
+        # budget_cap can read current-cycle spend (the proxy runs in-process).
+        return cls(
+            list(getattr(config, "policies", []) or []),
+            context=PolicyContext(config=config, db=db),
+        )
 
     def evaluate(self, gate_decision: GateDecision, request: PolicyRequest) -> PolicyEnvelope:
         """Evaluate all applicable policies for an eligible request.
@@ -248,7 +415,7 @@ class PolicyEngine:
                 enforcement_gated=gated, details={},
             )
         try:
-            outcome = evaluator(policy, request)
+            outcome = _call_evaluator(evaluator, policy, request, self.context)
         except Exception as exc:  # noqa: BLE001 — one bad policy never breaks the rest
             return PolicyEvaluation(
                 policy_name=name, kind=kind, mode=mode, would_action=ACTION_ERROR,

--- a/tokenjam/proxy/server.py
+++ b/tokenjam/proxy/server.py
@@ -24,15 +24,19 @@ logger = logging.getLogger("tokenjam.proxy")
 class ProxyRunner:
     """Owns the proxy's uvicorn server + its lifecycle within an event loop."""
 
-    def __init__(self, config: Any, observer: ProxyObserver | None = None) -> None:
+    def __init__(self, config: Any, observer: ProxyObserver | None = None,
+                 db: Any = None) -> None:
         self.config = config
         self.observer = observer or ProxyObserver()
+        # Shared tj-serve DB (optional) so in-process policies (budget_cap, #222)
+        # can read current-cycle spend without opening a second connection.
+        self.db = db
         self._server: uvicorn.Server | None = None
         self._task: asyncio.Task | None = None
 
     def start(self) -> None:
         """Schedule the proxy server on the running event loop (non-blocking)."""
-        app = build_proxy_app(self.config, observer=self.observer)
+        app = build_proxy_app(self.config, observer=self.observer, db=self.db)
         uconfig = uvicorn.Config(
             app,
             host=self.config.proxy.host,


### PR DESCRIPTION
The first concrete policy on the #220 engine — `budget_cap` — replacing the `noop` reference as the proof that the rails carry real policy logic end-to-end. A per-provider spending ceiling is deterministic, so it has **no validation/certification dependency**: that's why it goes first, and why it's the policy that can graduate to enforce-mode first when that gate opens (not built here).

## What it does
- Reads the existing per-provider ceiling **`[budget.<provider>] usd`** (`ProviderBudget.usd`) and the provider's **current billing-cycle spend**:
  - spend **over** the ceiling → **`would_block`**
  - at/above `warn_at` × ceiling (default 0.8) but under → a soft **`near_ceiling`** warning (still a no-op action)
  - under → **`noop`**
- **Suggest mode only.** It reports what it WOULD do — never "blocked". The envelope stays `enforced=False` / `suggest_only=True` and carries the **`unvalidated`** label like every OSS policy. `ENFORCE_GATE_OPEN` is untouched (stays `False`).
- Runs **only on POLICY-path** (api/usage-billed) traffic — the engine's api-only guard guarantees it; budget_cap never sees observe-only traffic.

## Engine plumbing (minimal, backward-compatible)
Evaluators may now take an optional third `context` arg (`PolicyContext`: config + the shared DuckDB + injectable spend/clock hooks for tests). The engine **inspects arity** and passes `context` only to kinds that accept it, so the stateless `noop` kind and existing evaluators are unchanged (all prior engine tests stay green).

budget_cap reads the ceiling from `context.config.budgets` and cycle spend from `context.cycle_spend_usd` — a parameterised DuckDB `SUM(cost_usd)` scoped by provider + `cycle_start_day` + `applies_to_services`, mirroring the budget-projection analyzer's window so the proxy and `tj optimize` agree. The proxy runs **in-process** inside `tj serve`, so the serve DB is threaded `ProxyRunner → build_proxy_app → PolicyEngine.from_config(config, db=…)` and reused via per-thread cursors (#124). Spend is best-effort: no DB / no data → graceful no-op, never a guess.

## Tests / Verification
`tests/unit/test_budget_cap_policy.py` (HTTP-free, factories): would_block over ceiling / noop under; the near-ceiling warn + configurable `warn_at`; **reads the right provider's ceiling** (same spend blocks anthropic@$10, fine on openai@$1000); the **real DuckDB cycle-spend path** (provider-scoped, current-cycle-only, prior-cycle spend excluded); graceful no-op with no ceiling / no spend source; the **api-only guard** means budget_cap never runs on observe-only traffic; envelope is `unvalidated` + suggest-only and says "would block", never "blocked"; `from_config(db=…)` threads the DB through.

- Full `pytest tests/unit tests/integration tests/synthetic tests/agents` → **1065 passed**; existing proxy/engine tests unchanged. `ruff check tokenjam/` + `mypy tokenjam/` clean.

## What's NOT in this PR
- Enforce mode (actual request blocking) — gated off behind the certification track; budget_cap is the candidate to graduate first, but that lands elsewhere.

Closes #222

🤖 Generated with [Claude Code](https://claude.com/claude-code)