### PR TITLE
Add summarize scan surface: tj summarize list + MCP tool

### DIFF
--- a/tests/integration/test_summarize_cli.py
+++ b/tests/integration/test_summarize_cli.py
@@ -1,0 +1,99 @@
+"""Integration tests for `tj summarize list` via CliRunner."""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+from click.testing import CliRunner
+
+from tokenjam.cli.main import cli
+from tokenjam.core.config import TjConfig
+from tokenjam.core.summarize import candidates
+from tokenjam.core.summarize.catalog import Catalog
+
+
+@pytest.fixture
+def runner():
+    return CliRunner()
+
+
+@pytest.fixture(autouse=True)
+def iso_catalog(monkeypatch):
+    """No real globals — controlled catalog so output is deterministic."""
+    fake = Catalog(project_files=frozenset({"CLAUDE.md", "AGENTS.md"}),
+                   project_globs=(), global_paths=(), forbidden_roots=())
+    monkeypatch.setattr(candidates, "load_catalog", lambda: fake)
+
+
+def _invoke(runner, args, open_db_side_effect=None):
+    with patch("tokenjam.cli.main.load_config", return_value=TjConfig(version="1")), \
+         patch("tokenjam.cli.main.open_db", side_effect=open_db_side_effect) as open_db:
+        result = runner.invoke(cli, args)
+    return result, open_db
+
+
+def _invoke_cfg(runner, args, config, inp=None):
+    """Invoke with a specific config and a poisoned open_db (summarize must never touch it)."""
+    with patch("tokenjam.cli.main.load_config", return_value=config), \
+         patch("tokenjam.cli.main.open_db",
+               side_effect=AssertionError("summarize must not open the DB")):
+        return runner.invoke(cli, args, input=inp)
+
+
+def _tmp_storage_config(tmp_path):
+    from tokenjam.core.config import StorageConfig
+    return TjConfig(version="1", storage=StorageConfig(path=str(tmp_path / "t.duckdb")))
+
+
+def test_summarize_never_opens_db(runner, tmp_path):
+    (tmp_path / "CLAUDE.md").write_text("instructions " * 200)
+    result, open_db = _invoke(
+        runner, ["summarize", "list", str(tmp_path)],
+        open_db_side_effect=AssertionError("summarize must not open the DB"),
+    )
+    assert result.exit_code == 0, result.output
+    open_db.assert_not_called()                       # pins the no_db_commands wiring
+
+
+def test_list_divides_requested_from_global(runner, tmp_path, monkeypatch):
+    """`list` prints the scanned location first, then a divider, then catalog globals."""
+    gfile = tmp_path / "ghome" / ".claude" / "CLAUDE.md"
+    gfile.parent.mkdir(parents=True)
+    gfile.write_text("global instructions " * 200)
+    fake = Catalog(project_files=frozenset({"CLAUDE.md"}), project_globs=(),
+                   global_paths=(str(gfile),), forbidden_roots=())
+    monkeypatch.setattr(candidates, "load_catalog", lambda: fake)
+    proj = tmp_path / "proj"
+    proj.mkdir()
+    (proj / "notes.md").write_text("plain project doc " * 200)        # requested, kind=other
+    res = _invoke_cfg(runner, ["summarize", "list", str(proj), "--ext", "md"],
+                      _tmp_storage_config(tmp_path))
+    assert res.exit_code == 0, res.output
+    assert "global / catalog" in res.output                           # the divider line is present
+    # requested doc (kind 'other') sits above the divider; the global prompt below it
+    assert res.output.index("other") < res.output.index("global / catalog") < res.output.index("prompt")
+
+
+def test_list_json_shape(runner, tmp_path):
+    (tmp_path / "CLAUDE.md").write_text("instructions " * 200)
+    result, _ = _invoke(runner, ["summarize", "list", str(tmp_path), "--json"])
+    assert result.exit_code == 0, result.output
+    data = json.loads(result.output)
+    assert {"candidates", "count", "root", "note"} <= data.keys()
+    assert any(Path(c["path"]).name == "CLAUDE.md" for c in data["candidates"])
+    assert any(c["kind"] == "prompt" for c in data["candidates"])
+
+
+def test_json_note_carries_caveat(runner, tmp_path):
+    (tmp_path / "CLAUDE.md").write_text("instructions " * 200)
+    result, _ = _invoke(runner, ["summarize", "list", str(tmp_path), "--json"])
+    data = json.loads(result.output)
+    assert "review the summary before adopting" in data["note"]   # honesty discipline (Rule 14)
+
+
+def test_repo_recursive_mutually_exclusive(runner):
+    result, _ = _invoke(runner, ["summarize", "list", "--repo", "--recursive"])
+    assert result.exit_code != 0
+    assert "mutually exclusive" in result.output

--- a/tests/unit/test_mcp_server.py
+++ b/tests/unit/test_mcp_server.py
@@ -25,6 +25,7 @@ from tokenjam.mcp.server import (
     _tool_get_drift_report,
     _tool_acknowledge_alert,
     _tool_setup_project,
+    _tool_list_summarize_candidates,
 )
 
 
@@ -642,3 +643,41 @@ def test_get_budget_headroom_http_mode_reads_live_limits():
         assert abs(result["daily_remaining_usd"] - 17.0) < 0.01
     finally:
         _set_serve_url(None)
+
+
+# --- list_summarize_candidates (advisory scan; no DB) ---
+
+@pytest.fixture
+def _iso_summarize_catalog(monkeypatch):
+    """Controlled catalog (no real ~/.claude globals) so the MCP scan is deterministic."""
+    from tokenjam.core.summarize import candidates as _cand
+    from tokenjam.core.summarize.catalog import Catalog
+    fake = Catalog(project_files=frozenset({"CLAUDE.md", "AGENTS.md"}),
+                   project_globs=(), global_paths=(), forbidden_roots=())
+    monkeypatch.setattr(_cand, "load_catalog", lambda: fake)
+
+
+def test_summarize_candidates_lists_prompt(tmp_path, _iso_summarize_catalog):
+    (tmp_path / "CLAUDE.md").write_text("instructions " * 200)
+    result = _tool_list_summarize_candidates(_make_config(), path=str(tmp_path))
+    assert result["count"] == len(result["candidates"]) >= 1
+    claude = [c for c in result["candidates"] if Path(c["path"]).name == "CLAUDE.md"]
+    assert claude and claude[0]["kind"] == "prompt"
+    assert claude[0]["est_tokens_saved"] > 0
+    assert "review before adopting" in result["note"]   # honesty caveat survives the MCP layer
+
+
+def test_summarize_candidates_recursive_passthrough(tmp_path, _iso_summarize_catalog):
+    nested = tmp_path / "sub" / "deep"
+    nested.mkdir(parents=True)
+    (nested / "CLAUDE.md").write_text("instructions " * 200)
+    flat = _tool_list_summarize_candidates(_make_config(), path=str(tmp_path))
+    deep = _tool_list_summarize_candidates(_make_config(), path=str(tmp_path), recursive=True)
+    assert not any("deep" in c["path"] for c in flat["candidates"])   # no walk without -r
+    assert any("deep" in c["path"] for c in deep["candidates"])       # recursive flag reaches core
+    assert deep["recursive"] is True
+
+
+def test_summarize_candidates_no_config():
+    result = _tool_list_summarize_candidates(None)
+    assert "error" in result and "config" in result["error"].lower()  # _no_config sentinel

--- a/tests/unit/test_summarize_candidates.py
+++ b/tests/unit/test_summarize_candidates.py
@@ -1,0 +1,175 @@
+"""Unit tests for the summarize scan — net, ranking, repo detection, boundary safety.
+
+Every test runs against an isolated catalog (a tmp global file, controlled
+project_files) so it never depends on the developer's real ~/.claude.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from tokenjam.core.summarize import candidates
+from tokenjam.core.summarize.catalog import Catalog
+
+
+@pytest.fixture
+def iso(tmp_path, monkeypatch):
+    """Controlled catalog: one tmp global prompt; project files CLAUDE.md/AGENTS.md."""
+    gfile = tmp_path / "globalhome" / ".claude" / "CLAUDE.md"
+    gfile.parent.mkdir(parents=True)
+    gfile.write_text("global instructions " * 200)
+    fake = Catalog(
+        project_files=frozenset({"CLAUDE.md", "AGENTS.md"}),
+        project_globs=(".claude/agents/*.md",),
+        global_paths=(str(gfile),),
+        forbidden_roots=(),
+    )
+    monkeypatch.setattr(candidates, "load_catalog", lambda: fake)
+    return {"global_file": str(gfile)}
+
+
+def test_is_boundary_predicate():
+    home = Path("/home/alice")
+    assert candidates._is_boundary(Path("/"), home) is True
+    assert candidates._is_boundary(Path("/etc"), home) is True
+    assert candidates._is_boundary(Path("/opt"), home) is True
+    assert candidates._is_boundary(home, home) is True
+    assert candidates._is_boundary(Path("/opt/foo"), home) is False
+    assert candidates._is_boundary(Path("/home/alice/code"), home) is False
+
+
+def test_find_repo_root_nearest_and_boundary(tmp_path, monkeypatch, iso):
+    (tmp_path / "outer" / ".git").mkdir(parents=True)
+    inner = tmp_path / "outer" / "inner"
+    (inner / ".git").mkdir(parents=True)
+    deep = inner / "a" / "b"
+    deep.mkdir(parents=True)
+    assert candidates.find_repo_root(deep) == inner.resolve()      # nearest .git wins
+
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)            # treat tmp_path as home
+    norepo = tmp_path / "x" / "y"
+    norepo.mkdir(parents=True)
+    assert candidates.find_repo_root(norepo) is None              # no .git below the home boundary
+    (tmp_path / ".git").mkdir()
+    assert candidates.find_repo_root(tmp_path / "x") is None      # a .git AT home is refused
+
+
+def test_default_is_catalog_only(tmp_path, monkeypatch, iso):
+    proj = tmp_path / "proj"
+    proj.mkdir()
+    (proj / "CLAUDE.md").write_text("instructions " * 200)
+    (proj / "README.md").write_text("readme prose " * 300)
+    monkeypatch.chdir(proj)
+    paths = [c.path for c in candidates.list_candidates(config=None).candidates]
+    assert str(proj / "CLAUDE.md") in paths
+    assert not any("README" in p for p in paths)                 # catalog-only: doc excluded
+
+
+def test_any_flag_opens_net_and_ext(tmp_path, monkeypatch, iso):
+    proj = tmp_path / "proj"
+    proj.mkdir()
+    (proj / "CLAUDE.md").write_text("x " * 200)
+    (proj / "README.md").write_text("y " * 300)
+    (proj / "notes.txt").write_text("z " * 300)
+    paths = [c.path for c in candidates.list_candidates(str(proj), config=None).candidates]
+    assert any("README.md" in p for p in paths)                  # explicit path opens *.md
+    assert not any("notes.txt" in p for p in paths)              # .txt not in default net
+    paths2 = [c.path for c in
+              candidates.list_candidates(str(proj), config=None, extra_exts=("txt",)).candidates]
+    assert any("notes.txt" in p for p in paths2)                 # --ext txt includes it
+
+
+def test_prompts_rank_before_docs(tmp_path, monkeypatch, iso):
+    repo = tmp_path / "repo"
+    (repo / ".git").mkdir(parents=True)
+    (repo / "CLAUDE.md").write_text("small prompt " * 110)        # small prompt
+    (repo / "README.md").write_text("big doc " * 4000)           # huge doc
+    monkeypatch.chdir(repo)
+    res = candidates.list_candidates(recursive=True, config=None, include_global=False)
+    kinds = [c.is_prompt for c in res.candidates]
+    last_prompt = max((i for i, k in enumerate(kinds) if k), default=-1)
+    first_other = next((i for i, k in enumerate(kinds) if not k), len(kinds))
+    assert last_prompt < first_other                             # every prompt before every doc
+    paths = [c.path for c in res.candidates]
+    assert paths.index(str(repo / "CLAUDE.md")) < paths.index(str(repo / "README.md"))
+
+
+def test_scanned_location_before_global(tmp_path, monkeypatch, iso):
+    proj = tmp_path / "proj"
+    proj.mkdir()
+    (proj / "CLAUDE.md").write_text("proj " * 200)
+    monkeypatch.chdir(proj)
+    paths = [c.path for c in candidates.list_candidates(config=None).candidates]
+    gfile = iso["global_file"]
+    assert str(proj / "CLAUDE.md") in paths and gfile in paths
+    assert paths.index(str(proj / "CLAUDE.md")) < paths.index(gfile)   # project before global
+
+
+def test_requested_scope_outranks_global_even_as_a_doc(tmp_path, iso):
+    """Scope is the primary split: a requested plain doc ranks before a global prompt
+    (kind only orders WITHIN a section). Regression for 'the tmp file buried in globals'."""
+    f = tmp_path / "notes.md"
+    f.write_text("plain project doc " * 200)               # scope=path, kind=other (not a catalog name)
+    res = candidates.list_candidates(str(f), config=None)  # explicit file + the iso global (a CLAUDE.md prompt)
+    paths = [c.path for c in res.candidates]
+    gfile = iso["global_file"]
+    assert str(f) in paths and gfile in paths
+    assert paths.index(str(f)) < paths.index(gfile)        # requested doc before global prompt
+
+
+def test_recursive_refuses_without_repo(tmp_path, monkeypatch, iso):
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    work = tmp_path / "work"
+    work.mkdir()
+    (work / "CLAUDE.md").write_text("x " * 200)                  # must NOT be walked to
+    monkeypatch.chdir(work)
+    res = candidates.list_candidates(recursive=True, config=None)
+    assert "no safe root" in res.note
+    assert all(c.scope == "global" for c in res.candidates)      # globals only — nothing walked
+    assert not any("work" in c.path for c in res.candidates)
+
+
+def test_explicit_file_any_name(tmp_path, monkeypatch, iso):
+    f = tmp_path / "weird_name.md"
+    f.write_text("prompt content " * 200)
+    res = candidates.list_candidates(str(f), config=None, include_global=False)
+    paths = [c.path for c in res.candidates]
+    assert paths == [str(f)]                                      # vouched file, analyzed by-name
+
+
+def test_min_prose_override(tmp_path, monkeypatch, iso):
+    proj = tmp_path / "proj"
+    proj.mkdir()
+    (proj / "CLAUDE.md").write_text("w " * 150)                  # 150 prose words
+    monkeypatch.chdir(proj)
+    base = candidates.list_candidates(config=None, include_global=False).candidates
+    assert any(c.scope == "project" for c in base)              # passes the default-100 gate
+    raised = candidates.list_candidates(config=None, include_global=False,
+                                        min_prose_words=200).candidates
+    assert not any(c.scope == "project" for c in raised)        # dropped above 150
+
+
+def test_repo_without_git_notes_and_uses_project_scope(tmp_path, monkeypatch, iso):
+    """--repo outside a git repo: emit a note and use 'project' scope, not a pretend 'repo' root."""
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)        # boundary safety → no repo root found
+    work = tmp_path / "work"
+    work.mkdir()
+    (work / "CLAUDE.md").write_text("instructions " * 200)
+    monkeypatch.chdir(work)
+    res = candidates.list_candidates(repo=True, config=None, include_global=False)
+    assert "no git repo" in res.note
+    assert res.candidates and all(c.scope == "project" for c in res.candidates)   # project, never "repo"
+
+
+def test_explicit_missing_path_notes_not_found(tmp_path, iso):
+    """A non-existent explicit PATH surfaces a 'not found' note whose tail matches what's shown."""
+    missing = tmp_path / "nope" / "ghost.md"
+    # --no-global: nothing is shown, so the note must NOT claim "globals only"
+    res = candidates.list_candidates(str(missing), config=None, include_global=False)
+    assert "not found" in res.note.lower() and "nothing to show" in res.note
+    assert res.candidates == []
+    # with globals included, they ARE shown — the note says so
+    res2 = candidates.list_candidates(str(missing), config=None, include_global=True)
+    assert "not found" in res2.note.lower() and "globals only" in res2.note
+    assert res2.candidates                                     # the iso global is present

--- a/tests/unit/test_summarize_candidates.py
+++ b/tests/unit/test_summarize_candidates.py
@@ -173,3 +173,20 @@ def test_explicit_missing_path_notes_not_found(tmp_path, iso):
     res2 = candidates.list_candidates(str(missing), config=None, include_global=True)
     assert "not found" in res2.note.lower() and "globals only" in res2.note
     assert res2.candidates                                     # the iso global is present
+
+
+def test_explicit_missing_path_notes_not_found_recursive(tmp_path, iso):
+    """Regression: a missing explicit PATH must surface the same 'not found' note even
+    with --recursive. Previously the recursive branch ran first, set walk_root to the
+    non-existent target (not None), walked it to [], and swallowed the error silently."""
+    missing = tmp_path / "nope" / "ghost_dir"
+    res = candidates.list_candidates(str(missing), config=None, recursive=True,
+                                     include_global=False)
+    assert "PATH not found" in res.note and "nothing to show" in res.note
+    assert res.candidates == []
+    # globals still surface; the note must be the not-found one, NOT "--recursive needs a repo"
+    res2 = candidates.list_candidates(str(missing), config=None, recursive=True,
+                                      include_global=True)
+    assert "PATH not found" in res2.note and "globals only" in res2.note
+    assert "no safe root" not in res2.note
+    assert res2.candidates                                     # the iso global is present

--- a/tests/unit/test_summarize_catalog.py
+++ b/tests/unit/test_summarize_catalog.py
@@ -1,0 +1,50 @@
+"""Unit tests for the agent-file catalog loader (packaged + user override + cache)."""
+from __future__ import annotations
+
+import pytest
+
+from tokenjam.core.summarize import catalog
+
+
+@pytest.fixture(autouse=True)
+def _clean_cache():
+    catalog.clear_catalog_cache()
+    yield
+    catalog.clear_catalog_cache()
+
+
+def test_packaged_catalog_has_core_files():
+    cat = catalog.load_catalog()
+    assert {"CLAUDE.md", "AGENTS.md", "GEMINI.md"} <= cat.project_files
+    assert any("CLAUDE.md" in g for g in cat.global_paths)
+
+
+def test_user_override_merges(tmp_path, monkeypatch):
+    override = tmp_path / "agent_files.toml"
+    override.write_text('[custom]\nproject_files = ["MYPROMPT.md"]\n')
+    monkeypatch.setattr(catalog, "USER_CATALOG", override)
+    catalog.clear_catalog_cache()
+    cat = catalog.load_catalog()
+    assert "MYPROMPT.md" in cat.project_files          # user addition
+    assert "CLAUDE.md" in cat.project_files            # packaged entries survive the merge
+
+
+def test_malformed_override_skipped(tmp_path, monkeypatch):
+    override = tmp_path / "agent_files.toml"
+    override.write_text("this is { not ] valid toml ===")
+    monkeypatch.setattr(catalog, "USER_CATALOG", override)
+    catalog.clear_catalog_cache()
+    cat = catalog.load_catalog()                       # must not raise
+    assert "CLAUDE.md" in cat.project_files            # falls back to the packaged table
+
+
+def test_cache_invalidation(tmp_path, monkeypatch):
+    override = tmp_path / "agent_files.toml"
+    override.write_text('[custom]\nproject_files = ["A.md"]\n')
+    monkeypatch.setattr(catalog, "USER_CATALOG", override)
+    catalog.clear_catalog_cache()
+    assert "A.md" in catalog.load_catalog().project_files
+    override.write_text('[custom]\nproject_files = ["B.md"]\n')
+    assert "B.md" not in catalog.load_catalog().project_files   # still cached
+    catalog.clear_catalog_cache()
+    assert "B.md" in catalog.load_catalog().project_files       # reflects the edit

--- a/tests/unit/test_summarize_detect.py
+++ b/tests/unit/test_summarize_detect.py
@@ -1,0 +1,57 @@
+"""Unit tests for summarize structure detection + the worth-it gate."""
+from __future__ import annotations
+
+from tokenjam.core.summarize import detect
+
+
+def test_code_fence_excluded_from_prose():
+    text = "word " * 50 + "\n```python\n" + "code_token " * 100 + "\n```\n" + "word " * 50
+    b = detect.analyze(text)
+    assert b.protected_blocks == 1           # the fenced block
+    assert b.prose_words == 100              # only the 100 prose words, not the 100 code tokens
+
+
+def test_unclosed_fence_counts_as_prose():
+    # Documents the stdlib-regex behavior: a lone ``` with no closer is NOT a
+    # protected span (so it can't swallow the rest of the file). Edge: real
+    # markdown would treat it as code-to-EOF; we don't, by design (no md parser).
+    text = "```\n" + "word " * 120
+    b = detect.analyze(text)
+    assert b.protected_blocks == 0
+    assert b.prose_words >= 100
+
+
+def test_longest_span_wins_on_overlap():
+    text = ("intro " * 8 + "<example>" + "x " * 20 + "`inline` " + "y " * 20
+            + "</example>" + " outro " * 8)
+    b = detect.analyze(text)
+    assert b.protected_blocks == 1           # tag block absorbs the inline span (no double count)
+    assert b.prose_words == 16               # only the 8 intro + 8 outro words
+
+
+def test_gate_boundary():
+    assert detect.is_candidate("w " * 99) is False
+    assert detect.is_candidate("w " * 100) is True
+
+
+def test_structure_only_and_empty():
+    assert detect.analyze("").prose_words == 0
+    assert detect.is_candidate("") is False
+    assert detect.is_candidate("```\n" + "x " * 500 + "\n```") is False   # all code → ~0 prose
+
+
+def test_markdown_table_protected():
+    table = "| Sym | Meaning |\n|-----|---------|\n| a | b |\n| c | d |\n"
+    text = "word " * 60 + "\n\n" + table + "\nword " * 60
+    b = detect.analyze(text)
+    assert b.protected_blocks == 1                              # the table is one protected block
+    assert tuple(k for _, _, k in detect.protected_spans(text)) == ("table",)
+    assert b.prose_words == 120                                 # table cells are NOT counted as prose
+    assert "Sym" not in detect.prose_text(text)                 # …and never reach the summarizer
+
+
+def test_tj_keep_marker_literal_protected():
+    text = 'Docs mention <tj-keep id="99"/> as literal marker syntax. ' + "word " * 120
+    spans = detect.protected_spans(text)
+    assert tuple(k for _, _, k in spans) == ("tj_keep_marker",)
+    assert '<tj-keep id="99"/>' not in detect.prose_text(text)

--- a/tests/unit/test_summarize_estimate.py
+++ b/tests/unit/test_summarize_estimate.py
@@ -1,0 +1,24 @@
+"""Unit tests for the per-candidate savings estimate."""
+from __future__ import annotations
+
+from tokenjam.core.summarize import detect, estimate
+
+
+def test_structure_excluded_from_savings():
+    # Two files; the second is *longer* but mostly code. Only prose is
+    # summarizable, so the code-heavy file's estimated saving is smaller.
+    all_prose = "word " * 400
+    half_prose_lots_of_code = "word " * 200 + "\n```\n" + "code " * 1200 + "\n```\n"
+    saved_prose = estimate.tokens_saved(detect.analyze(all_prose))
+    saved_code_heavy = estimate.tokens_saved(detect.analyze(half_prose_lots_of_code))
+    assert saved_code_heavy > 0
+    assert saved_prose > saved_code_heavy
+
+
+def test_ratio_bounds_and_monotonic():
+    b = detect.analyze("word " * 1000)
+    assert estimate.tokens_saved(b, ratio=1.0) == 0
+    assert estimate.tokens_saved(b, ratio=1.5) == 0
+    # lower target ratio keeps less prose → saves more
+    assert estimate.tokens_saved(b, ratio=0.0) > estimate.tokens_saved(b, ratio=0.5)
+    assert estimate.tokens_saved(b, ratio=0.5) > estimate.tokens_saved(b, ratio=0.9)

--- a/tokenjam/cli/cmd_summarize.py
+++ b/tokenjam/cli/cmd_summarize.py
@@ -1,0 +1,126 @@
+"""`tj summarize` — structure-aware prompt summarization (advisory in v1).
+
+`tj summarize list` finds prompt files worth summarizing and estimates the
+per-call token saving. Bare = the known-location catalog (globals + this dir).
+A scope-widening input — a PATH, `--repo`, `--recursive`, or `--ext` — opens it
+to all `*.md`; the scanned location is shown first, the catalog globals after a
+divider. It only reads and reports — it never rewrites a file. See DEC-020/021.
+"""
+from __future__ import annotations
+
+import json
+
+import click
+from rich.markup import escape
+
+from tokenjam.core.config import TjConfig
+from tokenjam.core.summarize.candidates import list_candidates
+from tokenjam.utils.formatting import console, format_tokens
+
+# Honesty discipline (CLAUDE.md Rule 14): every candidate is a suggestion to
+# review, never an assertion the rewrite is safe — and the saving is estimated.
+CANDIDATE_NOTE = (
+    "Candidates only — review the summary before adopting. The figure is the "
+    "estimated per-call token reduction, which amortizes across every reuse of "
+    "the (cached) prompt."
+)
+
+
+@click.group("summarize", invoke_without_command=False)
+def cmd_summarize() -> None:
+    """Structure-aware prompt summarization (advisory preview)."""
+
+
+@cmd_summarize.command("list")
+@click.argument("path", required=False, default=None)
+@click.option("-r", "--recursive", is_flag=True,
+              help="Walk the repo subtree (or PATH) — opens to all .md.")
+@click.option("--repo", "repo", is_flag=True,
+              help="Check the git-repo root (no walk) — opens to all .md.")
+@click.option("--no-global", "no_global", is_flag=True,
+              help="Skip the global/system locations (project only).")
+@click.option("--ext", "ext", default=None,
+              help="Also scan these comma-separated extensions, e.g. txt,rst "
+                   "(opens beyond the catalog).")
+@click.option("--json", "output_json_flag", is_flag=True,
+              help="Emit machine-readable JSON.")
+@click.option("--min-prose", "min_prose", default=None, type=int,
+              help="Minimum prose words to flag a file (default 100).")
+@click.pass_context
+def cmd_summarize_list(
+    ctx: click.Context, path: str | None, recursive: bool, repo: bool,
+    no_global: bool, ext: str | None, output_json_flag: bool, min_prose: int | None,
+) -> None:
+    """List prompt files worth summarizing (bare = catalog; a PATH/--repo/--recursive/--ext opens to .md)."""
+    config: TjConfig = ctx.obj["config"]
+    output_json: bool = output_json_flag or ctx.obj.get("output_json", False)
+
+    if repo and recursive:
+        raise click.UsageError("--repo and --recursive are mutually exclusive.")
+    if repo and path is not None:
+        raise click.UsageError("--repo cannot be combined with an explicit PATH.")
+
+    extra_exts = tuple(e for e in (ext.split(",") if ext else []) if e.strip())
+    kwargs: dict = {}
+    if min_prose is not None:
+        kwargs["min_prose_words"] = min_prose
+    result = list_candidates(
+        path, config=config, recursive=recursive, repo=repo,
+        include_global=not no_global, extra_exts=extra_exts, **kwargs,
+    )
+
+    if output_json:
+        payload = result.to_dict()
+        payload["note"] = result.note or CANDIDATE_NOTE
+        click.echo(json.dumps(payload, indent=2))
+        return
+
+    # Transparency — what was scanned (DEC-020).
+    scanned: list[str] = []
+    if result.root:
+        scanned.append(f"{escape(result.root)}{' (recursive)' if result.recursive else ''}")
+    if result.globals_checked:
+        scanned.append(f"{result.globals_checked} global location(s)")
+    if scanned:
+        console.print(f"[dim]Scanned: {' + '.join(scanned)}[/dim]")
+    if result.walk_capped:
+        console.print("[yellow]Walk hit the file cap — results truncated; "
+                      "narrow with a PATH.[/yellow]")
+    if result.note:
+        console.print(f"[yellow]{escape(result.note)}[/yellow]")
+
+    if not result.candidates:
+        console.print("[dim]No summarize candidates found.[/dim]")
+        return
+
+    from rich.table import Table
+
+    def _new_table(show_header: bool) -> Table:
+        t = Table(show_header=show_header, header_style="bold", box=None, padding=(0, 2))
+        t.add_column("FILE")
+        t.add_column("KIND", style="dim")
+        t.add_column("PROSE WORDS", justify="right")
+        t.add_column("EST. TOKENS/CALL", justify="right")
+        return t
+
+    def _add_rows(t: Table, items: list) -> None:
+        for c in items:
+            t.add_row(escape(c.path), "prompt" if c.is_prompt else "other",
+                      str(c.prose_words), f"~{format_tokens(c.est_tokens_saved)}")
+
+    # What the user asked for (the scanned location) prints first; the always-on catalog
+    # globals follow a divider — supplementary, not the focus (DEC-021). Kind orders within.
+    requested = [c for c in result.candidates if c.scope != "global"]
+    catalog_globals = [c for c in result.candidates if c.scope == "global"]
+    if requested:
+        t = _new_table(show_header=True)
+        _add_rows(t, requested)
+        console.print(t)
+    if catalog_globals:
+        if requested:
+            console.print("[dim]── global / catalog defaults (always included) ──[/dim]")
+        t = _new_table(show_header=not requested)
+        _add_rows(t, catalog_globals)
+        console.print(t)
+    console.print()
+    console.print(f"[dim]{escape(CANDIDATE_NOTE)}[/dim]")

--- a/tokenjam/cli/main.py
+++ b/tokenjam/cli/main.py
@@ -40,7 +40,7 @@ def cli(ctx: click.Context, config_path: str | None, output_json: bool,
         config.storage.path = db_path
 
     # Commands that don't need a database connection
-    no_db_commands = {"stop", "uninstall", "onboard", "mcp", "demo", "policy", "proxy"}
+    no_db_commands = {"stop", "uninstall", "onboard", "mcp", "demo", "policy", "proxy", "summarize"}
     invoked = ctx.invoked_subcommand
     if invoked in no_db_commands:
         ctx.obj["config"] = config
@@ -138,3 +138,6 @@ cli.add_command(cmd_mcp, name="mcp")
 
 from tokenjam.cli.cmd_demo import cmd_demo  # noqa: E402
 cli.add_command(cmd_demo, name="demo")
+
+from tokenjam.cli.cmd_summarize import cmd_summarize  # noqa: E402
+cli.add_command(cmd_summarize, name="summarize")

--- a/tokenjam/core/summarize/__init__.py
+++ b/tokenjam/core/summarize/__init__.py
@@ -1,0 +1,27 @@
+"""TokenJam Summarize — structure-aware prompt summarization.
+
+v1 (PR1) ships the **advisory** surface only: detect prompt files worth
+summarizing and estimate the per-call token saving, without writing anything.
+The mechanism (protect → summarize → restore → verify) and apply/backup land in
+later PRs. Pure `core` logic — no CLI or HTTP imports.
+"""
+from tokenjam.core.summarize.detect import (
+    MIN_PROSE_WORDS,
+    StructureBreakdown,
+    analyze,
+    is_candidate,
+)
+from tokenjam.core.summarize.estimate import DEFAULT_TARGET_RATIO, tokens_saved
+from tokenjam.core.summarize.candidates import Candidate, ScanResult, list_candidates
+
+__all__ = [
+    "MIN_PROSE_WORDS",
+    "StructureBreakdown",
+    "analyze",
+    "is_candidate",
+    "DEFAULT_TARGET_RATIO",
+    "tokens_saved",
+    "Candidate",
+    "ScanResult",
+    "list_candidates",
+]

--- a/tokenjam/core/summarize/agent_files.toml
+++ b/tokenjam/core/summarize/agent_files.toml
@@ -1,0 +1,36 @@
+# Catalog of known AI-agent prompt-file locations (where `tj summarize` looks).
+# Curated data — PRs welcome, like tokenjam/pricing/models.toml. Anil decides what ships.
+# Per tool:
+#   project_files = bare filenames checked at the scan root (and matched while --recursive walks)
+#   project_globs = root-relative globs for "obvious" prompt folders (shallow, no deep walk)
+#   global_paths  = user/system locations loaded regardless of project ("~" is expanded)
+# Users can extend/override locally at ~/.config/tj/agent_files.toml (merged over this).
+
+[claude]                 # Claude Code
+project_files = ["CLAUDE.md", "CLAUDE.local.md"]   # .local = historical local override
+project_globs = [
+    ".claude/rules/*.md",
+    ".claude/skills/*/SKILL.md",
+    ".claude/commands/*.md",
+    ".claude/agents/*.md",
+]
+global_paths = [
+    "~/.claude/CLAUDE.md", "/etc/claude-code/CLAUDE.md",
+    "~/.claude/agents/*.md", "~/.claude/skills/*/SKILL.md", "~/.claude/commands/*.md",
+]
+
+[gemini]                 # Gemini CLI
+project_files = ["GEMINI.md"]
+project_globs = []
+global_paths = ["~/.gemini/GEMINI.md"]
+
+[codex]                  # Codex CLI (AGENTS.md = cross-tool universal standard)
+project_files = ["AGENTS.md", "codex.md"]                          # codex.md = historical
+project_globs = []
+global_paths = ["~/.codex/AGENTS.md", "~/.codex/instructions.md"]  # instructions.md = historical
+
+[safety]
+# Extra dirs (depth >= 2) to never treat as a repo root. The core gates — filesystem
+# root, the user's home, and any bare top-level dir — live in code and cannot be
+# disabled here; this list only ADDS boundaries.
+forbidden_roots = []

--- a/tokenjam/core/summarize/candidates.py
+++ b/tokenjam/core/summarize/candidates.py
@@ -1,0 +1,334 @@
+"""Discover summarize candidates from the known prompt-file catalog (DEC-020/021).
+
+The **net** is flag-gated: bare `tj summarize list` considers only catalog-known
+prompt files (by name/location); **any** widening input — a ``path``,
+``--repo``, ``--recursive``, or extra extensions — opens it to **all `*.md`**
+(plus those extensions). A "scan for me" command should be generous when asked;
+the default stays minimal.
+
+**Ranking is sectioned** (DEC-021, refined): what you *asked for* comes first.
+  1. the scanned location (an explicit PATH / ``--repo`` / ``--recursive`` / cwd)
+     before the always-on catalog **globals** — the requested scope is the focus;
+     globals are supplementary and the CLI shows them under a divider;
+  2. WITHIN a section, kind is the differentiator: catalog-recognized **prompts**
+     first, then other files, grouped by directory (path), biggest first.
+
+Boundary-safe (pure-filesystem `.git` detection; never `/`, home, or a bare
+top-level). Advisory only — reads and reports, never writes.
+"""
+from __future__ import annotations
+
+import glob as _glob
+import os
+from dataclasses import dataclass
+from pathlib import Path
+from typing import TYPE_CHECKING, Iterable, Iterator
+
+from tokenjam.core.summarize.catalog import load_catalog
+from tokenjam.core.summarize.detect import MIN_PROSE_WORDS, analyze
+from tokenjam.core.summarize.estimate import DEFAULT_TARGET_RATIO, tokens_saved
+
+if TYPE_CHECKING:
+    from tokenjam.core.config import TjConfig
+
+# Directories never descended into during a --recursive walk.
+_SKIP_DIRS = {
+    ".git", "node_modules", ".venv", "venv", "env", "__pycache__", ".tj",
+    ".mypy_cache", ".pytest_cache", ".ruff_cache", "dist", "build",
+    ".idea", ".vscode", "site-packages",
+}
+# Extensions the opened-up net considers by default (the user can add more).
+_DEFAULT_EXTS = {".md", ".markdown"}
+_MAX_BYTES = 512 * 1024     # never read a file larger than this
+_MIN_BYTES = 400            # stat pre-filter: below this can't hold ~100 prose words
+_MAX_WALK_FILES = 5000      # hard cap on a --recursive walk (then bail, flagged)
+
+
+@dataclass(frozen=True)
+class Candidate:
+    """One file flagged as worth summarizing."""
+
+    path: str
+    prose_words: int
+    total_chars: int
+    protected_blocks: int
+    est_tokens_saved: int
+    pricing_mode: str
+    scope: str                  # "global" | "project" | "repo" | "path"
+    is_prompt: bool             # matched a catalog prompt name/location
+
+    def to_dict(self) -> dict:
+        return {
+            "path": self.path,
+            "prose_words": self.prose_words,
+            "total_chars": self.total_chars,
+            "protected_blocks": self.protected_blocks,
+            "est_tokens_saved": self.est_tokens_saved,
+            "pricing_mode": self.pricing_mode,
+            "scope": self.scope,
+            "is_prompt": self.is_prompt,
+            "kind": "prompt" if self.is_prompt else "other",
+        }
+
+
+@dataclass(frozen=True)
+class ScanResult:
+    """Candidates plus what was scanned (transparency, DEC-020)."""
+
+    candidates: list[Candidate]
+    root: str | None
+    recursive: bool
+    globals_checked: int
+    walk_capped: bool
+    note: str
+
+    def to_dict(self) -> dict:
+        return {
+            "candidates": [c.to_dict() for c in self.candidates],
+            "count": len(self.candidates),
+            "root": self.root,
+            "recursive": self.recursive,
+            "globals_checked": self.globals_checked,
+            "walk_capped": self.walk_capped,
+            "note": self.note,
+        }
+
+
+# --------------------------------------------------------------------------- #
+# Catalog matching — what counts as a "prompt"
+# --------------------------------------------------------------------------- #
+
+def _is_prompt(path: Path) -> bool:
+    """True iff ``path`` is a catalog-known prompt file — by exact name, or by
+    matching a catalog glob from the right (so a nested `.claude/skills/*/SKILL.md`
+    is recognized regardless of where it sits)."""
+    cat = load_catalog()
+    if path.name in cat.project_files:
+        return True
+    return any(path.match(pattern) for pattern in cat.project_globs)
+
+
+def _norm_ext(ext: str) -> str:
+    e = ext.strip().lower().lstrip(".")
+    return f".{e}" if e else ""
+
+
+# --------------------------------------------------------------------------- #
+# Repo detection + boundary safety — pure filesystem, no git subprocess.
+# --------------------------------------------------------------------------- #
+
+def _is_boundary(d: Path, home: Path) -> bool:
+    """A dir we must never treat as a repo root: filesystem root, the user's home,
+    or any bare top-level dir (<=2 path components)."""
+    return d == Path(d.anchor) or d == home or len(d.parts) <= 2
+
+
+def find_repo_root(start: "str | os.PathLike[str]") -> Path | None:
+    """Nearest ancestor of ``start`` containing a ``.git`` (dir or file), or None.
+
+    Walks up by path only — no listing, no subprocess — and STOPS (returns None)
+    at the first boundary (filesystem root, the user's home, any bare top-level,
+    or a catalog ``forbidden_roots`` entry). So a repo root is always >=2 levels
+    below ``/`` and never home/system; a project nested under a system dir
+    (``/opt/foo``, ``~/code/x``) still resolves correctly.
+    """
+    cur = Path(start).expanduser().resolve()
+    home = Path.home().resolve()
+    extra = {Path(p).expanduser().resolve() for p in load_catalog().forbidden_roots}
+    for d in [cur, *cur.parents]:
+        if _is_boundary(d, home) or d in extra:
+            return None
+        if (d / ".git").exists():
+            return d
+    return None
+
+
+# --------------------------------------------------------------------------- #
+# File -> Candidate
+# --------------------------------------------------------------------------- #
+
+def _read(path: Path) -> str | None:
+    try:
+        if path.stat().st_size > _MAX_BYTES:
+            return None
+        return path.read_text(encoding="utf-8")
+    except (OSError, UnicodeDecodeError):
+        return None
+
+
+def _candidate(path: Path, mode: str, scope: str, min_prose_words: int,
+               ratio: float) -> Candidate | None:
+    text = _read(path)
+    if text is None:
+        return None
+    b = analyze(text)
+    if b.prose_words < min_prose_words:
+        return None
+    return Candidate(
+        path=str(path), prose_words=b.prose_words, total_chars=b.total_chars,
+        protected_blocks=b.protected_blocks, est_tokens_saved=tokens_saved(b, ratio),
+        pricing_mode=mode, scope=scope, is_prompt=_is_prompt(path),
+    )
+
+
+def _pricing_mode(config: "TjConfig | None") -> str:
+    if config is None:
+        return "unknown"
+    from tokenjam.core.framing import config_declared_plan, pricing_mode_for
+    plan = config_declared_plan(config)
+    return pricing_mode_for(plan) if plan else "unknown"
+
+
+# --------------------------------------------------------------------------- #
+# Target enumeration
+# --------------------------------------------------------------------------- #
+
+def _global_targets() -> list[Path]:
+    """Catalog global/system paths ("~" expanded; glob patterns expanded)."""
+    out: list[Path] = []
+    for raw in load_catalog().global_paths:
+        ep = os.path.expanduser(raw)
+        if any(ch in ep for ch in "*?["):
+            out.extend(Path(x) for x in sorted(_glob.glob(ep)))
+        else:
+            out.append(Path(ep))
+    return out
+
+
+def _project_targets(root: Path, ext_set: set[str]) -> Iterator[Path]:
+    """Catalog names + globs at ``root`` (always); plus, when ``ext_set`` is
+    non-empty (the net is open), every root-level file with a matching extension."""
+    cat = load_catalog()
+    for name in sorted(cat.project_files):
+        yield root / name
+    for pattern in cat.project_globs:
+        yield from sorted(root.glob(pattern))
+    if ext_set:
+        try:
+            for p in sorted(root.iterdir()):
+                if p.is_file() and p.suffix.lower() in ext_set:
+                    yield p
+        except OSError:
+            pass
+
+
+def _walk_targets(root: Path, ext_set: set[str]) -> tuple[list[Path], bool]:
+    """--recursive: catalog filenames + matching extensions under ``root``; skip-dirs
+    pruned, stat pre-filtered, capped. Returns ``(paths, capped)``."""
+    names = load_catalog().project_files
+    out: list[Path] = []
+    for dirpath, dirnames, filenames in os.walk(root):
+        dirnames[:] = sorted(d for d in dirnames if d not in _SKIP_DIRS)
+        for fn in sorted(filenames):
+            p = Path(dirpath) / fn
+            if fn not in names and p.suffix.lower() not in ext_set:
+                continue
+            try:
+                if p.stat().st_size < _MIN_BYTES:
+                    continue
+            except OSError:
+                continue
+            out.append(p)
+            if len(out) >= _MAX_WALK_FILES:
+                return out, True
+    return out, False
+
+
+# --------------------------------------------------------------------------- #
+# Public API
+# --------------------------------------------------------------------------- #
+
+def list_candidates(
+    path: "str | os.PathLike[str] | None" = None,
+    *,
+    config: "TjConfig | None" = None,
+    recursive: bool = False,
+    repo: bool = False,
+    include_global: bool = True,
+    min_prose_words: int = MIN_PROSE_WORDS,
+    ratio: float = DEFAULT_TARGET_RATIO,
+    extra_exts: Iterable[str] = (),
+) -> ScanResult:
+    """Find summarize candidates per DEC-020/021. Advisory: reads only, never writes."""
+    mode = _pricing_mode(config)
+    extra = {e for e in (_norm_ext(x) for x in extra_exts) if e}
+    # The net opens to all-md (+ extras) the moment ANY widening input is given.
+    widened = (path is not None) or recursive or repo or bool(extra)
+    ext_set = (_DEFAULT_EXTS | extra) if widened else set()
+
+    seen: set[str] = set()
+    cands: list[Candidate] = []
+    note = ""
+    walk_capped = False
+    root_used: Path | None = None
+
+    def _add(p: Path, scope: str) -> None:
+        key = str(p.resolve()) if p.exists() else str(p)
+        if key in seen:
+            return
+        seen.add(key)
+        c = _candidate(p, mode, scope, min_prose_words, ratio)
+        if c is not None:
+            cands.append(c)
+
+    # 1) Globals (the floor) — always catalog prompts, unless suppressed.
+    globals_checked = 0
+    if include_global:
+        for gp in _global_targets():
+            if gp.exists():
+                globals_checked += 1
+                _add(gp, "global")
+
+    # 2) Project scope.
+    explicit = path is not None
+    target = Path(path).expanduser() if explicit else Path.cwd()
+
+    if explicit and target.is_file():
+        # NOTE: a specific file still invokes the catalog globals (added above as
+        # the floor) unless --no-global; scoping to JUST the named file is deferred
+        # (DEF-005).
+        root_used = target
+        _add(target, "path")
+    elif recursive:
+        walk_root = target if explicit else find_repo_root(Path.cwd())
+        if walk_root is None:
+            tail = "showing globals only" if cands else "nothing to show"
+            note = ("--recursive needs a git repo or an explicit PATH; no safe root "
+                    f"found — {tail}.")
+        else:
+            root_used = walk_root
+            paths, walk_capped = _walk_targets(walk_root, ext_set)
+            for p in paths:
+                _add(p, "path" if explicit else "repo")
+    else:
+        if repo and not explicit:
+            found = find_repo_root(Path.cwd())
+            if found is None:                       # --repo but no repo: don't fake a "repo" root
+                scope_root, scope = Path.cwd(), "project"
+                note = "--repo: no git repo found — scanning the current directory instead."
+            else:
+                scope_root, scope = found, "repo"
+        else:
+            scope_root = target
+            scope = "path" if explicit else "project"
+            if explicit and not target.exists():    # a typo'd PATH shouldn't silently show only globals
+                tail = "showing globals only" if cands else "nothing to show"
+                note = f"PATH not found: {target} — {tail}."
+        root_used = scope_root
+        for p in _project_targets(scope_root, ext_set):
+            _add(p, scope)
+
+    # Sectioned sort (DEC-021, refined): what the user asked for first — the scanned
+    # location (non-global) before the always-on catalog globals (supplementary, shown
+    # under a divider). Kind is the WITHIN-section differentiator: prompts before other
+    # files; then by directory (path, alpha); size desc within.
+    cands.sort(key=lambda c: (1 if c.scope == "global" else 0, 0 if c.is_prompt else 1,
+                              str(Path(c.path).parent), -c.est_tokens_saved))
+    return ScanResult(
+        candidates=cands,
+        root=str(root_used) if root_used is not None else None,
+        recursive=recursive,
+        globals_checked=globals_checked,
+        walk_capped=walk_capped,
+        note=note,
+    )

--- a/tokenjam/core/summarize/candidates.py
+++ b/tokenjam/core/summarize/candidates.py
@@ -283,7 +283,15 @@ def list_candidates(
     explicit = path is not None
     target = Path(path).expanduser() if explicit else Path.cwd()
 
-    if explicit and target.is_file():
+    if explicit and not target.exists():
+        # A typo'd / missing PATH shouldn't silently show only globals. This MUST be
+        # checked before the --recursive branch: with an explicit PATH, walk_root is
+        # the (non-existent) target rather than None, so _walk_targets() just returns
+        # [] and the error gets swallowed. Single source of truth for the note.
+        tail = "showing globals only" if cands else "nothing to show"
+        note = f"PATH not found: {target} — {tail}."
+        root_used = target
+    elif explicit and target.is_file():
         # NOTE: a specific file still invokes the catalog globals (added above as
         # the floor) unless --no-global; scoping to JUST the named file is deferred
         # (DEF-005).
@@ -311,9 +319,6 @@ def list_candidates(
         else:
             scope_root = target
             scope = "path" if explicit else "project"
-            if explicit and not target.exists():    # a typo'd PATH shouldn't silently show only globals
-                tail = "showing globals only" if cands else "nothing to show"
-                note = f"PATH not found: {target} — {tail}."
         root_used = scope_root
         for p in _project_targets(scope_root, ext_set):
             _add(p, scope)

--- a/tokenjam/core/summarize/catalog.py
+++ b/tokenjam/core/summarize/catalog.py
@@ -1,0 +1,91 @@
+"""Loader for the agent-prompt-file catalog — where known prompt files live.
+
+Mirrors `core/pricing.py`: a packaged default (`agent_files.toml` beside this
+module) merged with an optional user override (`~/.config/tj/agent_files.toml`),
+cached. Curated data — PRs welcome, like `pricing/models.toml`; Anil decides
+what ships. Enumerates, per tool (Claude / Gemini / Codex), the global/system
+fixed paths plus the project-relative filenames and globs the summarize scan
+looks at (DEC-020).
+"""
+from __future__ import annotations
+
+import logging
+import sys
+from dataclasses import dataclass
+from functools import lru_cache
+from pathlib import Path
+
+if sys.version_info >= (3, 11):
+    import tomllib
+else:
+    import tomli as tomllib  # type: ignore[no-redef]
+
+log = logging.getLogger(__name__)
+
+CATALOG_FILE = Path(__file__).parent / "agent_files.toml"
+USER_CATALOG = Path.home() / ".config" / "tj" / "agent_files.toml"
+
+_SAFETY_SECTION = "safety"
+
+
+@dataclass(frozen=True)
+class Catalog:
+    """Flattened catalog the scan consumes (unioned across tool sections)."""
+
+    project_files: frozenset[str]      # bare filenames checked at a scan root
+    project_globs: tuple[str, ...]     # root-relative globs (e.g. .claude/skills/*/SKILL.md)
+    global_paths: tuple[str, ...]      # user/system paths ("~" expanded by the caller)
+    forbidden_roots: tuple[str, ...]   # extra dirs never treated as a repo root
+
+
+def _read(path: Path) -> dict:
+    try:
+        with open(path, "rb") as f:
+            return tomllib.load(f)
+    except FileNotFoundError:
+        return {}
+    except (OSError, tomllib.TOMLDecodeError) as exc:  # malformed override → skip, never fatal
+        log.warning("Could not read agent-file catalog %s (%s); skipping it.", path, exc)
+        return {}
+
+
+def _merge(base: dict, over: dict) -> dict:
+    """Per-section merge: a user section updates the packaged one key-by-key
+    (lists replace, not concatenate — predictable)."""
+    out: dict = {k: (dict(v) if isinstance(v, dict) else v) for k, v in base.items()}
+    for section, val in over.items():
+        if isinstance(val, dict) and isinstance(out.get(section), dict):
+            out[section].update(val)
+        else:
+            out[section] = val
+    return out
+
+
+@lru_cache(maxsize=1)
+def load_catalog() -> Catalog:
+    """Packaged catalog merged with the optional user override, cached."""
+    raw = _merge(_read(CATALOG_FILE), _read(USER_CATALOG))
+    files: set[str] = set()
+    globs: list[str] = []
+    globals_: list[str] = []
+    forbidden: list[str] = []
+    for section, body in raw.items():
+        if not isinstance(body, dict):
+            continue
+        if section == _SAFETY_SECTION:
+            forbidden.extend(str(x) for x in body.get("forbidden_roots", []))
+            continue
+        files.update(str(x) for x in body.get("project_files", []))
+        globs.extend(str(x) for x in body.get("project_globs", []))
+        globals_.extend(str(x) for x in body.get("global_paths", []))
+    return Catalog(
+        project_files=frozenset(files),
+        project_globs=tuple(dict.fromkeys(globs)),       # dedupe, keep order
+        global_paths=tuple(dict.fromkeys(globals_)),
+        forbidden_roots=tuple(dict.fromkeys(forbidden)),
+    )
+
+
+def clear_catalog_cache() -> None:
+    """Drop the cache so the next load re-reads from disk (test hook / runtime reload)."""
+    load_catalog.cache_clear()

--- a/tokenjam/core/summarize/detect.py
+++ b/tokenjam/core/summarize/detect.py
@@ -1,0 +1,111 @@
+"""Structured-input detection for the summarize surface (stdlib only).
+
+Segments a prompt into PROSE vs PROTECTED structured regions (fenced code, tag
+blocks, inline code, templates, markdown tables, and any literal tj-keep markers
+the source itself contains), counts prose words, and exposes the worth-it gate. Deliberately stdlib-only — no markdown-it / numpy / yaml — so it adds no
+dependency to the base install. The protected-span detectors mirror the
+research verifier's regexes so the eventual wrap/restore mechanism stays
+consistent with what the detector counts as structure.
+"""
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+
+# Minimum prose words (after structure is set aside) for a prompt to be worth
+# summarizing. Below this the savings don't justify a rewrite. The default;
+# overridable via a future [summarize] config section.
+MIN_PROSE_WORDS = 100
+
+# Rough English chars-per-token, matching the trim analyzer's basis so token
+# estimates are comparable across surfaces.
+CHARS_PER_TOKEN = 4
+
+_CODE_FENCE_RE = re.compile(r"```.*?```", re.DOTALL)
+_INLINE_RE = re.compile(r"``[^`]+``|(?<!`)`[^`\n]+`(?!`)")
+_TAGBLOCK_RE = re.compile(r"<([a-zA-Z][\w:-]*)(?:\s[^>]*?)?>.*?</\1\s*>", re.DOTALL)
+_TEMPLATE_RE = re.compile(r"\$\{[^}]*\}|\{\{[^}]*\}\}|\{%[^%]*%\}|<%[^%]*%>")
+_TJ_KEEP_MARKER_RE = re.compile(r'<tj-keep id="\d+"[^>]*?(?:/>|>.*?</tj-keep>)', re.DOTALL)
+# Markdown table (GitHub-flavored canonical form: leading + trailing pipes, a dash delimiter row).
+# Conservative on purpose — prose rarely has a `|...|` line followed by a `|---|---|` row.
+_TABLE_RE = re.compile(
+    r"^[ \t]*\|.+\|[ \t]*\n"                        # header row
+    r"[ \t]*\|(?:[ \t]*:?-+:?[ \t]*\|)+[ \t]*\n"    # delimiter row ( ---|--- )
+    r"(?:[ \t]*\|.+\|[ \t]*\n?)*",                  # zero+ body rows
+    re.MULTILINE)
+_WORD_RE = re.compile(r"\S+")
+
+# Order matters only for the kind label on overlap; merge is longest-wins below.
+_DETECTORS: tuple[tuple[str, re.Pattern[str]], ...] = (
+    ("code_fence", _CODE_FENCE_RE),
+    ("table", _TABLE_RE),
+    ("tj_keep_marker", _TJ_KEEP_MARKER_RE),
+    ("tag_block", _TAGBLOCK_RE),
+    ("inline_code", _INLINE_RE),
+    ("template", _TEMPLATE_RE),
+)
+
+
+def protected_spans(text: str) -> list[tuple[int, int, str]]:
+    """Non-overlapping protected spans ``[(start, end, kind)]``, longest-wins.
+
+    Candidates from all detectors are sorted by (earliest start, longest span)
+    and greedily kept if they don't overlap an already-kept span — so an outer
+    fenced block wins over an inline span nested inside it.
+    """
+    spans: list[tuple[int, int, str]] = []
+    for kind, rx in _DETECTORS:
+        for m in rx.finditer(text):
+            spans.append((m.start(), m.end(), kind))
+    spans.sort(key=lambda s: (s[0], -(s[1] - s[0])))
+    out: list[tuple[int, int, str]] = []
+    last = -1
+    for start, end, kind in spans:
+        if start >= last:
+            out.append((start, end, kind))
+            last = end
+    return out
+
+
+def prose_text(text: str) -> str:
+    """Return ``text`` with every protected span removed (what a summarizer rewrites)."""
+    spans = protected_spans(text)
+    if not spans:
+        return text
+    parts: list[str] = []
+    cur = 0
+    for start, end, _ in spans:
+        parts.append(text[cur:start])
+        cur = end
+    parts.append(text[cur:])
+    return "".join(parts)
+
+
+@dataclass(frozen=True)
+class StructureBreakdown:
+    """Prose-vs-structure measurement of a single prompt."""
+
+    total_chars: int
+    prose_chars: int
+    protected_chars: int
+    prose_words: int
+    protected_blocks: int
+
+
+def analyze(text: str) -> StructureBreakdown:
+    """Measure prose vs protected structure in ``text``."""
+    spans = protected_spans(text)
+    protected_chars = sum(end - start for start, end, _ in spans)
+    prose = prose_text(text)
+    return StructureBreakdown(
+        total_chars=len(text),
+        prose_chars=len(prose),
+        protected_chars=protected_chars,
+        prose_words=len(_WORD_RE.findall(prose)),
+        protected_blocks=len(spans),
+    )
+
+
+def is_candidate(text: str, min_prose_words: int = MIN_PROSE_WORDS) -> bool:
+    """True if ``text`` has enough prose to be worth summarizing."""
+    return analyze(text).prose_words >= min_prose_words

--- a/tokenjam/core/summarize/estimate.py
+++ b/tokenjam/core/summarize/estimate.py
@@ -1,0 +1,29 @@
+"""Per-candidate savings estimate for the summarize surface.
+
+Honesty discipline: this estimates the **per-call token reduction** of
+summarizing a static prompt's prose. It needs no telemetry — tokens are derived
+from the file. The saving amortizes across every reuse of the (cached) prompt.
+
+Dollar figures are deliberately NOT fabricated here: a per-call dollar amount at
+default rates is noise, and the meaningful *amortized* figure needs a real
+call-count (telemetry), which the optional usage-ranked path can add later. The
+token figure is the one we can stand behind from the file alone.
+"""
+from __future__ import annotations
+
+from tokenjam.core.summarize.detect import CHARS_PER_TOKEN, StructureBreakdown
+
+# Summarize prose to ~half its words by default; only prose shrinks.
+DEFAULT_TARGET_RATIO = 0.5
+
+
+def tokens_saved(breakdown: StructureBreakdown, ratio: float = DEFAULT_TARGET_RATIO) -> int:
+    """Estimated tokens removed per call by summarizing the prose to ``ratio``.
+
+    Protected structure (fenced code/JSON, tables, tags, inline code, templates) is preserved
+    verbatim and never counted as savings — only prose shrinks. Returns 0 when ``ratio >= 1``.
+    """
+    if ratio >= 1.0:
+        return 0
+    prose_tokens = breakdown.prose_chars / CHARS_PER_TOKEN
+    return max(0, int(prose_tokens * (1.0 - ratio)))

--- a/tokenjam/mcp/server.py
+++ b/tokenjam/mcp/server.py
@@ -1261,3 +1261,42 @@ def suggest_policies() -> dict:
         return _tool_suggest_policies(_ro_db, _config)
     except Exception as e:
         return {"error": str(e)}
+
+
+def _tool_list_summarize_candidates(config, path=None, recursive=False, repo=False) -> dict:
+    """Advisory summarize scan (no DB, config-only). Powers list_summarize_candidates."""
+    if config is None:
+        return _no_config()
+    from tokenjam.core.summarize.candidates import list_candidates
+    result = list_candidates(path, config=config, recursive=recursive, repo=repo)
+    payload = result.to_dict()
+    if not payload.get("note"):
+        payload["note"] = (
+            "Candidates only — review before adopting. The figure is the "
+            "estimated per-call token reduction (amortizes across reuse)."
+        )
+    return payload
+
+
+@mcp.tool()
+def list_summarize_candidates(
+    path: str | None = None, recursive: bool = False, repo: bool = False,
+) -> dict:
+    """
+    List prompt files worth summarizing — large, prose-heavy CLAUDE.md / AGENTS.md
+    / *.md files under `path` (default: the current project). Returns each
+    candidate's prose word count and the ESTIMATED per-call token reduction from
+    summarizing its prose (structure — fenced & inline code, tags, templates, and
+    tables — is preserved verbatim). Use this when the user asks what prompts they could shrink, where
+    token bloat lives in their static prompts, or wants summarize candidates.
+
+    Advisory only: reads and reports, never rewrites a file. Savings are an
+    estimated per-call reduction that amortizes across every reuse of the cached
+    prompt — candidates to review, not a guarantee the rewrite is safe.
+    """
+    try:
+        return _tool_list_summarize_candidates(
+            _config, path, recursive=recursive, repo=repo,
+        )
+    except Exception as e:
+        return {"error": str(e)}


### PR DESCRIPTION
## Summary

PR1 of the stacked Summarize series — an advisory, read-only scan. `tj summarize list`
and the `list_summarize_candidates` MCP tool find instruction-style prompt files worth
summarizing and report an estimated per-call token saving per file. Nothing is written;
user selection and the prep/check/apply flow come in later PRs.

- **Catalog-default, opt-in reach:** bare `list` = known prompt locations + globals; any
  scope-widening input (PATH / `--repo` / `--recursive` / `--ext`) opens the net to `*.md`
  (+ any `--ext` extensions).
- **Pure-filesystem repo detection** (nearest ancestor `.git`, no git subprocess) with
  boundary safety (never above home / fs-root / a bare top-level). `--recursive` walks only a
  validated root or an explicit PATH, with skip-dirs + a stat pre-filter + a hard file cap.
- **Sectioned, honest output:** scanned location first, always-on catalog globals after a
  divider; prompts rank before other files within each section; reports root + depth +
  globals checked. Framing stays "candidate — review" / "estimated per-call reduction,"
  never "saves you."
- **Config-only:** summarize never opens the DB.

Includes a fix found in review: a missing explicit PATH was silent under `--recursive` (the
recursive branch ran before the not-found check, set the walk root to the non-existent target,
walked it to an empty result, emitted no note). The existence check is now hoisted above the
scope dispatch, so a typo'd PATH reports "PATH not found:" in every mode (plain / `--repo` /
`--recursive`); covered by a regression test.

## Related issue

Part of #329 (Summarize feature series) — first of the stack, so no `Closes`.

## What's NOT in this PR (stacked series)

- `prep`/`check` (wrap → summarize → restore → verify) — next (mechanism) PR
- `apply`/`undo`/backup + skip-already-done — apply PR
- delivery (`--via claude-p` / `--via api`) — delivery PRs
- pre-existing `test_mcp_server.py` import debt (E402/F811) — separate lint chore

## Checklist

- [x] Tests pass (`pytest tests/unit/ tests/synthetic/ tests/agents/ tests/integration/`) — 1208 passed, 2 skipped
- [x] Lint clean (`ruff check tokenjam/`)
- [x] Type check clean (`mypy tokenjam/`)
- [x] CLAUDE.md updated (if architecture changed) — N/A, additive feature, no arch change
- [x] Test spans use tests/factories.py (not raw NormalizedSpan) — N/A, scan tests are filesystem/catalog, no spans
- [ ] Requested @anilmurty as reviewer — set via `--reviewer anilmurty` on PR creation
