### PR TITLE
fix(lens): gate Analytics Stack control to stacking charts (#295)

### DIFF
--- a/tests/unit/test_lens_ui_regression.py
+++ b/tests/unit/test_lens_ui_regression.py
@@ -468,6 +468,29 @@ def test_analytics_leaderboard_has_inline_bars(html):
     assert ".lb-bar" in html
 
 
+# --- #295: Stack gated to stacking charts; empty cross-tab gets a clear state - #
+def test_analytics_stack_gated_to_stacking_charts(html):
+    # Stack only applies to the multi-series charts (bar/line). The Leaderboard
+    # (hbar) ignores stack, so the control is hidden AND stack_by is dropped from
+    # the query for non-stacking charts — otherwise a stale stack strands the
+    # leaderboard on an empty cross-tab ("No data", #295).
+    assert "const stackApplies = chart === 'bar' || chart === 'line'" in html
+    assert "const effStack = stackApplies ? stack : ''" in html
+    # query drops stack_by when the chart doesn't stack
+    assert "stack_by: effStack || undefined" in html
+    assert "stack_by: stack || undefined" not in html  # the buggy unconditional form is gone
+    # the Stack control is conditionally rendered (hidden on the leaderboard)
+    assert "${stackApplies ? html`<label class=\"ctl\">Stack" in html
+
+
+def test_analytics_empty_cross_tab_offers_clear_stack(html):
+    # A structurally-empty stacked breakdown (e.g. Model x Tool category, since a
+    # span carries a model OR a tool, never both) shows a "Clear stack" affordance
+    # instead of a bare "No data in this window" (#295).
+    assert "const emptyFromStack" in html
+    assert "Clear stack" in html
+
+
 # --- #215: cost-annotated trace waterfall ---------------------------------- #
 def test_trace_waterfall_cost_summary(html):
     # A cost-first trace summary header (total cost + tokens + duration + spans).

--- a/tokenjam/ui/index.html
+++ b/tokenjam/ui/index.html
@@ -3148,13 +3148,22 @@ function AnalyticsView({ params, route = 'analytics', embedded = false, kpiCapti
   const setFilter = (k, v) => navigate(route, { ...cur, [k]: v }, DEFAULTS);
   const applyPreset = (q) => navigate(route, { ...cur, ...q }, DEFAULTS);
 
+  // #295: Stack only makes sense on the multi-series charts (bar/line). The
+  // Leaderboard (hbar) collapses the time dimension into a single per-group
+  // total and ignores stack entirely, so a stale stack there just strands the
+  // view on an empty cross-tab ("No data"). Gate it: hide the Stack control AND
+  // drop stack_by from the query for non-stacking charts. The chosen stack stays
+  // in the URL, so it returns when the user switches back to a bar/line chart.
+  const stackApplies = chart === 'bar' || chart === 'line';
+  const effStack = stackApplies ? stack : '';
+
   const [st, setSt] = useState({ loading: true, error: null, resp: null });
 
   const load = useCallback(async () => {
     setSt(s => ({ ...s, loading: !s.resp, error: null }));
     try {
       const resp = await api('/analytics', {
-        metric, group_by: groupBy, stack_by: stack || undefined, since,
+        metric, group_by: groupBy, stack_by: effStack || undefined, since,
         agent_id: fAgent || undefined, provider: fProvider || undefined,
         model: fModel || undefined, tool: fTool || undefined,
       });
@@ -3188,6 +3197,15 @@ function AnalyticsView({ params, route = 'analytics', embedded = false, kpiCapti
   const toolDimNoMetric = (groupBy === 'tool' || groupBy === 'tool_category')
     && (metric === 'spend' || metric === 'tokens');
 
+  // #295: a stacked breakdown can be structurally empty even when the metric has
+  // plenty of data — e.g. Model × Tool category, since a span is either an LLM
+  // call or a tool call, never both. Detect that so we can prompt the user to
+  // clear the stack instead of stranding them on a bare "No data" chart. (Only
+  // bar/line carry a stack — effStack is '' for the leaderboard.)
+  const noRows = !!resp && Array.isArray(resp.rows) && resp.rows.length === 0;
+  const emptyFromStack = !!effStack && noRows;
+  const labelOf = dim => (ANALYTICS_DIMENSIONS.find(d => d[0] === dim) || [, dim])[1];
+
   return html`
     ${embedded ? null : html`<div class="page-title" style="display:flex;align-items:center;gap:10px;flex-wrap:wrap">
       Analytics <${PlanBadge} framing=${framing} />
@@ -3202,11 +3220,11 @@ function AnalyticsView({ params, route = 'analytics', embedded = false, kpiCapti
         <select value=${groupBy} onChange=${e => setFilter('group_by', e.target.value)}>
           ${ANALYTICS_DIMENSIONS.map(([v, l]) => html`<option value=${v}>${l}</option>`)}
         </select></label>
-      <label class="ctl">Stack
+      ${stackApplies ? html`<label class="ctl">Stack
         <select value=${stack} onChange=${e => setFilter('stack', e.target.value)}>
           <option value="">none</option>
           ${ANALYTICS_DIMENSIONS.filter(d => d[0] !== groupBy).map(([v, l]) => html`<option value=${v}>${l}</option>`)}
-        </select></label>
+        </select></label>` : null}
       <label class="ctl">Chart
         <select value=${chart} onChange=${e => setFilter('chart', e.target.value)}>
           ${ANALYTICS_CHARTS.map(([v, l]) => html`<option value=${v}>${l}</option>`)}
@@ -3280,6 +3298,11 @@ function AnalyticsView({ params, route = 'analytics', embedded = false, kpiCapti
             </div>
           </div>`
           : loading ? html`<div class="shimmer" style="height:200px"></div>`
+          : emptyFromStack ? html`
+            <div class="empty" style="padding:32px 16px;text-align:center">
+              <div style="font-size:13px;margin-bottom:12px">No rows for ${labelOf(groupBy)} × ${labelOf(effStack)}. That breakdown is empty because a span carries only one of these — e.g. an LLM call has a model but no tool, a tool span has a tool but no model.</div>
+              <button class="btn" onClick=${() => setFilter('stack', '')}>Clear stack</button>
+            </div>`
           : chart === 'hbar'
             ? (board && board.length ? html`
               <div class="leaderboard">


### PR DESCRIPTION
Fixes #295.

## Problem
In the Analytics / Explore pivot, choosing a **Stack** dimension returned "No data in this window" for many combinations (e.g. Metric=Events, By=Model, Stack=Tool category, Chart=Leaderboard). Two root causes:

1. **Stacking is meaningless on the Leaderboard (`hbar`).** It collapses the time dimension into a single per-group total and ignores `stack` entirely — yet the query still sent `stack_by`, producing an empty cross-tab and stranding the view on "No data".
2. **Many cross-tabs are structurally empty** because a span carries only one dimension — e.g. an LLM call has a `model` but no `tool`; a tool span has a `tool` but no `model`. So `Model × Tool category` has zero rows.

## Fix (UI-only, `tokenjam/ui/index.html`)
- **Gate the Stack control to stacking charts (bar/line).** It's hidden on the Leaderboard.
- **Drop `stack_by` from the `/analytics` query for non-stacking charts**, so a stale stack in the URL can't strand the leaderboard on "No data". The chosen stack is preserved in the URL and returns when switching back to bar/line.
- **Clear empty state for empty cross-tabs.** On bar/line, a structurally-empty breakdown now shows *"No rows for X × Y … "* with a **Clear stack** button instead of a bare "No data in this window".

## Verified
- Leaderboard + stale `stack=tool_category` → Stack control hidden, model leaderboard renders (was "No data").
- Bars + `Model × Tool category` → "Clear stack" empty state.
- Bars + `Tool × Tool category` (valid cross-tab) → real stacked bar chart.

## Tests
- Static regression guards in `tests/unit/test_lens_ui_regression.py` (proven to fail on the buggy UI, pass on the fix).
- Full UI guard suite green: `test_lens_ui_regression.py` + `test_ui_offline.py` (115 passed).
