### PR TITLE
[feature] Audit log + savings meter (#221)

### DIFF
--- a/docs/policy/overview.md
+++ b/docs/policy/overview.md
@@ -91,14 +91,33 @@ policies.demo-cap kind=noop, mode=suggest, label=unvalidated, provider=openai  [
 ...
 Enforcement-plane policies ([[policies]]) run 'unvalidated' (suggest mode only — ...).
 
-$ tj policy decisions        # recent decisions from a running `tj serve` proxy
-TIME       PROVIDER  PATH                  WOULD-DO  POLICIES   LABEL
-2026-…     openai    /v1/chat/completions  noop      demo-cap   unvalidated
+$ tj policy decisions        # persisted decisions + the estimated-recoverable meter
+TIME       PROVIDER  PATH                  WOULD-DO  POLICY    LABEL
+2026-…     openai    /v1/chat/completions  noop      demo-cap  unvalidated
+
+Estimated recoverable: ~$0.0000 vs actual spend $12.3400 (3 decisions, label=unvalidated)
+Estimated recoverable — suggest mode enforces nothing, so this is what these
+policies WOULD have recovered if enforced, not realized savings. Unvalidated.
 ```
 
-`tj policy decisions` reads the recent in-memory decisions from a running proxy
-(`tj proxy enable` + `tj serve`); without one it prints a hint. The
-`add | edit | apply` lifecycle remains out of scope this sprint.
+### Audit log + savings meter (#221)
+
+Every recorded decision is persisted to an append-only DuckDB audit log
+(`policy_decisions`), and each eligible POLICY-path decision also writes a
+`savings_ledger` row. The audit log records **both** paths: `gate_decision` +
+`passthrough_tos` distinguish "we *chose* not to act" (policy path, action
+`noop`) from "we were *not permitted* to act" (subscription, TOS).
+
+**The savings meter is estimated-recoverable, never realized.** Suggest mode
+enforces nothing, so `tj policy decisions` shows what these policies *would have
+recovered if enforced* — reconciled against actual spend from the same source
+`tj cost` reads — and `realized` is always `False`. It never says "saved", and
+the `unvalidated` label rides through to every persisted row.
+
+`tj policy decisions` reads the **persisted** decisions + meter from the DB; if
+a running `tj serve` holds the DB lock, it falls back to the proxy's recent
+in-memory ring. The `add | edit | apply` lifecycle remains out of scope this
+sprint.
 
 ## Why a preview?
 

--- a/tests/integration/test_db.py
+++ b/tests/integration/test_db.py
@@ -42,8 +42,8 @@ def _insert_agent(db, agent_id="test-agent"):
 def test_migrations_run_on_empty_db():
     backend = InMemoryBackend()
     rows = backend.conn.execute("SELECT version FROM schema_migrations").fetchall()
-    assert len(rows) == 5
-    assert {r[0] for r in rows} == {1, 2, 3, 4, 5}
+    assert len(rows) == 6
+    assert {r[0] for r in rows} == {1, 2, 3, 4, 5, 6}
     backend.close()
 
 
@@ -52,7 +52,7 @@ def test_migrations_are_idempotent():
     # Running migrations again should not raise
     run_migrations(backend.conn)
     rows = backend.conn.execute("SELECT version FROM schema_migrations").fetchall()
-    assert len(rows) == 5
+    assert len(rows) == 6
     backend.close()
 
 

--- a/tests/unit/test_cmd_policy.py
+++ b/tests/unit/test_cmd_policy.py
@@ -260,7 +260,9 @@ def test_list_json_includes_unvalidated_note_when_policies_present(runner):
     assert any(r["policy"] == "policies.cap" for r in payload["policies"])
 
 
-_SAMPLE_DECISIONS = {"decisions": [{
+# --- #221: `tj policy decisions` reads persisted decisions + savings from DB ---
+
+_SAMPLE_PROXY = {"decisions": [{
     "ts": "2026-06-24T00:00:00+00:00", "provider": "openai",
     "path": "/v1/chat/completions",
     "policy": {"overall_action": "would_block", "label": "unvalidated",
@@ -268,40 +270,80 @@ _SAMPLE_DECISIONS = {"decisions": [{
 }], "label": "unvalidated"}
 
 
-def test_decisions_json_surfaces_envelope_and_label(runner):
-    cfg = TjConfig(version="1")
-    with patch("tokenjam.cli.cmd_policy._fetch_proxy_json", return_value=_SAMPLE_DECISIONS):
-        result = _invoke(runner, cfg, ["--json", "policy", "decisions"])
-    assert result.exit_code == 0, result.output
-    payload = json.loads(result.output)
-    assert payload["label"] == "unvalidated"
-    assert payload["reachable"] is True
-    assert payload["decisions"][0]["policy"]["overall_action"] == "would_block"
+def _seed_decision_db():
+    """An InMemoryBackend with one persisted decision + savings entry (#221)."""
+    from tokenjam.core.db import InMemoryBackend
+    from tokenjam.core.models import PolicyDecisionRecord, SavingsLedgerEntry
+    from tokenjam.utils.time_parse import utcnow
+    db = InMemoryBackend()
+    db.insert_policy_decision(PolicyDecisionRecord(
+        decision_id="d1", ts=utcnow(), provider="openai", pricing_mode="api",
+        gate_decision="policy", path="/v1/chat/completions", would_action="would_block",
+        policy_name="blocker", policy_kind="noop",
+        envelope={"overall_action": "would_block", "label": "unvalidated"}))
+    db.insert_savings_entry(SavingsLedgerEntry(
+        ledger_id="l1", decision_id="d1", ts=utcnow(), provider="openai",
+        pricing_mode="api", would_action="would_block",
+        estimated_recoverable_usd=0.50, estimate_basis="stub", billing_period="2026-06"))
+    return db
 
 
-def test_decisions_renders_recent_envelopes(runner):
-    # The human table renders without error; width-robust assertions only (Rich
-    # truncates cells under the narrow CliRunner terminal).
+def test_decisions_reads_persisted_from_db(runner):
     cfg = TjConfig(version="1")
-    with patch("tokenjam.cli.cmd_policy._fetch_proxy_json", return_value=_SAMPLE_DECISIONS):
+    db = _seed_decision_db()
+    with patch("tokenjam.core.db.open_db", return_value=db):
         result = _invoke(runner, cfg, ["policy", "decisions"])
     assert result.exit_code == 0, result.output
     assert "openai" in result.output
     assert "unvalidated" in result.output
+    # The savings meter is shown and is ESTIMATED / RECOVERABLE — never "saved".
+    assert "Estimated recoverable" in result.output
 
 
-def test_decisions_graceful_when_proxy_unreachable(runner):
+def test_decisions_savings_never_says_saved(runner):
     cfg = TjConfig(version="1")
-    with patch("tokenjam.cli.cmd_policy._fetch_proxy_json", return_value=None):
+    db = _seed_decision_db()
+    with patch("tokenjam.core.db.open_db", return_value=db):
+        result = _invoke(runner, cfg, ["--json", "policy", "decisions"])
+    assert result.exit_code == 0, result.output
+    payload = json.loads(result.output)
+    assert payload["source"] == "db"
+    assert payload["label"] == "unvalidated"
+    sv = payload["savings"]
+    assert sv["realized"] is False
+    assert sv["estimated_recoverable_usd"] == 0.5
+    # Honesty: the meter never claims realized savings.
+    assert "saved" not in json.dumps(sv).lower().replace("would-have-saved", "")
+    assert "not realized" in sv["disclaimer"].lower()
+
+
+def test_decisions_falls_back_to_proxy_when_db_locked(runner):
+    cfg = TjConfig(version="1")
+    with patch("tokenjam.core.db.open_db", side_effect=RuntimeError("locked")), \
+         patch("tokenjam.cli.cmd_policy._fetch_proxy_json", return_value=_SAMPLE_PROXY):
+        result = _invoke(runner, cfg, ["--json", "policy", "decisions"])
+    assert result.exit_code == 0, result.output
+    payload = json.loads(result.output)
+    assert payload["source"] == "proxy"
+    assert payload["decisions"][0]["would_action"] == "would_block"
+
+
+def test_decisions_unreachable_when_db_locked_and_no_proxy(runner):
+    cfg = TjConfig(version="1")
+    with patch("tokenjam.core.db.open_db", side_effect=RuntimeError("locked")), \
+         patch("tokenjam.cli.cmd_policy._fetch_proxy_json", return_value=None):
         result = _invoke(runner, cfg, ["policy", "decisions"])
     assert result.exit_code == 0, result.output
-    assert "No running proxy reachable" in result.output
+    assert "no running proxy reachable" in result.output.lower()
 
 
-def test_decisions_does_not_open_db(runner):
+def test_decisions_startup_does_not_open_db(runner):
+    # `policy` is in no_db_commands: STARTUP must not open the DB (main.open_db).
+    # The command opens its OWN connection lazily, which is allowed.
     cfg = TjConfig(version="1")
     with patch("tokenjam.cli.main.load_config", return_value=cfg), \
-         patch("tokenjam.cli.main.open_db", side_effect=AssertionError("must not open db")), \
+         patch("tokenjam.cli.main.open_db", side_effect=AssertionError("startup must not open db")), \
+         patch("tokenjam.core.db.open_db", side_effect=RuntimeError("locked")), \
          patch("tokenjam.cli.cmd_policy._fetch_proxy_json", return_value=None):
         result = runner.invoke(cli, ["policy", "decisions"])
     assert result.exit_code == 0, result.output

--- a/tests/unit/test_proxy_audit.py
+++ b/tests/unit/test_proxy_audit.py
@@ -1,0 +1,202 @@
+"""Tests for the audit log + savings meter (#221).
+
+Covers: migration 6 creates both tables; the observer sink persists decisions +
+the savings ledger; observe-only (subscription) is logged with passthrough_tos
+and accrues NO savings; the savings figure is always estimated-recoverable /
+would-have-saved and NEVER "saved" (Critical Rule 14); the reconciliation math
+vs actual spend reconciles to the same source `tj cost` reads.
+"""
+from __future__ import annotations
+
+from tokenjam.core.db import InMemoryBackend
+from tokenjam.core.models import PolicyDecisionFilters
+from tokenjam.proxy.audit import (
+    SAVINGS_DISCLAIMER,
+    AuditSink,
+    reconcile_savings,
+)
+from tokenjam.proxy.engine import (
+    ACTION_WOULD_BLOCK,
+    PolicyEnvelope,
+    PolicyEvaluation,
+)
+from tokenjam.proxy.gate import OBSERVE_ONLY, POLICY, GateDecision
+from tokenjam.proxy.observer import ProxyObserver
+from tokenjam.utils.time_parse import utcnow
+from tests.factories import make_llm_span, make_session
+
+
+def _db():
+    return InMemoryBackend()
+
+
+def _policy_envelope(usd=0.0, tokens=0, basis=""):
+    details = {}
+    if usd:
+        details["estimated_recoverable_usd"] = usd
+    if tokens:
+        details["estimated_recoverable_tokens"] = tokens
+    if basis:
+        details["estimate_basis"] = basis
+    return PolicyEnvelope(
+        ts=utcnow().isoformat(), provider="openai", path="/v1/chat/completions",
+        agent=None, gate_path=POLICY, overall_action=ACTION_WOULD_BLOCK,
+        evaluations=[PolicyEvaluation(
+            policy_name="blocker", kind="test", mode="suggest",
+            would_action=ACTION_WOULD_BLOCK, reason="stub",
+            enforcement_gated=False, details=details)],
+    )
+
+
+def _policy_gate():
+    return GateDecision(provider="openai", plan_tier="api", pricing_mode="api",
+                        path=POLICY, reason="api_usage_billed")
+
+
+def _observe_gate():
+    return GateDecision(provider="anthropic", plan_tier="max_5x",
+                        pricing_mode="subscription", path=OBSERVE_ONLY,
+                        reason="subscription_passthrough")
+
+
+# --- migration ---
+
+def test_migration_creates_audit_tables():
+    db = _db()
+    tables = {r[0] for r in db.conn.execute(
+        "SELECT table_name FROM information_schema.tables").fetchall()}
+    assert "policy_decisions" in tables
+    assert "savings_ledger" in tables
+    applied = {r[0] for r in db.conn.execute(
+        "SELECT version FROM schema_migrations").fetchall()}
+    assert 6 in applied
+    db.close()
+
+
+# --- persistence via the observer sink ---
+
+def test_sink_persists_policy_decision_and_savings():
+    db = _db()
+    observer = ProxyObserver(sink=AuditSink(db))
+    observer.record(method="POST", path="/v1/chat/completions",
+                    decision=_policy_gate(),
+                    envelope=_policy_envelope(usd=0.42, basis="stub"))
+
+    decisions = db.get_policy_decisions(PolicyDecisionFilters())
+    assert len(decisions) == 1
+    d = decisions[0]
+    assert d.gate_decision == "policy"
+    assert d.would_action == ACTION_WOULD_BLOCK
+    assert d.policy_name == "blocker"
+    assert d.label == "unvalidated"
+    assert d.envelope["overall_action"] == ACTION_WOULD_BLOCK  # round-tripped JSON
+
+    savings = db.get_savings_entries(PolicyDecisionFilters())
+    assert len(savings) == 1
+    assert savings[0].estimated_recoverable_usd == 0.42
+    assert savings[0].decision_id == d.decision_id
+    assert savings[0].realized is False  # suggest mode: never realized
+    assert savings[0].label == "unvalidated"
+    db.close()
+
+
+def test_observe_only_logs_passthrough_tos_and_no_savings():
+    db = _db()
+    observer = ProxyObserver(sink=AuditSink(db))
+    # Subscription observe-only — recorded, but never acted on → no savings.
+    observer.record(method="POST", path="/v1/messages",
+                    decision=_observe_gate(), envelope=None)
+
+    decisions = db.get_policy_decisions(PolicyDecisionFilters())
+    assert len(decisions) == 1
+    assert decisions[0].gate_decision == "observe_only"
+    assert decisions[0].passthrough_tos is True   # "not permitted to act" (TOS)
+    assert db.get_savings_entries(PolicyDecisionFilters()) == []
+    db.close()
+
+
+def test_noop_envelope_records_zero_savings():
+    db = _db()
+    observer = ProxyObserver(sink=AuditSink(db))
+    observer.record(method="POST", path="/v1/chat/completions",
+                    decision=_policy_gate(), envelope=_policy_envelope())  # no estimate
+    s = db.get_savings_entries(PolicyDecisionFilters())
+    assert len(s) == 1
+    assert s[0].estimated_recoverable_usd == 0.0  # a noop would recover nothing
+    db.close()
+
+
+def test_sink_never_raises_on_bad_db():
+    class _BrokenDB:
+        def insert_policy_decision(self, *_a, **_k):
+            raise RuntimeError("boom")
+
+    # AuditSink swallows persistence errors so the proxy never breaks.
+    sink = AuditSink(_BrokenDB())
+    observer = ProxyObserver(sink=sink)
+    # Should not raise.
+    observer.record(method="POST", path="/v1/chat/completions",
+                    decision=_policy_gate(), envelope=_policy_envelope(usd=1.0))
+
+
+# --- savings meter: honesty + reconciliation ---
+
+def test_savings_disclaimer_never_says_saved():
+    # The load-bearing honesty check.
+    assert "saved" not in SAVINGS_DISCLAIMER.lower().replace("would-have-saved", "")
+    assert "estimated recoverable" in SAVINGS_DISCLAIMER.lower()
+    assert "not realized" in SAVINGS_DISCLAIMER.lower()
+
+
+def test_reconcile_savings_reconciles_to_cost_summary():
+    db = _db()
+    # Seed ACTUAL spend the same way `tj cost` reads it (spans with cost_usd).
+    sess = make_session(agent_id="codegen", total_cost_usd=10.0)
+    db.upsert_session(sess)
+    db.insert_span(make_llm_span(agent_id="codegen", provider="openai",
+                                 model="gpt-4o", cost_usd=6.0, session_id=sess.session_id))
+    db.insert_span(make_llm_span(agent_id="codegen", provider="openai",
+                                 model="gpt-4o", cost_usd=4.0, session_id=sess.session_id))
+
+    # Seed two policy decisions that WOULD have recovered $1.50 + $0.50.
+    observer = ProxyObserver(sink=AuditSink(db))
+    observer.record(method="POST", path="/v1/chat/completions",
+                    decision=_policy_gate(), envelope=_policy_envelope(usd=1.50, basis="a"))
+    observer.record(method="POST", path="/v1/chat/completions",
+                    decision=_policy_gate(), envelope=_policy_envelope(usd=0.50, basis="b"))
+
+    summary = reconcile_savings(db)
+    # Actual spend matches what get_cost_summary (the tj cost source) reports.
+    from tokenjam.core.models import CostFilters
+    cost_total = sum(r.cost_usd for r in db.get_cost_summary(CostFilters(group_by="day")))
+    assert summary.actual_spend_usd == cost_total == 10.0
+    # Estimated recoverable is the sum of the would-have figures.
+    assert summary.estimated_recoverable_usd == 2.0
+    assert summary.estimated_recoverable_pct == 20.0  # 2 / 10 * 100
+    assert summary.realized is False
+    assert summary.decisions == 2
+    db.close()
+
+
+def test_savings_summary_to_dict_is_estimated_never_saved():
+    db = _db()
+    observer = ProxyObserver(sink=AuditSink(db))
+    observer.record(method="POST", path="/v1/chat/completions",
+                    decision=_policy_gate(), envelope=_policy_envelope(usd=3.0))
+    d = reconcile_savings(db).to_dict()
+    assert "estimated_recoverable_usd" in d
+    assert d["realized"] is False
+    assert d["label"] == "unvalidated"
+    assert "saved" not in str({k: v for k, v in d.items() if k != "disclaimer"}).lower()
+    db.close()
+
+
+def test_zero_spend_window_has_no_pct():
+    db = _db()
+    observer = ProxyObserver(sink=AuditSink(db))
+    observer.record(method="POST", path="/v1/chat/completions",
+                    decision=_policy_gate(), envelope=_policy_envelope(usd=1.0))
+    summary = reconcile_savings(db)
+    assert summary.actual_spend_usd == 0.0
+    assert summary.estimated_recoverable_pct is None  # no divide-by-zero claim
+    db.close()

--- a/tokenjam/cli/cmd_policy.py
+++ b/tokenjam/cli/cmd_policy.py
@@ -128,32 +128,82 @@ def _fetch_proxy_json(config: TjConfig, path: str) -> dict | None:
     return None
 
 
+def _read_decisions_from_db(config: TjConfig, since, limit: int):
+    """Read PERSISTED decisions + savings from the DB (#221).
+
+    Returns (decisions, savings_dict) or None when the DB can't be opened (e.g.
+    `tj serve` holds the write lock) so the caller falls back to the live proxy.
+    """
+    from tokenjam.core.db import open_db
+    from tokenjam.core.models import PolicyDecisionFilters
+    from tokenjam.proxy.audit import decision_to_display_dict, reconcile_savings
+    try:
+        db = open_db(config.storage)
+    except Exception:  # noqa: BLE001 — locked / missing → caller falls back
+        return None
+    try:
+        recs = db.get_policy_decisions(PolicyDecisionFilters(since=since, limit=limit))
+        savings = reconcile_savings(db, since=since).to_dict()
+        return [decision_to_display_dict(r) for r in recs], savings
+    finally:
+        db.close()
+
+
 @cmd_policy.command("decisions")
 @click.option("--json", "output_json_flag", is_flag=True,
               help="Emit machine-readable JSON.")
 @click.option("--limit", default=20, show_default=True,
               help="Max number of recent decisions to show.")
+@click.option("--since", default=None,
+              help="Window for the savings summary (e.g. 7d, 30d).")
 @click.pass_context
-def cmd_policy_decisions(ctx: click.Context, output_json_flag: bool, limit: int) -> None:
-    """Show recent policy decisions (what each policy WOULD do) from the proxy."""
+def cmd_policy_decisions(ctx: click.Context, output_json_flag: bool, limit: int,
+                         since: str | None) -> None:
+    """Show recent persisted policy decisions + the estimated-recoverable meter."""
     config: TjConfig = ctx.obj["config"]
     output_json: bool = output_json_flag or ctx.obj.get("output_json", False)
 
-    payload = _fetch_proxy_json(config, "/__tj/policy/decisions")
-    decisions = (payload or {}).get("decisions", [])
-    decisions = decisions[-limit:] if limit and len(decisions) > limit else decisions
+    since_dt = None
+    if since:
+        from tokenjam.utils.time_parse import parse_since
+        since_dt = parse_since(since)
+
+    # Persisted DB read is the richer source (history + savings). If the DB is
+    # locked by a running daemon, fall back to the live proxy's in-memory ring.
+    db_result = _read_decisions_from_db(config, since_dt, limit)
+    savings = None
+    source = "db"
+    if db_result is not None:
+        decisions, savings = db_result
+    else:
+        source = "proxy"
+        payload = _fetch_proxy_json(config, "/__tj/policy/decisions")
+        raw = (payload or {}).get("decisions", [])
+        # Normalise the live-proxy envelope shape to the display shape.
+        decisions = [{
+            "ts": d.get("ts", ""), "provider": d.get("provider", ""),
+            "path": d.get("path", ""),
+            "would_action": (d.get("policy") or {}).get("overall_action", "-"),
+            "policy_name": ", ".join(
+                e.get("policy_name", "") for e in (d.get("policy") or {}).get("evaluations", [])
+            ) or None,
+            "label": (d.get("policy") or {}).get("label", UNVALIDATED_LABEL),
+        } for d in raw][-limit:]
+        if payload is None:
+            decisions = None  # signals "unreachable" below
 
     if output_json:
         click.echo(json.dumps({
-            "decisions": decisions,
+            "source": source,
+            "decisions": decisions or [],
+            "savings": savings,
             "label": UNVALIDATED_LABEL,
-            "reachable": payload is not None,
         }, indent=2))
         return
 
-    if payload is None:
+    if decisions is None:
         console.print(
-            "[dim]No running proxy reachable at "
+            "[dim]No persisted decisions and no running proxy reachable at "
             f"http://{config.proxy.host}:{config.proxy.port}. "
             "Start it with `tj proxy enable` + `tj serve`.[/dim]"
         )
@@ -162,28 +212,44 @@ def cmd_policy_decisions(ctx: click.Context, output_json_flag: bool, limit: int)
         console.print("[dim]No policy decisions recorded yet "
                       "(suggest mode — eligible api traffic only).[/dim]")
         console.print()
+        if savings is not None:
+            _print_savings_summary(savings)
         console.print(f"[yellow]{escape(UNVALIDATED_NOTE)}[/yellow]")
         return
 
     from rich.table import Table
 
     table = Table(show_header=True, header_style="bold", box=None, padding=(0, 2))
-    for col in ("TIME", "PROVIDER", "PATH", "WOULD-DO", "POLICIES", "LABEL"):
+    for col in ("TIME", "PROVIDER", "PATH", "WOULD-DO", "POLICY", "LABEL"):
         table.add_column(col, style="dim" if col in ("TIME", "LABEL") else None)
     for d in decisions:
-        pol = d.get("policy") or {}
-        evals = pol.get("evaluations", [])
         table.add_row(
             escape(str(d.get("ts", ""))[:19]),
-            escape(str(d.get("provider", ""))),
-            escape(str(d.get("path", ""))),
-            escape(str(pol.get("overall_action", "-"))),
-            escape(", ".join(e.get("policy_name", "") for e in evals) or "-"),
-            escape(str(pol.get("label", UNVALIDATED_LABEL))),
+            escape(str(d.get("provider") or "")),
+            escape(str(d.get("path") or "")),
+            escape(str(d.get("would_action") or "-")),
+            escape(str(d.get("policy_name") or "-")),
+            escape(str(d.get("label", UNVALIDATED_LABEL))),
         )
     console.print(table)
     console.print()
+    if savings is not None:
+        _print_savings_summary(savings)
     console.print(f"[yellow]{escape(UNVALIDATED_NOTE)}[/yellow]")
+
+
+def _print_savings_summary(savings: dict) -> None:
+    """Render the savings meter — always 'estimated recoverable', NEVER 'saved'."""
+    est = savings.get("estimated_recoverable_usd", 0.0)
+    spend = savings.get("actual_spend_usd", 0.0)
+    pct = savings.get("estimated_recoverable_pct")
+    pct_str = f" ({pct:.1f}% of actual spend)" if pct is not None else ""
+    console.print(
+        f"[bold]Estimated recoverable:[/bold] ~${est:.4f}{pct_str} "
+        f"vs actual spend ${spend:.4f} "
+        f"[dim]({savings.get('decisions', 0)} decisions, label={savings.get('label')})[/dim]"
+    )
+    console.print(f"[dim]{escape(savings.get('disclaimer', ''))}[/dim]")
 
 
 def _collect_rows(config: TjConfig) -> list[PolicyRow]:

--- a/tokenjam/cli/cmd_serve.py
+++ b/tokenjam/cli/cmd_serve.py
@@ -65,7 +65,8 @@ def cmd_serve(ctx: click.Context, host: str | None, port: int | None,
     if config.proxy.enabled:
         from tokenjam.proxy.server import ProxyRunner
         # Pass the serve DB so in-process policies (budget_cap, #222) can read
-        # current-cycle spend from the same connection (per-thread cursors, #124).
+        # current-cycle spend AND policy decisions + the savings ledger are
+        # persisted (#221) — all over the same per-thread-cursor connection (#124).
         proxy_runner = ProxyRunner(config, db=db)
 
     @asynccontextmanager

--- a/tokenjam/core/db.py
+++ b/tokenjam/core/db.py
@@ -21,6 +21,9 @@ from tokenjam.core.models import (
     CostRow,
     DriftBaseline,
     NormalizedSpan,
+    PolicyDecisionFilters,
+    PolicyDecisionRecord,
+    SavingsLedgerEntry,
     SchemaValidationResult,
     SessionRecord,
     SpanKind,
@@ -40,6 +43,14 @@ class StorageBackend(Protocol):
     def insert_span(self, span: NormalizedSpan) -> None: ...
     def insert_alert(self, alert: Alert) -> None: ...
     def insert_validation(self, result: SchemaValidationResult) -> None: ...
+    def insert_policy_decision(self, decision: PolicyDecisionRecord) -> None: ...
+    def insert_savings_entry(self, entry: SavingsLedgerEntry) -> None: ...
+    def get_policy_decisions(
+        self, filters: PolicyDecisionFilters,
+    ) -> list[PolicyDecisionRecord]: ...
+    def get_savings_entries(
+        self, filters: PolicyDecisionFilters,
+    ) -> list[SavingsLedgerEntry]: ...
     def upsert_session(self, session: SessionRecord) -> None: ...
     def upsert_agent(self, agent: AgentRecord) -> None: ...
     def upsert_baseline(self, baseline: DriftBaseline) -> None: ...
@@ -207,6 +218,50 @@ MIGRATIONS: list[tuple[int, str]] = [
     # _row_to_span helper coerces NULL -> None and ingest writes 0 for
     # spans that don't carry the count.
     (5, "ALTER TABLE spans ADD COLUMN IF NOT EXISTS cache_write_tokens BIGINT"),
+    # Migration 6: enforcement-plane audit log + savings meter (#221).
+    # `policy_decisions` is the append-only audit log — one row per recorded
+    # proxy observation (both the POLICY path and observe-only). `gate_decision`
+    # + `passthrough_tos` let the log distinguish "we CHOSE not to act" (policy
+    # path, action=noop) from "we were NOT PERMITTED to act" (subscription TOS).
+    # `savings_ledger` records what each policy decision WOULD have recovered —
+    # SUGGEST MODE ENFORCES NOTHING, so `realized` is always FALSE and the
+    # figures are estimated-recoverable / would-have-saved, NEVER realized
+    # savings (Critical Rule 14). The `label` ('unvalidated') rides through from
+    # the envelope on both tables.
+    (6, (
+        "CREATE TABLE IF NOT EXISTS policy_decisions (\n"
+        "    decision_id     TEXT PRIMARY KEY,\n"
+        "    ts              TIMESTAMPTZ NOT NULL,\n"
+        "    provider        TEXT,\n"
+        "    pricing_mode    TEXT,\n"
+        "    gate_decision   TEXT,\n"
+        "    path            TEXT,\n"
+        "    policy_name     TEXT,\n"
+        "    policy_kind     TEXT,\n"
+        "    would_action    TEXT,\n"
+        "    passthrough_tos BOOLEAN DEFAULT FALSE,\n"
+        "    label           TEXT,\n"
+        "    suggest_only    BOOLEAN DEFAULT TRUE,\n"
+        "    envelope        JSON\n"
+        ");\n"
+        "CREATE TABLE IF NOT EXISTS savings_ledger (\n"
+        "    ledger_id                    TEXT PRIMARY KEY,\n"
+        "    decision_id                  TEXT NOT NULL,\n"
+        "    ts                           TIMESTAMPTZ NOT NULL,\n"
+        "    provider                     TEXT,\n"
+        "    pricing_mode                 TEXT,\n"
+        "    policy_name                  TEXT,\n"
+        "    would_action                 TEXT,\n"
+        "    estimated_recoverable_usd    DOUBLE DEFAULT 0.0,\n"
+        "    estimated_recoverable_tokens BIGINT DEFAULT 0,\n"
+        "    estimate_basis               TEXT,\n"
+        "    billing_period               TEXT,\n"
+        "    label                        TEXT,\n"
+        "    realized                     BOOLEAN DEFAULT FALSE\n"
+        ");\n"
+        "CREATE INDEX IF NOT EXISTS idx_policy_decisions_ts ON policy_decisions(ts);\n"
+        "CREATE INDEX IF NOT EXISTS idx_savings_ledger_ts   ON savings_ledger(ts)"
+    )),
 ]
 
 
@@ -466,6 +521,104 @@ class DuckDBBackend:
                 result.validated_at, result.passed, json.dumps(result.errors),
             ],
         )
+
+    def insert_policy_decision(self, decision: PolicyDecisionRecord) -> None:
+        # Append-only audit log (#221). Named columns so future migrations stay safe.
+        self.conn.execute(
+            "INSERT INTO policy_decisions ("
+            "decision_id, ts, provider, pricing_mode, gate_decision, path, "
+            "policy_name, policy_kind, would_action, passthrough_tos, label, "
+            "suggest_only, envelope"
+            ") VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12,$13)",
+            [
+                decision.decision_id, decision.ts, decision.provider,
+                decision.pricing_mode, decision.gate_decision, decision.path,
+                decision.policy_name, decision.policy_kind, decision.would_action,
+                decision.passthrough_tos, decision.label, decision.suggest_only,
+                json.dumps(decision.envelope) if decision.envelope is not None else None,
+            ],
+        )
+
+    def insert_savings_entry(self, entry: SavingsLedgerEntry) -> None:
+        self.conn.execute(
+            "INSERT INTO savings_ledger ("
+            "ledger_id, decision_id, ts, provider, pricing_mode, policy_name, "
+            "would_action, estimated_recoverable_usd, estimated_recoverable_tokens, "
+            "estimate_basis, billing_period, label, realized"
+            ") VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12,$13)",
+            [
+                entry.ledger_id, entry.decision_id, entry.ts, entry.provider,
+                entry.pricing_mode, entry.policy_name, entry.would_action,
+                entry.estimated_recoverable_usd, entry.estimated_recoverable_tokens,
+                entry.estimate_basis, entry.billing_period, entry.label,
+                entry.realized,
+            ],
+        )
+
+    def _decision_where(self, filters: PolicyDecisionFilters) -> tuple[str, list]:
+        clauses: list[str] = ["1=1"]
+        params: list[object] = []
+        idx = 1
+        if filters.since:
+            clauses.append(f"ts >= ${idx}")
+            params.append(filters.since)
+            idx += 1
+        if filters.until:
+            clauses.append(f"ts <= ${idx}")
+            params.append(filters.until)
+            idx += 1
+        if filters.provider:
+            clauses.append(f"provider = ${idx}")
+            params.append(filters.provider)
+            idx += 1
+        return " AND ".join(clauses), params
+
+    def get_policy_decisions(
+        self, filters: PolicyDecisionFilters,
+    ) -> list[PolicyDecisionRecord]:
+        where, params = self._decision_where(filters)
+        rows = self.conn.execute(
+            "SELECT decision_id, ts, provider, pricing_mode, gate_decision, path, "
+            "policy_name, policy_kind, would_action, passthrough_tos, label, "
+            "suggest_only, envelope "
+            f"FROM policy_decisions WHERE {where} ORDER BY ts DESC LIMIT ${len(params)+1}",
+            [*params, filters.limit],
+        ).fetchall()
+        out: list[PolicyDecisionRecord] = []
+        for r in rows:
+            env = r[12]
+            if isinstance(env, str):
+                env = json.loads(env)
+            out.append(PolicyDecisionRecord(
+                decision_id=r[0], ts=r[1], provider=r[2], pricing_mode=r[3],
+                gate_decision=r[4], path=r[5], policy_name=r[6], policy_kind=r[7],
+                would_action=r[8], passthrough_tos=bool(r[9]), label=r[10],
+                suggest_only=bool(r[11]), envelope=env,
+            ))
+        return out
+
+    def get_savings_entries(
+        self, filters: PolicyDecisionFilters,
+    ) -> list[SavingsLedgerEntry]:
+        where, params = self._decision_where(filters)
+        rows = self.conn.execute(
+            "SELECT ledger_id, decision_id, ts, provider, pricing_mode, policy_name, "
+            "would_action, estimated_recoverable_usd, estimated_recoverable_tokens, "
+            "estimate_basis, billing_period, label, realized "
+            f"FROM savings_ledger WHERE {where} ORDER BY ts DESC LIMIT ${len(params)+1}",
+            [*params, filters.limit],
+        ).fetchall()
+        return [
+            SavingsLedgerEntry(
+                ledger_id=r[0], decision_id=r[1], ts=r[2], provider=r[3],
+                pricing_mode=r[4], policy_name=r[5], would_action=r[6],
+                estimated_recoverable_usd=float(r[7] or 0.0),
+                estimated_recoverable_tokens=int(r[8] or 0),
+                estimate_basis=r[9] or "", billing_period=r[10] or "",
+                label=r[11], realized=bool(r[12]),
+            )
+            for r in rows
+        ]
 
     def upsert_session(self, session: SessionRecord) -> None:
         # plan_tier: promote unknown → known on conflict; never overwrite a

--- a/tokenjam/core/models.py
+++ b/tokenjam/core/models.py
@@ -240,6 +240,63 @@ class CostRow:
     cost_usd:     float       = 0.0
 
 
+# -- Enforcement-plane audit log + savings meter (#221) --
+
+@dataclass
+class PolicyDecisionRecord:
+    """One persisted proxy observation — a row in the append-only audit log.
+
+    Records both the POLICY path and observe-only traffic. ``gate_decision`` +
+    ``passthrough_tos`` distinguish "we chose not to act" (policy path,
+    would_action='noop') from "we were not permitted to act" (subscription TOS).
+    ``label`` ('unvalidated') rides through from the envelope.
+    """
+    decision_id:     str
+    ts:              datetime
+    provider:        str | None
+    pricing_mode:    str
+    gate_decision:   str            # observe_only | policy
+    path:            str
+    would_action:    str            # overall action; 'noop' on observe-only
+    policy_name:     str | None = None
+    policy_kind:     str | None = None
+    passthrough_tos: bool = False   # observe-only due to provider TOS (subscription)
+    label:           str = "unvalidated"
+    suggest_only:    bool = True
+    envelope:        dict | None = None  # full round-trippable envelope (None observe-only)
+
+
+@dataclass
+class SavingsLedgerEntry:
+    """What ONE policy decision WOULD have recovered — never a realized figure.
+
+    Suggest mode enforces nothing, so ``realized`` is always False and the
+    amounts are ESTIMATED-RECOVERABLE / would-have-saved (Critical Rule 14).
+    Dollar figures are api-only; subscription/local accrue token-quota framing.
+    """
+    ledger_id:                    str
+    decision_id:                  str
+    ts:                           datetime
+    provider:                     str | None
+    pricing_mode:                 str
+    would_action:                 str
+    policy_name:                  str | None = None
+    estimated_recoverable_usd:    float = 0.0
+    estimated_recoverable_tokens: int = 0
+    estimate_basis:               str = ""
+    billing_period:               str = ""       # YYYY-MM
+    label:                        str = "unvalidated"
+    realized:                     bool = False    # suggest mode: NEVER realized
+
+
+@dataclass
+class PolicyDecisionFilters:
+    since:    datetime | None = None
+    until:    datetime | None = None
+    provider: str | None = None
+    limit:    int = 100
+
+
 # -- Filter dataclasses used by StorageBackend --
 
 @dataclass

--- a/tokenjam/proxy/audit.py
+++ b/tokenjam/proxy/audit.py
@@ -1,0 +1,212 @@
+"""Audit log + savings meter persistence for proxy decisions (#221).
+
+The observer (`observer.py`) holds recent decisions in memory; this module is
+the durable sink. It converts each recorded :class:`ProxyObservation` into an
+append-only ``policy_decisions`` row and, for eligible POLICY-path decisions, a
+``savings_ledger`` row.
+
+**Honesty (Critical Rule 14).** Suggest mode enforces NOTHING. The savings meter
+therefore records ESTIMATED-RECOVERABLE / "would-have-saved" amounts — what each
+policy WOULD have recovered *if it had been enforced* — never realized savings.
+``realized`` is always False; dollar figures are api-only; the ``unvalidated``
+label rides through from the envelope. :func:`reconcile_savings` reports the
+estimate against actual spend from the SAME source ``tj cost`` reads
+(:meth:`get_cost_summary`), and its summary never uses the word "saved".
+
+This module lives in the proxy package (it may import core); core never imports
+it (package-dependency rule).
+"""
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+from datetime import datetime
+from typing import Any
+
+from tokenjam.core.models import (
+    CostFilters,
+    PolicyDecisionFilters,
+    PolicyDecisionRecord,
+    SavingsLedgerEntry,
+)
+from tokenjam.utils.ids import new_uuid
+from tokenjam.utils.time_parse import utcnow
+
+logger = logging.getLogger("tokenjam.proxy")
+
+UNVALIDATED_LABEL = "unvalidated"
+
+# The load-bearing honesty string. Suggest mode enforces nothing, so this is a
+# counterfactual estimate, never a realized number. Never the word "saved".
+SAVINGS_DISCLAIMER = (
+    "Estimated recoverable — suggest mode enforces nothing, so this is what these "
+    "policies WOULD have recovered if enforced, not realized savings. Unvalidated."
+)
+
+
+def _billing_period(ts: datetime) -> str:
+    return ts.strftime("%Y-%m")
+
+
+def _extract_savings(envelope: dict | None) -> tuple[float, int, str]:
+    """Sum the would-have-recovered estimate the evaluators put in `details`.
+
+    A `kind` (e.g. a future budget_cap, #222) advertises its counterfactual via
+    `details.estimated_recoverable_usd` / `estimated_recoverable_tokens` /
+    `estimate_basis`. The shipped `noop` kind advertises nothing → 0 (honest:
+    a no-op would recover nothing).
+    """
+    if not envelope:
+        return 0.0, 0, ""
+    usd = 0.0
+    tokens = 0
+    bases: list[str] = []
+    for ev in envelope.get("evaluations", []):
+        details = ev.get("details") or {}
+        usd += float(details.get("estimated_recoverable_usd", 0) or 0)
+        tokens += int(details.get("estimated_recoverable_tokens", 0) or 0)
+        basis = details.get("estimate_basis")
+        if basis:
+            bases.append(str(basis))
+    return usd, tokens, "; ".join(bases)
+
+
+class AuditSink:
+    """Persists each recorded observation to the audit log + savings ledger.
+
+    Wired into :class:`ProxyObserver` as its ``sink``. Best-effort: a persistence
+    failure is logged and swallowed so it never breaks proxy pass-through.
+    """
+
+    def __init__(self, db: Any) -> None:
+        self.db = db
+
+    def __call__(self, obs: Any) -> None:
+        try:
+            self._persist(obs)
+        except Exception:  # noqa: BLE001 — audit must never break the proxy
+            logger.exception("policy-decision audit persistence failed (ignored)")
+
+    def _persist(self, obs: Any) -> None:
+        env = getattr(obs, "policy", None)
+        is_policy = obs.decision == "policy"
+        ts = utcnow()
+
+        evals = (env or {}).get("evaluations", []) if env else []
+        primary = evals[0] if evals else {}
+        # Observe-only due to provider TOS (subscription) = "not permitted to act",
+        # distinct from a policy-path noop = "we chose not to act".
+        passthrough_tos = (not is_policy) and obs.pricing_mode == "subscription"
+
+        decision_id = new_uuid()
+        self.db.insert_policy_decision(PolicyDecisionRecord(
+            decision_id=decision_id,
+            ts=ts,
+            provider=obs.provider,
+            pricing_mode=obs.pricing_mode,
+            gate_decision=obs.decision,
+            path=obs.path,
+            would_action=(env or {}).get("overall_action", "noop") if env else "noop",
+            policy_name=primary.get("policy_name"),
+            policy_kind=primary.get("kind"),
+            passthrough_tos=passthrough_tos,
+            label=(env or {}).get("label", UNVALIDATED_LABEL),
+            suggest_only=bool(getattr(obs, "suggest_only", True)),
+            envelope=env,
+        ))
+
+        # Savings accrue ONLY on the POLICY path (api/usage-billed). Observe-only
+        # traffic is never acted on, so it can never "would-have-saved".
+        if is_policy:
+            usd, tokens, basis = _extract_savings(env)
+            self.db.insert_savings_entry(SavingsLedgerEntry(
+                ledger_id=new_uuid(),
+                decision_id=decision_id,
+                ts=ts,
+                provider=obs.provider,
+                pricing_mode=obs.pricing_mode,
+                policy_name=primary.get("policy_name"),
+                would_action=(env or {}).get("overall_action", "noop"),
+                estimated_recoverable_usd=usd,
+                estimated_recoverable_tokens=tokens,
+                estimate_basis=basis,
+                billing_period=_billing_period(ts),
+                label=(env or {}).get("label", UNVALIDATED_LABEL),
+                realized=False,  # suggest mode: NEVER realized
+            ))
+
+
+@dataclass(frozen=True)
+class SavingsSummary:
+    """The savings meter — estimated-recoverable reconciled vs actual spend.
+
+    Every field is an ESTIMATE / would-have figure (suggest mode enforces
+    nothing). ``realized`` is always False and there is no "saved" field.
+    """
+    since:                        datetime | None
+    until:                        datetime | None
+    decisions:                    int
+    estimated_recoverable_usd:    float
+    estimated_recoverable_tokens: int
+    actual_spend_usd:             float       # from get_cost_summary — the tj cost source
+    estimated_recoverable_pct:    float | None  # est_recoverable / actual_spend * 100
+    realized:                     bool = False
+    label:                        str = UNVALIDATED_LABEL
+    disclaimer:                   str = SAVINGS_DISCLAIMER
+
+    def to_dict(self) -> dict:
+        return {
+            "decisions": self.decisions,
+            "estimated_recoverable_usd": round(self.estimated_recoverable_usd, 6),
+            "estimated_recoverable_tokens": self.estimated_recoverable_tokens,
+            "actual_spend_usd": round(self.actual_spend_usd, 6),
+            "estimated_recoverable_pct": (
+                round(self.estimated_recoverable_pct, 2)
+                if self.estimated_recoverable_pct is not None else None
+            ),
+            "realized": self.realized,
+            "label": self.label,
+            "disclaimer": self.disclaimer,
+        }
+
+
+def reconcile_savings(
+    db: Any, *, since: datetime | None = None, until: datetime | None = None,
+    provider: str | None = None,
+) -> SavingsSummary:
+    """Reconcile the savings ledger's estimate against actual spend.
+
+    Actual spend comes from :meth:`get_cost_summary` — the SAME source ``tj
+    cost`` reads — so the meter always reconciles to it. The returned figure is
+    "estimated recoverable" (what enforcing these policies WOULD have recovered),
+    never a realized saving.
+    """
+    entries = db.get_savings_entries(
+        PolicyDecisionFilters(since=since, until=until, provider=provider, limit=100_000)
+    )
+    est_usd = sum(e.estimated_recoverable_usd for e in entries)
+    est_tokens = sum(e.estimated_recoverable_tokens for e in entries)
+
+    cost_rows = db.get_cost_summary(CostFilters(since=since, until=until, group_by="day"))
+    actual_spend = sum(r.cost_usd for r in cost_rows)
+
+    pct = (est_usd / actual_spend * 100.0) if actual_spend > 0 else None
+    return SavingsSummary(
+        since=since, until=until, decisions=len(entries),
+        estimated_recoverable_usd=est_usd, estimated_recoverable_tokens=est_tokens,
+        actual_spend_usd=actual_spend, estimated_recoverable_pct=pct,
+    )
+
+
+def decision_to_display_dict(d: PolicyDecisionRecord) -> dict:
+    """A row-friendly dict for `tj policy decisions` (DB-backed view)."""
+    return {
+        "ts": d.ts.isoformat() if hasattr(d.ts, "isoformat") else str(d.ts),
+        "provider": d.provider,
+        "path": d.path,
+        "gate_decision": d.gate_decision,
+        "would_action": d.would_action,
+        "policy_name": d.policy_name,
+        "passthrough_tos": d.passthrough_tos,
+        "label": d.label,
+    }

--- a/tokenjam/proxy/observer.py
+++ b/tokenjam/proxy/observer.py
@@ -12,7 +12,7 @@ from __future__ import annotations
 import logging
 from collections import deque
 from dataclasses import asdict, dataclass
-from typing import Any, Deque
+from typing import Any, Callable, Deque, Optional
 
 from tokenjam.proxy.gate import GateDecision
 from tokenjam.utils.time_parse import utcnow
@@ -38,10 +38,18 @@ class ProxyObservation:
 
 
 class ProxyObserver:
-    """Keeps the last ``maxlen`` observations and logs each one."""
+    """Keeps the last ``maxlen`` observations, logs each, and (optionally) sinks.
 
-    def __init__(self, maxlen: int = 256) -> None:
+    ``sink`` is a best-effort persistence hook (e.g. the #221 ``AuditSink``)
+    called with each :class:`ProxyObservation` after it's recorded. It must never
+    raise into the proxy — the sink is expected to swallow its own errors, and
+    the observer guards it as well.
+    """
+
+    def __init__(self, maxlen: int = 256,
+                 sink: Optional[Callable[["ProxyObservation"], None]] = None) -> None:
         self._ring: Deque[ProxyObservation] = deque(maxlen=maxlen)
+        self._sink = sink
 
     def record(self, *, method: str, path: str, decision: GateDecision,
                forwarded: bool = True, envelope: Any = None) -> ProxyObservation:
@@ -70,6 +78,13 @@ class ProxyObserver:
             )
         except Exception:  # noqa: BLE001 — recording must never break pass-through
             pass
+        # Durable sink (#221) — persist the decision + savings ledger. Best-effort:
+        # never let a persistence failure break proxy pass-through.
+        if self._sink is not None:
+            try:
+                self._sink(obs)
+            except Exception:  # noqa: BLE001
+                logger.exception("proxy observation sink failed (ignored)")
         return obs
 
     @property

--- a/tokenjam/proxy/server.py
+++ b/tokenjam/proxy/server.py
@@ -27,10 +27,17 @@ class ProxyRunner:
     def __init__(self, config: Any, observer: ProxyObserver | None = None,
                  db: Any = None) -> None:
         self.config = config
-        self.observer = observer or ProxyObserver()
-        # Shared tj-serve DB (optional) so in-process policies (budget_cap, #222)
-        # can read current-cycle spend without opening a second connection.
+        # Shared tj-serve DB (optional). Used two ways: in-process policies
+        # (budget_cap, #222) read current-cycle spend from it, AND the audit sink
+        # (#221) persists decisions + the savings ledger through it.
         self.db = db
+        if observer is None:
+            sink = None
+            if db is not None:
+                from tokenjam.proxy.audit import AuditSink
+                sink = AuditSink(db)
+            observer = ProxyObserver(sink=sink)
+        self.observer = observer
         self._server: uvicorn.Server | None = None
         self._task: asyncio.Task | None = None
 


### PR DESCRIPTION
Builds on the #220 engine: the observer held recorded decisions (incl. the policy envelope) in memory only. This adds durable persistence + a savings meter, both append-only and honesty-disciplined.

## Summary
- **Audit log** — migration 6 adds an append-only `policy_decisions` table; each recorded proxy observation (POLICY path **and** observe-only) is persisted via a new best-effort observer **sink** (`AuditSink`), wired by `ProxyRunner` when `tj serve` passes the db.
- **Savings meter** — an append-only `savings_ledger`; each eligible POLICY-path decision records what it WOULD have recovered. `reconcile_savings` reports it against actual spend from the **same source `tj cost` reads** (`get_cost_summary`).
- **Surface** — `tj policy decisions` now reads PERSISTED decisions + the meter from the DB (falling back to the proxy's in-memory ring when a daemon holds the write lock).

## Audit log (`policy_decisions`)
Records both paths. `gate_decision` + `passthrough_tos` distinguish **"we chose not to act"** (policy path, action `noop`) from **"we were not permitted to act"** (subscription, TOS). The full round-trippable envelope is stored as JSON; the `unvalidated` label rides through. Persistence is best-effort — a failure is logged and swallowed so it never breaks proxy pass-through.

## Savings meter (`savings_ledger`) — the load-bearing honesty
Suggest mode enforces **nothing**, so every figure is **estimated-recoverable / "would-have-saved" — NEVER "saved"**:
- `realized` is hard-coded `False` on every ledger row and in the summary.
- The disclaimer states "…not realized savings. Unvalidated."
- Dollar figures are api-only (the gate already guarantees the policy path is api/usage-billed); the `unvalidated` label persists to both tables.
- `reconcile_savings` reconciles to `get_cost_summary` — the exact source `tj cost` reads — so the estimate always lines up with actual spend.

## Conventions
DuckDB only (TIMESTAMPTZ, parameterized named-column SQL); a NEW `(6, sql)` tuple appended to `MIGRATIONS` (no existing migration touched); `PolicyDecisionRecord` / `SavingsLedgerEntry` + four methods added to the `StorageBackend` protocol; `utcnow()` throughout; test spans via factories.

## Tests / Verification
- `tests/unit/test_proxy_audit.py`: migration 6 creates both tables; the observer sink persists decisions + savings and reads them back; observe-only logs `passthrough_tos` and accrues **no** savings; the savings figure asserts it **NEVER says "saved"**; **reconciliation math** vs actual spend reconciles to `get_cost_summary`; zero-spend window has no pct (no divide-by-zero claim); the sink never raises on a broken db.
- `tests/integration/test_db.py`: migration count updated to 6 (+ idempotency).
- `tests/unit/test_cmd_policy.py`: `tj policy decisions` reads persisted decisions from the DB, shows the labeled meter, proves it never prints "saved", and falls back to the proxy when the DB is locked — while STARTUP still never opens the DB (`policy` stays in `no_db_commands`).
- Full suite **1075 passed** (post-rebase onto #222); `ruff` + `mypy` clean.
- **Live smoke**: real `ProxyRunner` + a savings-bearing stub policy → request forwarded, decision + `$0.73` ledger row persisted (`realized=False`), and `tj policy decisions` (separate process) renders the table + "Estimated recoverable … not realized savings" meter.

## What's NOT in this PR
- **Escalation netting** ("escalated/failed sessions count at full cost") — there's no escalation signal in suggest mode yet; the estimate is already conservative (only what evaluators advertise). Hook can land with concrete escalating policies.
- **`tj policy log` / API / MCP** query surfaces from the issue — `tj policy decisions` covers the CLI read this sprint; the API/MCP surfaces can follow.
- **Subscription quota-savings units** — the ledger carries `estimated_recoverable_tokens` for the framing, but no subscription policy produces them yet (savings only accrue on the api policy path, which the gate guarantees).
- **Realized/enforce accounting** — enforce mode is gated off (#220); nothing is ever realized here by construction.

Closes #221

🤖 Generated with [Claude Code](https://claude.com/claude-code)