### PR TITLE
Fix #298: Clarify drift baseline agent scope and live session rules

### DIFF
--- a/tests/integration/test_cli.py
+++ b/tests/integration/test_cli.py
@@ -314,6 +314,12 @@ def test_drift_no_baselines_exits_0(runner, db, config):
     assert data["agents"] == []
 
 
+def test_drift_no_baselines_warning_message(runner, db, config):
+    result = _invoke(runner, db, config, ["drift"])
+    assert result.exit_code == 0
+    assert "No drift baselines found." in result.output
+
+
 def test_drift_with_baseline_no_violations(runner, db, config):
     """Normal session (tokens within threshold) -> exit 0."""
     # Use a baseline without tool sequences so Jaccard doesn't fire

--- a/tokenjam/cli/cmd_drift.py
+++ b/tokenjam/cli/cmd_drift.py
@@ -45,7 +45,8 @@ def cmd_drift(ctx: click.Context, agent: str | None, output_json: bool) -> None:
         else:
             console.print(
                 "[dim]No drift baselines found. "
-                "Need at least 10 completed sessions to build a baseline.[/dim]"
+                "Need at least 10 completed live sessions for a single agent to build its baseline "
+                "(note: drift baselines are computed per-agent and only from live sessions, so historical backfilled sessions will not build a baseline).[/dim]"
             )
         ctx.exit(0)
         return

--- a/tokenjam/ui/index.html
+++ b/tokenjam/ui/index.html
@@ -2501,7 +2501,7 @@ function DriftView({ params }) {
 
   // /drift returns a single-agent shape when agent_id is set; normalize to a list.
   const agents = data.agents || (data.agent_id ? [data] : []);
-  if (!agents.length) return html`<div class="empty">No baselines built yet. Run at least 10 sessions to establish a behavioral baseline.</div>`;
+  if (!agents.length) return html`<div class="empty">No drift baselines built yet. Run at least 10 completed live sessions for a single agent to establish its behavioral baseline (note: drift baselines are computed per-agent, and only from live sessions, so historical backfilled sessions will not build a baseline).</div>`;
 
   const metrics = [
     ['Input tokens', 'avg_input_tokens', 'stddev_input_tokens', 'input_tokens'],


### PR DESCRIPTION
Explain that behavioral drift baseline thresholds are computed per-agent (rather than globally) and build only from live sessions. Update the empty page warning on the Web UI and the CLI fallback message to explicitly state this.

## Summary
- **Web UI**: Updated the Drift View empty-state warning message in `tokenjam/ui/index.html` to clarify the per-agent live threshold.
- **CLI**: Updated the fallback warning printed by `tj drift` when no baselines exist in `tokenjam/cli/cmd_drift.py` to match the Web UI message.

## Tests / Verification
- Added `test_drift_no_baselines_warning_message` in `tests/integration/test_cli.py` to verify that `tj drift` prints the warning header when no baselines exist.
- Executed the full test suite successfully (**1,154 passed**).

## What's NOT in this PR (if scope was deliberately limited)
- **Phase 2 (Backfill baseline compilation)**: Auto-building baselines during `tj backfill` is deferred to a future follow-up issue/PR.

## Related issue
Closes #298

@anilmurty please review

## Checklist

- [X] Tests pass (`pytest tests/unit/ tests/synthetic/ tests/agents/ tests/integration/`)
- [X] Lint clean (`ruff check tokenjam/`)
- [X] Type check clean (`mypy tokenjam/`)
- [ ] CLAUDE.md updated (if architecture changed)
- [ ] Test spans use `tests/factories.py` (not raw `NormalizedSpan`)
- [X] Requested `@anilmurty` as reviewer (or @-mentioned him above)
