### PR TITLE
fix: batch of 7 bug-hunt fixes (optimize, mcp, db, analytics, sdk)

### DIFF
--- a/tests/integration/test_analytics.py
+++ b/tests/integration/test_analytics.py
@@ -189,3 +189,30 @@ async def test_kpi_delta_non_null_when_prior_window_has_data():
     assert d["kpi_prev"]["spend"] > 0, "prior window should have seeded data"
     assert d["kpi_deltas"]["spend"] is not None
     assert isinstance(d["kpi_deltas"]["spend"], float)
+
+
+@pytest.mark.asyncio
+async def test_session_spanning_buckets_counted_once_in_totals_by_group():
+    """#45: a session active across multiple time buckets must count once in
+    `totals_by_group` for the sessions metric (COUNT(DISTINCT) is non-additive),
+    so the grouped totals reconcile with the window-wide Sessions KPI rather than
+    inflating to the per-bucket sum."""
+    db = InMemoryBackend()
+    cfg = TjConfig(version="1")
+    now = utcnow()
+    sid = "spanning"
+    db.upsert_session(make_session(session_id=sid, plan_tier="api", agent_id="cc"))
+    # One session with two LLM spans on consecutive days -> two daily buckets.
+    for d in (0, 1):
+        db.insert_span(make_llm_span(
+            session_id=sid, agent_id="cc", model="claude-opus-4-7",
+            provider="anthropic", input_tokens=1000, output_tokens=100,
+            cost_usd=0.05, start_time=now - timedelta(days=d),
+        ))
+    d = await _get(db, cfg, "metric=sessions&group_by=agent&since=30d")
+    assert d["metric"] == "sessions"
+    # True window-wide distinct session count per group is 1, not the 2 you get
+    # by summing the per-bucket distinct counts.
+    assert d["totals_by_group"]["cc"] == 1
+    # And it reconciles with the Sessions KPI tile on the same screen.
+    assert d["totals_by_group"]["cc"] == d["kpis"]["sessions"]

--- a/tests/integration/test_api.py
+++ b/tests/integration/test_api.py
@@ -700,6 +700,35 @@ async def test_status_exposes_active_seconds(client, db):
     assert a["active_seconds"] == pytest.approx(6.0)
 
 
+# ── Sessions ───────────────────────────────────────────────────────────────
+
+async def test_sessions_active_enumerates_per_session(client, db):
+    """GET /api/v1/sessions?status=active returns one row per active session,
+    including multiple concurrent sessions for the same agent (#35) — unlike
+    /status which collapses to one record per agent."""
+    db.upsert_session(make_session(agent_id="alpha", session_id="s1", status="active"))
+    db.upsert_session(make_session(agent_id="alpha", session_id="s2", status="active"))
+    db.upsert_session(make_session(agent_id="beta", session_id="s3", status="active"))
+    db.upsert_session(make_session(agent_id="alpha", session_id="s4", status="completed"))
+
+    resp = await client.get("/api/v1/sessions", params={"status": "active"})
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["count"] == 3
+    ids = {s["session_id"] for s in data["sessions"]}
+    assert ids == {"s1", "s2", "s3"}  # both alpha sessions present; completed excluded
+
+
+async def test_sessions_filter_by_agent_id(client, db):
+    db.upsert_session(make_session(agent_id="alpha", session_id="s1", status="active"))
+    db.upsert_session(make_session(agent_id="beta", session_id="s2", status="active"))
+
+    resp = await client.get("/api/v1/sessions", params={"agent_id": "alpha"})
+    assert resp.status_code == 200
+    data = resp.json()
+    assert {s["session_id"] for s in data["sessions"]} == {"s1"}
+
+
 # ── Budget ─────────────────────────────────────────────────────────────────
 
 async def test_post_budget_zero_clears_limit(db):

--- a/tests/unit/test_litellm_integration.py
+++ b/tests/unit/test_litellm_integration.py
@@ -303,6 +303,62 @@ class TestLiteLLMIntegration:
         integration.uninstall()
         assert litellm.completion is original
 
+    def test_sync_streaming_error_resets_suppression(self, tracer_and_spans):
+        """A streaming call that raises before the wrapper is built must still
+        reset the suppression contextvar and end the span (regression #48)."""
+        tracer, spans = tracer_and_spans
+        import litellm
+        from tokenjam.sdk.integrations.litellm import _tj_litellm_active
+
+        litellm.completion = MagicMock(side_effect=RuntimeError("stream boom"))
+
+        from tokenjam.sdk.integrations.litellm import LiteLLMIntegration
+        integration = LiteLLMIntegration()
+        integration.install(tracer)
+
+        with pytest.raises(RuntimeError, match="stream boom"):
+            litellm.completion(
+                model="openai/gpt-4o-mini", messages=[], stream=True,
+            )
+
+        try:
+            # Suppression must be reset so later provider calls are captured.
+            assert _tj_litellm_active.get(False) is False
+            span = spans[0]
+            span.end.assert_called_once()
+        finally:
+            # Hygiene: if the bug is present the contextvar leaks True and
+            # would pollute sibling tests in this thread.
+            _tj_litellm_active.set(False)
+
+    def test_async_streaming_error_resets_suppression(self, tracer_and_spans):
+        """Async streaming call that raises before the wrapper is built must
+        still reset the suppression contextvar and end the span (#48)."""
+        tracer, spans = tracer_and_spans
+        import litellm
+        from tokenjam.sdk.integrations.litellm import _tj_litellm_active
+
+        async def _boom(*a, **kw):
+            raise RuntimeError("astream boom")
+
+        litellm.acompletion = _boom
+
+        from tokenjam.sdk.integrations.litellm import LiteLLMIntegration
+        integration = LiteLLMIntegration()
+        integration.install(tracer)
+
+        async def _run():
+            with pytest.raises(RuntimeError, match="astream boom"):
+                await litellm.acompletion(
+                    model="anthropic/claude-haiku-4-5", messages=[], stream=True,
+                )
+            # Assert inside the coroutine's context where the leak would live.
+            return _tj_litellm_active.get(False)
+
+        leaked = asyncio.run(_run())
+        assert leaked is False
+        spans[0].end.assert_called_once()
+
     def test_context_var_suppresses_openai_patch(self, tracer_and_spans):
         """When litellm patch is active, the openai patch skips span creation."""
         from tokenjam.sdk.integrations.litellm import _tj_litellm_active

--- a/tests/unit/test_mcp_server.py
+++ b/tests/unit/test_mcp_server.py
@@ -550,27 +550,77 @@ def test_list_alerts_http_mode():
 # --- test_list_active_sessions_http_mode ---
 
 def test_list_active_sessions_http_mode():
+    # Serve mode now proxies to /api/v1/sessions?status=active, which returns
+    # one row per active session (not one per agent).
     fake_response = {
-        "agents": [
+        "sessions": [
             {
-                "agent_id": "alpha",
-                "status": "active",
                 "session_id": "s1",
+                "agent_id": "alpha",
+                "started_at": "2026-04-11T10:00:00+00:00",
+                "total_cost_usd": 1.23,
                 "input_tokens": 100,
                 "output_tokens": 50,
                 "tool_call_count": 5,
                 "error_count": 0,
-                "cost_today": 1.23,
-                "active_alerts": 0,
             }
         ],
-        "has_active_alerts": False,
+        "count": 1,
     }
     _set_serve_url("http://127.0.0.1:7391")
     try:
         with patch("tokenjam.mcp.server._http_get", return_value=fake_response):
             result = _tool_list_active_sessions(None)
         assert result["count"] == 1
+        assert result["sessions"][0]["session_id"] == "s1"
+    finally:
+        _set_serve_url(None)
+
+
+def test_list_active_sessions_http_mode_enumerates_per_session():
+    """Serve mode must surface EVERY active session, including multiple
+    concurrent sessions for the same agent — matching the direct-DB path (#35).
+    The old code proxied to /api/v1/status (one record per agent) and
+    undercounted; it must now hit a per-session endpoint."""
+    sessions_response = {
+        "sessions": [
+            {
+                "session_id": "s1", "agent_id": "alpha",
+                "started_at": "2026-04-11T10:00:00+00:00", "total_cost_usd": 1.0,
+                "input_tokens": 10, "output_tokens": 5,
+                "tool_call_count": 1, "error_count": 0,
+            },
+            {
+                "session_id": "s2", "agent_id": "alpha",
+                "started_at": "2026-04-11T10:05:00+00:00", "total_cost_usd": 2.0,
+                "input_tokens": 20, "output_tokens": 8,
+                "tool_call_count": 2, "error_count": 0,
+            },
+        ],
+        "count": 2,
+    }
+    # /status collapses alpha's two concurrent sessions to one record — the
+    # shape the broken serve path used to read.
+    status_response = {
+        "agents": [
+            {"agent_id": "alpha", "status": "active", "session_id": "s2"}
+        ],
+        "has_active_alerts": False,
+    }
+
+    def fake_http_get(path, params=None):
+        if "/sessions" in path:
+            assert params and params.get("status") == "active"
+            return sessions_response
+        return status_response
+
+    _set_serve_url("http://127.0.0.1:7391")
+    try:
+        with patch("tokenjam.mcp.server._http_get", side_effect=fake_http_get):
+            result = _tool_list_active_sessions(None)
+        assert result["count"] == 2
+        ids = {s["session_id"] for s in result["sessions"]}
+        assert ids == {"s1", "s2"}
     finally:
         _set_serve_url(None)
 

--- a/tests/unit/test_mcp_server.py
+++ b/tests/unit/test_mcp_server.py
@@ -608,6 +608,54 @@ def test_acknowledge_alert_http_mode_proxies_patch():
         _srv._config = None
 
 
+def test_acknowledge_alert_read_only_fallback_returns_actionable_error(tmp_path):
+    """In read-only DuckDB fallback (tj serve unreachable, _ro_conn open, no
+    _serve_url) acknowledge_alert must NOT open a conflicting read-write
+    connection to the same file — that raises a raw DuckDB ConnectionException.
+    It should return a clear, actionable message instead (#34)."""
+    import duckdb
+    from tokenjam.core.config import StorageConfig
+    from tokenjam.core.db import DuckDBBackend
+
+    db_file = tmp_path / "telemetry.duckdb"
+    # Seed the DB (schema + one alert) via a normal read-write backend, then
+    # close it so the read-only connection below is the only one in process.
+    backend = DuckDBBackend(StorageConfig(path=str(db_file)))
+    alert = Alert(
+        alert_id=new_uuid(),
+        fired_at=utcnow(),
+        type=AlertType.RETRY_LOOP,
+        severity=Severity.WARNING,
+        title="Retry loop",
+        detail={},
+        agent_id="a",
+        session_id=None,
+        span_id=None,
+        acknowledged=False,
+        suppressed=False,
+    )
+    backend.insert_alert(alert)
+    backend._conn.close()
+
+    ro_conn = duckdb.connect(str(db_file), read_only=True)
+    config = _make_config("a")
+    config.storage = StorageConfig(path=str(db_file))
+    _srv._ro_conn = ro_conn
+    _srv._config = config
+    _set_serve_url(None)
+    try:
+        result = _srv.acknowledge_alert(alert.alert_id)
+        assert "error" in result
+        msg = result["error"].lower()
+        # Actionable guidance — not a raw DuckDB connection exception.
+        assert "read-only" in msg or "dashboard" in msg
+        assert "configuration" not in msg  # raw DuckDB conflict phrasing
+    finally:
+        ro_conn.close()
+        _srv._ro_conn = None
+        _srv._config = None
+
+
 # --- test_get_budget_headroom_http_mode ---
 
 def test_get_budget_headroom_http_mode_reads_live_limits():

--- a/tests/unit/test_optimize.py
+++ b/tests/unit/test_optimize.py
@@ -209,3 +209,44 @@ def test_downgrade_candidates_have_pricing_for_alternative():
             assert get_rates(provider, alt) is not None, (
                 f"Pricing missing for {provider}/{alt}"
             )
+
+
+def test_subscription_json_zeros_monthly_savings_usd(db, monkeypatch, tmp_path):
+    """`tj optimize --json` must not leak a dollar `monthly_savings_usd` for
+    subscription users — the same suppression the human render applies (#32).
+
+    The renderer reframes downgrade savings as a token share for flat-fee
+    plans, so the machine payload must agree: `monthly_savings_usd == 0`.
+    """
+    import json
+    from unittest.mock import patch
+
+    from click.testing import CliRunner
+
+    from tokenjam.cli.main import cli
+    from tokenjam.core.config import ApiAuthConfig, ApiConfig, TjConfig
+    from tests.factories import make_session
+
+    # Keep config_declared_plan's global fallback off this dev machine.
+    monkeypatch.setattr("pathlib.Path.home", lambda: tmp_path)
+
+    # One subscription-tier session whose spans match the downgrade heuristic
+    # (small Opus session → projected dollar savings the renderer suppresses).
+    db.upsert_session(make_session(
+        agent_id="claude-code-x", session_id="s-small", plan_tier="max_5x",
+    ))
+    _insert_small_opus_session(db, session_id="s-small")
+
+    config = TjConfig(version="1", api=ApiConfig(auth=ApiAuthConfig(enabled=False)))
+
+    runner = CliRunner()
+    with patch("tokenjam.cli.main.load_config", return_value=config), \
+         patch("tokenjam.cli.main.open_db", return_value=db):
+        result = runner.invoke(cli, ["optimize", "--since", "30d", "--json"])
+
+    assert result.exit_code == 0, result.output
+    payload = json.loads(result.output)
+    assert payload["pricing_mode"] == "subscription"
+    downgrade = payload["downgrade"]
+    assert downgrade is not None
+    assert downgrade["monthly_savings_usd"] == 0

--- a/tests/unit/test_optimize.py
+++ b/tests/unit/test_optimize.py
@@ -80,6 +80,26 @@ def test_summarize_window_counts_and_costs(db):
     assert abs(s.total_cost_usd - (0.030 + 1.500)) < 1e-6
 
 
+def test_summarize_window_total_includes_cache_read_tokens(db):
+    """Window header total must include cache-read tokens, sharing one basis
+    with the downsize denominator + the canonical WindowTotals (#33)."""
+    start = utcnow() - timedelta(days=2)
+    db.insert_span(make_llm_span(
+        model="claude-opus-4-7",
+        provider="anthropic",
+        input_tokens=1000,
+        output_tokens=200,
+        cache_tokens=5000,
+        cost_usd=0.030,
+        session_id="cache-heavy",
+        start_time=start,
+    ))
+    since = utcnow() - timedelta(days=30)
+    until = utcnow() + timedelta(hours=1)
+    s = summarize_window(db.conn, since, until)
+    assert s.total_tokens == 1000 + 200 + 5000
+
+
 def test_downgrade_flags_small_opus_but_not_large(db):
     _insert_small_opus_session(db, session_id="a")
     _insert_large_opus_session(db, session_id="b")

--- a/tests/unit/test_spans_stats_repair.py
+++ b/tests/unit/test_spans_stats_repair.py
@@ -101,3 +101,75 @@ class TestRepairSpansStats:
         repair_spans_stats(conn)
         repair_spans_stats(conn)
         assert conn.execute("SELECT COUNT(*) FROM spans").fetchone()[0] == 3
+
+
+class TestRepairPreservesSchema:
+    """Regression for #38: the repair must not strip the spans table's
+    PRIMARY KEY, NOT NULL constraints, or secondary indexes."""
+
+    @staticmethod
+    def _constraints(conn) -> list[str]:
+        return [
+            r[0]
+            for r in conn.execute(
+                "SELECT constraint_type FROM duckdb_constraints() "
+                "WHERE table_name = 'spans'"
+            ).fetchall()
+        ]
+
+    @staticmethod
+    def _index_names(conn) -> set[str]:
+        return {
+            r[0]
+            for r in conn.execute(
+                "SELECT index_name FROM duckdb_indexes() WHERE table_name = 'spans'"
+            ).fetchall()
+        }
+
+    def test_primary_key_survives_repair(self, conn):
+        _insert_minimal_span(conn, trace_id="t1", span_id="s1")
+        repair_spans_stats(conn)
+        assert "PRIMARY KEY" in self._constraints(conn)
+
+    def test_not_null_constraints_survive_repair(self, conn):
+        _insert_minimal_span(conn, trace_id="t1", span_id="s1")
+        repair_spans_stats(conn)
+        assert "NOT NULL" in self._constraints(conn)
+
+    def test_secondary_indexes_survive_repair(self, conn):
+        _insert_minimal_span(conn, trace_id="t1", span_id="s1")
+        repair_spans_stats(conn)
+        expected = {
+            "idx_spans_trace_id",
+            "idx_spans_agent_id",
+            "idx_spans_start_time",
+            "idx_spans_tool_name",
+            "idx_spans_conv_id",
+        }
+        assert expected <= self._index_names(conn)
+
+    def test_duplicate_span_id_rejected_after_repair(self, conn):
+        _insert_minimal_span(conn, trace_id="t1", span_id="dup")
+        repair_spans_stats(conn)
+        with pytest.raises(duckdb.ConstraintException):
+            _insert_minimal_span(conn, trace_id="t2", span_id="dup")
+
+    def test_schema_identical_to_freshly_migrated(self, conn, tmp_path):
+        """After repair, the spans columns match a freshly-migrated table."""
+        _insert_minimal_span(conn, trace_id="t1", span_id="s1")
+        repair_spans_stats(conn)
+        repaired = conn.execute(
+            "SELECT column_name, data_type, is_nullable FROM information_schema.columns "
+            "WHERE table_name = 'spans' ORDER BY ordinal_position"
+        ).fetchall()
+
+        fresh = duckdb.connect(str(tmp_path / "fresh.duckdb"))
+        try:
+            run_migrations(fresh)
+            expected = fresh.execute(
+                "SELECT column_name, data_type, is_nullable FROM information_schema.columns "
+                "WHERE table_name = 'spans' ORDER BY ordinal_position"
+            ).fetchall()
+        finally:
+            fresh.close()
+        assert repaired == expected

--- a/tokenjam/api/app.py
+++ b/tokenjam/api/app.py
@@ -70,6 +70,7 @@ def create_app(
     from tokenjam.api.routes.drift import router as drift_router
     from tokenjam.api.routes.metrics import router as metrics_router
     from tokenjam.api.routes.status import router as status_router
+    from tokenjam.api.routes.sessions import router as sessions_router
     from tokenjam.api.routes.otlp import router as otlp_router
     from tokenjam.api.routes.budget import router as budget_router
     from tokenjam.api.routes.agents import router as agents_router
@@ -87,6 +88,7 @@ def create_app(
     app.include_router(alerts_router, prefix="/api/v1")
     app.include_router(drift_router, prefix="/api/v1")
     app.include_router(status_router, prefix="/api/v1")
+    app.include_router(sessions_router, prefix="/api/v1")
     app.include_router(budget_router, prefix="/api/v1")
     app.include_router(agents_router, prefix="/api/v1")
     app.include_router(optimize_router, prefix="/api/v1")

--- a/tokenjam/api/routes/analytics.py
+++ b/tokenjam/api/routes/analytics.py
@@ -255,6 +255,21 @@ async def get_analytics(
         if g2v is not None:
             stacks[str(g2v)] = stacks.get(str(g2v), 0.0) + val
 
+    # `sessions` is COUNT(DISTINCT session_id) — non-additive (#45). Summing the
+    # per-bucket distinct counts above double-counts a session spanning buckets,
+    # so the per-group total must instead come from a SEPARATE window-wide
+    # GROUP BY <dimension> distinct count, mirroring how the Sessions KPI below
+    # counts a spanning session once. Additive metrics keep the rollup above.
+    if metric == "sessions":
+        totals = {}
+        tbg_sql = (
+            "SELECT " + g1 + " AS g1, COUNT(DISTINCT session_id) AS s"
+            + " FROM spans WHERE " + where + " GROUP BY g1"
+        )
+        for tr in conn.execute(tbg_sql, params).fetchall():
+            g1v = tr[0] if tr[0] is not None else "(none)"
+            totals[str(g1v)] = float(tr[1] or 0)
+
     groups = sorted(totals, key=lambda k: totals[k], reverse=True)
     stack_keys = sorted(stacks, key=lambda k: stacks[k], reverse=True)
 

--- a/tokenjam/api/routes/sessions.py
+++ b/tokenjam/api/routes/sessions.py
@@ -1,0 +1,63 @@
+"""GET /api/v1/sessions — session enumeration (one row per session).
+
+Unlike /status (which collapses to one record per agent via
+`ORDER BY started_at DESC LIMIT 1`), this route returns every matching
+session, so a single agent running multiple concurrent sessions is fully
+represented. The MCP `list_active_sessions` tool proxies here in serve mode
+so its output matches the direct-DB path (#35).
+"""
+from __future__ import annotations
+
+from fastapi import APIRouter, Depends, Request
+
+from tokenjam.api.deps import require_api_key
+
+router = APIRouter(dependencies=[Depends(require_api_key)])
+
+
+@router.get("/sessions")
+async def list_sessions(
+    request: Request,
+    status: str | None = None,
+    agent_id: str | None = None,
+) -> dict:
+    """Enumerate sessions one row per session, newest first.
+
+    `status` filters by session status (e.g. 'active'); `agent_id` scopes to a
+    single agent. Both are optional.
+    """
+    db = request.app.state.db
+    conn = getattr(db, "conn", None)
+    if conn is None:
+        return {"sessions": [], "count": 0}
+
+    clauses: list[str] = []
+    params: list = []
+    if status:
+        params.append(status)
+        clauses.append(f"status = ${len(params)}")
+    if agent_id:
+        params.append(agent_id)
+        clauses.append(f"agent_id = ${len(params)}")
+    where = (" WHERE " + " AND ".join(clauses)) if clauses else ""
+
+    rows = conn.execute(
+        "SELECT session_id, agent_id, started_at, total_cost_usd, "
+        "input_tokens, output_tokens, tool_call_count, error_count "
+        f"FROM sessions{where} ORDER BY started_at DESC",
+        params,
+    ).fetchall()
+    sessions = [
+        {
+            "session_id": r[0],
+            "agent_id": r[1],
+            "started_at": r[2].isoformat() if r[2] else None,
+            "total_cost_usd": float(r[3]) if r[3] else 0.0,
+            "input_tokens": r[4] or 0,
+            "output_tokens": r[5] or 0,
+            "tool_call_count": r[6] or 0,
+            "error_count": r[7] or 0,
+        }
+        for r in rows
+    ]
+    return {"sessions": sessions, "count": len(sessions)}

--- a/tokenjam/cli/cmd_optimize.py
+++ b/tokenjam/cli/cmd_optimize.py
@@ -255,8 +255,10 @@ def cmd_optimize(
         d = payload.get("downgrade") or {}
         if d and pricing_mode in {"subscription", "local"}:
             d["monthly_tokens_freed"] = d.get("monthly_tokens_in_candidates", 0)
-            if pricing_mode == "local":
-                d["monthly_savings_usd"] = 0
+            # Zero the misleading dollar projection for BOTH flat-fee
+            # subscription tiers and local (zero-marginal-cost) inference —
+            # matching the token-share framing the human renderer applies.
+            d["monthly_savings_usd"] = 0
         click.echo(json.dumps(payload, default=str))
         return
 

--- a/tokenjam/core/db.py
+++ b/tokenjam/core/db.py
@@ -95,36 +95,11 @@ class StorageBackend(Protocol):
 # Schema & migrations
 # ---------------------------------------------------------------------------
 
-INITIAL_SCHEMA_SQL = """\
-CREATE TABLE IF NOT EXISTS schema_migrations (
-    version     INTEGER PRIMARY KEY,
-    applied_at  TIMESTAMPTZ NOT NULL
-);
-
-CREATE TABLE IF NOT EXISTS agents (
-    agent_id    TEXT PRIMARY KEY,
-    name        TEXT,
-    version     TEXT,
-    provider    TEXT,
-    first_seen  TIMESTAMPTZ NOT NULL,
-    last_seen   TIMESTAMPTZ NOT NULL
-);
-
-CREATE TABLE IF NOT EXISTS sessions (
-    session_id          TEXT PRIMARY KEY,
-    agent_id            TEXT NOT NULL,
-    conversation_id     TEXT,
-    started_at          TIMESTAMPTZ NOT NULL,
-    ended_at            TIMESTAMPTZ,
-    status              TEXT NOT NULL DEFAULT 'active',
-    total_cost_usd      DOUBLE,
-    input_tokens        BIGINT DEFAULT 0,
-    output_tokens       BIGINT DEFAULT 0,
-    cache_tokens        BIGINT DEFAULT 0,
-    tool_call_count     INTEGER DEFAULT 0,
-    error_count         INTEGER DEFAULT 0
-);
-
+# Canonical spans table DDL. Single-sourced here so the repair path
+# (`repair_spans_stats`) can rebuild a table that is schema-identical to a
+# freshly-migrated one — PRIMARY KEY, NOT NULL constraints and all. Referenced
+# by INITIAL_SCHEMA_SQL below; do not inline a second copy.
+SPANS_TABLE_SQL = """\
 CREATE TABLE IF NOT EXISTS spans (
     span_id             TEXT PRIMARY KEY,
     trace_id            TEXT NOT NULL,
@@ -154,6 +129,52 @@ CREATE TABLE IF NOT EXISTS spans (
     -- different rates. See models.py::NormalizedSpan for the read/write split.
     cache_write_tokens  BIGINT
 );
+"""
+
+# Secondary indexes on spans. Single-sourced so migration 3 and the repair path
+# create the same set; keep in sync with the DROPs in migration 2.
+SPANS_INDEX_SQL = (
+    "CREATE INDEX IF NOT EXISTS idx_spans_trace_id    ON spans(trace_id);\n"
+    "CREATE INDEX IF NOT EXISTS idx_spans_agent_id    ON spans(agent_id);\n"
+    "CREATE INDEX IF NOT EXISTS idx_spans_start_time  ON spans(start_time);\n"
+    "CREATE INDEX IF NOT EXISTS idx_spans_tool_name   ON spans(tool_name);\n"
+    "CREATE INDEX IF NOT EXISTS idx_spans_conv_id     ON spans(conversation_id)"
+)
+
+INITIAL_SCHEMA_SQL = (
+    """\
+CREATE TABLE IF NOT EXISTS schema_migrations (
+    version     INTEGER PRIMARY KEY,
+    applied_at  TIMESTAMPTZ NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS agents (
+    agent_id    TEXT PRIMARY KEY,
+    name        TEXT,
+    version     TEXT,
+    provider    TEXT,
+    first_seen  TIMESTAMPTZ NOT NULL,
+    last_seen   TIMESTAMPTZ NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS sessions (
+    session_id          TEXT PRIMARY KEY,
+    agent_id            TEXT NOT NULL,
+    conversation_id     TEXT,
+    started_at          TIMESTAMPTZ NOT NULL,
+    ended_at            TIMESTAMPTZ,
+    status              TEXT NOT NULL DEFAULT 'active',
+    total_cost_usd      DOUBLE,
+    input_tokens        BIGINT DEFAULT 0,
+    output_tokens       BIGINT DEFAULT 0,
+    cache_tokens        BIGINT DEFAULT 0,
+    tool_call_count     INTEGER DEFAULT 0,
+    error_count         INTEGER DEFAULT 0
+);
+
+"""
+    + SPANS_TABLE_SQL
+    + """\
 
 CREATE TABLE IF NOT EXISTS alerts (
     alert_id        TEXT PRIMARY KEY,
@@ -199,6 +220,7 @@ CREATE INDEX IF NOT EXISTS idx_sessions_conv_id   ON sessions(conversation_id);
 CREATE INDEX IF NOT EXISTS idx_alerts_agent_id    ON alerts(agent_id);
 CREATE INDEX IF NOT EXISTS idx_alerts_fired_at    ON alerts(fired_at);
 """
+)
 
 MIGRATIONS: list[tuple[int, str]] = [
     (1, INITIAL_SCHEMA_SQL),
@@ -209,13 +231,7 @@ MIGRATIONS: list[tuple[int, str]] = [
         "DROP INDEX IF EXISTS idx_spans_tool_name;\n"
         "DROP INDEX IF EXISTS idx_spans_conv_id"
     )),
-    (3, (
-        "CREATE INDEX IF NOT EXISTS idx_spans_trace_id    ON spans(trace_id);\n"
-        "CREATE INDEX IF NOT EXISTS idx_spans_agent_id    ON spans(agent_id);\n"
-        "CREATE INDEX IF NOT EXISTS idx_spans_start_time  ON spans(start_time);\n"
-        "CREATE INDEX IF NOT EXISTS idx_spans_tool_name   ON spans(tool_name);\n"
-        "CREATE INDEX IF NOT EXISTS idx_spans_conv_id     ON spans(conversation_id)"
-    )),
+    (3, SPANS_INDEX_SQL),
     # Migration 4: billing_account on spans, plan_tier on sessions.
     # `billing_account` is provider-only (anthropic | openai | google |
     # bedrock | local.ollama). Plan tier lives on sessions, not spans.
@@ -467,10 +483,45 @@ def repair_spans_stats(conn: duckdb.DuckDBPyConnection) -> None:
     Idempotent — safe to call when the table is healthy. Data is preserved.
     Caller is responsible for ensuring no other process holds a write lock on
     the database file (DuckDB enforces exclusive write access).
+
+    The rebuild recreates the table from the canonical DDL rather than a bare
+    `CREATE TABLE … AS SELECT` (#38). A CTAS copies DATA ONLY — it would drop the
+    `span_id` PRIMARY KEY, the NOT NULL constraints, and every `idx_spans_*`
+    index, permanently (migrations are already marked applied, so nothing
+    recreates them). Instead we move the live rows aside, recreate `spans` with
+    its full schema, copy the rows back, and re-issue the indexes — leaving the
+    repaired table schema-identical to a freshly-migrated one.
     """
+    # Stash the live rows + their column layout in a constraint-free holder, then
+    # drop spans (which also drops its dependent indexes) so it can be rebuilt.
     conn.execute("CREATE TABLE _spans_repair AS SELECT * FROM spans")
+    live_cols = conn.execute(
+        "SELECT column_name, data_type FROM information_schema.columns "
+        "WHERE table_name = '_spans_repair' ORDER BY ordinal_position"
+    ).fetchall()
     conn.execute("DROP TABLE spans")
-    conn.execute("ALTER TABLE _spans_repair RENAME TO spans")
+    # Recreate the constraint-bearing base table from the canonical DDL.
+    conn.execute(SPANS_TABLE_SQL)
+    # Re-add any columns later migrations appended to spans (e.g. billing_account,
+    # request_params, request_tools), reading their definitions from the holder
+    # so the rebuild tracks the live schema without duplicating the list.
+    base_cols = {
+        row[0]
+        for row in conn.execute(
+            "SELECT column_name FROM information_schema.columns "
+            "WHERE table_name = 'spans'"
+        ).fetchall()
+    }
+    for name, data_type in live_cols:
+        if name not in base_cols:
+            conn.execute(f'ALTER TABLE spans ADD COLUMN "{name}" {data_type}')
+    # Column sets now match; BY NAME copy is order-independent.
+    conn.execute("INSERT INTO spans BY NAME SELECT * FROM _spans_repair")
+    conn.execute("DROP TABLE _spans_repair")
+    for statement in SPANS_INDEX_SQL.split(";"):
+        statement = statement.strip()
+        if statement:
+            conn.execute(statement)
     conn.execute("CHECKPOINT")
 
 

--- a/tokenjam/core/optimize/runner.py
+++ b/tokenjam/core/optimize/runner.py
@@ -60,7 +60,7 @@ def summarize_window(
     row = conn.execute(
         f"SELECT COUNT(*) AS spans, "
         f"COUNT(DISTINCT session_id) AS sessions, "
-        f"COALESCE(SUM(COALESCE(input_tokens,0) + COALESCE(output_tokens,0)), 0) AS tokens, "
+        f"COALESCE(SUM(COALESCE(input_tokens,0) + COALESCE(output_tokens,0) + COALESCE(cache_tokens,0)), 0) AS tokens, "
         f"COALESCE(SUM(cost_usd), 0.0) AS cost "
         f"FROM spans WHERE {where}",
         params,

--- a/tokenjam/mcp/server.py
+++ b/tokenjam/mcp/server.py
@@ -1081,6 +1081,20 @@ def acknowledge_alert(alert_id: str) -> dict:
                 req.add_header("Authorization", f"Bearer {_config.api.auth.api_key}")
             with _urlreq.urlopen(req, timeout=5) as resp:
                 return _json.loads(resp.read())
+        if _ro_conn is not None:
+            # Read-only DuckDB fallback: a module-global read-only connection is
+            # already open against this file. DuckDB forbids opening the same
+            # file read-write while a read-only connection exists in the same
+            # process, so attempting the UPDATE here raises a raw
+            # ConnectionException (#34). Return actionable guidance instead.
+            return {
+                "error": (
+                    "Acknowledging alerts requires a writable database, but it's "
+                    "open read-only because tj serve holds the lock (or wasn't "
+                    "reachable). Acknowledge from the dashboard, or stop tj serve "
+                    "and retry."
+                )
+            }
         from pathlib import Path
         import duckdb as _duckdb
         db_path = str(Path(_config.storage.path).expanduser())

--- a/tokenjam/mcp/server.py
+++ b/tokenjam/mcp/server.py
@@ -505,24 +505,26 @@ def _tool_list_agents(conn) -> dict:
 
 
 def _tool_list_active_sessions(conn) -> dict:
-    # HTTP mode: proxy to serve status endpoint and filter for active
+    # HTTP mode: proxy to the per-session endpoint so concurrent sessions for
+    # the same agent are all surfaced. /api/v1/status collapses to one record
+    # per agent and undercounted parallel sessions (#35); /api/v1/sessions
+    # returns one row per session, matching the direct-DB path below.
     if conn is None:
         if _serve_url is None:
             return _no_config()
-        data = _http_get("/api/v1/status")
+        data = _http_get("/api/v1/sessions", {"status": "active"})
         sessions = [
             {
-                "session_id": a.get("session_id"),
-                "agent_id": a["agent_id"],
-                "started_at": a.get("started_at"),
-                "total_cost_usd": float(a.get("total_cost_usd", 0.0)),
-                "input_tokens": a.get("input_tokens", 0),
-                "output_tokens": a.get("output_tokens", 0),
-                "tool_call_count": a.get("tool_call_count", 0),
-                "error_count": a.get("error_count", 0),
+                "session_id": s.get("session_id"),
+                "agent_id": s.get("agent_id"),
+                "started_at": s.get("started_at"),
+                "total_cost_usd": float(s.get("total_cost_usd", 0.0)),
+                "input_tokens": s.get("input_tokens", 0),
+                "output_tokens": s.get("output_tokens", 0),
+                "tool_call_count": s.get("tool_call_count", 0),
+                "error_count": s.get("error_count", 0),
             }
-            for a in data.get("agents", [])
-            if a.get("status") == "active"
+            for s in data.get("sessions", [])
         ]
         return {"sessions": sessions, "count": len(sessions)}
 

--- a/tokenjam/sdk/integrations/litellm.py
+++ b/tokenjam/sdk/integrations/litellm.py
@@ -225,10 +225,13 @@ class LiteLLMIntegration:
             record_full_request(span, kwargs)
 
             token = _tj_litellm_active.set(True)
+            handed_off = False
             try:
                 response = integration._original_completion(*args, **kwargs)
                 if is_stream:
-                    return _SyncStreamWrapper(response, span, raw_model, token)
+                    wrapper = _SyncStreamWrapper(response, span, raw_model, token)
+                    handed_off = True
+                    return wrapper
                 _record_usage(response, span, raw_model)
                 span.set_status(trace.Status(trace.StatusCode.OK))
                 return response
@@ -238,7 +241,10 @@ class LiteLLMIntegration:
                 )
                 raise
             finally:
-                if not is_stream:
+                # Clean up unless the stream wrapper took ownership; this also
+                # covers a streaming call that raised before the wrapper was
+                # built, which would otherwise leak the contextvar + span (#48).
+                if not handed_off:
                     span.end()
                     _tj_litellm_active.reset(token)
 
@@ -270,12 +276,17 @@ class LiteLLMIntegration:
             record_full_request(span, kwargs)
 
             token = _tj_litellm_active.set(True)
+            handed_off = False
             try:
                 response = await integration._original_acompletion(
                     *args, **kwargs,
                 )
                 if is_stream:
-                    return _AsyncStreamWrapper(response, span, raw_model, token)
+                    wrapper = _AsyncStreamWrapper(
+                        response, span, raw_model, token,
+                    )
+                    handed_off = True
+                    return wrapper
                 _record_usage(response, span, raw_model)
                 span.set_status(trace.Status(trace.StatusCode.OK))
                 return response
@@ -285,7 +296,10 @@ class LiteLLMIntegration:
                 )
                 raise
             finally:
-                if not is_stream:
+                # Clean up unless the stream wrapper took ownership; this also
+                # covers a streaming call that raised before the wrapper was
+                # built, which would otherwise leak the contextvar + span (#48).
+                if not handed_off:
                     span.end()
                     _tj_litellm_active.reset(token)
 


### PR DESCRIPTION
Batch fix of 7 confirmed bugs surfaced by a codebase-wide bug-hunt sweep (each adversarially verified, then fixed TDD-style with a failing test first). All commits are atomic and independently reviewable; full suite is green (`1189 passed, 1 skipped`), `ruff` + `mypy` clean.

## Fixes

| Commit | Area | Bug |
|--------|------|-----|
| `ca81860` | `cli/cmd_optimize.py` | Subscription `tj optimize --json` leaked the dollar savings projection the human renderer suppresses — `monthly_savings_usd` zeroing was nested under the `local`-only branch, so subscription payloads kept the misleading dollar figure. Now zeroed for both subscription and local. |
| `39d5077` | `core/optimize/runner.py` | `summarize_window` total excluded cache-read tokens, so the "tokens this cycle" header disagreed with the downsize token-share line and the canonical window total on cache-heavy workloads. Now includes `cache_tokens`, matching the downsize denominator. |
| `2f31b9e` | `mcp/server.py` | `acknowledge_alert` opened a second read-write DuckDB connection while the read-only fallback connection was open, raising a raw `ConnectionException` — non-functional in the entire RO fallback mode. Now returns an actionable message instead of a raw connection error. |
| `709cb26` | `mcp/server.py`, new `api/routes/sessions.py` | `list_active_sessions` proxied to `/api/v1/status` (one row per agent) in serve mode, dropping concurrent sessions for the same agent and undercounting. Added a `GET /api/v1/sessions` route (one row per session) and pointed the serve path at it, restoring parity with the direct-DB path. |
| `53ee1af` | `core/db.py` | `repair_spans_stats` rebuilt the spans table with bare `CREATE TABLE … AS SELECT`, permanently dropping the `span_id` PRIMARY KEY, NOT NULL constraints, and all `idx_spans_*` indexes. Now single-sources the canonical DDL and recreates the full schema + indexes after the copy. |
| `7696e48` | `api/routes/analytics.py` | The `sessions` metric summed per-bucket `COUNT(DISTINCT session_id)` into `totals_by_group`, double-counting sessions that span multiple time buckets (so the grouped totals couldn't reconcile with the Sessions KPI tile). Now computes per-group totals with a window-wide distinct query, mirroring the KPI. |
| `257ca1a` | `sdk/integrations/litellm.py` | A streaming LiteLLM call that raised before the stream wrapper was built leaked the `_tj_litellm_active` suppression contextvar (and the OTel span), silently dropping all subsequent Anthropic/OpenAI telemetry on that context. Added a `handed_off` flag so the `finally` cleans up on the streaming-error path (sync + async) while still deferring to the wrapper on success. |

## Test plan
- [x] New failing-first test added per fix (RED confirmed, then GREEN)
- [x] `make test` → 1189 passed, 1 skipped
- [x] `make lint` (ruff) → clean
- [x] `make typecheck` (mypy) → no issues in 133 source files

🤖 Generated with [Claude Code](https://claude.com/claude-code)
