### PR TITLE
Fix #294: dedup Claude Code backfill so resumed sessions don't over-count tokens

### DIFF
--- a/tests/unit/test_backfill.py
+++ b/tests/unit/test_backfill.py
@@ -25,27 +25,33 @@ def _make_session_file(tmp_path: Path, session_id: str, cwd: str,
 def _assistant_record(uuid: str, model: str, input_tokens: int, output_tokens: int,
                        timestamp: str, session_id: str, cwd: str,
                        tool_uses: list[tuple[str, str]] | None = None,
-                       cache_read: int = 0, cache_creation: int = 0) -> dict:
+                       cache_read: int = 0, cache_creation: int = 0,
+                       message_id: str | None = None) -> dict:
     content: list[dict] = [{"type": "text", "text": "ok"}]
     if tool_uses:
         for tu_id, tu_name in tool_uses:
             content.append({"type": "tool_use", "id": tu_id, "name": tu_name})
+    message: dict = {
+        "model": model,
+        "content": content,
+        "usage": {
+            "input_tokens": input_tokens,
+            "output_tokens": output_tokens,
+            "cache_read_input_tokens": cache_read,
+            "cache_creation_input_tokens": cache_creation,
+        },
+    }
+    # The Anthropic API response id — stable per real call, regenerated `uuid`
+    # notwithstanding (#294). Optional so existing tests use the uuid fallback.
+    if message_id is not None:
+        message["id"] = message_id
     return {
         "type": "assistant",
         "uuid": uuid,
         "timestamp": timestamp,
         "sessionId": session_id,
         "cwd": cwd,
-        "message": {
-            "model": model,
-            "content": content,
-            "usage": {
-                "input_tokens": input_tokens,
-                "output_tokens": output_tokens,
-                "cache_read_input_tokens": cache_read,
-                "cache_creation_input_tokens": cache_creation,
-            },
-        },
+        "message": message,
     }
 
 
@@ -435,3 +441,159 @@ def test_iter_skips_files_before_since(tmp_path):
     cutoff = datetime(2025, 1, 1, tzinfo=timezone.utc)
     sessions = list(iter_claude_code_sessions(root=tmp_path, since=cutoff))
     assert sessions == []
+
+
+# --- #294: dedup resumed/branched sessions (over-counted tokens) -------------- #
+
+_CWD = "/Users/me/proj"
+
+
+def test_resumed_session_dedups_same_call_by_message_id(tmp_path):
+    """The same logical call replayed under a NEW record uuid (same message.id)
+    on resume must collapse to ONE span with single-call totals (#294)."""
+    path = _make_session_file(
+        tmp_path, session_id="sess-resume", cwd=_CWD,
+        records=[
+            # Original turn.
+            _assistant_record("uuid-A", "claude-opus-4-7", 3289, 692,
+                              "2026-04-01T10:00:00.000Z", "sess-resume", _CWD,
+                              cache_creation=42981, message_id="msg_stable_1"),
+            # A user turn in between (ignored).
+            {"type": "user", "message": {"role": "user", "content": "more"}},
+            # Resume replays the SAME assistant turn — fresh uuid, SAME message.id.
+            _assistant_record("uuid-B", "claude-opus-4-7", 3289, 692,
+                              "2026-04-01T10:05:00.000Z", "sess-resume", _CWD,
+                              cache_creation=42981, message_id="msg_stable_1"),
+            # …and a third replay (the 3–4× repeat seen in real data).
+            _assistant_record("uuid-C", "claude-opus-4-7", 3289, 692,
+                              "2026-04-01T10:05:01.000Z", "sess-resume", _CWD,
+                              cache_creation=42981, message_id="msg_stable_1"),
+        ],
+    )
+    parsed = parse_claude_code_session(path)
+    assert parsed is not None
+    llm_spans = [s for s in parsed.spans if s.name == "gen_ai.llm.call"]
+    assert len(llm_spans) == 1, "the same message.id must collapse to one span"
+    # Totals reflect a SINGLE call, not 3×.
+    assert parsed.total_input_tokens == 3289
+    assert parsed.total_output_tokens == 692
+    assert llm_spans[0].cache_write_tokens == 42981
+
+
+def test_resume_last_wins_keeps_finalized_usage(tmp_path):
+    """Early replay snapshots carry partial output_tokens; the LAST record has the
+    complete generation. Dedup keeps the finalized usage (last-wins, #294)."""
+    path = _make_session_file(
+        tmp_path, session_id="sess-snap", cwd=_CWD,
+        records=[
+            # Partial snapshot: tiny output.
+            _assistant_record("uuid-1", "claude-opus-4-7", 2, 1,
+                              "2026-04-01T10:00:00.000Z", "sess-snap", _CWD,
+                              cache_read=15764, cache_creation=4317,
+                              message_id="msg_snap"),
+            # Finalized: full output.
+            _assistant_record("uuid-2", "claude-opus-4-7", 2, 575,
+                              "2026-04-01T10:00:02.000Z", "sess-snap", _CWD,
+                              cache_read=15764, cache_creation=4317,
+                              message_id="msg_snap"),
+        ],
+    )
+    parsed = parse_claude_code_session(path)
+    assert parsed is not None
+    llm_spans = [s for s in parsed.spans if s.name == "gen_ai.llm.call"]
+    assert len(llm_spans) == 1
+    # The complete output (575), not the partial snapshot (1) nor their sum (576).
+    assert parsed.total_output_tokens == 575
+    assert llm_spans[0].output_tokens == 575
+
+
+def test_distinct_calls_with_identical_usage_not_deduped(tmp_path):
+    """Two REAL calls can legitimately share identical token counts. Dedup keys on
+    the stable message.id, never on a usage signature, so both survive (#294)."""
+    path = _make_session_file(
+        tmp_path, session_id="sess-twins", cwd=_CWD,
+        records=[
+            _assistant_record("uuid-x", "claude-opus-4-7", 2, 691,
+                              "2026-04-01T10:00:00.000Z", "sess-twins", _CWD,
+                              message_id="msg_call_A"),
+            _assistant_record("uuid-y", "claude-opus-4-7", 2, 691,
+                              "2026-04-01T10:00:03.000Z", "sess-twins", _CWD,
+                              message_id="msg_call_B"),
+        ],
+    )
+    parsed = parse_claude_code_session(path)
+    assert parsed is not None
+    llm_spans = [s for s in parsed.spans if s.name == "gen_ai.llm.call"]
+    assert len(llm_spans) == 2, "distinct message.ids are distinct calls"
+    assert parsed.total_output_tokens == 1382  # 691 + 691, not deduped
+
+
+def test_tool_use_dedups_on_resume(tmp_path):
+    """A tool_use replayed on resume (stable tool_use id) collapses to one span."""
+    path = _make_session_file(
+        tmp_path, session_id="sess-tool", cwd=_CWD,
+        records=[
+            _assistant_record("uuid-a", "claude-opus-4-7", 10, 5,
+                              "2026-04-01T10:00:00.000Z", "sess-tool", _CWD,
+                              tool_uses=[("toolu_stable", "Read")],
+                              message_id="msg_tool"),
+            _assistant_record("uuid-b", "claude-opus-4-7", 10, 5,
+                              "2026-04-01T10:05:00.000Z", "sess-tool", _CWD,
+                              tool_uses=[("toolu_stable", "Read")],
+                              message_id="msg_tool"),
+        ],
+    )
+    parsed = parse_claude_code_session(path)
+    assert parsed is not None
+    tool_spans = [s for s in parsed.spans if s.name == "gen_ai.tool.call"]
+    assert len(tool_spans) == 1
+    assert parsed.tool_call_count == 1
+
+
+def test_falls_back_to_uuid_when_message_id_absent(tmp_path):
+    """Without message.id (older logs), distinct uuids stay distinct calls."""
+    path = _make_session_file(
+        tmp_path, session_id="sess-noid", cwd=_CWD,
+        records=[
+            _assistant_record("uuid-p", "claude-opus-4-7", 100, 20,
+                              "2026-04-01T10:00:00.000Z", "sess-noid", _CWD),
+            _assistant_record("uuid-q", "claude-opus-4-7", 100, 20,
+                              "2026-04-01T10:00:03.000Z", "sess-noid", _CWD),
+        ],
+    )
+    parsed = parse_claude_code_session(path)
+    assert parsed is not None
+    assert len([s for s in parsed.spans if s.name == "gen_ai.llm.call"]) == 2
+
+
+def test_ingest_resumed_session_writes_one_span_per_call(tmp_path):
+    """End-to-end through ingest: a resumed session lands deduped in the DB with
+    single-call session totals (#294)."""
+    _make_session_file(
+        tmp_path, session_id="sess-e2e", cwd=_CWD,
+        records=[
+            _assistant_record("u1", "claude-opus-4-7", 1000, 200,
+                              "2026-04-01T10:00:00.000Z", "sess-e2e", _CWD,
+                              message_id="msg_e2e_1"),
+            _assistant_record("u2", "claude-opus-4-7", 1000, 200,
+                              "2026-04-01T10:05:00.000Z", "sess-e2e", _CWD,
+                              message_id="msg_e2e_1"),  # resume replay
+            _assistant_record("u3", "claude-opus-4-7", 500, 80,
+                              "2026-04-01T10:06:00.000Z", "sess-e2e", _CWD,
+                              message_id="msg_e2e_2"),  # a second real call
+        ],
+    )
+    db = InMemoryBackend()
+    try:
+        ingest_claude_code(db, root=tmp_path)
+        rows = db.conn.execute(
+            "SELECT COUNT(*), COALESCE(SUM(output_tokens),0) FROM spans "
+            "WHERE name = 'gen_ai.llm.call'"
+        ).fetchone()
+        assert rows[0] == 2, "two distinct calls, not three records"
+        assert rows[1] == 280, "200 + 80, not 200 + 200 + 80"
+        sess = db.get_session("sess-e2e")
+        assert sess is not None
+        assert sess.output_tokens == 280
+    finally:
+        db.close()

--- a/tokenjam/core/backfill.py
+++ b/tokenjam/core/backfill.py
@@ -200,12 +200,13 @@ def parse_claude_code_session(path: Path) -> ParsedSession | None:
     earliest: datetime | None = None
     latest: datetime | None = None
 
-    spans: list[NormalizedSpan] = []
-    total_input = 0
-    total_output = 0
-    total_cache = 0
-    total_cost = 0.0
-    tool_count = 0
+    # Dedup by span_id WITHIN the session (#294). Claude Code replays/re-snapshots
+    # assistant turns into the same JSONL on resume/branch — each appended record
+    # gets a fresh `uuid` but the SAME `message.id` (the stable Anthropic API
+    # response id) and same `requestId`. Keying span_id on message.id collapses
+    # these to one span; `last-wins` keeps the finalized usage (early snapshots
+    # carry partial output_tokens; the last record has the complete generation).
+    spans_by_id: dict[str, NormalizedSpan] = {}
 
     try:
         text = path.read_text(encoding="utf-8", errors="replace")
@@ -261,13 +262,18 @@ def parse_claude_code_session(path: Path) -> ParsedSession | None:
         if input_tokens == 0 and output_tokens == 0 and cache_read == 0 and cache_creation == 0:
             continue
 
-        message_uuid = record.get("uuid") or msg.get("id") or f"{line_no}"
+        # Prefer the Anthropic API response id (`message.id`, msg_…) — it is
+        # STABLE per real call and survives resume/branch re-ingest, where the
+        # record `uuid` is regenerated (#294). Fall back to the record uuid only
+        # when message.id is absent. NEVER key on the token-usage signature:
+        # distinct real calls can share identical token counts.
+        message_key = msg.get("id") or record.get("uuid") or f"{line_no}"
         sid_str = session_id or path.stem
         # One trace per session (#243): all assistant turns + their tool calls
-        # in this conversation share a trace_id. span_id stays per-message so
-        # idempotency (deterministic span IDs) is unaffected.
+        # in this conversation share a trace_id. span_id is keyed on the stable
+        # message.id so idempotency holds across resumed/branched sessions.
         trace_id = _trace_id_for(sid_str)
-        span_id = _span_id_for_assistant(sid_str, message_uuid)
+        span_id = _span_id_for_assistant(sid_str, message_key)
 
         provider = _provider_for_model(model)
         cost = calculate_cost(
@@ -286,75 +292,80 @@ def parse_claude_code_session(path: Path) -> ParsedSession | None:
 
         agent_id = _agent_id_from_cwd(cwd)
         start_time = ts or datetime.now(tz=timezone.utc)
-        # Duration unknown from on-disk format; leave None
-        spans.append(
-            NormalizedSpan(
-                span_id=span_id,
-                trace_id=trace_id,
-                name="gen_ai.llm.call",
-                kind=SpanKind.CLIENT,
-                status_code=SpanStatus.OK,
-                start_time=start_time,
-                end_time=start_time,
-                duration_ms=None,
-                agent_id=agent_id,
-                session_id=sid_str,
-                provider=provider,
-                model=model,
-                input_tokens=input_tokens,
-                output_tokens=output_tokens,
-                cache_tokens=cache_read,
-                cache_write_tokens=cache_creation,
-                cost_usd=cost,
-                request_type="completion",
-                conversation_id=sid_str,
-                attributes={"source": "backfill.claude_code"},
-                billing_account="anthropic",
-            )
+        # Duration unknown from on-disk format; leave None.
+        # last-wins: a later replay of the same message.id overwrites earlier,
+        # partial snapshots so the finalized usage/cost is the one we keep (#294).
+        spans_by_id[span_id] = NormalizedSpan(
+            span_id=span_id,
+            trace_id=trace_id,
+            name="gen_ai.llm.call",
+            kind=SpanKind.CLIENT,
+            status_code=SpanStatus.OK,
+            start_time=start_time,
+            end_time=start_time,
+            duration_ms=None,
+            agent_id=agent_id,
+            session_id=sid_str,
+            provider=provider,
+            model=model,
+            input_tokens=input_tokens,
+            output_tokens=output_tokens,
+            cache_tokens=cache_read,
+            cache_write_tokens=cache_creation,
+            cost_usd=cost,
+            request_type="completion",
+            conversation_id=sid_str,
+            attributes={"source": "backfill.claude_code"},
+            billing_account="anthropic",
         )
-        total_input += input_tokens
-        total_output += output_tokens
-        # Session-level cache_tokens tracks cache-READ only, matching the live
-        # path (IngestPipeline aggregates span.cache_tokens) and SessionRecord's
-        # documented semantics (it has no cache_write_tokens field).
-        total_cache += cache_read
-        total_cost += cost
 
-        # Tool uses inside the assistant message become tool spans
+        # Tool uses inside the assistant message become tool spans. tool_use `id`
+        # is stable across resumes (verified in real data), so keying on it
+        # collapses replays the same way. A per-message index (not a global
+        # counter) keeps the no-id fallback deterministic across re-ingest.
         content = msg.get("content") or []
         if isinstance(content, list):
-            for item in content:
-                if not isinstance(item, dict):
-                    continue
-                if item.get("type") != "tool_use":
-                    continue
+            for tool_idx, item in enumerate(b for b in content if isinstance(b, dict)
+                                            and b.get("type") == "tool_use"):
                 tool_use_id = item.get("id") or _det_id(
-                    "tool-fallback", sid_str, message_uuid, str(tool_count)
+                    "tool-fallback", sid_str, message_key, str(tool_idx)
                 )
                 tool_span_id = _span_id_for_tool(sid_str, tool_use_id)
                 tool_name = item.get("name") or "unknown"
-                spans.append(
-                    NormalizedSpan(
-                        span_id=tool_span_id,
-                        trace_id=trace_id,
-                        parent_span_id=span_id,
-                        name="gen_ai.tool.call",
-                        kind=SpanKind.INTERNAL,
-                        status_code=SpanStatus.OK,
-                        start_time=start_time,
-                        end_time=start_time,
-                        duration_ms=None,
-                        agent_id=agent_id,
-                        session_id=sid_str,
-                        tool_name=tool_name,
-                        conversation_id=sid_str,
-                        attributes={"source": "backfill.claude_code"},
-                    )
+                spans_by_id[tool_span_id] = NormalizedSpan(
+                    span_id=tool_span_id,
+                    trace_id=trace_id,
+                    parent_span_id=span_id,
+                    name="gen_ai.tool.call",
+                    kind=SpanKind.INTERNAL,
+                    status_code=SpanStatus.OK,
+                    start_time=start_time,
+                    end_time=start_time,
+                    duration_ms=None,
+                    agent_id=agent_id,
+                    session_id=sid_str,
+                    tool_name=tool_name,
+                    conversation_id=sid_str,
+                    attributes={"source": "backfill.claude_code"},
                 )
-                tool_count += 1
 
-    if not spans or session_id is None:
+    if not spans_by_id or session_id is None:
         return None
+
+    # Totals are computed from the DEDUPED spans (#294) — never from per-record
+    # accumulation, which would re-count every replayed snapshot. cache_tokens is
+    # cache-READ only, matching the live path + SessionRecord semantics.
+    spans = list(spans_by_id.values())
+    total_input = total_output = total_cache = tool_count = 0
+    total_cost = 0.0
+    for s in spans:
+        if s.name == "gen_ai.tool.call":
+            tool_count += 1
+            continue
+        total_input += s.input_tokens or 0
+        total_output += s.output_tokens or 0
+        total_cache += s.cache_tokens or 0
+        total_cost += s.cost_usd or 0.0
 
     agent_id = _agent_id_from_cwd(cwd)
     started_at = earliest or datetime.now(tz=timezone.utc)


### PR DESCRIPTION
Claude Code backfill over-counted tokens/cost ~2–3× because the same logical LLM call is re-ingested under multiple record uuids — resumed/branched sessions replay earlier turns into the same JSONL with fresh uuids. This blocks the 0.5.2 release; token/cost figures must be trustworthy.

## Phase 1 — confirmed the mechanism (against real on-disk data)
Inspected `~/.claude/projects/*.jsonl` (393 files, 19,497 assistant-with-usage records):

- **The duplicate records share a stable `message.id`.** Every record carries the Anthropic API response id (`message.id`, `msg_…`) — present on **100%** of records. 6,307 message.ids appear more than once; **all duplicates are same-file** (resume replays history into the *same* file, not a new one), each with a **distinct `uuid`** but the **same `message.id`** and `requestId`. The primary hypothesis holds: `uuid` is regenerated on resume; `message.id` is stable per real call.
- **The inflation matches.** Naive per-record totals vs deduped-by-`message.id`: **output 2.52×, input 2.34×, cache_write 2.28×, cache_read 2.02×**.
- **Inconsistent-usage cases are streaming snapshots.** 859 message.ids have records that differ — only in `output_tokens`: early records carry a partial count (1/3/5), the **last** record has the finalized generation. So dedup is **last-wins** (first-wins would under-count output ~5%).
- **`tool_use.id` is already stable** — 0 of 9,703 tool_use ids reused under a different record uuid — so keying tool spans on it dedups them identically.

## Phase 2 — the fix (`tokenjam/core/backfill.py`, parser only)
- Key the assistant span id on **`message.id`**, falling back to the record `uuid` only when message.id is absent (older logs). Dedup **within the session** via a `span_id → span` dict, **last-wins**, so a resumed call collapses to one span with the finalized usage.
- Session totals are computed from the **deduped** spans, never per-record accumulation.
- **Never dedup on a usage/token signature** — distinct real calls can share identical token counts (there's a test for this). Identity is `message.id` only.
- Session/trace grouping (#243) and plan-tier stamping (#176) untouched. The insert-time idempotency (skip existing `span_id`) now also catches cross-run resume duplicates because the id is stable.

## Tests
New synthetic-JSONL regression tests (all go through `parse_claude_code_session` / `ingest_claude_code`, no direct `NormalizedSpan`):
- same call replayed under two uuids (same message.id) → **one** span, single-call totals;
- last-wins keeps the finalized output (575, not the partial 1, not their sum);
- two distinct message.ids with identical token counts → **both** survive (no over-dedup);
- tool_use replay → one tool span;
- no-message.id fallback → distinct uuids stay distinct;
- end-to-end ingest → DB has one span per call with correct session totals.

`pytest tests/unit tests/synthetic tests/agents tests/integration` = **1124 passed**; `ruff` + `mypy` clean.

## Verification on real data (the worst-duplication session, `457e6836…`)
```
                      BEFORE (uuid)   AFTER (message.id)     drop
LLM spans                     3,451                1,833    1.88x
input tokens                 31,401                9,879    3.18x
output tokens             3,771,434            1,690,375    2.23x
cache_read tokens     1,815,456,583          954,685,627    1.90x
```
- **Longest run of consecutive identical-usage LLM spans dropped from 3–4 → 1.**
- All span_ids unique; totals fall to plausible levels; the inflated "total tokens" the trace header showed is gone.

## ⚠️ Note: existing backfilled DBs are NOT retroactively cleaned
Fixing the parser does **not** correct data already in a DB — the over-counted spans persist under their old uuid-derived ids (the new run writes the deduped spans under *new* message.id-derived ids and skips nothing old, so a stale DB would now hold **both**). **A clean re-backfill (wipe + re-ingest) is required to correct existing data.** I'd recommend a fast-follow: either a documented "delete `~/.tj/telemetry.duckdb` and re-run `tj onboard --claude-code`" note in the release, or a `tj backfill claude-code --reset` path that clears prior `backfill.claude_code` spans before re-ingesting. Flagging for the master to decide — not implemented here (out of scope).

## What's NOT in this PR
- **Retroactive DB cleanup / `--reset`** — see the note above; needs a product decision.
- **Cache-read "total tokens" display semantics** (#294's second bullet — cache-read is ~94% of the naive token sum and dominates the headline) — explicitly a separate follow-up.

Closes #294

🤖 Generated with [Claude Code](https://claude.com/claude-code)