### PR TITLE
feat(lens): show breakdown subtotal on the active KPI tile (#318)

### DIFF
--- a/tests/unit/test_lens_ui_regression.py
+++ b/tests/unit/test_lens_ui_regression.py
@@ -468,6 +468,21 @@ def test_analytics_leaderboard_has_inline_bars(html):
     assert ".lb-bar" in html
 
 
+# --- #318: active tile shows the breakdown subtotal for a partial dimension --- #
+def test_analytics_active_tile_shows_breakdown_subtotal(html):
+    # When grouping by a PARTIAL dimension (only some spans carry it, e.g. tool),
+    # the active count-metric tile shows the breakdown subtotal beneath the window
+    # total so the tile reconciles with the smaller chart subtotal (#318). Count
+    # metrics only; only when there's an actual gap.
+    assert "const breakdownTotal = (resp.rows || []).reduce" in html
+    assert "const activeSub = ((metric === 'events' || metric === 'sessions')" in html
+    assert "by ${breakdownDim}" in html
+    # KpiTile renders the optional sub-line; defaults null so other callers (e.g.
+    # the Dashboard preview) are unaffected.
+    assert "onSelect, sub = null }" in html
+    assert "kpi-sub-val" in html
+
+
 # --- #295: Stack gated to stacking charts; empty cross-tab gets a clear state - #
 def test_analytics_stack_gated_to_stacking_charts(html):
     # Stack only applies to the multi-series charts (bar/line). The Leaderboard

--- a/tokenjam/ui/index.html
+++ b/tokenjam/ui/index.html
@@ -381,6 +381,9 @@ tr.clickable:hover td.chevron { color: var(--accent); }
 .kpi-tile .delta-chip { font-family: 'Geist Mono', monospace; font-size: 11px; margin-top: 6px; display: inline-block; }
 .kpi-val { font-family: 'Geist Mono', monospace; font-size: 20px; font-weight: 600; }
 .kpi-lab { font-size: 11px; color: var(--text-dim); margin-top: 2px; }
+.kpi-sub { margin-top: 8px; padding-top: 8px; border-top: 1px solid var(--border); }
+.kpi-sub-val { font-family: 'Geist Mono', monospace; font-size: 15px; font-weight: 600; color: var(--text); }
+.kpi-sub-lab { font-size: 11px; color: var(--text-dim); margin-left: 5px; }
 .leaderboard { display: flex; flex-direction: column; gap: 6px; padding: 6px 0; }
 .lb-row { display: grid; grid-template-columns: 24px minmax(80px, 160px) 1fr auto; align-items: center; gap: 10px; font-size: 13px; }
 .lb-rank { color: var(--text-faint); font-family: 'Geist Mono', monospace; text-align: right; }
@@ -2084,16 +2087,19 @@ function Sparkline({ values, color = 'var(--accent)', width = 92, height = 26 })
 // `onSelect` makes the tile the metric selector (#247): the kpi-active border
 // already implied it was clickable; wiring onClick fulfills that. Falls back to
 // a static tile when no handler is given.
-function KpiTile({ label, value, active, series, delta, cost, prevThin, onSelect }) {
+function KpiTile({ label, value, active, series, delta, cost, prevThin, onSelect, sub = null }) {
   const cls = 'kpi-tile' + (active ? ' kpi-active' : '') + (onSelect ? ' kpi-clickable' : '');
   const props = onSelect
     ? { class: cls, role: 'button', tabindex: '0', 'aria-pressed': String(!!active),
         onClick: onSelect,
         onKeyDown: (e) => { if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); onSelect(); } } }
     : { class: cls };
+  // #318: optional secondary line — the breakdown subtotal on the active tile
+  // when grouping by a partial dimension (defaults null, so other callers are
+  // unaffected).
   return html`<div ...${props}>
     <div class="kpi-top">
-      <div class="kpi-num"><div class="kpi-val">${value}</div><div class="kpi-lab">${label}</div></div>
+      <div class="kpi-num"><div class="kpi-val">${value}</div><div class="kpi-lab">${label}</div>${sub ? html`<div class="kpi-sub"><span class="kpi-sub-val">${sub.value}</span><span class="kpi-sub-lab">${sub.label}</span></div>` : null}</div>
       <${Sparkline} values=${series} />
     </div>
     <${DeltaChip} pct=${delta} cost=${cost} prevThin=${prevThin} />
@@ -3277,6 +3283,16 @@ function AnalyticsView({ params, route = 'analytics', embedded = false, kpiCapti
       // window's session count as the universal "did anything happen" proxy.
       const prevThin = !!resp.kpi_prev && (resp.kpi_prev.sessions || 0) < 2;
       const onMetric = (k) => setFilter('metric', k);
+      // #318: the ACTIVE count-metric tile shows the breakdown subtotal next to
+      // the window total when grouping by a PARTIAL dimension (only some spans
+      // carry it, e.g. tool), so the window-wide tile reconciles with the smaller
+      // chart subtotal. Count metrics only (events/sessions — spend/tokens framing
+      // is more complex); only when there's an actual gap.
+      const breakdownTotal = (resp.rows || []).reduce((s, r) => s + (r.value || 0), 0);
+      const breakdownDim = (ANALYTICS_DIMENSIONS.find(d => d[0] === groupBy) || [, groupBy])[1].toLowerCase();
+      const activeSub = ((metric === 'events' || metric === 'sessions')
+        && breakdownTotal > 0 && breakdownTotal < (kpis[metric] || 0))
+        ? { value: fmtCount(breakdownTotal), label: `by ${breakdownDim}` } : null;
       const tiles = [];
       if (spend) {
         tiles.push({ key: 'spend', label: spend.label, cost: true, value: spend.value,
@@ -3292,6 +3308,7 @@ function AnalyticsView({ params, route = 'analytics', embedded = false, kpiCapti
         <div class="kpi-row">
           ${tiles.map(t => html`<${KpiTile} label=${t.label} value=${t.value} active=${t.key === metric}
               series=${t.series} delta=${t.delta == null ? null : t.delta} cost=${t.cost}
+              sub=${t.key === metric ? activeSub : null}
               prevThin=${prevThin} onSelect=${() => onMetric(t.key)} />`)}
         </div>
         ${kpiCaption ? html`<div class="kpi-caption">${kpiCaption}</div>` : null}`;


### PR DESCRIPTION
Fixes #318.

## Problem
In the Analytics pivot, when grouping by a **partial dimension** (one only some spans carry — e.g. `Tool`), the active count-metric KPI tile showed the **window-wide total** (e.g. Events = 1,804) while the chart below covered only a **subset** (295). Nothing on the tile reconciled the two, so the tile and the chart looked like they disagreed.

## Fix (UI-only, `tokenjam/ui/index.html`)
Split the **active** tile: the window total stays the headline, and below a divider it shows the **breakdown subtotal** with the dimension label:

```
1,804
Events
──────────
295  by tool
```

- **Count metrics only** (events/sessions — spend/tokens framing is more complex).
- **Only when there's an actual gap** (subtotal < window total) — so grouping by a universal dimension (Day/Agent) shows just the total, no sub-line.
- `KpiTile` gains an optional `sub` prop **defaulting to `null`**, so every other caller (incl. the Dashboard preview) is unchanged.

(Vertical/stacked layout chosen over a horizontal side-by-side after an A/B — the vertical keeps the total-vs-subset hierarchy clear.)

## Verified
- Events by Tool → tile shows `1,804 / Events / 295 by tool`; reconciles with the leaderboard's "Total: 295 · 7 tools" (#313).
- Events by Model → `1,509 by model`. Events by Day → no sub-line (nothing missing). Spend/Tokens → no sub-line.
- Other screens (Dashboard tiles) unchanged.

## Tests
- Static regression guard in `tests/unit/test_lens_ui_regression.py`.
- Full UI guard suite green (117 passed). Rebased on top of the merged #313.
