### PR TITLE
Fix #303: add long-window options to Traces

### DIFF
--- a/tests/unit/test_lens_ui_regression.py
+++ b/tests/unit/test_lens_ui_regression.py
@@ -19,6 +19,16 @@ def html() -> str:
     return _UI.read_text(encoding="utf-8")
 
 
+def test_traces_window_select_exposes_longer_supported_windows(html):
+    # Traces honors these URL/API windows already; keep the filter dropdown in sync
+    # so #/traces?since=30d and #/traces?since=90d render selected options.
+    traces_start = html.index("function TracesListView")
+    traces_end = html.index("function dedup", traces_start)
+    traces_view = html[traces_start:traces_end]
+    assert '<option value="30d">Last 30d</option>' in traces_view
+    assert '<option value="90d">Last 90d</option>' in traces_view
+
+
 # --- #126: Downsize typed slot always rendered ----------------------------- #
 def test_downsize_section_always_renders(html):
     # The no-candidates branch renders a literal Downsize section id instead of

--- a/tokenjam/ui/index.html
+++ b/tokenjam/ui/index.html
@@ -1685,6 +1685,8 @@ function TracesListView({ params }) {
         <option value="1h">Last 1h</option>
         <option value="24h">Last 24h</option>
         <option value="7d">Last 7d</option>
+        <option value="30d">Last 30d</option>
+        <option value="90d">Last 90d</option>
       </select>
       <select value=${result} onChange=${e => setFilter('result', e.target.value)}>
         <option value="">All results</option>


### PR DESCRIPTION
## Summary

The Traces view already accepts `since=30d` and `since=90d` from the URL/API, but its window dropdown only exposed 1h, 24h, and 7d. This adds the missing options so deep links like `#/traces?since=30d` show a selected value instead of a blank control.

## Tests / Verification
- Added a Lens UI regression assertion for the Traces window options.
- `python3 -m pytest tests/unit/test_lens_ui_regression.py -q`
- `ruff check tokenjam/ tests/unit/test_lens_ui_regression.py`
- `mypy tokenjam/`
- `python3 -m pytest tests/unit/ tests/synthetic/ tests/agents/ tests/integration/ -q`

Closes #303
