### PR TITLE
test: isolate CLI onboard tests so test_cli.py can't hang (#23)

### DIFF
--- a/tests/integration/test_cli.py
+++ b/tests/integration/test_cli.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 import json
+import subprocess
 from unittest.mock import patch
 
 import pytest
@@ -39,6 +40,50 @@ def config():
 @pytest.fixture
 def runner():
     return CliRunner()
+
+
+@pytest.fixture(autouse=True)
+def _isolate_real_world_side_effects(tmp_path_factory, monkeypatch):
+    """Keep every CLI test off real user/daemon state so the file runs to
+    completion deterministically, in any order (#23).
+
+    The ``tj onboard``/``tj onboard --claude-code`` path otherwise reaches out
+    to live, machine-global resources as a side effect of the command — none of
+    which these tests are actually asserting on:
+
+    * runs the real ``ingest_claude_code`` against ``~/.claude/projects`` (6 GB+
+      on a dev box) and writes the real ``~/.tj/telemetry.duckdb``;
+    * registers the real ``claude`` MCP server via ``subprocess``;
+    * pokes the real ``tj serve`` daemon to release the DuckDB write lock.
+
+    Because the DuckDB write lock is process- and order-dependent, whenever the
+    daemon (or a sibling test) is holding it, ``ingest_claude_code`` blocks on
+    ``upsert_session`` forever — so the file passes test-by-test but hangs when
+    run as a group. Pointing every machine-global resource at a throwaway temp
+    location (and stubbing the daemon/MCP shell-outs) makes the suite hermetic.
+    """
+    iso = tmp_path_factory.mktemp("cli-iso")
+
+    # No Claude Code logs to ingest -> onboard skips the open_db + ingest block
+    # entirely, so it never touches the real telemetry DB or its write lock.
+    monkeypatch.setattr(
+        "tokenjam.core.backfill.CLAUDE_CODE_PROJECTS_ROOT",
+        iso / "no-such-claude-projects",
+        raising=False,
+    )
+    # Never shell out to the real `claude` CLI to register the MCP server.
+    monkeypatch.setattr("tokenjam.cli.cmd_onboard.shutil.which", lambda _name: None)
+    monkeypatch.setattr(
+        "tokenjam.cli.cmd_onboard.subprocess.run",
+        lambda *a, **k: subprocess.CompletedProcess(a[0] if a else [], 0, b"", b""),
+    )
+    # Never touch the real `tj serve` daemon lifecycle.
+    monkeypatch.setattr(
+        "tokenjam.cli.cmd_onboard._stop_serve_for_db_write", lambda: False
+    )
+    # Storage paths resolve via os.path.expanduser($HOME); redirect them at the
+    # default ``~/.tj/telemetry.duckdb`` so any stray open_db lands in tmp.
+    monkeypatch.setenv("HOME", str(iso))
 
 
 def _invoke(runner, db, config, args):


### PR DESCRIPTION
`tests/integration/test_cli.py` passed test-by-test but **hung when the whole file ran**, on the `tj onboard --claude-code` (daemon-install) subset. This made `make test` / CI hang and could mask real failures (#23, surfaced resolving #20).

## Root cause
The onboard tests drive the *real* `tj onboard` command, which as a side effect reaches out to live, machine-global resources — none of which the tests actually assert on:

- runs the real `ingest_claude_code` against `~/.claude/projects` (6 GB+ on a dev box) and writes the real `~/.tj/telemetry.duckdb`;
- registers the real `claude` MCP server via `subprocess`;
- pokes the real `tj serve` daemon to release the DuckDB write lock.

The DuckDB write lock is process- and order-dependent. Whenever the daemon (or a sibling test that opened the real DB) holds it, `ingest_claude_code` blocks **forever** on `upsert_session` — so the file passes when a test runs alone but hangs when the file runs as a group. Captured via `faulthandler`:

```
File ".../core/db.py", line 647 in upsert_session
File ".../core/backfill.py", line 551 in _insert_session_idempotent
File ".../core/backfill.py", line 468 in ingest_claude_code
File ".../cli/cmd_onboard.py", line 452 in _onboard_claude_code
...
File ".../tests/integration/test_cli.py", line 419 in test_onboard_claude_code_writes_settings
```

## Fix
Add a module-level `autouse` fixture that makes the suite hermetic — it points every machine-global resource at a throwaway temp location and stubs the daemon/MCP shell-outs:

- **non-existent Claude Code projects root** → onboard skips the `open_db` + `ingest_claude_code` block entirely (so it never touches the real telemetry DB or its write lock);
- **no-op `claude` MCP registration** (`shutil.which` → None, `subprocess.run` stubbed);
- **no-op daemon stop** (`_stop_serve_for_db_write` → False);
- **`$HOME` redirected to tmp** so any stray `open_db` (e.g. plan-tier backfill) lands off the real `~/.tj/telemetry.duckdb`.

These tests assert on `settings.json` writing, config creation, budget prompts, and secret resync — the live ingest/MCP/daemon access was purely incidental, so nothing under test is lost.

## Tests / Verification
- **Before:** full `tests/integration/test_cli.py` hangs indefinitely (killed at 120s timeout, stuck at `test_onboard_claude_code_writes_settings`).
- **After:** `python3 -m pytest tests/integration/test_cli.py` → **51 passed in ~2s**.
- Verified order-independence: explicit interleaving of non-onboard → onboard tests (the original repro order) passes; full file passes repeatedly.
- No regressions: full `tests/integration/` suite → **221 passed in ~9s**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)