### PR TITLE
[chore] Complete StorageBackend protocol, remove direct db.conn access (#309)

### DIFF
--- a/tests/synthetic/test_cost_tracking.py
+++ b/tests/synthetic/test_cost_tracking.py
@@ -1,104 +1,85 @@
-"""Synthetic tests for CostEngine with an in-memory DuckDB backend."""
+"""Synthetic tests for CostEngine against the real InMemoryBackend.
+
+Previously these ran against a hand-rolled `FakeDB` stub that exposed a raw
+`.conn` — which only worked because CostEngine reached into `db.conn` directly.
+Issue #309 moved those writes behind the StorageBackend protocol
+(`update_span_cost` / `increment_session_cost`), so the cost path now exercises
+the same backend production uses. Span cost is read back through
+`get_trace_spans`; the session total through `get_session().total_cost_usd`
+(the stored column, distinct from `get_session_cost`, which sums span costs).
+"""
 from __future__ import annotations
 
-import duckdb
 import pytest
 
 from tokenjam.core.cost import CostEngine
+from tokenjam.core.db import InMemoryBackend
 from tests.factories import make_llm_span, make_session
 
 
-class FakeDB:
-    """Minimal DB stub with just enough schema for CostEngine tests."""
-
-    def __init__(self) -> None:
-        self.conn = duckdb.connect(":memory:")
-        self.conn.execute("""
-            CREATE TABLE spans (
-                span_id TEXT PRIMARY KEY,
-                cost_usd DOUBLE
-            )
-        """)
-        self.conn.execute("""
-            CREATE TABLE sessions (
-                session_id TEXT PRIMARY KEY,
-                total_cost_usd DOUBLE
-            )
-        """)
-
-    def insert_span_stub(self, span_id: str) -> None:
-        self.conn.execute(
-            "INSERT INTO spans (span_id, cost_usd) VALUES (?, NULL)",
-            [span_id],
-        )
-
-    def insert_session_stub(self, session_id: str) -> None:
-        self.conn.execute(
-            "INSERT INTO sessions (session_id, total_cost_usd) VALUES (?, NULL)",
-            [session_id],
-        )
-
-    def get_span_cost(self, span_id: str) -> float | None:
-        row = self.conn.execute(
-            "SELECT cost_usd FROM spans WHERE span_id = ?", [span_id]
-        ).fetchone()
-        return row[0] if row else None
-
-    def get_session_cost(self, session_id: str) -> float | None:
-        row = self.conn.execute(
-            "SELECT total_cost_usd FROM sessions WHERE session_id = ?", [session_id]
-        ).fetchone()
-        return row[0] if row else None
+@pytest.fixture
+def db():
+    backend = InMemoryBackend()
+    yield backend
+    backend.close()
 
 
 @pytest.fixture
-def fake_db() -> FakeDB:
-    return FakeDB()
+def engine(db: InMemoryBackend) -> CostEngine:
+    return CostEngine(db)
 
 
-@pytest.fixture
-def engine(fake_db: FakeDB) -> CostEngine:
-    return CostEngine(fake_db)
+def _span_cost(db: InMemoryBackend, span) -> float | None:
+    """Read a single span's persisted cost_usd back via the protocol."""
+    for s in db.get_trace_spans(span.trace_id):
+        if s.span_id == span.span_id:
+            return s.cost_usd
+    return None
 
 
-def test_cost_engine_updates_span_cost_in_db(fake_db: FakeDB, engine: CostEngine) -> None:
+def _session_total(db: InMemoryBackend, session_id: str) -> float | None:
+    session = db.get_session(session_id)
+    return session.total_cost_usd if session else None
+
+
+def test_cost_engine_updates_span_cost_in_db(db: InMemoryBackend, engine: CostEngine) -> None:
     span = make_llm_span(
         provider="anthropic", model="claude-haiku-4-5",
         input_tokens=1000, output_tokens=200,
     )
-    fake_db.insert_span_stub(span.span_id)
+    db.insert_span(span)
 
     engine.process_span(span)
 
-    db_cost = fake_db.get_span_cost(span.span_id)
+    db_cost = _span_cost(db, span)
     assert db_cost is not None
     assert db_cost == pytest.approx(0.0016)
     assert span.cost_usd == pytest.approx(0.0016)
 
 
-def test_cost_engine_updates_session_total_cost(fake_db: FakeDB, engine: CostEngine) -> None:
-    session = make_session()
-    fake_db.insert_session_stub(session.session_id)
+def test_cost_engine_updates_session_total_cost(db: InMemoryBackend, engine: CostEngine) -> None:
+    session = make_session(total_cost_usd=None)
+    db.upsert_session(session)
 
     span = make_llm_span(
         provider="anthropic", model="claude-haiku-4-5",
         input_tokens=1000, output_tokens=200,
         session_id=session.session_id,
     )
-    fake_db.insert_span_stub(span.span_id)
+    db.insert_span(span)
 
     engine.process_span(span)
 
-    session_cost = fake_db.get_session_cost(session.session_id)
+    session_cost = _session_total(db, session.session_id)
     assert session_cost is not None
     assert session_cost == pytest.approx(0.0016)
 
 
 def test_cost_engine_accumulates_across_multiple_spans(
-    fake_db: FakeDB, engine: CostEngine,
+    db: InMemoryBackend, engine: CostEngine,
 ) -> None:
-    session = make_session()
-    fake_db.insert_session_stub(session.session_id)
+    session = make_session(total_cost_usd=None)
+    db.upsert_session(session)
 
     for _ in range(3):
         span = make_llm_span(
@@ -106,30 +87,29 @@ def test_cost_engine_accumulates_across_multiple_spans(
             input_tokens=1000, output_tokens=200,
             session_id=session.session_id,
         )
-        fake_db.insert_span_stub(span.span_id)
+        db.insert_span(span)
         engine.process_span(span)
 
-    session_cost = fake_db.get_session_cost(session.session_id)
+    session_cost = _session_total(db, session.session_id)
     assert session_cost is not None
     # 3 * 0.0016 = 0.0048
     assert session_cost == pytest.approx(0.0048)
 
 
-def test_cost_engine_no_op_when_tokens_missing(fake_db: FakeDB, engine: CostEngine) -> None:
+def test_cost_engine_no_op_when_tokens_missing(db: InMemoryBackend, engine: CostEngine) -> None:
     span = make_llm_span(
         provider="anthropic", model="claude-haiku-4-5",
         input_tokens=0, output_tokens=0,
     )
-    fake_db.insert_span_stub(span.span_id)
+    db.insert_span(span)
 
     engine.process_span(span)
 
-    db_cost = fake_db.get_span_cost(span.span_id)
-    assert db_cost is None
+    assert _span_cost(db, span) is None
     assert span.cost_usd is None
 
 
-def test_cost_engine_costs_cache_only_span(fake_db: FakeDB, engine: CostEngine) -> None:
+def test_cost_engine_costs_cache_only_span(db: InMemoryBackend, engine: CostEngine) -> None:
     # A span with no new input/output but cache-read tokens (a cache hit) still
     # costs the cache-read rate and must be recorded, not dropped as a no-op.
     # claude-haiku-4-5: cache_read=0.08 per MTok.
@@ -137,37 +117,35 @@ def test_cost_engine_costs_cache_only_span(fake_db: FakeDB, engine: CostEngine) 
         provider="anthropic", model="claude-haiku-4-5",
         input_tokens=0, output_tokens=0, cache_tokens=1_000_000,
     )
-    fake_db.insert_span_stub(span.span_id)
+    db.insert_span(span)
 
     engine.process_span(span)
 
-    db_cost = fake_db.get_span_cost(span.span_id)
-    assert db_cost == pytest.approx(0.08)
+    assert _span_cost(db, span) == pytest.approx(0.08)
     assert span.cost_usd == pytest.approx(0.08)
 
 
 def test_cost_engine_cache_only_span_updates_session_total(
-    fake_db: FakeDB, engine: CostEngine,
+    db: InMemoryBackend, engine: CostEngine,
 ) -> None:
     # The cache-only span's cost must also accumulate into the session total,
     # not just the span row — dropping it previously under-reported the session.
-    session = make_session()
-    fake_db.insert_session_stub(session.session_id)
+    session = make_session(total_cost_usd=None)
+    db.upsert_session(session)
 
     span = make_llm_span(
         provider="anthropic", model="claude-haiku-4-5",
         input_tokens=0, output_tokens=0, cache_tokens=1_000_000,
         session_id=session.session_id,
     )
-    fake_db.insert_span_stub(span.span_id)
+    db.insert_span(span)
 
     engine.process_span(span)
 
-    session_cost = fake_db.get_session_cost(session.session_id)
-    assert session_cost == pytest.approx(0.08)
+    assert _session_total(db, session.session_id) == pytest.approx(0.08)
 
 
-def test_cost_engine_costs_cache_write_span(fake_db: FakeDB, engine: CostEngine) -> None:
+def test_cost_engine_costs_cache_write_span(db: InMemoryBackend, engine: CostEngine) -> None:
     # A span whose only tokens are cache-CREATION (cache write) must be costed at
     # the cache-write rate, not dropped as a no-op and not charged the read rate.
     # claude-haiku-4-5: cache_write=1.00 per MTok.
@@ -175,17 +153,16 @@ def test_cost_engine_costs_cache_write_span(fake_db: FakeDB, engine: CostEngine)
         provider="anthropic", model="claude-haiku-4-5",
         input_tokens=0, output_tokens=0, cache_write_tokens=1_000_000,
     )
-    fake_db.insert_span_stub(span.span_id)
+    db.insert_span(span)
 
     engine.process_span(span)
 
-    db_cost = fake_db.get_span_cost(span.span_id)
-    assert db_cost == pytest.approx(1.00)
+    assert _span_cost(db, span) == pytest.approx(1.00)
     assert span.cost_usd == pytest.approx(1.00)
 
 
 def test_cost_engine_costs_cache_read_and_write_together(
-    fake_db: FakeDB, engine: CostEngine,
+    db: InMemoryBackend, engine: CostEngine,
 ) -> None:
     # Read and write cache tokens are priced at different rates and must both be
     # charged. claude-haiku-4-5: cache_read=0.08, cache_write=1.00 per MTok.
@@ -194,68 +171,62 @@ def test_cost_engine_costs_cache_read_and_write_together(
         input_tokens=0, output_tokens=0,
         cache_tokens=1_000_000, cache_write_tokens=1_000_000,
     )
-    fake_db.insert_span_stub(span.span_id)
+    db.insert_span(span)
 
     engine.process_span(span)
 
-    db_cost = fake_db.get_span_cost(span.span_id)
-    assert db_cost == pytest.approx(1.08)
+    assert _span_cost(db, span) == pytest.approx(1.08)
     assert span.cost_usd == pytest.approx(1.08)
 
 
 def test_cost_engine_cache_write_span_updates_session_total(
-    fake_db: FakeDB, engine: CostEngine,
+    db: InMemoryBackend, engine: CostEngine,
 ) -> None:
     # The cache-write span's cost must also accumulate into the session total.
-    session = make_session()
-    fake_db.insert_session_stub(session.session_id)
+    session = make_session(total_cost_usd=None)
+    db.upsert_session(session)
 
     span = make_llm_span(
         provider="anthropic", model="claude-haiku-4-5",
         input_tokens=0, output_tokens=0, cache_write_tokens=1_000_000,
         session_id=session.session_id,
     )
-    fake_db.insert_span_stub(span.span_id)
+    db.insert_span(span)
 
     engine.process_span(span)
 
-    session_cost = fake_db.get_session_cost(session.session_id)
-    assert session_cost == pytest.approx(1.00)
+    assert _session_total(db, session.session_id) == pytest.approx(1.00)
 
 
 def test_cost_engine_cache_write_pre_priced_does_not_double_count_session(
-    fake_db: FakeDB, engine: CostEngine,
+    db: InMemoryBackend, engine: CostEngine,
 ) -> None:
     # A pre-priced span (cost_usd already set, e.g. from the parser) has its
     # session cost handled by ingest's _build_or_update_session. process_span
     # must still recompute the span cost but must NOT re-add to the session
     # total, or cache-write spend would be double-counted.
-    session = make_session()
-    fake_db.conn.execute(
-        "INSERT INTO sessions (session_id, total_cost_usd) VALUES (?, ?)",
-        [session.session_id, 5.0],
-    )
+    session = make_session(total_cost_usd=5.0)
+    db.upsert_session(session)
 
     span = make_llm_span(
         provider="anthropic", model="claude-haiku-4-5",
         input_tokens=0, output_tokens=0, cache_write_tokens=1_000_000,
         session_id=session.session_id, cost_usd=1.00,
     )
-    fake_db.insert_span_stub(span.span_id)
+    db.insert_span(span)
 
     engine.process_span(span)
 
     # Span cost recomputed, session total left untouched (no double-count).
-    assert fake_db.get_span_cost(span.span_id) == pytest.approx(1.00)
-    assert fake_db.get_session_cost(session.session_id) == pytest.approx(5.0)
+    assert _span_cost(db, span) == pytest.approx(1.00)
+    assert _session_total(db, session.session_id) == pytest.approx(5.0)
 
 
-def test_cost_engine_no_op_when_provider_missing(fake_db: FakeDB, engine: CostEngine) -> None:
+def test_cost_engine_no_op_when_provider_missing(db: InMemoryBackend, engine: CostEngine) -> None:
     span = make_llm_span(input_tokens=1000, output_tokens=200)
     span.provider = None
-    fake_db.insert_span_stub(span.span_id)
+    db.insert_span(span)
 
     engine.process_span(span)
 
-    db_cost = fake_db.get_span_cost(span.span_id)
-    assert db_cost is None
+    assert _span_cost(db, span) is None

--- a/tests/unit/test_compare.py
+++ b/tests/unit/test_compare.py
@@ -92,7 +92,7 @@ def test_compute_window_totals_aggregates(db):
         db.insert_span(span)
 
     totals = compute_window_totals(
-        db.conn,
+        db,
         since=base - timedelta(hours=1),
         until=base + timedelta(hours=1),
     )

--- a/tests/unit/test_db_helpers.py
+++ b/tests/unit/test_db_helpers.py
@@ -1,6 +1,8 @@
 """Unit tests for small db.py query helpers."""
 from __future__ import annotations
 
+from datetime import datetime, timedelta, timezone
+
 import pytest
 
 from tokenjam.core.db import InMemoryBackend, session_active_seconds
@@ -33,3 +35,113 @@ def test_active_seconds_none_when_no_spans(db):
 
 def test_active_seconds_none_for_unknown_session(db):
     assert session_active_seconds(db.conn, "does-not-exist") is None
+
+
+# ---------------------------------------------------------------------------
+# Issue #309: StorageBackend methods that used to be direct db.conn access in
+# CostEngine / cmd_status / cost-compare. Exercised here against InMemoryBackend.
+# ---------------------------------------------------------------------------
+
+def test_update_span_cost_and_increment_session_cost(db):
+    sess = make_session(session_id="s1", total_cost_usd=None)
+    db.upsert_session(sess)
+    span = make_llm_span(session_id="s1")
+    db.insert_span(span)
+
+    db.update_span_cost(span.span_id, 0.5)
+    db.increment_session_cost("s1", 0.5)
+    db.increment_session_cost("s1", 0.25)
+
+    stored = [s for s in db.get_trace_spans(span.trace_id) if s.span_id == span.span_id][0]
+    assert stored.cost_usd == pytest.approx(0.5)
+    assert db.get_session("s1").total_cost_usd == pytest.approx(0.75)
+
+
+def test_get_distinct_agent_ids_sorted_and_deduped(db):
+    for aid in ("zeta", "alpha", "alpha", "mid"):
+        db.upsert_session(make_session(agent_id=aid))
+    assert db.get_distinct_agent_ids() == ["alpha", "mid", "zeta"]
+
+
+def test_get_active_session_prefers_active_over_completed(db):
+    db.upsert_session(make_session(agent_id="a1", session_id="done", status="completed"))
+    db.upsert_session(make_session(agent_id="a1", session_id="live", status="active"))
+
+    active = db.get_active_session("a1")
+    assert active is not None
+    assert active.session_id == "live"
+    # No active session for an unknown agent.
+    assert db.get_active_session("nobody") is None
+
+
+def test_get_session_active_seconds_matches_helper(db):
+    db.upsert_session(make_session(agent_id="a1", session_id="s1"))
+    for ms in (1000.0, 1000.0):
+        sp = make_llm_span(agent_id="a1", duration_ms=ms)
+        sp.session_id = "s1"
+        db.insert_span(sp)
+    assert db.get_session_active_seconds("s1") == pytest.approx(2.0)
+    assert db.get_session_active_seconds("missing") is None
+
+
+def test_count_unknown_plan_tier_sessions(db):
+    db.upsert_session(make_session(session_id="api1", plan_tier="api"))
+    db.upsert_session(make_session(session_id="unk1", plan_tier="unknown"))
+    db.upsert_session(make_session(session_id="unk2", plan_tier="unknown"))
+    assert db.count_unknown_plan_tier_sessions() == 2
+
+
+def test_get_window_cost_totals_aggregates_and_scopes(db):
+    base = datetime(2026, 5, 10, tzinfo=timezone.utc)
+    for i in range(2):
+        db.upsert_session(make_session(session_id=f"s{i}", agent_id="a1"))
+        db.insert_span(make_llm_span(
+            session_id=f"s{i}", agent_id="a1",
+            input_tokens=1000, output_tokens=200, cache_tokens=50, cost_usd=0.01,
+            start_time=base + timedelta(minutes=i),
+        ))
+    # An out-of-window span must be excluded.
+    db.upsert_session(make_session(session_id="old", agent_id="a1"))
+    db.insert_span(make_llm_span(
+        session_id="old", agent_id="a1", input_tokens=9999, cost_usd=9.0,
+        start_time=base - timedelta(days=5),
+    ))
+
+    sessions, in_tok, out_tok, cache_tok, cost = db.get_window_cost_totals(
+        base - timedelta(hours=1), base + timedelta(hours=1),
+    )
+    assert (sessions, in_tok, out_tok, cache_tok) == (2, 2000, 400, 100)
+    assert cost == pytest.approx(0.02)
+
+
+def test_get_cost_delta_by_group_ranks_shifts(db):
+    now = datetime(2026, 5, 15, tzinfo=timezone.utc)
+    cur_since, cur_until = now - timedelta(days=3), now
+    prev_since, prev_until = now - timedelta(days=10), now - timedelta(days=7)
+
+    db.upsert_session(make_session(session_id="p"))
+    db.insert_span(make_llm_span(
+        session_id="p", agent_id="a1", cost_usd=0.01,
+        start_time=prev_since + timedelta(hours=1),
+    ))
+    db.upsert_session(make_session(session_id="c"))
+    db.insert_span(make_llm_span(
+        session_id="c", agent_id="a1", cost_usd=0.05,
+        start_time=cur_since + timedelta(hours=1),
+    ))
+
+    rows = db.get_cost_delta_by_group(
+        "agent_id", cur_since, cur_until, prev_since, prev_until, top_n=5,
+    )
+    assert rows[0]["group"] == "a1"
+    assert rows[0]["current_cost"] == pytest.approx(0.05)
+    assert rows[0]["previous_cost"] == pytest.approx(0.01)
+    assert rows[0]["delta"] == pytest.approx(0.04)
+
+
+def test_get_cost_delta_by_group_rejects_unknown_column(db):
+    with pytest.raises(ValueError):
+        db.get_cost_delta_by_group(
+            "drop_table", datetime.now(timezone.utc), datetime.now(timezone.utc),
+            datetime.now(timezone.utc), datetime.now(timezone.utc), top_n=5,
+        )

--- a/tokenjam/cli/cmd_status.py
+++ b/tokenjam/cli/cmd_status.py
@@ -22,11 +22,8 @@ def cmd_status(ctx: click.Context, agent: str | None, output_json: bool) -> None
     if agent_filter:
         agent_ids = [agent_filter]
     elif hasattr(db, "conn"):
-        # Direct DB access
-        rows = db.conn.execute(
-            "SELECT DISTINCT agent_id FROM sessions WHERE agent_id IS NOT NULL ORDER BY agent_id"
-        ).fetchall()
-        agent_ids = [r[0] for r in rows]
+        # Local DB mode
+        agent_ids = db.get_distinct_agent_ids()
     else:
         # API mode — discover agents from recent traces
         from tokenjam.core.models import TraceFilters
@@ -46,18 +43,11 @@ def cmd_status(ctx: click.Context, agent: str | None, output_json: bool) -> None
     for aid in agent_ids:
         session = None
         if hasattr(db, "conn"):
-            # Direct DB access
+            # Local DB mode — prefer the live active session, fall back to the
+            # most recent completed one.
             sessions = db.get_completed_sessions(aid, limit=1)
-            active_rows = db.conn.execute(
-                "SELECT * FROM sessions WHERE agent_id = $1 AND status = 'active' "
-                "ORDER BY started_at DESC LIMIT 1",
-                [aid],
-            ).fetchall()
-            if active_rows:
-                cols = [d[0] for d in db.conn.description]
-                from tokenjam.core.db import _row_to_session
-                session = _row_to_session(active_rows[0], cols)
-            elif sessions:
+            session = db.get_active_session(aid)
+            if session is None and sessions:
                 session = sessions[0]
         else:
             # API mode — limited session info
@@ -70,8 +60,7 @@ def cmd_status(ctx: click.Context, agent: str | None, output_json: bool) -> None
         # (issue #147).
         active_seconds = None
         if session is not None and hasattr(db, "conn"):
-            from tokenjam.core.db import session_active_seconds
-            active_seconds = session_active_seconds(db.conn, session.session_id)
+            active_seconds = db.get_session_active_seconds(session.session_id)
 
         today_cost = db.get_daily_cost(aid, utcnow().date())
 
@@ -115,10 +104,7 @@ def cmd_status(ctx: click.Context, agent: str | None, output_json: bool) -> None
     unknown_count = 0
     if hasattr(db, "conn"):
         try:
-            row = db.conn.execute(
-                "SELECT COUNT(*) FROM sessions WHERE plan_tier IS NULL OR plan_tier = 'unknown'"
-            ).fetchone()
-            unknown_count = int(row[0]) if row else 0
+            unknown_count = db.count_unknown_plan_tier_sessions()
         except Exception:
             unknown_count = 0
 

--- a/tokenjam/core/cost.py
+++ b/tokenjam/core/cost.py
@@ -109,21 +109,20 @@ class CostEngine:
 
         span.cost_usd = cost
 
-        # Update span cost in DB
-        if hasattr(self.db, 'conn'):
-            self.db.conn.execute(
-                "UPDATE spans SET cost_usd = $1 WHERE span_id = $2",
-                [cost, span.span_id],
-            )
+        # Persist through the StorageBackend protocol (issue #309 — this used to
+        # reach into self.db.conn directly). Backends that can't persist (e.g.
+        # the read-only API backend) simply don't expose these methods, mirroring
+        # the previous hasattr(self.db, 'conn') guard.
+        update = getattr(self.db, "update_span_cost", None)
+        if update is None:
+            return
+        update(span.span_id, cost)
 
-            # Only accumulate into session total when we computed the cost here.
-            # Skip the session update for pre-priced spans to avoid double-counting.
-            if span.session_id and not was_pre_priced:
-                self.db.conn.execute(
-                    "UPDATE sessions SET total_cost_usd = COALESCE(total_cost_usd, 0) + $1 "
-                    "WHERE session_id = $2",
-                    [cost, span.session_id],
-                )
+        # Only accumulate into the session total when we computed the cost here.
+        # Skip the session update for pre-priced spans to avoid double-counting
+        # (their session cost is handled by ingest's _build_or_update_session).
+        if span.session_id and not was_pre_priced:
+            self.db.increment_session_cost(span.session_id, cost)
 
 
 # ---------------------------------------------------------------------------
@@ -261,31 +260,23 @@ def override_since_for_compare(
 
 
 def compute_window_totals(
-    conn, since: datetime, until: datetime, agent_id: str | None = None,
+    db, since: datetime, until: datetime, agent_id: str | None = None,
 ) -> WindowTotals:
-    """Aggregate sessions/tokens/cost across the spans table for a window."""
-    clauses = ["start_time >= $1", "start_time < $2"]
-    params: list = [since, until]
-    if agent_id:
-        clauses.append(f"agent_id = ${len(params) + 1}")
-        params.append(agent_id)
-    where = " AND ".join(clauses)
-    row = conn.execute(
-        f"SELECT COUNT(DISTINCT session_id) AS sessions, "
-        f"COALESCE(SUM(input_tokens), 0)   AS in_tok, "
-        f"COALESCE(SUM(output_tokens), 0)  AS out_tok, "
-        f"COALESCE(SUM(cache_tokens), 0)   AS cache_tok, "
-        f"COALESCE(SUM(cost_usd), 0.0)     AS cost "
-        f"FROM spans WHERE {where}",
-        params,
-    ).fetchone()
+    """Aggregate sessions/tokens/cost across the spans table for a window.
+
+    Reads through the StorageBackend protocol (`get_window_cost_totals`) rather
+    than touching `db.conn` directly (issue #309).
+    """
+    sessions, in_tok, out_tok, cache_tok, cost = db.get_window_cost_totals(
+        since, until, agent_id,
+    )
     return WindowTotals(
         since=since, until=until,
-        sessions=int(row[0] or 0),
-        input_tokens=int(row[1] or 0),
-        output_tokens=int(row[2] or 0),
-        cache_tokens=int(row[3] or 0),
-        total_cost_usd=float(row[4] or 0.0),
+        sessions=sessions,
+        input_tokens=in_tok,
+        output_tokens=out_tok,
+        cache_tokens=cache_tok,
+        total_cost_usd=cost,
     )
 
 
@@ -302,47 +293,24 @@ def compute_cost_diff(
 
     Reports per-agent and per-model cost deltas (top N each) so the renderer
     can surface which agents/models drove the change.
-    """
-    conn = getattr(db, "conn", None)
-    if conn is None:
-        raise RuntimeError("compare requires a direct DuckDB connection")
 
+    Reads through the StorageBackend protocol (issue #309) rather than reaching
+    into `db.conn`.
+    """
     prev_since, prev_until = parse_compare_window(
         compare, current_since, current_until,
     )
 
-    current = compute_window_totals(conn, current_since, current_until, agent_id)
-    previous = compute_window_totals(conn, prev_since, prev_until, agent_id)
-
-    # Per-agent and per-model cost deltas. Joins are window-scoped because we
-    # only care about agents/models that appear in either window.
-    def _grouped_delta(group_col: str) -> list[dict]:
-        sql = f"""
-            SELECT {group_col} AS grp,
-                   COALESCE(SUM(CASE WHEN start_time >= $1 AND start_time < $2
-                                     THEN cost_usd ELSE 0 END), 0.0) AS cur_cost,
-                   COALESCE(SUM(CASE WHEN start_time >= $3 AND start_time < $4
-                                     THEN cost_usd ELSE 0 END), 0.0) AS prev_cost
-            FROM spans
-            WHERE (start_time >= $3 AND start_time < $2)
-              AND {group_col} IS NOT NULL
-            GROUP BY {group_col}
-            HAVING ABS(cur_cost - prev_cost) > 0.0001
-            ORDER BY ABS(cur_cost - prev_cost) DESC
-            LIMIT $5
-        """
-        rows = conn.execute(
-            sql, [current_since, current_until, prev_since, prev_until, top_n],
-        ).fetchall()
-        return [
-            {"group": r[0], "current_cost": float(r[1]), "previous_cost": float(r[2]),
-             "delta": float(r[1]) - float(r[2])}
-            for r in rows
-        ]
+    current = compute_window_totals(db, current_since, current_until, agent_id)
+    previous = compute_window_totals(db, prev_since, prev_until, agent_id)
 
     return CostDiff(
         current=current,
         previous=previous,
-        by_agent=_grouped_delta("agent_id"),
-        by_model=_grouped_delta("model"),
+        by_agent=db.get_cost_delta_by_group(
+            "agent_id", current_since, current_until, prev_since, prev_until, top_n,
+        ),
+        by_model=db.get_cost_delta_by_group(
+            "model", current_since, current_until, prev_since, prev_until, top_n,
+        ),
     )

--- a/tokenjam/core/db.py
+++ b/tokenjam/core/db.py
@@ -70,6 +70,23 @@ class StorageBackend(Protocol):
     def get_daily_cost(self, agent_id: str, date: date) -> float: ...
     def get_session_cost(self, session_id: str) -> float: ...
     def get_recent_spans(self, session_id: str, limit: int) -> list[NormalizedSpan]: ...
+    # Issue #309: methods that callers (CostEngine, cmd_status, cost compare)
+    # used to satisfy by reaching into `db.conn` directly. Having them on the
+    # protocol keeps those paths behind the abstraction and lets InMemoryBackend
+    # exercise them in unit tests.
+    def update_span_cost(self, span_id: str, cost_usd: float) -> None: ...
+    def increment_session_cost(self, session_id: str, delta_usd: float) -> None: ...
+    def get_distinct_agent_ids(self) -> list[str]: ...
+    def get_active_session(self, agent_id: str) -> SessionRecord | None: ...
+    def get_session_active_seconds(self, session_id: str) -> float | None: ...
+    def count_unknown_plan_tier_sessions(self) -> int: ...
+    def get_window_cost_totals(
+        self, since: datetime, until: datetime, agent_id: str | None = None,
+    ) -> tuple[int, int, int, int, float]: ...
+    def get_cost_delta_by_group(
+        self, group_col: str, current_since: datetime, current_until: datetime,
+        prev_since: datetime, prev_until: datetime, top_n: int,
+    ) -> list[dict]: ...
     def delete_spans_before(self, cutoff: datetime) -> int: ...
     def close(self) -> None: ...
 
@@ -1036,6 +1053,106 @@ class DuckDBBackend:
         rows = cur.fetchall()
         cols = [d[0] for d in cur.description]
         return [_row_to_span(r, cols) for r in rows]
+
+    # -- issue #309: queries moved off direct db.conn access in callers --
+
+    def update_span_cost(self, span_id: str, cost_usd: float) -> None:
+        self.conn.execute(
+            "UPDATE spans SET cost_usd = $1 WHERE span_id = $2",
+            [cost_usd, span_id],
+        )
+
+    def increment_session_cost(self, session_id: str, delta_usd: float) -> None:
+        self.conn.execute(
+            "UPDATE sessions SET total_cost_usd = COALESCE(total_cost_usd, 0) + $1 "
+            "WHERE session_id = $2",
+            [delta_usd, session_id],
+        )
+
+    def get_distinct_agent_ids(self) -> list[str]:
+        rows = self.conn.execute(
+            "SELECT DISTINCT agent_id FROM sessions WHERE agent_id IS NOT NULL "
+            "ORDER BY agent_id"
+        ).fetchall()
+        return [r[0] for r in rows]
+
+    def get_active_session(self, agent_id: str) -> SessionRecord | None:
+        cur = self.conn.execute(
+            "SELECT * FROM sessions WHERE agent_id = $1 AND status = 'active' "
+            "ORDER BY started_at DESC LIMIT 1",
+            [agent_id],
+        )
+        rows = cur.fetchall()
+        if not rows:
+            return None
+        cols = [d[0] for d in cur.description]
+        return _row_to_session(rows[0], cols)
+
+    def get_session_active_seconds(self, session_id: str) -> float | None:
+        return session_active_seconds(self.conn, session_id)
+
+    def count_unknown_plan_tier_sessions(self) -> int:
+        row = self.conn.execute(
+            "SELECT COUNT(*) FROM sessions "
+            "WHERE plan_tier IS NULL OR plan_tier = 'unknown'"
+        ).fetchone()
+        return int(row[0]) if row else 0
+
+    def get_window_cost_totals(
+        self, since: datetime, until: datetime, agent_id: str | None = None,
+    ) -> tuple[int, int, int, int, float]:
+        clauses = ["start_time >= $1", "start_time < $2"]
+        params: list = [since, until]
+        if agent_id:
+            clauses.append(f"agent_id = ${len(params) + 1}")
+            params.append(agent_id)
+        where = " AND ".join(clauses)
+        row = self.conn.execute(
+            f"SELECT COUNT(DISTINCT session_id) AS sessions, "
+            f"COALESCE(SUM(input_tokens), 0)   AS in_tok, "
+            f"COALESCE(SUM(output_tokens), 0)  AS out_tok, "
+            f"COALESCE(SUM(cache_tokens), 0)   AS cache_tok, "
+            f"COALESCE(SUM(cost_usd), 0.0)     AS cost "
+            f"FROM spans WHERE {where}",
+            params,
+        ).fetchone()
+        if row is None:  # COALESCE aggregate always returns a row; guard for typing
+            return (0, 0, 0, 0, 0.0)
+        return (
+            int(row[0] or 0), int(row[1] or 0), int(row[2] or 0),
+            int(row[3] or 0), float(row[4] or 0.0),
+        )
+
+    def get_cost_delta_by_group(
+        self, group_col: str, current_since: datetime, current_until: datetime,
+        prev_since: datetime, prev_until: datetime, top_n: int,
+    ) -> list[dict]:
+        # group_col is an internal, fixed identifier (never user input); the
+        # allow-list keeps it that way so the interpolation below stays safe.
+        if group_col not in ("agent_id", "model"):
+            raise ValueError(f"Unsupported group_col {group_col!r}")
+        sql = f"""
+            SELECT {group_col} AS grp,
+                   COALESCE(SUM(CASE WHEN start_time >= $1 AND start_time < $2
+                                     THEN cost_usd ELSE 0 END), 0.0) AS cur_cost,
+                   COALESCE(SUM(CASE WHEN start_time >= $3 AND start_time < $4
+                                     THEN cost_usd ELSE 0 END), 0.0) AS prev_cost
+            FROM spans
+            WHERE (start_time >= $3 AND start_time < $2)
+              AND {group_col} IS NOT NULL
+            GROUP BY {group_col}
+            HAVING ABS(cur_cost - prev_cost) > 0.0001
+            ORDER BY ABS(cur_cost - prev_cost) DESC
+            LIMIT $5
+        """
+        rows = self.conn.execute(
+            sql, [current_since, current_until, prev_since, prev_until, top_n],
+        ).fetchall()
+        return [
+            {"group": r[0], "current_cost": float(r[1]), "previous_cost": float(r[2]),
+             "delta": float(r[1]) - float(r[2])}
+            for r in rows
+        ]
 
     def delete_spans_before(self, cutoff: datetime) -> int:
         result = self.conn.execute(


### PR DESCRIPTION
`CostEngine`, `cmd_status`, and the cost-compare path satisfied a handful of queries by reaching into `db.conn` directly, bypassing the `StorageBackend` abstraction. That coupled those paths to DuckDB and meant they could only be tested against a hand-rolled stub exposing a raw connection — the cost path in particular had no real in-memory backend coverage. This completes the protocol and routes every call site through it, with no behavior change.

## Summary
- Added 8 methods to the `StorageBackend` protocol and implemented them on `DuckDBBackend` (so `InMemoryBackend`, which subclasses it, inherits all of them):
  - `update_span_cost`, `increment_session_cost` — `CostEngine` writes
  - `get_distinct_agent_ids`, `get_active_session`, `get_session_active_seconds`, `count_unknown_plan_tier_sessions` — `cmd_status` reads
  - `get_window_cost_totals`, `get_cost_delta_by_group` — back `compute_window_totals` / `compute_cost_diff`
- Moved every direct `db.conn` query in `core/cost.py` and `cmd_status` behind those methods.

## Audit of the call sites that were converted
| Site | Was | Now |
|------|-----|-----|
| `CostEngine.process_span` | `self.db.conn.execute(UPDATE spans/sessions …)` | `update_span_cost` / `increment_session_cost` |
| `cmd_status` agent list | `db.conn.execute(SELECT DISTINCT agent_id …)` | `get_distinct_agent_ids` |
| `cmd_status` active session | `db.conn.execute(SELECT * … status='active')` + `_row_to_session` | `get_active_session` |
| `cmd_status` active seconds | `session_active_seconds(db.conn, …)` | `get_session_active_seconds` |
| `cmd_status` unknown-plan count | `db.conn.execute(SELECT COUNT(*) …)` | `count_unknown_plan_tier_sessions` |
| `compute_window_totals` | took a bare `conn` | takes `db`, calls `get_window_cost_totals` |
| `compute_cost_diff` | `getattr(db, "conn")` + inline SQL | `get_cost_delta_by_group` |

## The win — real in-memory coverage of the cost path
- `tests/synthetic/test_cost_tracking.py` drops its `FakeDB`-with-`.conn` stub and runs `CostEngine` against `InMemoryBackend`, reading span cost back via `get_trace_spans` and the session total via `get_session().total_cost_usd`. All original scenarios preserved (span/session cost, accumulation, cache-only / cache-write pricing, pre-priced no-double-count, no-op guards).
- `tests/unit/test_db_helpers.py` gains direct coverage of each new method (incl. the `get_cost_delta_by_group` allow-list rejecting an unknown column).

## Guardrails honored
- **Per-thread cursor (#124) untouched** — `conn` stays a `threading.local` per-thread cursor; the new methods call `self.conn` from inside the backend, they don't change its shape.
- **No collision with #308** — `core/optimize/` and `cmd_optimize.py` are not modified. `compute_cost_diff` / `compute_window_totals` keep stable public signatures, so `cmd_optimize`, `cmd_cost`, and the `cost_compare` route are unaffected (their `compute_cost_diff` calls are already guarded to the local-DB backend).
- `cmd_status` keeps its `hasattr(db, "conn")` mode discriminator (local DB vs API backend) — an attribute-existence check, not a query.

## Tests / Verification
- `pytest tests/unit tests/synthetic tests/agents tests/integration` → **1137 passed**.
- `ruff check` and `mypy` clean on `core/db.py`, `core/cost.py`, `cmd_status.py`.

## What's NOT in this PR
- `session_active_seconds` and `_row_to_session` remain module-level functions in `db.py` — still used by `api/routes/status.py` (outside this issue's ownership) and `tests/unit/test_db_helpers.py`. The new `get_session_active_seconds` wraps the former.
- `ApiBackend` was not given the new methods — the converted call sites only invoke them in local-DB mode, which is the issue's scope (DuckDB + InMemory).

Closes #309

🤖 Generated with [Claude Code](https://claude.com/claude-code)