### PR TITLE
fix(lens): show leaderboard total + reconcile partial-dimension gap (#313)

### DIFF
--- a/tests/unit/test_lens_ui_regression.py
+++ b/tests/unit/test_lens_ui_regression.py
@@ -491,6 +491,19 @@ def test_analytics_empty_cross_tab_offers_clear_stack(html):
     assert "Clear stack" in html
 
 
+# --- #313: leaderboard surfaces its total + reconciles the partial-dim gap --- #
+def test_analytics_leaderboard_shows_total_and_gap(html):
+    # The leaderboard ranks items but used to show no sum; it now surfaces its
+    # own item count + subtotal, and when grouping by a PARTIAL dimension (only
+    # some spans carry it, e.g. tool) it reconciles the gap against the all-events
+    # KPI so the smaller subtotal doesn't look contradictory (#313).
+    assert "const boardTotal = board ? board.reduce" in html
+    assert "const boardGap = kpiCount != null" in html
+    assert "Total: ${fmtVal(boardTotal)}" in html
+    assert "${boardCount} ${boardCount === 1 ? dimName : dimNamePlural}" in html
+    assert "have a ${dimName}" in html
+
+
 # --- #215: cost-annotated trace waterfall ---------------------------------- #
 def test_trace_waterfall_cost_summary(html):
     # A cost-first trace summary header (total cost + tokens + duration + spans).

--- a/tokenjam/ui/index.html
+++ b/tokenjam/ui/index.html
@@ -3206,6 +3206,20 @@ function AnalyticsView({ params, route = 'analytics', embedded = false, kpiCapti
   const emptyFromStack = !!effStack && noRows;
   const labelOf = dim => (ANALYTICS_DIMENSIONS.find(d => d[0] === dim) || [, dim])[1];
 
+  // #313: surface the leaderboard's own total + item count (a ranked list with
+  // no sum is confusing), and reconcile the gap when grouping by a PARTIAL
+  // dimension — only some spans carry it (e.g. a tool), so the breakdown subtotal
+  // is legitimately smaller than the all-events KPI and otherwise looks
+  // contradictory. Purely additive: only the leaderboard (hbar) branch reads
+  // these; nothing else changes.
+  const boardTotal = board ? board.reduce((s, e) => s + (e.value || 0), 0) : 0;
+  const boardCount = board ? board.length : 0;
+  const dimName = (ANALYTICS_DIMENSIONS.find(d => d[0] === groupBy) || [, groupBy])[1].toLowerCase();
+  const dimNamePlural = (/y$/.test(dimName) && !/[aeiou]y$/.test(dimName)) ? dimName.slice(0, -1) + 'ies' : dimName + 's';
+  const countMetric = (metric === 'events' || metric === 'sessions') ? metric : null;
+  const kpiCount = (countMetric && kpis) ? kpis[countMetric] : null;
+  const boardGap = kpiCount != null && boardTotal > 0 && boardTotal < kpiCount;
+
   return html`
     ${embedded ? null : html`<div class="page-title" style="display:flex;align-items:center;gap:10px;flex-wrap:wrap">
       Analytics <${PlanBadge} framing=${framing} />
@@ -3305,6 +3319,7 @@ function AnalyticsView({ params, route = 'analytics', embedded = false, kpiCapti
             </div>`
           : chart === 'hbar'
             ? (board && board.length ? html`
+              <div class="dim" style="font-size:12px;margin:2px 0 8px">Total: ${fmtVal(boardTotal)} · ${boardCount} ${boardCount === 1 ? dimName : dimNamePlural}</div>
               <div class="leaderboard">
                 ${board.map((e, i) => {
                   const label = formatGroupLabel(e.group, groupBy);
@@ -3316,7 +3331,9 @@ function AnalyticsView({ params, route = 'analytics', embedded = false, kpiCapti
                     <span class="lb-val">${fmtVal(e.value)}</span>
                   </div>`;
                 })}
-              </div>` : html`<div class="empty" style="padding:32px 0">No data in this window.</div>`)
+              </div>
+              ${boardGap ? html`<div class="chart-foot"><span class="dim">Only ${fmtCount(boardTotal)} of ${fmtCount(kpiCount)} ${countMetric} have a ${dimName} — the rest aren't in this breakdown.</span></div>` : null}
+              ` : html`<div class="empty" style="padding:32px 0">No data in this window.</div>`)
             : (series ? html`
               ${chart === 'line'
                 ? html`<${SpendChart} data=${series.data} labels=${series.labels} height=${220} fmtY=${fmtV} axisFmtY=${axisFmt} showLegend=${series.labels.length > 1} bucket=${series.bucket} />`


### PR DESCRIPTION
Fixes #313.

## Problem
The Analytics leaderboard ranked items but showed **no total**. And when grouping by a **partial dimension** (one only some spans carry — e.g. `Tool`: tool spans have a tool, LLM spans don't), the breakdown subtotal was smaller than the all-events **KPI tile**, which looked contradictory (e.g. Events tile = 1,804 vs the leaderboard summing to 295).

## Fix (UI-only, `tokenjam/ui/index.html`, leaderboard branch only)
- **Total header** above the bars: `Total: <subtotal> · <N> <dimension>` (e.g. "Total: 295 · 7 tools").
- **Gap note** for count metrics where the subtotal is below the all-events KPI: *"Only 295 of 1,804 events have a tool — the rest aren't in this breakdown."*

Purely additive — only the leaderboard (`hbar`) branch reads the new derived values; `buildLeaderboard`, the bar/line charts, the empty states, and shared helpers are untouched.

## Verified
- Events by Tool → "Total: 295 · 7 tools" + gap note. Events by Model → "Total: 1.5k · 1 model" + "Only 1,509 of 1,804 events have a model…".
- Universal dimensions (Day/Agent) → Total shown, no gap note (nothing missing).
- Spend/Tokens by Tool → existing "Tools don't carry cost" empty state unchanged.
- Bar/line charts unchanged.

## Tests
- Static regression guard in `tests/unit/test_lens_ui_regression.py`.
- Full UI guard suite green (`test_lens_ui_regression.py` + `test_ui_offline.py`, 116 passed).

## Notes
- Rebased on top of the merged #295. Follow-up enhancement for the KPI tile itself filed as #318.


## Screenshots

_Events by Tool — leaderboard now shows "Total: 295 · 7 tools" header + the gap note (and Stack control hidden per #295):_
<!-- drag screenshot here -->

_Events by Model — "Total: 1.5k · 1 model" + "Only 1,509 of 1,804 events have a model …":_
<!-- drag screenshot here -->
