### PR TITLE
Bump version to 0.5.2

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "tokenjam"
-version = "0.5.1"
+version = "0.5.2"
 description = "TokenJam — local-first OTel-native observability for Autonomous AI agents"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/sdk-ts/package.json
+++ b/sdk-ts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tokenjam/sdk",
-  "version": "0.5.1",
+  "version": "0.5.2",
   "description": "TypeScript SDK for TokenJam — local-first observability for AI agents",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",


### PR DESCRIPTION
Release-cut PR for **0.5.2** — first-run accuracy + polish on the Lens 0.5.x line. Bumps `pyproject.toml` and `sdk-ts/package.json` to 0.5.2.

## What's in 0.5.2 (since v0.5.1)
**Accuracy / bug fixes (most user-visible):**
- **#294** — Claude Code backfill no longer over-counts tokens/cost (~2–4×) on resumed/branched sessions. Dedups on the stable Anthropic `message.id`, last-wins.
- **#291** — `tj demo` scenarios now ship in pip/pipx installs (were never packaged; `tj demo` listed nothing for installed users).
- **#274** — traces list raised to 200 default + "Showing N of M" + Load more pagination.
- **#281** — `tj budget --json`.

**Capability:**
- **#209** — full-request capture (sampling params + tools/tool_choice) on LLM spans.
- **#219–223** — OSS enforcement-plane substrate (proxy + pricing-mode gate + policy engine + budget_cap + audit/savings + MCP tools), shipping as an **experimental, suggest-mode-only preview** (enforces nothing; interfaces unstable).

**Docs / brand:**
- **#289** — contributing-guide clarity + black-on-white brand refresh. **#275** — Code of Conduct. **#273** — refreshed Lens screenshots.

## Note for existing users (release-note item)
The #294 parser fix corrects *new* backfills; it does not retroactively clean already-ingested data. Users wanting corrected historical numbers should wipe and re-run `tj backfill claude-code`. (No automated `--reset` this release — deliberate; see #294.)

## Tests / Verification
- Full suite **1124 passing**, ruff + mypy clean on main.
- Fresh-install smoke: clean-venv wheel install → CLI loads, `tj demo` runs, serve + new policy routes + UI verified.
- #294 re-verified against real data: 5 largest sessions all drop to `max_consecutive_identical_run=1` (was 3–4); biggest session 4,865 → 890 LLM spans.

After merge: create GitHub Release `v0.5.2` to fire publish-pypi + publish-npm.

🤖 Generated with [Claude Code](https://claude.com/claude-code)