### PR TITLE
Add Bedrock Nova Micro/Premier, Anthropic-on-Bedrock, and LiteLLM provider pricing entries

### DIFF
--- a/tokenjam/pricing/models.toml
+++ b/tokenjam/pricing/models.toml
@@ -106,6 +106,29 @@ output_per_mtok = 3.20
 input_per_mtok = 0.06
 output_per_mtok = 0.24
 
+[aws.us-amazon-nova-micro-v1]
+input_per_mtok = 0.035
+output_per_mtok = 0.14
+
+[aws.us-amazon-nova-premier-v1]
+input_per_mtok = 2.50
+output_per_mtok = 12.50
+
+# Anthropic-on-Bedrock (model IDs use the region/geo profile prefix, dots
+# flattened to hyphens, trailing ":N" version stripped — matches how
+# BedrockIntegration reports modelId). Rates match direct Anthropic API.
+[aws.us-anthropic-claude-opus-4-1-20250805-v1]
+input_per_mtok = 15.00
+output_per_mtok = 75.00
+cache_read_per_mtok = 1.50
+cache_write_per_mtok = 18.75
+
+[aws.global-anthropic-claude-opus-4-5-20251101-v1]
+input_per_mtok = 5.00
+output_per_mtok = 25.00
+cache_read_per_mtok = 0.50
+cache_write_per_mtok = 6.25
+
 # OpenAI-compatible providers (Groq, Together, Fireworks, xAI, Azure OpenAI)
 # use patch_openai() with a custom base_url — add their model names here
 # as they are encountered.
@@ -117,6 +140,24 @@ output_per_mtok = 0.79
 [xai.grok-3]
 input_per_mtok = 3.00
 output_per_mtok = 15.00
+
+[mistral.mistral-large-latest]
+input_per_mtok = 0.50
+output_per_mtok = 1.50
+
+[deepseek.deepseek-chat]
+input_per_mtok = 0.14
+output_per_mtok = 0.28
+cache_read_per_mtok = 0.0028
+
+[deepseek.deepseek-reasoner]
+input_per_mtok = 0.14
+output_per_mtok = 0.28
+cache_read_per_mtok = 0.0028
+
+[cohere.command-r-plus]
+input_per_mtok = 2.50
+output_per_mtok = 10.00
 
 # HUD managed inference (inference.hud.ai)
 [hud.claude-sonnet-4-5]


### PR DESCRIPTION
…vider pricing entries

Closes #311

## Summary

Fills in previously-missing AWS Bedrock pricing entries (Nova Micro, Nova Premier,
Anthropic-on-Bedrock via the Opus 4.1 US profile and Opus 4.5 global profile) and
adds three commonly-used LiteLLM-routed providers (Mistral Large, DeepSeek
Chat/Reasoner, Cohere Command R+) to the packaged pricing table, following the
existing [provider.model] structure with verified current rates.

@anilmurty

## Related issue

Closes #311

## Checklist

- [x] Tests pass (`pytest tests/unit/ tests/synthetic/ tests/agents/ tests/integration/`)
- [x] Lint clean (`ruff check tokenjam/`)
- [ ] Type check clean (`mypy tokenjam/`)
- [ ] CLAUDE.md updated (if architecture changed)
- [ ] Test spans use `tests/factories.py` (not raw `NormalizedSpan`)
- [x] Requested `@anilmurty` as reviewer (or @-mentioned him above)
