### PR TITLE
Fix #284: backfill --since flag parity

### DIFF
--- a/tests/unit/test_backfill.py
+++ b/tests/unit/test_backfill.py
@@ -5,7 +5,11 @@ import json
 from datetime import datetime, timezone
 from pathlib import Path
 
+from click.testing import CliRunner
+
+from tokenjam.cli import cmd_backfill as cmd_backfill_module
 from tokenjam.core.backfill import (
+    BackfillResult,
     ingest_claude_code,
     iter_claude_code_sessions,
     parse_claude_code_session,
@@ -441,6 +445,61 @@ def test_iter_skips_files_before_since(tmp_path):
     cutoff = datetime(2025, 1, 1, tzinfo=timezone.utc)
     sessions = list(iter_claude_code_sessions(root=tmp_path, since=cutoff))
     assert sessions == []
+
+
+def test_claude_code_backfill_accepts_since_window(tmp_path, monkeypatch):
+    captured: dict[str, datetime | None] = {}
+    fixed_now = datetime(2026, 6, 24, 12, 0, tzinfo=timezone.utc)
+
+    def fake_ingest(db, *, root, since, progress, config):
+        captured["since"] = since
+        return BackfillResult()
+
+    monkeypatch.setattr("tokenjam.utils.time_parse.utcnow", lambda: fixed_now)
+    monkeypatch.setattr(cmd_backfill_module, "ingest_claude_code", fake_ingest)
+
+    result = CliRunner().invoke(
+        cmd_backfill_module.claude_code,
+        ["--root", str(tmp_path), "--since", "30d", "--quiet"],
+        obj={"db": object(), "config": None},
+    )
+
+    assert result.exit_code == 0, result.output
+    assert captured["since"] == datetime(2026, 5, 25, 12, 0, tzinfo=timezone.utc)
+
+
+def test_claude_code_backfill_keeps_since_days_alias(tmp_path, monkeypatch):
+    captured: dict[str, datetime | None] = {}
+    fixed_now = datetime(2026, 6, 24, 12, 0, tzinfo=timezone.utc)
+
+    def fake_ingest(db, *, root, since, progress, config):
+        captured["since"] = since
+        return BackfillResult()
+
+    monkeypatch.setattr(cmd_backfill_module, "utcnow", lambda: fixed_now)
+    monkeypatch.setattr(cmd_backfill_module, "ingest_claude_code", fake_ingest)
+
+    result = CliRunner().invoke(
+        cmd_backfill_module.claude_code,
+        ["--root", str(tmp_path), "--since-days", "7", "--quiet"],
+        obj={"db": object(), "config": None},
+    )
+
+    assert result.exit_code == 0, result.output
+    assert captured["since"] == datetime(2026, 6, 17, 12, 0, tzinfo=timezone.utc)
+
+
+def test_claude_code_backfill_rejects_two_since_flags(tmp_path, monkeypatch):
+    monkeypatch.setattr(cmd_backfill_module, "ingest_claude_code", lambda **kwargs: BackfillResult())
+
+    result = CliRunner().invoke(
+        cmd_backfill_module.claude_code,
+        ["--root", str(tmp_path), "--since", "30d", "--since-days", "7", "--quiet"],
+        obj={"db": object(), "config": None},
+    )
+
+    assert result.exit_code != 0
+    assert "Use either --since or --since-days" in result.output
 
 
 # --- #294: dedup resumed/branched sessions (over-counted tokens) -------------- #

--- a/tokenjam/cli/cmd_backfill.py
+++ b/tokenjam/cli/cmd_backfill.py
@@ -15,7 +15,7 @@ from tokenjam.core.ingest_adapters.helicone import ingest_helicone
 from tokenjam.core.ingest_adapters.langfuse import ingest_langfuse
 from tokenjam.core.ingest_adapters.otlp import ingest_otlp
 from tokenjam.utils.formatting import console, format_cost
-from tokenjam.utils.time_parse import utcnow
+from tokenjam.utils.time_parse import parse_since, utcnow
 
 
 @click.group("backfill")
@@ -26,12 +26,14 @@ def cmd_backfill() -> None:
 @cmd_backfill.command("claude-code")
 @click.option("--root", "root_path", default=None,
               help=f"Override Claude Code projects root (default {CLAUDE_CODE_PROJECTS_ROOT}).")
+@click.option("--since", "since_value", default=None,
+              help="Only ingest sessions since a window like 30d, 7d, or YYYY-MM-DD.")
 @click.option("--since-days", type=int, default=None,
-              help="Only ingest sessions whose end time is within the last N days.")
+              help="Deprecated alias for --since Nd.")
 @click.option("--quiet", is_flag=True, help="Suppress per-session progress output.")
 @click.pass_context
-def claude_code(ctx: click.Context, root_path: str | None, since_days: int | None,
-                quiet: bool) -> None:
+def claude_code(ctx: click.Context, root_path: str | None, since_value: str | None,
+                since_days: int | None, quiet: bool) -> None:
     """Ingest Claude Code session logs from ~/.claude/projects/."""
     db = ctx.obj.get("db")
     if db is None:
@@ -47,7 +49,16 @@ def claude_code(ctx: click.Context, root_path: str | None, since_days: int | Non
         return
 
     since = None
-    if since_days is not None and since_days > 0:
+    if since_value and since_days is not None:
+        raise click.UsageError("Use either --since or --since-days, not both.")
+    if since_value:
+        try:
+            since = parse_since(since_value)
+        except ValueError as exc:
+            raise click.BadParameter(str(exc), param_hint="'--since'") from exc
+    elif since_days is not None:
+        if since_days <= 0:
+            raise click.BadParameter("amount must be > 0", param_hint="'--since-days'")
         since = utcnow() - timedelta(days=since_days)
 
     state = {"last_print": 0}


### PR DESCRIPTION
## Summary
- Adds `--since` window parsing to the local log backfill subcommand, matching the existing `30d` and date-style window vocabulary.
- Keeps `--since-days` as a compatibility alias and rejects using the two flags together.

## Related issue
Closes #284

## Testing
- [x] `pytest tests/unit/test_backfill.py -q`
- [x] `make test`
- [x] `ruff check tokenjam/ tests/unit/test_backfill.py`
- [x] `mypy tokenjam/`
