### PR TITLE
feat(cli): add read-only tj pricing list command

### DIFF
--- a/tests/unit/test_cmd_pricing.py
+++ b/tests/unit/test_cmd_pricing.py
@@ -52,12 +52,19 @@ _FAKE_TABLE = {
     },
 }
 
+# claude-sonnet-4 comes from an override layer; gpt-4o from the packaged table.
+_FAKE_SOURCES = {
+    ("anthropic", "claude-sonnet-4"): "override",
+    ("openai", "gpt-4o"): "packaged",
+}
+
 
 def test_pricing_list_json_outputs_resolved_rates(runner):
     """--json emits one object per model with the resolved rate fields."""
     with patch("tokenjam.cli.cmd_pricing.load_pricing_table",
                return_value=_FAKE_TABLE), \
-         patch("tokenjam.cli.cmd_pricing._source_map", return_value={}):
+         patch("tokenjam.cli.cmd_pricing.load_pricing_sources",
+               return_value=_FAKE_SOURCES):
         result = _invoke(runner, ["pricing", "list", "--json"])
 
     assert result.exit_code == 0
@@ -72,15 +79,14 @@ def test_pricing_list_json_outputs_resolved_rates(runner):
     assert sonnet["output_per_mtok"] == 15.0
     assert sonnet["cache_read_per_mtok"] == 0.3
     assert sonnet["cache_write_per_mtok"] == 3.75
-    # Not present in the (empty) source map -> falls through to "default".
-    assert sonnet["source"] == "default"
 
 
 def test_pricing_list_model_filter_is_case_insensitive_substring(runner):
     """--model narrows rows to a case-insensitive substring match on model."""
     with patch("tokenjam.cli.cmd_pricing.load_pricing_table",
                return_value=_FAKE_TABLE), \
-         patch("tokenjam.cli.cmd_pricing._source_map", return_value={}):
+         patch("tokenjam.cli.cmd_pricing.load_pricing_sources",
+               return_value=_FAKE_SOURCES):
         result = _invoke(runner, ["pricing", "list", "--model", "CLAUDE", "--json"])
 
     assert result.exit_code == 0
@@ -88,17 +94,16 @@ def test_pricing_list_model_filter_is_case_insensitive_substring(runner):
     assert [row["model"] for row in data] == ["claude-sonnet-4"]
 
 
-def test_pricing_list_source_reflects_override_layer(runner):
-    """A model present in the source map is labelled with that source."""
-    fake_sources = {("anthropic", "claude-sonnet-4"): "override"}
+def test_pricing_list_source_reflects_packaged_and_override(runner):
+    """Each row's source reflects the layer it resolved from."""
     with patch("tokenjam.cli.cmd_pricing.load_pricing_table",
                return_value=_FAKE_TABLE), \
-         patch("tokenjam.cli.cmd_pricing._source_map", return_value=fake_sources):
+         patch("tokenjam.cli.cmd_pricing.load_pricing_sources",
+               return_value=_FAKE_SOURCES):
         result = _invoke(runner, ["pricing", "list", "--json"])
 
     assert result.exit_code == 0
     data = json.loads(result.output)
     by_model = {row["model"]: row for row in data}
     assert by_model["claude-sonnet-4"]["source"] == "override"
-    # gpt-4o isn't in the source map -> "default".
-    assert by_model["gpt-4o"]["source"] == "default"
+    assert by_model["gpt-4o"]["source"] == "packaged"

--- a/tests/unit/test_cmd_pricing.py
+++ b/tests/unit/test_cmd_pricing.py
@@ -1,0 +1,104 @@
+"""Unit tests for `tj pricing list`."""
+from __future__ import annotations
+
+import json
+from unittest.mock import patch
+
+import pytest
+from click.testing import CliRunner
+
+from tokenjam.cli.main import cli
+from tokenjam.core.config import TjConfig
+from tokenjam.core.db import InMemoryBackend
+from tokenjam.core.pricing import ModelRates
+
+
+@pytest.fixture
+def runner():
+    return CliRunner()
+
+
+def _empty_config() -> TjConfig:
+    return TjConfig(version="1")
+
+
+def _invoke(runner, args):
+    """Invoke the CLI with a clean config and an in-memory db patched in."""
+    db = InMemoryBackend()
+    try:
+        with patch("tokenjam.cli.main.load_config", return_value=_empty_config()), \
+             patch("tokenjam.cli.main.open_db", return_value=db):
+            return runner.invoke(cli, args)
+    finally:
+        db.close()
+
+
+# A small, deterministic stand-in for the packaged pricing table so the test
+# doesn't depend on the exact contents of models.toml (which change over time).
+_FAKE_TABLE = {
+    "anthropic": {
+        "claude-sonnet-4": ModelRates(
+            input_per_mtok=3.0,
+            output_per_mtok=15.0,
+            cache_read_per_mtok=0.3,
+            cache_write_per_mtok=3.75,
+        ),
+    },
+    "openai": {
+        "gpt-4o": ModelRates(
+            input_per_mtok=2.5,
+            output_per_mtok=10.0,
+        ),
+    },
+}
+
+
+def test_pricing_list_json_outputs_resolved_rates(runner):
+    """--json emits one object per model with the resolved rate fields."""
+    with patch("tokenjam.cli.cmd_pricing.load_pricing_table",
+               return_value=_FAKE_TABLE), \
+         patch("tokenjam.cli.cmd_pricing._source_map", return_value={}):
+        result = _invoke(runner, ["pricing", "list", "--json"])
+
+    assert result.exit_code == 0
+    data = json.loads(result.output)
+    assert isinstance(data, list)
+    assert len(data) == 2
+
+    by_model = {row["model"]: row for row in data}
+    sonnet = by_model["claude-sonnet-4"]
+    assert sonnet["provider"] == "anthropic"
+    assert sonnet["input_per_mtok"] == 3.0
+    assert sonnet["output_per_mtok"] == 15.0
+    assert sonnet["cache_read_per_mtok"] == 0.3
+    assert sonnet["cache_write_per_mtok"] == 3.75
+    # Not present in the (empty) source map -> falls through to "default".
+    assert sonnet["source"] == "default"
+
+
+def test_pricing_list_model_filter_is_case_insensitive_substring(runner):
+    """--model narrows rows to a case-insensitive substring match on model."""
+    with patch("tokenjam.cli.cmd_pricing.load_pricing_table",
+               return_value=_FAKE_TABLE), \
+         patch("tokenjam.cli.cmd_pricing._source_map", return_value={}):
+        result = _invoke(runner, ["pricing", "list", "--model", "CLAUDE", "--json"])
+
+    assert result.exit_code == 0
+    data = json.loads(result.output)
+    assert [row["model"] for row in data] == ["claude-sonnet-4"]
+
+
+def test_pricing_list_source_reflects_override_layer(runner):
+    """A model present in the source map is labelled with that source."""
+    fake_sources = {("anthropic", "claude-sonnet-4"): "override"}
+    with patch("tokenjam.cli.cmd_pricing.load_pricing_table",
+               return_value=_FAKE_TABLE), \
+         patch("tokenjam.cli.cmd_pricing._source_map", return_value=fake_sources):
+        result = _invoke(runner, ["pricing", "list", "--json"])
+
+    assert result.exit_code == 0
+    data = json.loads(result.output)
+    by_model = {row["model"]: row for row in data}
+    assert by_model["claude-sonnet-4"]["source"] == "override"
+    # gpt-4o isn't in the source map -> "default".
+    assert by_model["gpt-4o"]["source"] == "default"

--- a/tokenjam/cli/cmd_pricing.py
+++ b/tokenjam/cli/cmd_pricing.py
@@ -2,46 +2,8 @@ import json
 
 import click
 
-from tokenjam.core.pricing import (
-    PRICING_FILE,
-    _override_raw_sources,
-    _split_pricing_raw,
-    load_pricing_table,
-)
+from tokenjam.core.pricing import load_pricing_sources, load_pricing_table
 from tokenjam.utils.formatting import console, make_table
-
-try:
-    import tomllib
-except ModuleNotFoundError:  # Python < 3.11
-    import tomli as tomllib  # type: ignore[no-redef]
-
-
-def _source_map() -> dict[tuple[str, str], str]:
-    """Map each (provider, model) to where its rate resolved from.
-
-    Mirrors the precedence in pricing._build_pricing(): override layers win
-    over the packaged models.toml, which wins over the built-in default. A
-    model present in an override layer is labelled "override"; one present
-    only in the packaged table is "packaged"; anything else falls through to
-    "default" (handled by the caller for models not seen in either layer).
-    """
-    sources: dict[tuple[str, str], str] = {}
-
-    # Packaged table (the base layer) -> "packaged".
-    with open(PRICING_FILE, "rb") as fh:
-        packaged_providers, _ = _split_pricing_raw(tomllib.load(fh))
-    for provider, models in packaged_providers.items():
-        for model_name in models:
-            sources[(provider, model_name)] = "packaged"
-
-    # Override layers win over the packaged table -> "override".
-    for raw in _override_raw_sources():
-        override_providers, _ = _split_pricing_raw(raw)
-        for provider, models in override_providers.items():
-            for model_name in models:
-                sources[(provider, model_name)] = "override"
-
-    return sources
 
 
 @click.group("pricing", invoke_without_command=False)
@@ -62,10 +24,13 @@ def cmd_pricing_list(ctx: click.Context, model: str | None,
     output_json: bool = output_json_flag or ctx.obj.get("output_json", False)
 
     table = load_pricing_table()  # {provider: {model: ModelRates}}
-    source_map = _source_map()
+    sources = load_pricing_sources()  # {(provider, model): "override"|"packaged"}
 
     # Flatten the nested table into one row per (provider, model), optionally
-    # filtered by a case-insensitive substring match on the model name.
+    # filtered by a case-insensitive substring match on the model name. Every
+    # listed model is in the resolved table, so its source is "packaged" or
+    # "override" (the built-in default only applies to models absent from the
+    # table, which never appear here); "packaged" is a defensive fallback.
     rows = []
     for provider in sorted(table):
         for model_name in sorted(table[provider]):
@@ -79,7 +44,7 @@ def cmd_pricing_list(ctx: click.Context, model: str | None,
                 "output_per_mtok": rates.output_per_mtok,
                 "cache_read_per_mtok": rates.cache_read_per_mtok,
                 "cache_write_per_mtok": rates.cache_write_per_mtok,
-                "source": source_map.get((provider, model_name), "default"),
+                "source": sources.get((provider, model_name), "packaged"),
             })
 
     if output_json:

--- a/tokenjam/cli/cmd_pricing.py
+++ b/tokenjam/cli/cmd_pricing.py
@@ -1,0 +1,108 @@
+import json
+
+import click
+
+from tokenjam.core.pricing import (
+    PRICING_FILE,
+    _override_raw_sources,
+    _split_pricing_raw,
+    load_pricing_table,
+)
+from tokenjam.utils.formatting import console, make_table
+
+try:
+    import tomllib
+except ModuleNotFoundError:  # Python < 3.11
+    import tomli as tomllib  # type: ignore[no-redef]
+
+
+def _source_map() -> dict[tuple[str, str], str]:
+    """Map each (provider, model) to where its rate resolved from.
+
+    Mirrors the precedence in pricing._build_pricing(): override layers win
+    over the packaged models.toml, which wins over the built-in default. A
+    model present in an override layer is labelled "override"; one present
+    only in the packaged table is "packaged"; anything else falls through to
+    "default" (handled by the caller for models not seen in either layer).
+    """
+    sources: dict[tuple[str, str], str] = {}
+
+    # Packaged table (the base layer) -> "packaged".
+    with open(PRICING_FILE, "rb") as fh:
+        packaged_providers, _ = _split_pricing_raw(tomllib.load(fh))
+    for provider, models in packaged_providers.items():
+        for model_name in models:
+            sources[(provider, model_name)] = "packaged"
+
+    # Override layers win over the packaged table -> "override".
+    for raw in _override_raw_sources():
+        override_providers, _ = _split_pricing_raw(raw)
+        for provider, models in override_providers.items():
+            for model_name in models:
+                sources[(provider, model_name)] = "override"
+
+    return sources
+
+
+@click.group("pricing", invoke_without_command=False)
+def cmd_pricing() -> None:
+    """Inspect the resolved model pricing table (read-only)."""
+
+
+@cmd_pricing.command("list")
+@click.option("--model", default=None,
+              help="Filter to model names containing this substring.")
+@click.option("--json", "output_json_flag", is_flag=True,
+              help="Emit machine-readable JSON.")
+@click.pass_context
+def cmd_pricing_list(ctx: click.Context, model: str | None,
+                     output_json_flag: bool) -> None:
+    """List the resolved per-model rates (input/output/cache, in $/MTok)."""
+    # Honour either `tj --json pricing list` or `tj pricing list --json`.
+    output_json: bool = output_json_flag or ctx.obj.get("output_json", False)
+
+    table = load_pricing_table()  # {provider: {model: ModelRates}}
+    source_map = _source_map()
+
+    # Flatten the nested table into one row per (provider, model), optionally
+    # filtered by a case-insensitive substring match on the model name.
+    rows = []
+    for provider in sorted(table):
+        for model_name in sorted(table[provider]):
+            if model and model.lower() not in model_name.lower():
+                continue
+            rates = table[provider][model_name]
+            rows.append({
+                "provider": provider,
+                "model": model_name,
+                "input_per_mtok": rates.input_per_mtok,
+                "output_per_mtok": rates.output_per_mtok,
+                "cache_read_per_mtok": rates.cache_read_per_mtok,
+                "cache_write_per_mtok": rates.cache_write_per_mtok,
+                "source": source_map.get((provider, model_name), "default"),
+            })
+
+    if output_json:
+        click.echo(json.dumps(rows, indent=2))
+        return
+
+    if not rows:
+        msg = (f"No pricing entries match '{model}'." if model
+               else "No pricing entries found.")
+        console.print(f"[dim]{msg}[/dim]")
+        return
+
+    t = make_table("PROVIDER", "MODEL", "INPUT", "OUTPUT",
+                   "CACHE READ", "CACHE WRITE", "SOURCE")
+    for row in rows:
+        t.add_row(
+            row["provider"],
+            row["model"],
+            f"{row['input_per_mtok']:.2f}",
+            f"{row['output_per_mtok']:.2f}",
+            f"{row['cache_read_per_mtok']:.2f}",
+            f"{row['cache_write_per_mtok']:.2f}",
+            row["source"],
+        )
+    console.print(t)
+    console.print("[dim]Rates are USD per million tokens (MTok).[/dim]")

--- a/tokenjam/cli/main.py
+++ b/tokenjam/cli/main.py
@@ -40,7 +40,7 @@ def cli(ctx: click.Context, config_path: str | None, output_json: bool,
         config.storage.path = db_path
 
     # Commands that don't need a database connection
-    no_db_commands = {"stop", "uninstall", "onboard", "mcp", "demo", "policy", "proxy", "summarize"}
+    no_db_commands = {"stop", "uninstall", "onboard", "mcp", "demo", "policy", "proxy", "summarize", "pricing"}
     invoked = ctx.invoked_subcommand
     if invoked in no_db_commands:
         ctx.obj["config"] = config
@@ -103,6 +103,7 @@ from tokenjam.cli.cmd_tokenmaxx import cmd_tokenmaxx  # noqa: E402
 from tokenjam.cli.cmd_backfill import cmd_backfill  # noqa: E402
 from tokenjam.cli.cmd_report import cmd_report  # noqa: E402
 from tokenjam.cli.cmd_policy import cmd_policy  # noqa: E402
+from tokenjam.cli.cmd_pricing import cmd_pricing  # noqa: E402
 from tokenjam.cli.cmd_proxy import cmd_proxy  # noqa: E402
 
 cli.add_command(cmd_onboard, name="onboard")
@@ -124,6 +125,7 @@ cli.add_command(cmd_tokenmaxx, name="tokenmaxx")
 cli.add_command(cmd_backfill, name="backfill")
 cli.add_command(cmd_report, name="report")
 cli.add_command(cmd_policy, name="policy")
+cli.add_command(cmd_pricing, name="pricing")
 cli.add_command(cmd_proxy, name="proxy")
 
 # cmd_drift is provided by task 05 — register if available

--- a/tokenjam/core/pricing.py
+++ b/tokenjam/core/pricing.py
@@ -187,6 +187,37 @@ def _build_pricing() -> tuple[dict[str, dict[str, ModelRates]], dict[str, ModelR
     return provider_table, model_keyed
 
 
+def load_pricing_sources() -> dict[tuple[str, str], str]:
+    """Map each (provider, model) in the resolved table to its source layer.
+
+    Returns {(provider, model): "override" | "packaged"}, mirroring the
+    precedence in _build_pricing(): the packaged models.toml is the base
+    ("packaged"), and any provider/model present in an override source
+    (see _override_raw_sources) is promoted to "override". This is the
+    single source of truth for *where* a listed rate resolved from; callers
+    (e.g. `tj pricing list`) read it instead of re-deriving precedence.
+
+    Note: the built-in default flat rate is intentionally not represented
+    here -- it applies in get_rates() to models absent from the table, which
+    never appear as listed rows.
+    """
+    sources: dict[tuple[str, str], str] = {}
+
+    with open(PRICING_FILE, "rb") as f:
+        packaged_providers, _ = _split_pricing_raw(tomllib.load(f))
+    for provider, models in packaged_providers.items():
+        for model_name in models:
+            sources[(provider, model_name)] = "packaged"
+
+    for raw in _override_raw_sources():
+        override_providers, _ = _split_pricing_raw(raw)
+        for provider, models in override_providers.items():
+            for model_name in models:
+                sources[(provider, model_name)] = "override"
+
+    return sources
+
+
 @lru_cache(maxsize=1)
 def load_pricing_table() -> dict[str, dict[str, ModelRates]]:
     """


### PR DESCRIPTION
## Summary

read-only tj pricing list, with --json and --model, surfaces the resolved pricing table. Includes a source column (override/packaged/default) derived by comparing the packaged table against the override layers, as described in the issue.

cc @anilmurty

## Related issue

Closes #282

## Checklist

- [ x ] Tests pass (`pytest tests/unit/ tests/synthetic/ tests/agents/ tests/integration/`)
- [ x ] Lint clean (`ruff check tokenjam/`)
- [ x ] Type check clean (`mypy tokenjam/`)
- [ ] CLAUDE.md updated (if architecture changed)
- [ ] Test spans use `tests/factories.py` (not raw `NormalizedSpan`)
- [ x ] Requested `@anilmurty` as reviewer (or @-mentioned him above)
