### PR TITLE
Fix #299: align recent activity trace window

### DIFF
--- a/tests/unit/test_lens_ui_regression.py
+++ b/tests/unit/test_lens_ui_regression.py
@@ -29,6 +29,15 @@ def test_traces_window_select_exposes_longer_supported_windows(html):
     assert '<option value="90d">Last 90d</option>' in traces_view
 
 
+def test_dashboard_recent_activity_drills_into_matching_traces_window(html):
+    # The Dashboard defaults to 30d while Traces defaults to 24h. Keep the Recent
+    # activity drill-through tied to the Dashboard window so the tile count and
+    # destination list use the same basis (#299).
+    assert "function tracesHrefForWindow" in html
+    assert "tracesHrefForWindow(since)" in html
+    assert 'label="Recent activity" value=${(d.traces || []).length} attention=${errTraces > 0} href="#/traces"' not in html
+
+
 # --- #126: Downsize typed slot always rendered ----------------------------- #
 def test_downsize_section_always_renders(html):
     # The no-candidates branch renders a literal Downsize section id instead of

--- a/tokenjam/ui/index.html
+++ b/tokenjam/ui/index.html
@@ -1012,6 +1012,13 @@ function analyticsHref(q, route = 'analytics') {
   return '#/' + route + (s ? '?' + s : '');
 }
 
+function tracesHrefForWindow(since) {
+  const sp = new URLSearchParams();
+  if (since && since !== '24h') sp.set('since', since);
+  const s = sp.toString();
+  return '#/traces' + (s ? '?' + s : '');
+}
+
 // --- Charts (uPlot, issue #112) ---
 function cssVar(name) {
   return getComputedStyle(document.documentElement).getPropertyValue(name).trim();
@@ -3431,7 +3438,7 @@ function DashboardView({ params }) {
                     sub=${driftN ? 'review baselines' : 'within baseline'} />
                   <${HealthTile} label="Budgets at risk" value=${budgetAttn} attention=${budgetAttn > 0} href="#/budget"
                     sub=${budgets.length ? (budgetAttn ? 'over / near ceiling' : 'within ceiling') : 'none configured'} />
-                  <${HealthTile} label="Recent activity" value=${(d.traces || []).length} attention=${errTraces > 0} href="#/traces"
+                  <${HealthTile} label="Recent activity" value=${(d.traces || []).length} attention=${errTraces > 0} href=${tracesHrefForWindow(since)}
                     sub=${errTraces ? (errTraces + ' with errors') : 'last sessions'} />
                 </div>
               </div>


### PR DESCRIPTION
The Dashboard Recent activity tile counted traces with the selected Dashboard window, but its drill-through opened the Traces default window. This makes the drill-through carry the same window so the destination list matches the tile basis.

## Summary
- Add a small Traces href helper that preserves the Dashboard `since` window.
- Point the Recent activity tile at that window-aware href.
- Add a static Lens regression test for the drill-through.

## Fix #299
The Dashboard defaults to `30d`, while Traces defaults to `24h`. The tile now links to `#/traces?since=30d` for the Dashboard default, and keeps `#/traces` clean when the selected window is already the Traces default (`24h`).

## Tests / Verification
- `ruff check tokenjam/ tests/unit/test_lens_ui_regression.py`
- `mypy tokenjam/`
- `pytest tests/unit/test_lens_ui_regression.py -q`
- `pytest tests/unit/ tests/synthetic/ tests/agents/ tests/integration/ -q`
- `node --check /tmp/tokenjam-module.js`
- `git diff --check`

Closes #299
