### PR TITLE
[enhancement] Surface sample size + confidence interval on savings estimates (#308)

### DIFF
--- a/tests/unit/test_optimize_savings_ci.py
+++ b/tests/unit/test_optimize_savings_ci.py
@@ -1,0 +1,218 @@
+"""Sampling confidence interval on savings estimates (#308).
+
+Covers the bootstrap helper, that the downgrade analyzer populates
+n_sessions + ci_low/ci_high, that the fields round-trip through the report dict,
+and the load-bearing property: a small-n run produces a visibly WIDER interval
+than a large-n run drawn from the same per-session distribution.
+
+All synthetic data is built via tests/factories (Critical Rule 8).
+"""
+from __future__ import annotations
+
+from datetime import timedelta
+
+import pytest
+
+from tokenjam.core.db import InMemoryBackend
+from tokenjam.core.optimize import analyze_model_downgrade
+from tokenjam.core.optimize.runner import report_from_dict, report_to_dict
+from tokenjam.core.optimize.stats import bootstrap_ci
+from tokenjam.core.optimize.types import OptimizeReport, WindowSummary
+from tokenjam.utils.time_parse import utcnow
+from tests.factories import make_llm_span
+
+
+@pytest.fixture
+def db():
+    backend = InMemoryBackend()
+    yield backend
+    backend.close()
+
+
+def _small_opus(db, session_id, *, cost=0.030):
+    """One Opus session matching the downgrade heuristic (small in/out, no tools)."""
+    db.insert_span(make_llm_span(
+        agent_id="claude-code-x", model="claude-opus-4-7", provider="anthropic",
+        input_tokens=1000, output_tokens=200, cost_usd=cost,
+        session_id=session_id, start_time=utcnow() - timedelta(days=2),
+    ))
+
+
+# --- bootstrap_ci (the pure helper) --------------------------------------- #
+
+def test_bootstrap_ci_none_below_two_samples():
+    assert bootstrap_ci([]) is None
+    assert bootstrap_ci([5.0]) is None
+
+
+def test_bootstrap_ci_is_deterministic():
+    # A report must not jitter between runs — same input, same interval.
+    vals = [0.5, 1.0, 1.5, 2.0, 0.8]
+    assert bootstrap_ci(vals) == bootstrap_ci(vals)
+
+
+def test_bootstrap_ci_brackets_the_point_estimate():
+    vals = [1.0, 1.2, 0.9, 1.1, 1.0, 1.3]
+    point = sum(vals)  # scale=1.0
+    lo, hi = bootstrap_ci(vals)  # type: ignore[misc]
+    assert lo <= point <= hi
+    assert lo >= 0.0  # savings floored at 0
+
+
+def test_bootstrap_ci_scale_projects_point_estimate():
+    vals = [1.0, 1.0, 1.0, 1.0]  # window sum = 4
+    lo, hi = bootstrap_ci(vals, scale=7.5)  # type: ignore[misc]
+    # All-equal samples → zero spread → interval collapses on 4 * 7.5 = 30.
+    assert lo == pytest.approx(30.0)
+    assert hi == pytest.approx(30.0)
+
+
+def test_small_n_interval_wider_than_large_n():
+    # THE load-bearing property (#308): same per-session distribution, but a
+    # 5-session sample yields a much wider band than a 500-session one. Scale
+    # each so the point estimate is identical, isolating sampling spread.
+    base = [0.5, 2.0, 1.0, 1.5, 0.8]
+    small = bootstrap_ci(base, scale=10.0)              # n=5
+    large = bootstrap_ci(base * 100, scale=10.0 / 100)  # n=500, same mean
+    assert small is not None and large is not None
+    small_width = small[1] - small[0]
+    large_width = large[1] - large[0]
+    assert small_width > large_width
+    # And the point estimate is the same to within rounding.
+    assert sum(base) * 10.0 == pytest.approx(sum(base * 100) * (10.0 / 100))
+
+
+# --- analyzer populates the fields ---------------------------------------- #
+
+def test_downgrade_finding_carries_n_and_ci():
+    db = InMemoryBackend()
+    try:
+        for i in range(6):
+            _small_opus(db, f"s{i}", cost=0.03 + i * 0.005)  # varied savings
+        since = utcnow() - timedelta(days=30)
+        until = utcnow() + timedelta(hours=1)
+        f = analyze_model_downgrade(db.conn, since, until, agent_id=None,
+                                    window_days=30.0)
+        assert f is not None
+        assert f.n_sessions == 6
+        assert f.n_sessions == f.candidate_sessions
+        assert f.ci_low is not None and f.ci_high is not None
+        assert f.ci_low <= f.ci_high
+        # The monthly projection sits inside its own interval.
+        assert f.ci_low <= f.monthly_savings_usd <= f.ci_high
+    finally:
+        db.close()
+
+
+def test_single_candidate_session_has_no_interval():
+    # One session can't bracket a projection — n surfaces, CI stays None.
+    db = InMemoryBackend()
+    try:
+        _small_opus(db, "only")
+        since = utcnow() - timedelta(days=30)
+        until = utcnow() + timedelta(hours=1)
+        f = analyze_model_downgrade(db.conn, since, until, agent_id=None,
+                                    window_days=30.0)
+        assert f is not None
+        assert f.n_sessions == 1
+        assert f.ci_low is None
+        assert f.ci_high is None
+    finally:
+        db.close()
+
+
+# --- report dict round-trip ----------------------------------------------- #
+
+def test_n_and_ci_round_trip_through_report_dict():
+    db = InMemoryBackend()
+    try:
+        for i in range(5):
+            _small_opus(db, f"s{i}", cost=0.03 + i * 0.004)
+        since = utcnow() - timedelta(days=30)
+        until = utcnow() + timedelta(hours=1)
+        finding = analyze_model_downgrade(db.conn, since, until, agent_id=None,
+                                          window_days=30.0)
+        report = OptimizeReport(
+            window=WindowSummary(
+                since=since, until=until, days=30.0, sessions=5, spans=5,
+                total_tokens=6000, total_cost_usd=0.2, thin_data=False,
+            ),
+            downgrade=finding,
+        )
+        d = report_to_dict(report)
+        # Present in the serialised dict.
+        assert d["downgrade"]["n_sessions"] == finding.n_sessions
+        assert d["downgrade"]["ci_low"] == finding.ci_low
+        assert d["downgrade"]["ci_high"] == finding.ci_high
+        # And survive the deserialisation symmetrically.
+        restored = report_from_dict(d)
+        assert restored.downgrade is not None
+        assert restored.downgrade.n_sessions == finding.n_sessions
+        assert restored.downgrade.ci_low == finding.ci_low
+        assert restored.downgrade.ci_high == finding.ci_high
+    finally:
+        db.close()
+
+
+# --- CLI savings-line suffix (honesty framing) ---------------------------- #
+
+def _finding(n, ci_low, ci_high):
+    from tokenjam.core.optimize.types import DowngradeFinding
+    return DowngradeFinding(
+        candidate_sessions=n, total_sessions=n, actual_cost_usd=1.0,
+        alternative_cost_usd=0.5, monthly_savings_usd=15.0,
+        percent_of_sessions=100.0, examples=[], suggestions={},
+        n_sessions=n, ci_low=ci_low, ci_high=ci_high,
+    )
+
+
+def test_cli_suffix_shows_n_and_interval():
+    from tokenjam.cli.cmd_optimize import _sampling_ci_suffix
+    s = _sampling_ci_suffix(_finding(42, 8.0, 23.0))
+    assert "n=42" in s
+    assert "95% CI" in s
+    assert "/mo" in s
+
+
+def test_cli_suffix_reads_as_sampling_not_safety():
+    # Honesty (Rule 14): the label must frame sampling confidence, never imply
+    # the swap is safe / validated.
+    from tokenjam.cli.cmd_optimize import _sampling_ci_suffix
+    s = _sampling_ci_suffix(_finding(42, 8.0, 23.0)).lower()
+    assert "sampling confidence" in s
+    assert "not a safety claim" in s
+    for banned in ("safe to", "validated", "guarantee", "preserves quality"):
+        assert banned not in s
+
+
+def test_cli_suffix_thin_sample_surfaces_n_without_interval():
+    from tokenjam.cli.cmd_optimize import _sampling_ci_suffix
+    s = _sampling_ci_suffix(_finding(1, None, None))
+    assert "n=1" in s
+    assert "CI" not in s  # no invented interval for a single session
+
+
+def test_cli_suffix_empty_when_no_sessions():
+    from tokenjam.cli.cmd_optimize import _sampling_ci_suffix
+    assert _sampling_ci_suffix(_finding(0, None, None)) == ""
+
+
+def test_round_trip_tolerates_missing_ci_fields():
+    # A report produced by an older daemon (no n/ci keys) must still parse,
+    # defaulting n_sessions=0 and ci None — forward/backward compatibility.
+    d = {
+        "window": {"since": utcnow().isoformat(), "until": utcnow().isoformat(),
+                   "days": 7.0, "sessions": 1, "spans": 1,
+                   "total_tokens": 100, "total_cost_usd": 0.01, "thin_data": True},
+        "downgrade": {
+            "candidate_sessions": 1, "total_sessions": 1,
+            "actual_cost_usd": 0.03, "alternative_cost_usd": 0.01,
+            "monthly_savings_usd": 0.08, "percent_of_sessions": 100.0,
+            "examples": [], "suggestions": {},
+        },
+    }
+    restored = report_from_dict(d)
+    assert restored.downgrade is not None
+    assert restored.downgrade.n_sessions == 0
+    assert restored.downgrade.ci_low is None
+    assert restored.downgrade.ci_high is None

--- a/tokenjam/cli/cmd_optimize.py
+++ b/tokenjam/cli/cmd_optimize.py
@@ -440,6 +440,27 @@ def _render_report(
         )
 
 
+def _sampling_ci_suffix(d: DowngradeFinding) -> str:
+    """Sampling-confidence suffix for the savings line (#308).
+
+    Renders " (n=42, 95% CI $Y–$Z)" so a 5-session projection visibly differs
+    from a 500-session one. This is SAMPLING confidence — how much usage the
+    estimate rests on — NOT a claim the model swap is safe (the
+    MODEL_DOWNGRADE_CAVEAT governs that). The CI bounds are None when n < 2.
+    """
+    if d.n_sessions <= 0:
+        return ""
+    if d.ci_low is None or d.ci_high is None:
+        # Too few sessions to bracket the projection — surface n alone so the
+        # thinness is still visible, without inventing an interval.
+        return f"  [dim](n={d.n_sessions} sessions; too few to bracket)[/dim]"
+    return (
+        f"  [dim](n={d.n_sessions} sessions, 95% CI "
+        f"{format_cost(d.ci_low)}–{format_cost(d.ci_high)}/mo — sampling "
+        f"confidence, not a safety claim)[/dim]"
+    )
+
+
 def _render_downgrade(d: DowngradeFinding, pricing_mode: str = "api") -> None:
     """
     Render the downsize finding for the given pricing mode.
@@ -496,6 +517,7 @@ def _render_downgrade(d: DowngradeFinding, pricing_mode: str = "api") -> None:
         console.print(
             f"     • Projected savings if pattern holds: "
             f"[bold]{format_cost(d.monthly_savings_usd)}/mo[/bold]"
+            f"{_sampling_ci_suffix(d)}"
         )
     if d.suggestions:
         pairs = ", ".join(f"{k} → {v}" for k, v in d.suggestions.items())

--- a/tokenjam/core/optimize/analyzers/model_downgrade.py
+++ b/tokenjam/core/optimize/analyzers/model_downgrade.py
@@ -13,6 +13,7 @@ from datetime import datetime
 from typing import Any
 
 from tokenjam.core.optimize.registry import register
+from tokenjam.core.optimize.stats import bootstrap_ci
 from tokenjam.core.optimize.types import (
     AnalyzerContext,
     DowngradeExample,
@@ -127,6 +128,9 @@ def analyze_model_downgrade(
     window_total_tokens = 0
     examples: list[DowngradeExample] = []
     suggestions: dict[str, str] = {}
+    # Per-candidate-session window savings, for the sampling-confidence interval
+    # (#308). One value per candidate session = (actual cost − cheaper-model cost).
+    per_session_savings: list[float] = []
 
     for row in llm_rows:
         session_id, trace_id, _agent, start_time, end_time, provider, model, \
@@ -156,6 +160,9 @@ def analyze_model_downgrade(
         actual_cost += float(cost or 0.0)
         alt_cost += alt_unit
         candidate_tokens += int(in_tok or 0) + int(out_tok or 0) + int(cache_tok or 0)
+        # This session's recoverable saving (clamped at 0 — a cheaper model
+        # never costs more in our candidate set, but guard against pricing noise).
+        per_session_savings.append(max(float(cost or 0.0) - alt_unit, 0.0))
         suggestions[model] = alt
 
         if len(examples) < 3:
@@ -180,6 +187,15 @@ def analyze_model_downgrade(
     savings_window = max(actual_cost - alt_cost, 0.0)
     monthly_savings = (savings_window / window_days * 30.0) if window_days > 0 else 0.0
     percent = (candidate_sessions / total_sessions * 100.0) if total_sessions else 0.0
+
+    # Sampling confidence on the monthly projection (#308). Resample the
+    # candidate sessions with replacement and recompute the projected monthly
+    # savings, so the interval widens when the estimate rests on few sessions.
+    # Same `scale` as monthly_savings so the CI brackets that exact figure.
+    monthly_scale = (30.0 / window_days) if window_days > 0 else 1.0
+    ci = bootstrap_ci(per_session_savings, scale=monthly_scale)
+    ci_low = round(ci[0], 2) if ci else None
+    ci_high = round(ci[1], 2) if ci else None
     percent_tokens = (
         candidate_tokens / window_total_tokens * 100.0
         if window_total_tokens > 0 else 0.0
@@ -212,6 +228,9 @@ def analyze_model_downgrade(
             "candidate sessions routed to a cheaper model over the window — "
             "structural fit only, no quality validation"
         ),
+        n_sessions=candidate_sessions,
+        ci_low=ci_low,
+        ci_high=ci_high,
     )
 
 

--- a/tokenjam/core/optimize/runner.py
+++ b/tokenjam/core/optimize/runner.py
@@ -254,6 +254,10 @@ def report_from_dict(d: dict) -> OptimizeReport:
             estimated_recoverable_tokens=dd.get("estimated_recoverable_tokens"),
             estimate_basis=str(dd.get("estimate_basis", "")),
             estimate_confidence=str(dd.get("estimate_confidence", "heuristic")),
+            # Sampling confidence (#308) — round-trip n + the CI bounds.
+            n_sessions=int(dd.get("n_sessions", 0)),
+            ci_low=dd.get("ci_low"),
+            ci_high=dd.get("ci_high"),
         )
 
     budgets = []

--- a/tokenjam/core/optimize/stats.py
+++ b/tokenjam/core/optimize/stats.py
@@ -1,0 +1,80 @@
+"""Sampling-confidence helpers for savings estimates (#308).
+
+A savings projection drawn from 5 sessions is far less reliable than one drawn
+from 500, yet they render identically. These helpers attach a *sampling*
+confidence interval to a projection so the figure carries its own reliability
+signal.
+
+IMPORTANT — this is SAMPLING confidence on the projection (how much usage the
+estimate rests on), NOT a claim that the optimization preserves quality. The
+existing "estimated recoverable / review before switching" caveats stay; this
+only quantifies the spread you'd expect if you'd sampled a different slice of
+the same usage. The CI label must always read as sampling confidence.
+
+Pure Python only — no scipy / numpy (CLAUDE.md: no heavy deps).
+"""
+from __future__ import annotations
+
+import math
+import random
+
+# Default bootstrap parameters. Seed is FIXED so the same window produces the
+# same interval every run (a report shouldn't jitter between invocations).
+DEFAULT_RESAMPLES = 2000
+DEFAULT_CONFIDENCE = 0.95
+_BOOTSTRAP_SEED = 1308  # arbitrary, stable
+
+
+def bootstrap_ci(
+    per_session: list[float],
+    *,
+    scale: float = 1.0,
+    confidence: float = DEFAULT_CONFIDENCE,
+    resamples: int = DEFAULT_RESAMPLES,
+) -> tuple[float, float] | None:
+    """Bootstrap CI for the SUM of a per-session quantity, optionally scaled.
+
+    ``per_session`` holds one savings value per sampled session. The point
+    estimate is ``sum(per_session) * scale`` (e.g. window savings projected to a
+    month via ``scale = 30 / window_days``). We resample the sessions with
+    replacement, recompute the scaled sum each time, and take the central
+    ``confidence`` quantiles — capturing how much the total would swing if the
+    same number of sessions had landed differently.
+
+    Returns ``(ci_low, ci_high)`` or ``None`` when there isn't enough data to say
+    anything (0 or 1 session — a single point has no spread to estimate).
+    """
+    n = len(per_session)
+    if n < 2:
+        return None
+
+    rng = random.Random(_BOOTSTRAP_SEED)
+    totals: list[float] = []
+    for _ in range(resamples):
+        s = 0.0
+        for _ in range(n):
+            s += per_session[rng.randrange(n)]
+        totals.append(s * scale)
+    totals.sort()
+
+    alpha = (1.0 - confidence) / 2.0
+    low = _quantile(totals, alpha)
+    high = _quantile(totals, 1.0 - alpha)
+    # Savings can't go negative — clamp the lower bound at 0 (you never *gain*
+    # money by routing to a cheaper model; the floor is "no savings").
+    return (max(0.0, low), max(0.0, high))
+
+
+def _quantile(sorted_vals: list[float], q: float) -> float:
+    """Linear-interpolated quantile of an already-sorted list."""
+    if not sorted_vals:
+        return 0.0
+    if len(sorted_vals) == 1:
+        return sorted_vals[0]
+    pos = q * (len(sorted_vals) - 1)
+    lo = math.floor(pos)
+    hi = math.ceil(pos)
+    if lo == hi:
+        return sorted_vals[int(pos)]
+    frac = pos - lo
+    return sorted_vals[lo] * (1.0 - frac) + sorted_vals[hi] * frac

--- a/tokenjam/core/optimize/types.py
+++ b/tokenjam/core/optimize/types.py
@@ -79,6 +79,16 @@ class DowngradeFinding:
     estimated_recoverable_tokens: int | None   = None
     estimate_basis:               str          = ""
     estimate_confidence:          str          = "heuristic"
+    # Sampling confidence (#308). `n_sessions` is the candidate-session sample
+    # the projection rests on; `ci_low`/`ci_high` are the 95% bootstrap interval
+    # on `monthly_savings_usd`, so a 5-session estimate shows a visibly wider
+    # band than a 500-session one. This is SAMPLING confidence on the projection,
+    # NOT a claim the model swap preserves quality — the MODEL_DOWNGRADE_CAVEAT
+    # still governs that. ci_low/ci_high are None when n < 2 (no spread to
+    # estimate from a single point).
+    n_sessions:                   int          = 0
+    ci_low:                       float | None = None
+    ci_high:                      float | None = None
 
 
 @dataclass


### PR DESCRIPTION
A savings projection drawn from 5 sessions rendered identically to one drawn from 500, even though the small-n estimate is far less reliable. This attaches a **sampling** confidence signal to the `downsize` projection so the figure carries its own reliability indicator — directly reinforcing the honesty discipline.

## Summary
- New pure-Python `tokenjam/core/optimize/stats.py` — a seeded bootstrap CI (no scipy/numpy).
- `DowngradeFinding` gains `n_sessions`, `ci_low`, `ci_high`.
- The analyzer computes the interval over per-candidate-session window savings.
- Round-trips through `report_to_dict` / `report_from_dict`.
- The CLI savings line surfaces `(n=…, 95% CI $Y–$Z/mo)`.

## How it works
`bootstrap_ci(per_session, scale=…)` resamples the candidate sessions with replacement, recomputes the scaled total each time, and takes the central 95% quantiles — capturing how much the projection would swing if the same number of sessions had landed differently. A **fixed seed** keeps a report from jittering between runs; it returns `None` below 2 samples (a single point has no spread). `model_downgrade.py` collects each candidate session's `(actual − cheaper-model)` saving and computes the interval on the **monthly** projection using the same `30 / window_days` scale as `monthly_savings_usd`, so the CI brackets that exact figure.

### CLI render (api mode)
```
     • Projected savings if pattern holds: $0.4000/mo  (n=8 sessions, 95% CI $0.3200–$0.4700/mo — sampling confidence, not a safety claim)
     ! Candidate-flagging heuristic, not a quality judgment. Review the example sessions before changing models.
```

## Honesty framing (Critical Rule 14 — load-bearing)
This is **sampling** confidence on the projection (how much usage it rests on), **not** a claim the model swap preserves quality. The existing `MODEL_DOWNGRADE_CAVEAT` and "estimated recoverable / review before switching" framing are **untouched**, and the CI label is worded so it can't read as a safety/validation claim — a test asserts the suffix says "sampling confidence … not a safety claim" and never says "safe to" / "validated" / "guarantee" / "preserves quality".

## Tests (`tests/unit/test_optimize_savings_ci.py`, all via factories)
- bootstrap: None below 2 samples, deterministic, brackets the point estimate, scale projects correctly;
- **the load-bearing property**: a 5-session run yields a visibly WIDER interval than a 500-session run drawn from the same per-session distribution (same point estimate);
- the analyzer populates `n_sessions` + CI, and a single candidate session surfaces `n` with CI `None`;
- the fields round-trip through the report dict, and older payloads without the keys still parse (defaults);
- CLI suffix: shows n + interval, reads as sampling-not-safety, surfaces `n` alone when too thin, empty when n=0.

`pytest tests/unit tests/synthetic tests/agents tests/integration` = **1142 passed**; `ruff` + `mypy` clean.

## Ownership / collision (per the brief)
Only `core/optimize/` (new `stats.py`, `types.py`, `model_downgrade.py`, `runner.py`) + `cmd_optimize.py` are touched. **`core/db.py` / `core/cost.py` / `cmd_status` (#309) are NOT modified** — confirmed clean in the diff.

## What's NOT in this PR
- **Dashboard tile (index.html)** — explicitly optional in the brief. The dashboard's recoverable tiles aggregate across analyzers via a *different* path (`/cost/components` recoverable), not the `DowngradeFinding` object, so surfacing per-finding sampling CI there would need separate server plumbing — disproportionate to "keep it to one tile, minimize merge surface." Left for a focused follow-up. The required CLI + data layer is complete and the fields are already on the serialised report for any UI consumer.
- **CI on the other savings-bearing findings** (`reuse`, etc.) — the issue's example and the brief center on the `downsize` monthly projection; `reuse`'s per-cluster recoverable is a different shape (cache-reuse vs script-replacement bounds) and is best handled separately to avoid conflating two interval semantics.

Closes #308

🤖 Generated with [Claude Code](https://claude.com/claude-code)