### PR TITLE
Fix #291: package tj demo scenarios so they ship in pip/pipx installs

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -77,7 +77,15 @@ asyncio_mode = "auto"
 
 [tool.hatch.build.targets.wheel]
 packages = ["tokenjam"]
-artifacts = ["incidents"]
+
+# Ship the Agent Incident Library (`tj demo`) scenarios INSIDE the package so
+# they reach pip/pipx installs (#291). The source stays at repo-root `incidents/`
+# (the documented layout), but the wheel gets them at `tokenjam/incidents/<slug>/`
+# — `incidents/` is outside the `tokenjam/` package, so it is never wheeled on
+# its own. cmd_demo._discover_scenarios() resolves this packaged path first, with
+# a repo-root fallback for the dev tree.
+[tool.hatch.build.targets.wheel.force-include]
+"incidents" = "tokenjam/incidents"
 
 [tool.ruff]
 line-length = 100

--- a/tests/unit/test_demo_packaging.py
+++ b/tests/unit/test_demo_packaging.py
@@ -1,0 +1,78 @@
+"""Regression tests for `tj demo` scenario packaging (#291).
+
+The bug: `incidents/` lived outside the `tokenjam/` package, so it never made it
+into the wheel, and cmd_demo's discovery path resolved to a nonexistent
+`site-packages/incidents/`. CI ran from the repo tree (where the dev-tree path
+worked), so it never caught the broken install.
+
+These tests assert the two halves of the fix:
+1. the hatchling force-include mapping ships `incidents/` INTO the package, and
+2. discovery resolves the PACKAGED location (not only the repo tree).
+"""
+from __future__ import annotations
+
+import shutil
+import sys
+from pathlib import Path
+
+if sys.version_info >= (3, 11):
+    import tomllib
+else:  # pragma: no cover
+    import tomli as tomllib
+
+from tokenjam.cli import cmd_demo
+
+_EXPECTED_SLUGS = {"retry-loop", "surprise-cost", "hallucination-drift"}
+_REPO_ROOT = Path(__file__).resolve().parent.parent.parent
+
+
+def test_pyproject_force_includes_incidents_into_package():
+    """The wheel must ship `incidents/` as `tokenjam/incidents/` (#291)."""
+    with open(_REPO_ROOT / "pyproject.toml", "rb") as f:
+        pyproject = tomllib.load(f)
+    force_include = (
+        pyproject["tool"]["hatch"]["build"]["targets"]["wheel"]["force-include"]
+    )
+    assert force_include.get("incidents") == "tokenjam/incidents", (
+        "incidents/ must be force-included into the package so `tj demo` scenarios "
+        "ship in pip/pipx installs (#291)."
+    )
+
+
+def test_discover_scenarios_returns_all_three():
+    """Discovery finds every shipped scenario (here, via the repo-tree fallback)."""
+    assert set(cmd_demo._discover_scenarios()) == _EXPECTED_SLUGS
+
+
+def test_installed_candidate_is_tried_first():
+    """The packaged path (`tokenjam/incidents`) is candidate #0, repo-root is #1."""
+    candidates = cmd_demo._candidate_incidents_dirs()
+    pkg_root = Path(cmd_demo.__file__).resolve().parent.parent  # …/tokenjam
+    assert candidates[0] == pkg_root / "incidents"             # installed/wheel
+    assert candidates[1] == pkg_root.parent / "incidents"      # dev-tree fallback
+
+
+def test_discovery_resolves_packaged_layout(tmp_path, monkeypatch):
+    """Simulate an installed wheel: scenarios under `tokenjam/incidents/`, with NO
+    repo-root `incidents/`. This is the path CI never exercised (#291)."""
+    source = cmd_demo._incidents_dir()
+    assert source is not None  # the live scenarios dir (repo tree in CI)
+
+    # Copy the scenarios into a packaged-style location: <tmp>/tokenjam/incidents.
+    packaged = tmp_path / "tokenjam" / "incidents"
+    shutil.copytree(source, packaged)
+
+    # Point discovery ONLY at the packaged dir — the repo-root fallback is absent,
+    # exactly like a real site-packages install.
+    monkeypatch.setattr(cmd_demo, "_candidate_incidents_dirs", lambda: [packaged])
+
+    assert cmd_demo._incidents_dir() == packaged
+    assert set(cmd_demo._discover_scenarios()) == _EXPECTED_SLUGS
+
+
+def test_discovery_empty_when_no_incidents_dir(monkeypatch, tmp_path):
+    """No scenarios dir anywhere → empty (no crash), the graceful degrade path."""
+    monkeypatch.setattr(
+        cmd_demo, "_candidate_incidents_dirs", lambda: [tmp_path / "nope"]
+    )
+    assert cmd_demo._discover_scenarios() == {}

--- a/tokenjam/cli/cmd_demo.py
+++ b/tokenjam/cli/cmd_demo.py
@@ -9,8 +9,27 @@ import click
 
 from tokenjam.utils.formatting import console
 
-# incidents/ lives two levels above this file (tj/cli/ -> tj/ -> repo/site-packages root)
-_INCIDENTS_DIR = Path(__file__).parent.parent.parent / "incidents"
+# The scenarios live at repo-root `incidents/` in the dev tree, but ship INSIDE
+# the package at `tokenjam/incidents/` in a built wheel (via the hatchling
+# force-include in pyproject.toml — repo-root `incidents/` is outside the
+# `tokenjam/` package, so it is never wheeled on its own). Resolve both and use
+# whichever exists: installed location first, dev-tree fallback (#291). Scenarios
+# load by file path (spec_from_file_location), so the physical location doesn't
+# affect the import — both candidates work.
+def _candidate_incidents_dirs() -> list[Path]:
+    here = Path(__file__).resolve().parent  # …/tokenjam/cli
+    return [
+        here.parent / "incidents",         # installed: …/tokenjam/incidents (force-included)
+        here.parent.parent / "incidents",  # dev tree: repo-root incidents/
+    ]
+
+
+def _incidents_dir() -> Path | None:
+    """The first existing scenarios dir, or None when none are present."""
+    for candidate in _candidate_incidents_dirs():
+        if candidate.exists():
+            return candidate
+    return None
 
 
 def _discover_scenarios() -> dict[str, ModuleType]:
@@ -19,9 +38,10 @@ def _discover_scenarios() -> dict[str, ModuleType]:
     Returns a dict mapping scenario slug to loaded module.
     """
     scenarios: dict[str, ModuleType] = {}
-    if not _INCIDENTS_DIR.exists():
+    base = _incidents_dir()
+    if base is None:
         return scenarios
-    for scenario_file in sorted(_INCIDENTS_DIR.glob("*/scenario.py")):
+    for scenario_file in sorted(base.glob("*/scenario.py")):
         slug = scenario_file.parent.name
         spec = importlib.util.spec_from_file_location(
             f"incidents.{slug}.scenario", scenario_file


### PR DESCRIPTION
`tj demo` — the flagship "see it work instantly" onboarding hook — listed **zero scenarios** on every real install. The Agent Incident Library lives at repo-root `incidents/`, outside the `tokenjam/` package, so hatchling never wheeled it; and `cmd_demo`'s discovery path resolved to a nonexistent `site-packages/incidents/`. CI runs from the repo tree (where the dev-tree path works), so it never caught it.

## Summary
- **Package the scenarios** via a hatchling `force-include` so the wheel ships `tokenjam/incidents/<slug>/{scenario.py,README.md}` — source stays at the documented repo-root `incidents/` (no doc changes, no file moves).
- **Fix discovery**: `_discover_scenarios()` resolves two candidate dirs — installed `tokenjam/incidents` first, repo-root `incidents/` dev-tree fallback — and uses whichever exists. Scenarios load by file path, so location doesn't affect import.

## Root cause + fix
`incidents/` was outside the `tokenjam/` package → never in the wheel (the stale `artifacts = ["incidents"]` was an ineffective prior attempt at this and is replaced by the force-include). And `Path(__file__).parent.parent.parent / "incidents"` → `site-packages/incidents/` in an install (doesn't exist) vs `repo/incidents/` in the dev tree (exists). Both halves are now fixed.

## Tests / Verification
New regression test `tests/unit/test_demo_packaging.py` — the gap CI never covered:
- asserts the `force-include` mapping (`"incidents" = "tokenjam/incidents"`) is present in `pyproject.toml`;
- asserts `_discover_scenarios()` returns all three slugs;
- asserts the **packaged** candidate (`tokenjam/incidents`) is tried first;
- **simulates an installed wheel** (scenarios under a temp `tokenjam/incidents/`, no repo-root fallback) and confirms discovery finds all three — the path CI never exercised;
- graceful-empty when no incidents dir exists.

Full `pytest tests/unit/ tests/integration/` = **1006 passed**; `ruff` + `mypy` clean on `cmd_demo.py`.

### Acceptance verification (commands from the issue)
**1. Wheel contains the scenarios:**
```
$ pip wheel . --no-deps -w /tmp/d
$ unzip -l tokenjam-0.5.1-py3-none-any.whl | grep incidents
  tokenjam/incidents/hallucination-drift/{BLOG.md,README.md,scenario.py}
  tokenjam/incidents/retry-loop/{BLOG.md,README.md,scenario.py}
  tokenjam/incidents/surprise-cost/{BLOG.md,README.md,scenario.py}
```
(Before this fix: **0** `incidents/` entries in the wheel.)

**2. Clean venv install → `tj demo` works (the broken repro):**
```
$ python3 -m venv /tmp/demovenv && /tmp/demovenv/bin/pip install tokenjam-0.5.1-py3-none-any.whl
$ /tmp/demovenv/bin/tj demo
  hallucination-drift   Agent behavior shifts unexpectedly …
  retry-loop            Agent stuck retrying a failing tool …
  surprise-cost         Agent silently burns budget …
$ /tmp/demovenv/bin/tj demo retry-loop
  Incident: Your agent isn't flaky. You're blind.   (… full run …)
  EXIT: 0
```
Both previously returned an empty table / `Unknown scenario 'retry-loop'`.

## What's NOT in this PR
- **No version bump** — release-cut is a separate concern (per CLAUDE.md). The fix is purely packaging config + the discovery path.
- **No scenario/file moves, no demo CLI UX change** — scope is strictly packaging + discovery, keeping the documented repo-root `incidents/` layout intact.

Closes #291

🤖 Generated with [Claude Code](https://claude.com/claude-code)