### PR TITLE
Feat/mcp wiring doctor check

### DIFF
--- a/tests/integration/test_cli.py
+++ b/tests/integration/test_cli.py
@@ -2,7 +2,6 @@
 from __future__ import annotations
 
 import json
-from pathlib import Path
 from unittest.mock import patch
 
 import pytest

--- a/tests/integration/test_cli.py
+++ b/tests/integration/test_cli.py
@@ -274,6 +274,96 @@ def test_doctor_warns_on_schema_without_capture(runner, db, config, tmp_path):
     assert any(c["level"] == "warning" for c in schema_checks)
 
 
+def test_doctor_mcp_wiring_checks(runner, db, config, tmp_path):
+    # Set up a fake home directory and fake cwd
+    fake_home = tmp_path / "fake_home"
+    fake_home.mkdir()
+    fake_cwd = tmp_path / "fake_cwd"
+    fake_cwd.mkdir()
+
+    # Stub doctor config to avoid other warning noise
+    _clean_doctor_config(config, tmp_path)
+    config_file = tmp_path / "tokenjam.toml"
+    config_file.write_text('version = "1"\n')
+
+    # Case 1: No files, no executables -> should be level: "info"
+    with patch("pathlib.Path.home", return_value=fake_home), \
+         patch("pathlib.Path.cwd", return_value=fake_cwd), \
+         patch("shutil.which", return_value=None), \
+         patch("tokenjam.cli.cmd_doctor.find_config_file", return_value=config_file):
+        result = _invoke(runner, db, config, ["doctor", "--json"])
+        assert result.exit_code == 0
+        checks = json.loads(result.output)
+        mcp_checks = [c for c in checks if c["name"] == "MCP wiring"]
+        assert mcp_checks and mcp_checks[0]["level"] == "info"
+
+    # Case 2: Claude Code CLI is on PATH (shutil.which returns True), but no registration -> should be level: "warning"
+    with patch("pathlib.Path.home", return_value=fake_home), \
+         patch("pathlib.Path.cwd", return_value=fake_cwd), \
+         patch("shutil.which", side_effect=lambda cmd: "/bin/claude" if cmd == "claude" else None), \
+         patch("tokenjam.cli.cmd_doctor.find_config_file", return_value=config_file):
+        result = _invoke(runner, db, config, ["doctor", "--json"])
+        assert result.exit_code == 1
+        checks = json.loads(result.output)
+        mcp_checks = [c for c in checks if c["name"] == "MCP wiring"]
+        assert mcp_checks and mcp_checks[0]["level"] == "warning"
+        assert "Claude Code" in mcp_checks[0]["message"]
+
+    # Case 3: MCP registered globally in Codex (~/.codex/config.toml) -> should be level: "ok"
+    codex_dir = fake_home / ".codex"
+    codex_dir.mkdir(parents=True, exist_ok=True)
+    codex_config = codex_dir / "config.toml"
+    codex_config.write_text("[mcp_servers.tj]\ncommand = 'tj'\nargs = ['mcp']\n")
+
+    with patch("pathlib.Path.home", return_value=fake_home), \
+         patch("pathlib.Path.cwd", return_value=fake_cwd), \
+         patch("shutil.which", return_value=None), \
+         patch("tokenjam.cli.cmd_doctor.find_config_file", return_value=config_file):
+        result = _invoke(runner, db, config, ["doctor", "--json"])
+        assert result.exit_code == 0
+        checks = json.loads(result.output)
+        mcp_checks = [c for c in checks if c["name"] == "MCP wiring"]
+        assert mcp_checks and mcp_checks[0]["level"] == "ok"
+        assert "Codex" in mcp_checks[0]["message"]
+
+    # Clean up codex file
+    codex_config.unlink()
+    codex_dir.rmdir()
+
+    # Case 4: MCP registered globally in Claude Code (~/.claude.json) -> should be level: "ok"
+    claude_json = fake_home / ".claude.json"
+    claude_json.write_text('{"mcpServers": {"tj": {"command": "tj"}}}')
+
+    with patch("pathlib.Path.home", return_value=fake_home), \
+         patch("pathlib.Path.cwd", return_value=fake_cwd), \
+         patch("shutil.which", return_value=None), \
+         patch("tokenjam.cli.cmd_doctor.find_config_file", return_value=config_file):
+        result = _invoke(runner, db, config, ["doctor", "--json"])
+        assert result.exit_code == 0
+        checks = json.loads(result.output)
+        mcp_checks = [c for c in checks if c["name"] == "MCP wiring"]
+        assert mcp_checks and mcp_checks[0]["level"] == "ok"
+        assert "Claude Code" in mcp_checks[0]["message"]
+
+    # Clean up claude json file
+    claude_json.unlink()
+
+    # Case 5: MCP registered locally in project-level .mcp.json -> should be level: "ok"
+    project_mcp = fake_cwd / ".mcp.json"
+    project_mcp.write_text('{"mcpServers": {"tj": {"command": "tj"}}}')
+
+    with patch("pathlib.Path.home", return_value=fake_home), \
+         patch("pathlib.Path.cwd", return_value=fake_cwd), \
+         patch("shutil.which", return_value=None), \
+         patch("tokenjam.cli.cmd_doctor.find_config_file", return_value=config_file):
+        result = _invoke(runner, db, config, ["doctor", "--json"])
+        assert result.exit_code == 0
+        checks = json.loads(result.output)
+        mcp_checks = [c for c in checks if c["name"] == "MCP wiring"]
+        assert mcp_checks and mcp_checks[0]["level"] == "ok"
+        assert "project scope" in mcp_checks[0]["message"]
+
+
 # -- since flag parsing --
 
 def test_since_flag_parses_all_formats(runner, db, config):

--- a/tokenjam/cli/cmd_doctor.py
+++ b/tokenjam/cli/cmd_doctor.py
@@ -57,6 +57,9 @@ def cmd_doctor(ctx: click.Context, output_json: bool, repair: bool) -> None:
     # 11. Proxy base-URL wiring consistency (issue #219)
     checks.append(_check_proxy_wiring(config))
 
+    # 12. MCP server wiring (issue #285)
+    checks.append(_check_mcp_wiring(config))
+
     if output_json:
         click.echo(json.dumps(checks, default=str))
     else:
@@ -386,6 +389,98 @@ def _is_local_url(url: str) -> bool:
     from urllib.parse import urlparse
     hostname = urlparse(url).hostname
     return hostname in ("localhost", "127.0.0.1", "::1", "0.0.0.0") if hostname else False
+
+
+def _check_mcp_wiring(config: object) -> dict:
+    """Check if the tj MCP server is wired into Claude Code or Codex."""
+    import sys
+    if sys.version_info >= (3, 11):
+        import tomllib
+    else:
+        import tomli as tomllib  # type: ignore[no-redef]
+    import shutil
+    from pathlib import Path
+
+    codex_config_path = Path.home() / ".codex" / "config.toml"
+    claude_config_path = Path.home() / ".claude.json"
+
+    has_codex = False
+    has_claude = False
+
+    # Check Codex config
+    if codex_config_path.exists():
+        try:
+            with open(codex_config_path, "rb") as f:
+                codex_data = tomllib.load(f)
+            has_codex = bool(codex_data.get("mcp_servers", {}).get("tj"))
+        except Exception:
+            pass
+
+    # Check Claude Code global config
+    if claude_config_path.exists():
+        try:
+            with open(claude_config_path, "r", encoding="utf-8") as f:
+                claude_data = json.load(f)
+            has_claude = bool(claude_data.get("mcpServers", {}).get("tj"))
+        except Exception:
+            pass
+
+    # Check project-level configs in current directory
+    has_project = False
+    for name in (".mcp.json", ".claude.json"):
+        project_path = Path.cwd() / name
+        if project_path.exists():
+            try:
+                with open(project_path, "r", encoding="utf-8") as f:
+                    proj_data = json.load(f)
+                if bool(proj_data.get("mcpServers", {}).get("tj")):
+                    has_project = True
+                    break
+            except Exception:
+                pass
+
+    if has_codex or has_claude or has_project:
+        found_locations = []
+        if has_codex:
+            found_locations.append("Codex (global)")
+        if has_claude:
+            found_locations.append("Claude Code (global)")
+        if has_project:
+            found_locations.append("project scope")
+        return {
+            "name": "MCP wiring",
+            "level": "ok",
+            "message": f"MCP server registered in {', '.join(found_locations)}.",
+        }
+
+    # If not registered anywhere, decide level based on agent presence
+    codex_present = bool(shutil.which("codex")) or (Path.home() / ".codex").exists()
+    claude_present = bool(shutil.which("claude")) or (Path.home() / ".claude").exists()
+
+    if codex_present or claude_present:
+        agents = []
+        if claude_present:
+            agents.append("Claude Code")
+        if codex_present:
+            agents.append("Codex")
+        return {
+            "name": "MCP wiring",
+            "level": "warning",
+            "message": (
+                f"MCP server not registered in {', '.join(agents)}. Coding agents "
+                "won't be able to query TokenJam telemetry. Run `tj onboard --claude-code` "
+                "or `tj onboard --codex` to register it."
+            ),
+        }
+
+    return {
+        "name": "MCP wiring",
+        "level": "info",
+        "message": (
+            "MCP server is not registered in Claude Code or Codex. Run `tj onboard "
+            "--claude-code` or `tj onboard --codex` if using a coding agent."
+        ),
+    }
 
 
 def _print_check(check: dict) -> None:


### PR DESCRIPTION
## Summary

This PR resolves #285 by adding an **MCP-wiring health check** to `tj doctor`. 
Because TokenJam relies on integration with coding agents like Claude Code or Codex, first-run users who skip onboarding or miss the MCP server registration end up without a queryable telemetry layer. This check validates if the TokenJam MCP server (`tj mcp`) is properly wired. It based on which agents have mcp registered, dynamically lists them all


### Changes
- **CLI Check**: Added `_check_mcp_wiring(config)` to `tokenjam/cli/cmd_doctor.py`. It inspects:
  - Global Claude Code config (`~/.claude.json`) for `mcpServers.tj`.
  - Global Codex config (`~/.codex/config.toml`) for `[mcp_servers.tj]`.
  - Project-level configs (`.mcp.json` or `.claude.json` in the working directory) for registered MCP servers.
- **Adaptive Reporting Levels**:
  - `ok`: MCP server registered in at least one config file. 
  - `warning`: Missing registration, but the user has Claude Code or Codex installed/configured (prompts them to run `tj onboard --claude-code` or `tj onboard --codex`).
  - `info`: Missing registration, but no traces of any coding agents are detected.
- **Integration Tests**: Added `test_doctor_mcp_wiring_checks` to `tests/integration/test_cli.py` covering all logical levels and states.
---

### Verification Results
#### 1. Automated Tests
Ran the full test suite with `pytest`:
```bash
pytest tests/unit/ tests/synthetic/ tests/agents/ tests/integration/
======================= 1172 passed, 2 skipped in 43.65s =======================
```
---

## Related issue

Closes #285

@anilmurty please review

## Checklist

- [X] Tests pass (`pytest tests/unit/ tests/synthetic/ tests/agents/ tests/integration/`)
- [X] Lint clean (`ruff check tokenjam/`)
- [X] Type check clean (`mypy tokenjam/`)
- [X] CLAUDE.md updated (if architecture changed)
- [X] Test spans use `tests/factories.py` (not raw `NormalizedSpan`)
- [X] Requested `@anilmurty` as reviewer (or @-mentioned him above)
