### PR TITLE
fix: Claude Code session status + lifecycle (1/5 from #306)

### DIFF
--- a/tests/factories.py
+++ b/tests/factories.py
@@ -8,8 +8,47 @@ from tokenjam.core.models import (
     NormalizedSpan, SessionRecord,
     SpanStatus, SpanKind,
 )
+from tokenjam.otel.semconv import GenAIAttributes
 from tokenjam.utils.ids import new_uuid, new_trace_id, new_span_id
 from tokenjam.utils.time_parse import utcnow
+
+
+def make_invoke_agent_span(
+    agent_id: str = "test-agent",
+    session_id: str | None = None,
+    conversation_id: str | None = None,
+    duration_ms: float = 0.0,
+    start_time=None,
+    trace_id: str | None = None,
+    service_namespace: str | None = None,
+) -> NormalizedSpan:
+    """Create an ``invoke_agent`` span.
+
+    ``duration_ms == 0`` -> a zero-duration turn-start marker, exactly what the
+    Claude Code / Codex logs path emits for every ``user_prompt`` event
+    (``end_time == start_time``). These mark the *start* of a turn and must NOT
+    complete the session.
+
+    ``duration_ms > 0`` -> a real session-wrapping span, what the SDK
+    ``@watch()`` path emits to bracket a whole agent run. This DOES complete the
+    session.
+    """
+    now = start_time or utcnow()
+    end = now + timedelta(milliseconds=duration_ms)
+    return NormalizedSpan(
+        span_id=new_span_id(),
+        trace_id=trace_id or new_trace_id(),
+        name=GenAIAttributes.SPAN_INVOKE_AGENT,
+        kind=SpanKind.SERVER,
+        status_code=SpanStatus.OK,
+        start_time=now,
+        end_time=end,
+        duration_ms=duration_ms if duration_ms else None,
+        agent_id=agent_id,
+        session_id=session_id,
+        conversation_id=conversation_id,
+        service_namespace=service_namespace,
+    )
 
 
 def make_llm_span(
@@ -33,6 +72,8 @@ def make_llm_span(
     billing_account: str | None = "anthropic",
     request_params: dict | None = None,
     request_tools: dict | None = None,
+    service_namespace: str | None = None,
+    service_instance_id: str | None = None,
 ) -> NormalizedSpan:
     """
     Create a NormalizedSpan representing a single LLM call.
@@ -73,6 +114,8 @@ def make_llm_span(
         billing_account=billing_account,
         request_params=request_params,
         request_tools=request_tools,
+        service_namespace=service_namespace,
+        service_instance_id=service_instance_id,
     )
 
 
@@ -119,6 +162,10 @@ def make_session(
     status: str = "completed",
     duration_seconds: float = 60.0,
     plan_tier: str = "api",
+    started_at=None,
+    ended_at=None,
+    service_namespace: str | None = None,
+    service_instance_id: str | None = None,
 ) -> SessionRecord:
     """
     Create a SessionRecord with sensible defaults.
@@ -126,15 +173,26 @@ def make_session(
     `plan_tier` defaults to "api" so existing tests see dollar figures
     rendered normally (least-disruption). Tests for subscription / local /
     unknown rendering paths should pass it explicitly.
+
+    Pass `started_at` / `ended_at` to control the timeline explicitly (e.g.
+    to test ordering by last activity, or the idle/stale lifecycle tiers);
+    otherwise they derive from `duration_seconds` ending at "now".
+
+    `service_instance_id` sets the per-terminal label (used by close-by-instance
+    and session-lifecycle tests); `service_namespace` sets the project grouping.
     """
     now = utcnow()
-    started = now - timedelta(seconds=duration_seconds)
+    started = started_at or (now - timedelta(seconds=duration_seconds))
+    if ended_at is not None:
+        ended = ended_at
+    else:
+        ended = now if status == "completed" else None
 
     return SessionRecord(
         session_id=session_id or new_uuid(),
         agent_id=agent_id,
         started_at=started,
-        ended_at=now if status == "completed" else None,
+        ended_at=ended,
         conversation_id=conversation_id or new_uuid(),
         status=status,
         total_cost_usd=total_cost_usd,
@@ -143,6 +201,8 @@ def make_session(
         tool_call_count=tool_call_count,
         error_count=error_count,
         plan_tier=plan_tier,
+        service_namespace=service_namespace,
+        service_instance_id=service_instance_id,
     )
 
 

--- a/tests/integration/test_api.py
+++ b/tests/integration/test_api.py
@@ -19,7 +19,12 @@ from tokenjam.core.config import (
 )
 from tokenjam.core.db import InMemoryBackend
 from tokenjam.core.ingest import IngestPipeline
-from tests.factories import make_llm_span, make_session, make_tool_span
+from tests.factories import (
+    make_invoke_agent_span,
+    make_llm_span,
+    make_session,
+    make_tool_span,
+)
 
 
 INGEST_SECRET = "test-secret-token"
@@ -652,9 +657,14 @@ async def test_span_without_agent_id_normalizes_to_unknown(client):
     trace_agents = [t["agent_id"] for t in traces.json()["traces"]]
     assert "unknown" in trace_agents
 
-    # Verify sessions table agrees
+    # Verify sessions table agrees. The OTLP span carries an old timestamp, so
+    # the session is stale and surfaces in the archive (not a live tile).
     status = await client.get("/api/v1/status")
-    status_agents = [a["agent_id"] for a in status.json()["agents"]]
+    body_json = status.json()
+    status_agents = (
+        {a["agent_id"] for a in body_json["agents"]}
+        | {s["agent_id"] for s in body_json["archived"]}
+    )
     assert "unknown" in status_agents
 
 
@@ -675,16 +685,32 @@ async def test_status_and_traces_agree_on_agent_ids(client):
     status = await client.get("/api/v1/status")
     traces = await client.get("/api/v1/traces")
 
-    status_agents = {a["agent_id"] for a in status.json()["agents"]}
+    sj = status.json()
+    # An agent's sessions can be live (agents) or archived (closed/stale); the
+    # full set of known agent ids is the union of both.
+    status_agents = (
+        {a["agent_id"] for a in sj["agents"]}
+        | {s["agent_id"] for s in sj["archived"]}
+    )
     trace_agents = {t["agent_id"] for t in traces.json()["traces"]}
     assert trace_agents == status_agents
 
 
 async def test_status_exposes_active_seconds(client, db):
-    """Status payload carries active (compute) time alongside wall-clock (#147)."""
-    from tests.factories import make_llm_span, make_session
+    """Status payload carries active (compute) time alongside wall-clock (#147).
 
-    db.upsert_session(make_session(agent_id="a1", session_id="s1", status="completed"))
+    The status payload surfaces current (active/idle) sessions as tiles, so the
+    session must be active with recent activity to carry active_seconds.
+    """
+    from datetime import timedelta
+
+    from tests.factories import make_llm_span, make_session
+    from tokenjam.utils.time_parse import utcnow
+
+    now = utcnow()
+    db.upsert_session(make_session(
+        agent_id="a1", session_id="s1", status="active",
+        started_at=now - timedelta(minutes=2), ended_at=now - timedelta(minutes=1)))
     for ms in (1000.0, 2000.0, 3000.0):
         sp = make_llm_span(agent_id="a1", duration_ms=ms)
         sp.session_id = "s1"
@@ -751,3 +777,465 @@ async def test_post_budget_zero_clears_limit(db):
     assert resp.status_code == 200
     agent = resp.json()["agents"]["my-agent"]
     assert agent["configured"]["daily_usd"] is None  # limit was cleared
+
+
+# ===========================================================================
+# Status route: concurrent live sessions each get a tile, read as active
+#
+# Claude Code's logs path emits a zero-duration invoke_agent marker per user
+# prompt and never an explicit end. Each live terminal is its own session;
+# the status route surfaces one tile per recently-active session (not a single
+# collapsed/"completed" tile). Uses DuckDBBackend because /status reads via
+# db.conn.
+# ===========================================================================
+
+@pytest.mark.asyncio
+async def test_status_shows_live_session_over_empty_marker(tmp_path):
+    from tokenjam.core.db import DuckDBBackend
+    from tokenjam.core.config import StorageConfig
+    from tokenjam.core.models import AgentRecord
+    from tokenjam.utils.time_parse import utcnow
+
+    db = DuckDBBackend(StorageConfig(path=str(tmp_path / "t.duckdb")))
+    try:
+        config = TjConfig(
+            version="1",
+            security=SecurityConfig(ingest_secret=INGEST_SECRET),
+            api=ApiConfig(auth=ApiAuthConfig(enabled=False)),
+        )
+        pipeline = IngestPipeline(db=db, config=config)
+        now = utcnow()
+        db.upsert_agent(AgentRecord(agent_id="claude-code", first_seen=now, last_seen=now))
+
+        # Live session: turn-start marker + real LLM activity.
+        pipeline.process(make_invoke_agent_span(
+            agent_id="claude-code", session_id="live", conversation_id="c1", duration_ms=0.0))
+        pipeline.process(make_llm_span(
+            agent_id="claude-code", session_id="live", conversation_id="c1",
+            input_tokens=19562, output_tokens=1321, cost_usd=0.17))
+        # A newer but EMPTY marker session (used to win the tile and show 0/0).
+        pipeline.process(make_invoke_agent_span(
+            agent_id="claude-code", session_id="empty", conversation_id="c2", duration_ms=0.0))
+
+        app = create_app(config=config, db=db, ingest_pipeline=pipeline)
+        transport = httpx.ASGITransport(app=app)
+        async with httpx.AsyncClient(transport=transport, base_url="http://test") as c:
+            resp = await c.get("/api/v1/status")
+
+        assert resp.status_code == 200
+        # Concurrent active sessions each get their own tile (one per terminal).
+        cc_tiles = [a for a in resp.json()["agents"] if a["agent_id"] == "claude-code"]
+        by_session = {a["session_id"]: a for a in cc_tiles}
+        assert "live" in by_session and "empty" in by_session
+        live = by_session["live"]
+        assert live["status"] == "active"
+        assert live["input_tokens"] == 19562
+        assert live["output_tokens"] == 1321
+        # The just-started marker session is its own tile with no work yet.
+        assert by_session["empty"]["input_tokens"] == 0
+    finally:
+        db.close()
+
+
+@pytest.mark.asyncio
+async def test_status_returns_service_namespace(tmp_path):
+    """The status tile carries service.namespace so the dashboard groups by project."""
+    from tokenjam.core.db import DuckDBBackend
+    from tokenjam.core.config import StorageConfig
+    from tokenjam.core.models import AgentRecord
+    from tokenjam.utils.time_parse import utcnow
+
+    db = DuckDBBackend(StorageConfig(path=str(tmp_path / "t.duckdb")))
+    try:
+        config = TjConfig(
+            version="1",
+            security=SecurityConfig(ingest_secret=INGEST_SECRET),
+            api=ApiConfig(auth=ApiAuthConfig(enabled=False)),
+        )
+        pipeline = IngestPipeline(db=db, config=config)
+        now = utcnow()
+        db.upsert_agent(AgentRecord(agent_id="claude-code-harness", first_seen=now, last_seen=now))
+        pipeline.process(make_llm_span(
+            agent_id="claude-code-harness", session_id="s1",
+            service_namespace="aquanode"))
+
+        app = create_app(config=config, db=db, ingest_pipeline=pipeline)
+        transport = httpx.ASGITransport(app=app)
+        async with httpx.AsyncClient(transport=transport, base_url="http://test") as c:
+            resp = await c.get("/api/v1/status")
+
+        assert resp.status_code == 200
+        agents = {a["agent_id"]: a for a in resp.json()["agents"]}
+        assert agents["claude-code-harness"]["namespace"] == "aquanode"
+    finally:
+        db.close()
+
+
+@pytest.mark.asyncio
+async def test_status_namespace_falls_back_to_configured_project(tmp_path):
+    """Archived sessions with no per-session namespace still group via
+    [agents.<id>].project.
+
+    Covers the already-running session case: no service.namespace ever arrived
+    on the wire, but the server-side project mapping groups it anyway. A closed
+    session is no longer a live tile, so the fallback must apply to the archive.
+    """
+    from tokenjam.core.db import DuckDBBackend
+    from tokenjam.core.config import StorageConfig, AgentConfig
+    from tokenjam.core.models import AgentRecord
+    from tokenjam.utils.time_parse import utcnow
+
+    db = DuckDBBackend(StorageConfig(path=str(tmp_path / "t.duckdb")))
+    try:
+        config = TjConfig(
+            version="1",
+            security=SecurityConfig(ingest_secret=INGEST_SECRET),
+            api=ApiConfig(auth=ApiAuthConfig(enabled=False)),
+            agents={"claude-code-harness": AgentConfig(project="aquanode")},
+        )
+        pipeline = IngestPipeline(db=db, config=config)
+        now = utcnow()
+        db.upsert_agent(AgentRecord(agent_id="claude-code-harness", first_seen=now, last_seen=now))
+        # Pre-existing session with NO namespace (collected before the mapping).
+        # tool_call_count=1 so it clears the archive's 0-signal zombie filter.
+        db.upsert_session(make_session(
+            agent_id="claude-code-harness", session_id="s1", status="closed",
+            tool_call_count=1))
+
+        app = create_app(config=config, db=db, ingest_pipeline=pipeline)
+        transport = httpx.ASGITransport(app=app)
+        async with httpx.AsyncClient(transport=transport, base_url="http://test") as c:
+            resp = await c.get("/api/v1/status")
+
+        assert resp.status_code == 200
+        # Closed session -> archive, not a live tile.
+        assert resp.json()["agents"] == []
+        archived = {s["session_id"]: s for s in resp.json()["archived"]}
+        assert archived["s1"]["namespace"] == "aquanode"
+        assert archived["s1"]["status"] == "closed"
+    finally:
+        db.close()
+
+
+@pytest.mark.asyncio
+async def test_status_one_tile_per_concurrent_session(tmp_path):
+    """Three concurrent terminals under one agent each get a tile, grouped by project."""
+    from tokenjam.core.db import DuckDBBackend
+    from tokenjam.core.config import StorageConfig, AgentConfig
+    from tokenjam.core.models import AgentRecord
+    from tokenjam.utils.time_parse import utcnow
+
+    db = DuckDBBackend(StorageConfig(path=str(tmp_path / "t.duckdb")))
+    try:
+        config = TjConfig(
+            version="1",
+            security=SecurityConfig(ingest_secret=INGEST_SECRET),
+            api=ApiConfig(auth=ApiAuthConfig(enabled=False)),
+            agents={"claude-code-harness": AgentConfig(project="aquanode")},
+        )
+        pipeline = IngestPipeline(db=db, config=config)
+        now = utcnow()
+        db.upsert_agent(AgentRecord(agent_id="claude-code-harness", first_seen=now, last_seen=now))
+        # Three live terminals = three session ids under one agent.
+        for sid, intok in [("term-a", 100), ("term-b", 200), ("term-c", 300)]:
+            pipeline.process(make_llm_span(
+                agent_id="claude-code-harness", session_id=sid, conversation_id=sid,
+                input_tokens=intok, output_tokens=10))
+
+        app = create_app(config=config, db=db, ingest_pipeline=pipeline)
+        transport = httpx.ASGITransport(app=app)
+        async with httpx.AsyncClient(transport=transport, base_url="http://test") as c:
+            resp = await c.get("/api/v1/status")
+
+        assert resp.status_code == 200
+        tiles = [a for a in resp.json()["agents"] if a["agent_id"] == "claude-code-harness"]
+        assert len(tiles) == 3
+        assert {t["session_id"] for t in tiles} == {"term-a", "term-b", "term-c"}
+        assert all(t["namespace"] == "aquanode" for t in tiles)
+        assert all(t["status"] == "active" for t in tiles)
+        assert {t["session_id"]: t["input_tokens"] for t in tiles} == {
+            "term-a": 100, "term-b": 200, "term-c": 300,
+        }
+    finally:
+        db.close()
+
+
+@pytest.mark.asyncio
+async def test_status_session_labels(tmp_path):
+    """Session label resolves: manual override > service.instance.id > short id."""
+    from tokenjam.core.db import DuckDBBackend
+    from tokenjam.core.config import StorageConfig, AgentConfig
+    from tokenjam.core.models import AgentRecord
+    from tokenjam.utils.time_parse import utcnow
+
+    db = DuckDBBackend(StorageConfig(path=str(tmp_path / "t.duckdb")))
+    try:
+        config = TjConfig(
+            version="1",
+            security=SecurityConfig(ingest_secret=INGEST_SECRET),
+            api=ApiConfig(auth=ApiAuthConfig(enabled=False)),
+            agents={"claude-code-harness": AgentConfig(project="aquanode")},
+            # prefix override for a current terminal; "ovr" overrides instance.id
+            session_labels={"manual": "harness", "ovr": "config-wins"},
+        )
+        pipeline = IngestPipeline(db=db, config=config)
+        now = utcnow()
+        db.upsert_agent(AgentRecord(agent_id="claude-code-harness", first_seen=now, last_seen=now))
+        # instance.id on the wire -> durable label
+        pipeline.process(make_llm_span(
+            agent_id="claude-code-harness", session_id="wired", conversation_id="w",
+            service_instance_id="founder-os"))
+        # manual config prefix label only
+        pipeline.process(make_llm_span(
+            agent_id="claude-code-harness", session_id="manual-123", conversation_id="m"))
+        # both present -> manual override wins
+        pipeline.process(make_llm_span(
+            agent_id="claude-code-harness", session_id="ovr-9", conversation_id="o",
+            service_instance_id="wire-name"))
+        # neither -> label is None (UI falls back to short id)
+        pipeline.process(make_llm_span(
+            agent_id="claude-code-harness", session_id="plain", conversation_id="p"))
+
+        app = create_app(config=config, db=db, ingest_pipeline=pipeline)
+        transport = httpx.ASGITransport(app=app)
+        async with httpx.AsyncClient(transport=transport, base_url="http://test") as c:
+            resp = await c.get("/api/v1/status")
+
+        assert resp.status_code == 200
+        by = {a["session_id"]: a for a in resp.json()["agents"]
+              if a["agent_id"] == "claude-code-harness"}
+        assert by["wired"]["label"] == "founder-os"      # from instance.id
+        assert by["manual-123"]["label"] == "harness"    # from config prefix
+        assert by["ovr-9"]["label"] == "config-wins"     # config beats instance.id
+        assert by["plain"]["label"] is None              # no label
+    finally:
+        db.close()
+
+
+# ===========================================================================
+# Session lifecycle: active/idle tiers as tiles, closed/stale archived, cap.
+# ===========================================================================
+
+def _lifecycle_app(tmp_path, agents=None):
+    """A DuckDB-backed app for session-lifecycle tests (status reads db.conn)."""
+    from tokenjam.core.db import DuckDBBackend
+    from tokenjam.core.config import StorageConfig
+
+    db = DuckDBBackend(StorageConfig(path=str(tmp_path / "t.duckdb")))
+    config = TjConfig(
+        version="1",
+        security=SecurityConfig(ingest_secret=INGEST_SECRET),
+        api=ApiConfig(auth=ApiAuthConfig(enabled=False)),
+        agents=agents or {},
+    )
+    pipeline = IngestPipeline(db=db, config=config)
+    app = create_app(config=config, db=db, ingest_pipeline=pipeline)
+    return db, app
+
+
+@pytest.mark.asyncio
+async def test_status_active_and_idle_become_tiles_stale_archived(tmp_path):
+    from datetime import timedelta
+    from tokenjam.utils.time_parse import utcnow
+
+    db, app = _lifecycle_app(tmp_path)
+    try:
+        now = utcnow()
+        db.upsert_session(make_session(
+            agent_id="cc", session_id="act", status="active",
+            started_at=now - timedelta(minutes=2), ended_at=now - timedelta(minutes=1)))
+        db.upsert_session(make_session(
+            agent_id="cc", session_id="idl", status="active",
+            started_at=now - timedelta(minutes=40), ended_at=now - timedelta(minutes=30)))
+        db.upsert_session(make_session(
+            agent_id="cc", session_id="stl", status="active", tool_call_count=1,
+            started_at=now - timedelta(hours=6), ended_at=now - timedelta(hours=5)))
+
+        transport = httpx.ASGITransport(app=app)
+        async with httpx.AsyncClient(transport=transport, base_url="http://test") as c:
+            resp = await c.get("/api/v1/status")
+
+        assert resp.status_code == 200
+        sj = resp.json()
+        tiles = {a["session_id"]: a for a in sj["agents"]}
+        assert set(tiles) == {"act", "idl"}            # only active + idle
+        assert tiles["act"]["status"] == "active"
+        assert tiles["idl"]["status"] == "idle"
+        archived = {s["session_id"]: s for s in sj["archived"]}
+        assert "stl" in archived and archived["stl"]["status"] == "stale"
+        assert "act" not in archived and "idl" not in archived
+    finally:
+        db.close()
+
+
+@pytest.mark.asyncio
+async def test_status_no_fallback_tile_for_completed_or_closed(tmp_path):
+    db, app = _lifecycle_app(tmp_path)
+    try:
+        db.upsert_session(make_session(
+            agent_id="cc", session_id="done", status="completed"))
+        # tool_call_count=1 so "shut" clears the archive's 0-signal zombie filter.
+        db.upsert_session(make_session(
+            agent_id="cc", session_id="shut", status="closed", tool_call_count=1))
+
+        transport = httpx.ASGITransport(app=app)
+        async with httpx.AsyncClient(transport=transport, base_url="http://test") as c:
+            resp = await c.get("/api/v1/status")
+
+        sj = resp.json()
+        # No active/idle session for this agent -> no current tile at all.
+        assert sj["agents"] == []
+        archived = {s["session_id"]: s["status"] for s in sj["archived"]}
+        # Closed lands in the archive; completed is neither current nor archived.
+        assert archived.get("shut") == "closed"
+        assert "done" not in archived
+    finally:
+        db.close()
+
+
+@pytest.mark.asyncio
+async def test_status_caps_tiles_per_agent_and_reports_overflow(tmp_path):
+    from datetime import timedelta
+    from tokenjam.utils.time_parse import utcnow
+
+    db, app = _lifecycle_app(tmp_path)
+    try:
+        now = utcnow()
+        for i in range(9):
+            db.upsert_session(make_session(
+                agent_id="cc", session_id=f"s{i}", status="active",
+                started_at=now - timedelta(seconds=30 + i),
+                ended_at=now - timedelta(seconds=i)))
+
+        transport = httpx.ASGITransport(app=app)
+        async with httpx.AsyncClient(transport=transport, base_url="http://test") as c:
+            resp = await c.get("/api/v1/status")
+
+        tiles = [a for a in resp.json()["agents"] if a["agent_id"] == "cc"]
+        assert len(tiles) == 6                 # MAX_SESSION_TILES
+        assert all(t["overflow"] == 3 for t in tiles)  # 9 - 6 surfaced, not dropped
+    finally:
+        db.close()
+
+
+@pytest.mark.asyncio
+async def test_close_sessions_by_instance_marks_closed_idempotent(tmp_path):
+    db, app = _lifecycle_app(tmp_path)
+    try:
+        from tokenjam.utils.time_parse import utcnow
+        now = utcnow()
+        for sid in ("s1", "s2"):
+            db.upsert_session(make_session(
+                agent_id="cc", session_id=sid, status="active",
+                service_instance_id="term-x", ended_at=now))
+        db.upsert_session(make_session(
+            agent_id="cc", session_id="s3", status="active",
+            service_instance_id="other", ended_at=now))
+
+        transport = httpx.ASGITransport(app=app)
+        async with httpx.AsyncClient(transport=transport, base_url="http://test") as c:
+            resp = await c.post(
+                "/api/v1/sessions/close", json={"instance_id": "term-x"},
+                headers={"Authorization": f"Bearer {INGEST_SECRET}"})
+            assert resp.status_code == 200
+            assert resp.json()["closed"] == 2
+            # Re-closing is a no-op (idempotent).
+            resp2 = await c.post(
+                "/api/v1/sessions/close", json={"instance_id": "term-x"},
+                headers={"Authorization": f"Bearer {INGEST_SECRET}"})
+            assert resp2.json()["closed"] == 0
+
+        assert db.get_session("s1").status == "closed"
+        assert db.get_session("s2").status == "closed"
+        assert db.get_session("s3").status == "active"   # different instance
+    finally:
+        db.close()
+
+
+@pytest.mark.asyncio
+async def test_close_preserves_last_activity_ended_at(tmp_path):
+    # ended_at is the session's last-activity ("Last seen") time. Closing a
+    # session long after its last span must NOT advance ended_at to the close
+    # moment — regression for the close-bumps-last-seen bug.
+    db, app = _lifecycle_app(tmp_path)
+    try:
+        from datetime import timedelta
+        from tokenjam.utils.time_parse import utcnow
+        last_active = utcnow() - timedelta(days=2)
+        db.upsert_session(make_session(
+            agent_id="cc", session_id="old", status="active",
+            ended_at=last_active))
+        transport = httpx.ASGITransport(app=app)
+        async with httpx.AsyncClient(transport=transport, base_url="http://test") as c:
+            resp = await c.post(
+                "/api/v1/sessions/close", json={"session_id": "old"},
+                headers={"Authorization": f"Bearer {INGEST_SECRET}"})
+            assert resp.json()["closed"] == 1
+        s = db.get_session("old")
+        assert s.status == "closed"
+        assert s.ended_at == last_active   # unchanged, not bumped to "now"
+    finally:
+        db.close()
+
+
+@pytest.mark.asyncio
+async def test_close_stamps_ended_at_when_null(tmp_path):
+    # A session that never recorded an end time gets the close time stamped.
+    db, app = _lifecycle_app(tmp_path)
+    try:
+        db.upsert_session(make_session(
+            agent_id="cc", session_id="noend", status="active", ended_at=None))
+        assert db.get_session("noend").ended_at is None
+        transport = httpx.ASGITransport(app=app)
+        async with httpx.AsyncClient(transport=transport, base_url="http://test") as c:
+            resp = await c.post(
+                "/api/v1/sessions/close", json={"session_id": "noend"},
+                headers={"Authorization": f"Bearer {INGEST_SECRET}"})
+            assert resp.json()["closed"] == 1
+        assert db.get_session("noend").ended_at is not None
+    finally:
+        db.close()
+
+
+@pytest.mark.asyncio
+async def test_close_session_by_id(tmp_path):
+    db, app = _lifecycle_app(tmp_path)
+    try:
+        db.upsert_session(make_session(
+            agent_id="cc", session_id="s1", status="active"))
+        transport = httpx.ASGITransport(app=app)
+        async with httpx.AsyncClient(transport=transport, base_url="http://test") as c:
+            resp = await c.post(
+                "/api/v1/sessions/close", json={"session_id": "s1"},
+                headers={"Authorization": f"Bearer {INGEST_SECRET}"})
+        assert resp.json()["closed"] == 1
+        assert db.get_session("s1").status == "closed"
+    finally:
+        db.close()
+
+
+@pytest.mark.asyncio
+async def test_close_sessions_requires_ingest_secret(tmp_path):
+    db, app = _lifecycle_app(tmp_path)
+    try:
+        transport = httpx.ASGITransport(app=app)
+        async with httpx.AsyncClient(transport=transport, base_url="http://test") as c:
+            resp = await c.post(
+                "/api/v1/sessions/close", json={"instance_id": "term-x"})
+        assert resp.status_code == 401
+    finally:
+        db.close()
+
+
+@pytest.mark.asyncio
+async def test_close_sessions_requires_an_id(tmp_path):
+    db, app = _lifecycle_app(tmp_path)
+    try:
+        transport = httpx.ASGITransport(app=app)
+        async with httpx.AsyncClient(transport=transport, base_url="http://test") as c:
+            resp = await c.post(
+                "/api/v1/sessions/close", json={},
+                headers={"Authorization": f"Bearer {INGEST_SECRET}"})
+        assert resp.status_code == 400
+    finally:
+        db.close()

--- a/tests/integration/test_cli.py
+++ b/tests/integration/test_cli.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 
 import json
 import subprocess
+from pathlib import Path
 from unittest.mock import patch
 
 import pytest
@@ -556,7 +557,7 @@ def test_onboard_claude_code_writes_settings(runner, tmp_path):
     with patch("tokenjam.cli.cmd_onboard.find_config_file", return_value=None), \
          patch("tokenjam.cli.cmd_onboard.Path.home", return_value=fake_home), \
          patch("tokenjam.cli.cmd_onboard.click.confirm", return_value=False):
-        result = runner.invoke(cli, ["onboard", "--claude-code", "--no-daemon", "--budget", "5.0", "--plan", "max_20x"])
+        result = runner.invoke(cli, ["onboard", "--claude-code", "--no-daemon", "--budget", "5.0", "--plan", "max_20x", "--project", "aquanode"])
 
     assert result.exit_code == 0
     assert settings_path.exists()
@@ -580,7 +581,7 @@ def test_onboard_claude_code_preserves_existing(runner, tmp_path):
     with patch("tokenjam.cli.cmd_onboard.find_config_file", return_value=None), \
          patch("tokenjam.cli.cmd_onboard.Path.home", return_value=fake_home), \
          patch("tokenjam.cli.cmd_onboard.click.confirm", return_value=False):
-        runner.invoke(cli, ["onboard", "--claude-code", "--no-daemon", "--budget", "5.0", "--plan", "max_20x"])
+        runner.invoke(cli, ["onboard", "--claude-code", "--no-daemon", "--budget", "5.0", "--plan", "max_20x", "--project", "aquanode"])
 
     data = json.loads(settings_path.read_text())
     # Original top-level key preserved
@@ -600,7 +601,7 @@ def test_onboard_claude_code_creates_tj_config(runner, tmp_path):
          patch("tokenjam.cli.cmd_onboard.Path.home", return_value=fake_home), \
          patch("tokenjam.cli.cmd_onboard.click.confirm", return_value=False), \
          patch("tokenjam.core.config.write_config") as mock_write:
-        runner.invoke(cli, ["onboard", "--claude-code", "--no-daemon", "--budget", "5.0", "--plan", "max_20x"])
+        runner.invoke(cli, ["onboard", "--claude-code", "--no-daemon", "--budget", "5.0", "--plan", "max_20x", "--project", "aquanode"])
 
     # write_config should have been called with an TjConfig containing a claude-code-* agent
     assert mock_write.called
@@ -617,13 +618,94 @@ def test_onboard_claude_code_prompts_for_budget(runner, tmp_path):
          patch("tokenjam.cli.cmd_onboard.Path.home", return_value=fake_home), \
          patch("tokenjam.cli.cmd_onboard.click.confirm", return_value=False), \
          patch("tokenjam.core.config.write_config") as mock_write:
-        result = runner.invoke(cli, ["onboard", "--claude-code", "--no-daemon", "--plan", "max_20x"], input="7.0\n")
+        result = runner.invoke(cli, ["onboard", "--claude-code", "--no-daemon", "--plan", "max_20x", "--project", "aquanode"], input="7.0\n")
 
     assert result.exit_code == 0
     assert mock_write.called
     saved_config = mock_write.call_args[0][0]
     agent_id = next(k for k in saved_config.agents if k.startswith("claude-code-"))
     assert saved_config.agents[agent_id].budget.daily_usd == 7.0
+
+
+def test_onboard_claude_code_project_flag_sets_config_project(runner, tmp_path):
+    """--project sets [agents.<id>].project in config and does NOT write
+    OTEL_RESOURCE_ATTRIBUTES into project settings (the claude wrapper owns it)."""
+    from tokenjam.core.config import load_config
+
+    fake_home = tmp_path / "home"
+    fake_home.mkdir()
+
+    with runner.isolated_filesystem() as cwd, \
+         patch("tokenjam.cli.cmd_onboard.find_config_file", return_value=None), \
+         patch("tokenjam.cli.cmd_onboard.Path.home", return_value=fake_home), \
+         patch("tokenjam.cli.cmd_onboard.click.confirm", return_value=False):
+        result = runner.invoke(cli, [
+            "onboard", "--claude-code", "--no-daemon", "--budget", "5.0",
+            "--plan", "max_20x", "--project", "aquanode",
+        ])
+        assert result.exit_code == 0
+        env = json.loads(
+            (Path(cwd) / ".claude" / "settings.json").read_text()
+        ).get("env", {})
+        assert "OTEL_RESOURCE_ATTRIBUTES" not in env
+
+    cfg = load_config(str(fake_home / ".config" / "tj" / "config.toml"))
+    agent_id = next(k for k in cfg.agents if k.startswith("claude-code-"))
+    assert cfg.agents[agent_id].project == "aquanode"
+
+
+def test_onboard_claude_code_prompts_for_project_name(runner, tmp_path):
+    """Without --project, onboard prompts for a project name and stores it as
+    the agent's configured project (not in project settings.json)."""
+    from tokenjam.core.config import load_config
+
+    fake_home = tmp_path / "home"
+    fake_home.mkdir()
+
+    with runner.isolated_filesystem() as cwd, \
+         patch("tokenjam.cli.cmd_onboard.find_config_file", return_value=None), \
+         patch("tokenjam.cli.cmd_onboard.Path.home", return_value=fake_home), \
+         patch("tokenjam.cli.cmd_onboard.click.confirm", return_value=False):
+        # First prompt is the project name; budget is supplied via flag.
+        result = runner.invoke(cli, [
+            "onboard", "--claude-code", "--no-daemon", "--budget", "5.0",
+            "--plan", "max_20x",
+        ], input="myproject\n")
+        assert result.exit_code == 0
+        env = json.loads(
+            (Path(cwd) / ".claude" / "settings.json").read_text()
+        ).get("env", {})
+        assert "OTEL_RESOURCE_ATTRIBUTES" not in env
+
+    cfg = load_config(str(fake_home / ".config" / "tj" / "config.toml"))
+    agent_id = next(k for k in cfg.agents if k.startswith("claude-code-"))
+    assert cfg.agents[agent_id].project == "myproject"
+
+
+def test_onboard_claude_code_removes_existing_resource_attrs(runner, tmp_path):
+    """A pre-existing env.OTEL_RESOURCE_ATTRIBUTES in project settings is removed
+    (migrated); other env keys are preserved."""
+    fake_home = tmp_path / "home"
+    fake_home.mkdir()
+
+    with runner.isolated_filesystem() as cwd, \
+         patch("tokenjam.cli.cmd_onboard.find_config_file", return_value=None), \
+         patch("tokenjam.cli.cmd_onboard.Path.home", return_value=fake_home), \
+         patch("tokenjam.cli.cmd_onboard.click.confirm", return_value=False):
+        proj_settings = Path(cwd) / ".claude" / "settings.json"
+        proj_settings.parent.mkdir(parents=True)
+        proj_settings.write_text(json.dumps({
+            "env": {"OTEL_RESOURCE_ATTRIBUTES": "service.name=old", "KEEP": "yes"}
+        }) + "\n")
+
+        result = runner.invoke(cli, [
+            "onboard", "--claude-code", "--no-daemon", "--budget", "5.0",
+            "--plan", "max_20x", "--project", "aquanode",
+        ])
+        assert result.exit_code == 0
+        env = json.loads(proj_settings.read_text())["env"]
+        assert "OTEL_RESOURCE_ATTRIBUTES" not in env   # migrated away
+        assert env["KEEP"] == "yes"                    # other keys untouched
 
 
 def test_onboard_claude_code_resyncs_secret_on_rerun(runner, tmp_path):
@@ -667,7 +749,7 @@ def test_onboard_claude_code_resyncs_secret_on_rerun(runner, tmp_path):
          patch("tokenjam.core.config.write_config"), \
          patch("tokenjam.cli.cmd_onboard.Path.home", return_value=fake_home), \
          patch("tokenjam.cli.cmd_onboard.click.confirm", return_value=False):
-        result = runner.invoke(cli, ["onboard", "--claude-code", "--no-daemon", "--budget", "5.0", "--plan", "max_20x"])
+        result = runner.invoke(cli, ["onboard", "--claude-code", "--no-daemon", "--budget", "5.0", "--plan", "max_20x", "--project", "aquanode"])
 
     assert result.exit_code == 0
     data = json.loads(settings_path.read_text())
@@ -713,7 +795,7 @@ def test_onboard_claude_code_preserves_custom_otlp_headers(runner, tmp_path):
          patch("tokenjam.core.config.write_config"), \
          patch("tokenjam.cli.cmd_onboard.Path.home", return_value=fake_home), \
          patch("tokenjam.cli.cmd_onboard.click.confirm", return_value=False):
-        result = runner.invoke(cli, ["onboard", "--claude-code", "--no-daemon", "--budget", "5.0", "--plan", "max_20x"])
+        result = runner.invoke(cli, ["onboard", "--claude-code", "--no-daemon", "--budget", "5.0", "--plan", "max_20x", "--project", "aquanode"])
 
     assert result.exit_code == 0
     data = json.loads(settings_path.read_text())
@@ -1223,3 +1305,178 @@ def test_report_reuse_api_mode_writes_artifacts(runner, db, tmp_path, monkeypatc
     assert "needs direct database access" not in result.output
     assert len(list(tmp_path.glob("reuse-*.html"))) == 1
     assert len(list(tmp_path.glob("reuse-*.md"))) == 1   # skeleton text → sidecar
+
+
+# -- otel-resource-attrs tests --
+
+def test_otel_resource_attrs_includes_namespace_for_configured_project(runner):
+    """When the repo's agent has a project set, namespace is appended."""
+    cfg = TjConfig(
+        version="1",
+        agents={"claude-code-myrepo": AgentConfig(project="aquanode")},
+    )
+    with patch("tokenjam.cli.cmd_otel._derive_project_name", return_value="myrepo"), \
+         patch("tokenjam.cli.main.load_config", return_value=cfg):
+        result = runner.invoke(cli, ["otel-resource-attrs"])
+
+    assert result.exit_code == 0
+    assert result.output.strip() == (
+        "service.name=claude-code-myrepo,service.namespace=aquanode"
+    )
+
+
+def test_otel_resource_attrs_omits_namespace_without_config(runner):
+    """No config / no project => service.name only, single line, nothing else."""
+    cfg = TjConfig(version="1")  # no agents configured
+    with patch("tokenjam.cli.cmd_otel._derive_project_name", return_value="myrepo"), \
+         patch("tokenjam.cli.main.load_config", return_value=cfg):
+        result = runner.invoke(cli, ["otel-resource-attrs"])
+
+    assert result.exit_code == 0
+    assert result.output.strip() == "service.name=claude-code-myrepo"
+    # Single bare line — safe to embed in $(tj otel-resource-attrs).
+    assert "service.namespace" not in result.output
+    assert result.output.count("\n") == 1
+
+
+# -- onboard --claude-code per-terminal wrapper tests --
+
+def test_onboard_claude_code_installs_claude_wrapper(runner, tmp_path):
+    """--claude-code installs the per-terminal `claude` wrapper into ~/.zshrc."""
+    fake_home = tmp_path / "home"
+    fake_home.mkdir()
+    zshrc = fake_home / ".zshrc"
+
+    with patch("tokenjam.cli.cmd_onboard.find_config_file", return_value=None), \
+         patch("tokenjam.cli.cmd_onboard.Path.home", return_value=fake_home), \
+         patch("tokenjam.cli.cmd_onboard.click.confirm", return_value=False):
+        result = runner.invoke(cli, [
+            "onboard", "--claude-code", "--no-daemon", "--budget", "5.0",
+            "--plan", "max_20x", "--project", "aquanode",
+        ])
+
+    assert result.exit_code == 0
+    assert zshrc.exists()
+    text = zshrc.read_text()
+    assert "# tj per-terminal naming" in text
+    assert "claude() {" in text
+    # The wrapper sources project attrs from the new utility command and tags
+    # a per-terminal instance id, invoking the real binary without recursion.
+    assert "tj otel-resource-attrs" in text
+    assert "service.instance.id=" in text
+    assert "command claude" in text
+    assert "--as" in text
+    # Close-signal: reports the session ended on exit and on interrupt.
+    assert "tj session-end --instance" in text
+    assert "trap " in text
+
+
+def test_onboard_claude_code_wrapper_is_idempotent(runner, tmp_path):
+    """Re-running --claude-code does not duplicate the wrapper block."""
+    fake_home = tmp_path / "home"
+    fake_home.mkdir()
+    zshrc = fake_home / ".zshrc"
+
+    with patch("tokenjam.cli.cmd_onboard.find_config_file", return_value=None), \
+         patch("tokenjam.cli.cmd_onboard.Path.home", return_value=fake_home), \
+         patch("tokenjam.cli.cmd_onboard.click.confirm", return_value=False):
+        args = [
+            "onboard", "--claude-code", "--no-daemon", "--budget", "5.0",
+            "--plan", "max_20x", "--project", "aquanode",
+        ]
+        first = runner.invoke(cli, args)
+        second = runner.invoke(cli, args)
+
+    assert first.exit_code == 0
+    assert second.exit_code == 0
+    text = zshrc.read_text()
+    assert text.count("claude() {") == 1
+    assert text.count("# tj per-terminal naming") == 1
+    assert text.count("# end tj per-terminal naming") == 1
+
+
+def test_onboard_claude_code_wrapper_writes_bashrc_when_present(runner, tmp_path):
+    """~/.bashrc gets the wrapper only when it already exists."""
+    fake_home = tmp_path / "home"
+    fake_home.mkdir()
+    bashrc = fake_home / ".bashrc"
+    bashrc.write_text("# existing bashrc\n")
+
+    with patch("tokenjam.cli.cmd_onboard.find_config_file", return_value=None), \
+         patch("tokenjam.cli.cmd_onboard.Path.home", return_value=fake_home), \
+         patch("tokenjam.cli.cmd_onboard.click.confirm", return_value=False):
+        result = runner.invoke(cli, [
+            "onboard", "--claude-code", "--no-daemon", "--budget", "5.0",
+            "--plan", "max_20x", "--project", "aquanode",
+        ])
+
+    assert result.exit_code == 0
+    bashrc_text = bashrc.read_text()
+    assert "# existing bashrc" in bashrc_text  # preserved
+    assert "claude() {" in bashrc_text
+
+
+# -- session-end tests --
+
+def test_session_end_posts_to_endpoint(runner):
+    """`tj session-end --instance` POSTs to /api/v1/sessions/close with auth."""
+    from tokenjam.core.config import ApiConfig, SecurityConfig
+
+    cfg = TjConfig(
+        version="1",
+        security=SecurityConfig(ingest_secret="sek"),
+        api=ApiConfig(host="127.0.0.1", port=7391),
+    )
+    captured: dict = {}
+
+    class _Resp:
+        status = 200
+
+        def read(self):
+            return b'{"closed": 1}'
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *exc):
+            return False
+
+    def fake_urlopen(req, timeout=None):
+        captured["url"] = req.full_url
+        captured["data"] = req.data
+        captured["auth"] = req.headers.get("Authorization")
+        return _Resp()
+
+    with patch("tokenjam.cli.main.load_config", return_value=cfg), \
+         patch("tokenjam.cli.main.open_db", side_effect=AssertionError("must not open DB")), \
+         patch("tokenjam.cli.cmd_session_end.urllib.request.urlopen",
+               side_effect=fake_urlopen):
+        result = runner.invoke(cli, ["session-end", "--instance", "term-x"])
+
+    assert result.exit_code == 0
+    assert captured["url"].endswith("/api/v1/sessions/close")
+    assert b"term-x" in captured["data"]
+    assert captured["auth"] == "Bearer sek"
+
+
+def test_session_end_silent_when_daemon_unreachable(runner):
+    """Daemon down -> exit 0, nothing printed (must never break the shell)."""
+    import urllib.error
+    from tokenjam.core.config import SecurityConfig
+
+    cfg = TjConfig(version="1", security=SecurityConfig(ingest_secret="sek"))
+    with patch("tokenjam.cli.main.load_config", return_value=cfg), \
+         patch("tokenjam.cli.cmd_session_end.urllib.request.urlopen",
+               side_effect=urllib.error.URLError("connection refused")):
+        result = runner.invoke(cli, ["session-end", "--instance", "term-x"])
+
+    assert result.exit_code == 0
+    assert result.output.strip() == ""
+
+
+def test_session_end_requires_an_id(runner):
+    """Neither --instance nor --session -> usage error."""
+    cfg = TjConfig(version="1")
+    with patch("tokenjam.cli.main.load_config", return_value=cfg):
+        result = runner.invoke(cli, ["session-end"])
+    assert result.exit_code != 0

--- a/tests/integration/test_db.py
+++ b/tests/integration/test_db.py
@@ -42,8 +42,8 @@ def _insert_agent(db, agent_id="test-agent"):
 def test_migrations_run_on_empty_db():
     backend = InMemoryBackend()
     rows = backend.conn.execute("SELECT version FROM schema_migrations").fetchall()
-    assert len(rows) == 7
-    assert {r[0] for r in rows} == {1, 2, 3, 4, 5, 6, 7}
+    assert len(rows) == 11
+    assert {r[0] for r in rows} == {1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11}
     backend.close()
 
 
@@ -52,7 +52,7 @@ def test_migrations_are_idempotent():
     # Running migrations again should not raise
     run_migrations(backend.conn)
     rows = backend.conn.execute("SELECT version FROM schema_migrations").fetchall()
-    assert len(rows) == 7
+    assert len(rows) == 11
     backend.close()
 
 
@@ -344,6 +344,34 @@ def test_get_completed_sessions(db):
     assert len(completed) == 3
     for s in completed:
         assert s.status == "completed"
+
+
+def test_get_completed_sessions_orders_by_last_activity(db):
+    """A long session must rank ahead of a short fragment that started later.
+
+    Regression: the status tile showed a 40s fragment instead of the real
+    multi-hour session because ordering was by started_at, not last activity.
+    """
+    _insert_agent(db)
+    base = utcnow()
+    # Long session: started first, stayed active for ~4.5h.
+    long_session = make_session(
+        status="completed",
+        started_at=base - timedelta(hours=4, minutes=27),
+        ended_at=base,
+    )
+    # Short fragment: started 3 min AFTER the long one, ended 40s later.
+    short_fragment = make_session(
+        status="completed",
+        started_at=base - timedelta(hours=4, minutes=24),
+        ended_at=base - timedelta(hours=4, minutes=23, seconds=20),
+    )
+    db.upsert_session(long_session)
+    db.upsert_session(short_fragment)
+
+    latest = db.get_completed_sessions("test-agent", limit=1)
+    assert latest[0].session_id == long_session.session_id
+    assert latest[0].duration_seconds > 3600  # the multi-hour one, not the 40s blip
 
 
 def test_get_completed_session_count(db):

--- a/tests/synthetic/test_ingest.py
+++ b/tests/synthetic/test_ingest.py
@@ -6,7 +6,7 @@ from datetime import datetime
 
 import pytest
 
-from tokenjam.core.config import TjConfig, SecurityConfig, CaptureConfig
+from tokenjam.core.config import TjConfig, SecurityConfig, CaptureConfig, AgentConfig
 from tokenjam.core.ingest import (
     IngestPipeline,
     SpanRejectedError,
@@ -15,7 +15,12 @@ from tokenjam.core.ingest import (
 )
 from tokenjam.core.models import NormalizedSpan, SessionRecord, SpanStatus
 from tokenjam.otel.semconv import GenAIAttributes
-from tests.factories import make_llm_span, make_session, make_tool_span
+from tests.factories import (
+    make_invoke_agent_span,
+    make_llm_span,
+    make_session,
+    make_tool_span,
+)
 
 
 # ---------------------------------------------------------------------------
@@ -73,6 +78,7 @@ def _make_pipeline(
     security: SecurityConfig | None = None,
     capture: CaptureConfig | None = None,
     db: InMemoryBackend | None = None,
+    agents: dict | None = None,
 ) -> tuple[IngestPipeline, InMemoryBackend]:
     """Create an IngestPipeline with sensible defaults for testing."""
     db = db or InMemoryBackend()
@@ -80,6 +86,7 @@ def _make_pipeline(
         version="1",
         security=security or SecurityConfig(),
         capture=capture or CaptureConfig(),
+        agents=agents or {},
     )
     pipeline = IngestPipeline(
         db=db,
@@ -349,3 +356,111 @@ class TestErrorHandling:
         # Should NOT raise even though cost engine fails
         pipeline.process(span)
         assert len(db.spans) == 1
+
+
+# ===========================================================================
+# Session lifecycle tests
+#
+# Regression coverage for the Claude Code / Codex logs path, where each
+# user_prompt event is mapped to a zero-duration invoke_agent span. Treating
+# those turn-start markers as session completions force-completed every live
+# session on its first prompt — the dashboard showed active work as
+# "completed" with 0 duration, and the drift/alert session-end hooks fired on
+# every turn.
+# ===========================================================================
+
+class TestSessionLifecycle:
+
+    def test_zero_duration_invoke_agent_marker_keeps_session_active(self):
+        # Claude Code maps each user_prompt to a zero-duration invoke_agent
+        # span (end_time == start_time). It marks the START of a turn.
+        pipeline, db = _make_pipeline()
+        marker = make_invoke_agent_span(session_id="s1", duration_ms=0.0)
+
+        pipeline.process(marker)
+
+        session = db.get_session("s1")
+        assert session is not None
+        assert session.status == "active"
+
+    def test_streaming_activity_keeps_session_active(self):
+        # A marker followed by real LLM activity is still an ongoing session.
+        pipeline, db = _make_pipeline()
+        pipeline.process(make_invoke_agent_span(session_id="s1", duration_ms=0.0))
+        pipeline.process(make_llm_span(session_id="s1"))
+
+        assert db.get_session("s1").status == "active"
+
+    def test_real_invoke_agent_span_completes_session(self):
+        # The SDK @watch() path emits one invoke_agent span that brackets the
+        # whole run (end_time strictly after start_time). That DOES complete it.
+        pipeline, db = _make_pipeline()
+        end_span = make_invoke_agent_span(session_id="s1", duration_ms=5000.0)
+
+        pipeline.process(end_span)
+
+        assert db.get_session("s1").status == "completed"
+
+    def test_activity_reactivates_mistakenly_completed_session(self):
+        # An in-flight session left "completed" (e.g. by the old bug, or a
+        # prior restart) must self-heal when new activity arrives.
+        pipeline, db = _make_pipeline()
+        db.upsert_session(make_session(session_id="s1", status="completed"))
+
+        pipeline.process(make_llm_span(session_id="s1"))
+
+        assert db.get_session("s1").status == "active"
+
+
+class TestServiceNamespace:
+    """service.namespace (project grouping) capture on the session."""
+
+    def test_session_captures_service_namespace(self):
+        pipeline, db = _make_pipeline()
+        pipeline.process(make_llm_span(session_id="s1", service_namespace="aquanode"))
+
+        assert db.get_session("s1").service_namespace == "aquanode"
+
+    def test_namespace_late_resolves_from_later_span(self):
+        # A tool span with no namespace creates the session; a later LLM span
+        # that carries the namespace backfills it.
+        pipeline, db = _make_pipeline()
+        pipeline.process(make_invoke_agent_span(session_id="s1", service_namespace=None))
+        assert db.get_session("s1").service_namespace is None
+
+        pipeline.process(make_llm_span(session_id="s1", service_namespace="aquanode"))
+        assert db.get_session("s1").service_namespace == "aquanode"
+
+    def test_namespace_absent_stays_none(self):
+        pipeline, db = _make_pipeline()
+        pipeline.process(make_llm_span(session_id="s1"))
+
+        assert db.get_session("s1").service_namespace is None
+
+    def test_namespace_falls_back_to_configured_project(self):
+        # An already-running agent never sends service.namespace; the agent's
+        # configured project supplies it server-side (no restart needed).
+        pipeline, db = _make_pipeline(
+            agents={"claude-code-harness": AgentConfig(project="aquanode")},
+        )
+        pipeline.process(make_llm_span(agent_id="claude-code-harness", session_id="s1"))
+
+        assert db.get_session("s1").service_namespace == "aquanode"
+
+    def test_wire_namespace_wins_over_configured_project(self):
+        pipeline, db = _make_pipeline(
+            agents={"claude-code-harness": AgentConfig(project="aquanode")},
+        )
+        pipeline.process(make_llm_span(
+            agent_id="claude-code-harness", session_id="s1",
+            service_namespace="explicit-ns"))
+
+        assert db.get_session("s1").service_namespace == "explicit-ns"
+
+    def test_session_captures_service_instance_id(self):
+        # The per-terminal instance id (e.g. "founder-os") is persisted on the
+        # session for use as its display label.
+        pipeline, db = _make_pipeline()
+        pipeline.process(make_llm_span(session_id="s1", service_instance_id="founder-os"))
+
+        assert db.get_session("s1").service_instance_id == "founder-os"

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -232,6 +232,19 @@ class TestSerialise:
         assert _parse({"version": "1"}).policies == []
         assert _parse({"version": "1", "policies": [{"name": "x"}]}).policies == []  # no kind
 
+    def test_session_idle_minutes_roundtrip(self):
+        config = TjConfig(version="1", session_idle_minutes=90)
+        serialised = _serialise(config)
+        # Maps to the [sessions] table, not a bare top-level scalar.
+        assert serialised["sessions"]["idle_minutes"] == 90
+        assert "session_idle_minutes" not in serialised
+        restored = _parse(serialised)
+        assert restored.session_idle_minutes == 90
+
+    def test_session_idle_minutes_defaults_when_absent(self):
+        restored = _parse({"version": "1"})
+        assert restored.session_idle_minutes == 240
+
     def test_serialise_excludes_config_path(self):
         """Regression: config_path is a Path object which is not TOML
         serializable. _serialise() must exclude it. See v0.1.7 fix."""

--- a/tests/unit/test_db_close_backfill.py
+++ b/tests/unit/test_db_close_backfill.py
@@ -1,0 +1,84 @@
+"""Migration 10: repair ended_at on already-closed sessions.
+
+A prior bug advanced ended_at to the close time. The backfill recomputes
+ended_at from each closed session's actual spans (max end/start time) and only
+LOWERS it, never touching sessions already consistent with their spans.
+"""
+from __future__ import annotations
+
+from datetime import timedelta
+
+from tokenjam.core.config import StorageConfig
+from tokenjam.core.db import MIGRATIONS, DuckDBBackend
+from tokenjam.utils.time_parse import utcnow
+
+from tests.factories import make_session
+
+
+def _migration_8_sql() -> str:
+    return next(sql for version, sql in MIGRATIONS if version == 10)
+
+
+def _insert_span(db, session_id: str, start, end) -> None:
+    db.conn.execute(
+        "INSERT INTO spans (span_id, trace_id, session_id, name, kind, "
+        "status_code, start_time, end_time) "
+        "VALUES (?, ?, ?, 'n', 'INTERNAL', 'OK', ?, ?)",
+        [f"sp-{session_id}", f"tr-{session_id}", session_id, start, end],
+    )
+
+
+def test_backfill_lowers_bumped_ended_at(tmp_path):
+    db = DuckDBBackend(StorageConfig(path=str(tmp_path / "t.duckdb")))
+    try:
+        now = utcnow()
+        last_span = now - timedelta(days=2)
+        bumped = now  # the wrong "close time" ended_at
+        db.upsert_session(make_session(
+            agent_id="cc", session_id="closed1", status="closed",
+            ended_at=bumped))
+        _insert_span(db, "closed1", last_span - timedelta(seconds=5), last_span)
+
+        db.conn.execute(_migration_8_sql())
+
+        ended = db.get_session("closed1").ended_at
+        assert ended == last_span          # lowered to real last activity
+        assert ended < bumped
+    finally:
+        db.close()
+
+
+def test_backfill_leaves_consistent_session_untouched(tmp_path):
+    db = DuckDBBackend(StorageConfig(path=str(tmp_path / "t.duckdb")))
+    try:
+        now = utcnow()
+        last_span = now - timedelta(hours=1)
+        db.upsert_session(make_session(
+            agent_id="cc", session_id="ok1", status="closed",
+            ended_at=last_span))
+        _insert_span(db, "ok1", last_span - timedelta(seconds=5), last_span)
+
+        db.conn.execute(_migration_8_sql())
+
+        assert db.get_session("ok1").ended_at == last_span
+    finally:
+        db.close()
+
+
+def test_backfill_ignores_active_sessions(tmp_path):
+    db = DuckDBBackend(StorageConfig(path=str(tmp_path / "t.duckdb")))
+    try:
+        now = utcnow()
+        bumped = now
+        db.upsert_session(make_session(
+            agent_id="cc", session_id="live1", status="active",
+            ended_at=bumped))
+        _insert_span(db, "live1", now - timedelta(days=2, seconds=5),
+                     now - timedelta(days=2))
+
+        db.conn.execute(_migration_8_sql())
+
+        # status != 'closed' → untouched.
+        assert db.get_session("live1").ended_at == bumped
+    finally:
+        db.close()

--- a/tests/unit/test_lens_ui_regression.py
+++ b/tests/unit/test_lens_ui_regression.py
@@ -738,47 +738,56 @@ def test_dashboard_triage_drills_in_place(html):
     # state (not a jump to standalone #/analytics).
     assert "analyzerSliceHref(t.name, since, 'dashboard')" in html
     assert "function analyzerSliceHref(name, since, route = 'analytics')" in html
-# --- #241: Status screen Cards | List view toggle -------------------------- #
-def test_status_view_toggle_exists(html):
-    # A segmented Cards | List control on the Status screen, driven by the URL
-    # view param. List is the default (#263), omitted from the URL via navigate
-    # defaults; Cards carries ?view=cards.
-    assert ".view-toggle" in html  # segmented-control CSS
-    assert "const DEFAULTS = { view: 'list', agent_id: '' };" in html
-    assert "readParam(params, 'view', DEFAULTS.view, v => ['cards', 'list'].includes(v))" in html
-    assert "const setView = (v) => navigate('status', { agent_id: agentId, view: v }, DEFAULTS);" in html
-    # both toggle buttons present
-    assert "onClick=${() => setView('cards')}>Cards</button>" in html
-    assert "onClick=${() => setView('list')}>List</button>" in html
+# --- #306: Status screen is two content-defined zones (no view toggle) ------ #
+def test_status_screen_has_split_zones(html):
+    # The #241/#263 Cards|List view toggle is retired: the Status screen now
+    # renders two content-defined zones — coding sessions (cards + archive) and
+    # SDK services — rather than a user-selected view of one agent list.
+    start = html.index("function StatusView")
+    end = html.index("function TracesListView", start)
+    view = html[start:end]
+    assert 'class="zone-title">Coding sessions' in view
+    assert "SDK agents / services" in html
+    # the toggle wiring is gone
+    assert "const setView =" not in html
+    assert "onClick=${() => setView('cards')}" not in html
+    assert "function StatusListTable" not in html
 
 
-def test_status_list_is_default_view(html):
-    # #263: List is the default scan view (not Cards).
-    assert "const DEFAULTS = { view: 'list', agent_id: '' };" in html
-    assert "const DEFAULTS = { view: 'cards', agent_id: '' };" not in html
+def test_status_sdk_services_panel_exists(html):
+    # The SDK zone is its own component fed by data.sdk_services.
+    assert "function SdkServicesPanel({ services, framing })" in html
+    assert "<${SdkServicesPanel} services=${sdkServices} framing=${data.framing} />" in html
 
 
-def test_status_list_table_renderer_exists(html):
-    # The List view is a dedicated columned-table renderer, gated behind the
-    # view mode (now the default render path).
-    assert "function StatusListTable({ agents, framing })" in html
-    assert "? StatusListTable({ agents, framing: data.framing })" in html
+def test_sdk_panel_reuses_sparkline_and_splits_by_state(html):
+    # cost/min + err% sparklines come from the per-minute series; services are
+    # partitioned live vs went_quiet/long_dormant.
+    assert "values=${s.cost_per_min}" in html
+    assert "values=${s.err_pct_per_min}" in html
+    assert "s.state === 'live'" in html
+    assert "s.state === 'went_quiet'" in html
 
 
-def test_status_list_table_horizontally_scrolls(html):
-    # #263: the list table sits in the scrolling .table-wrap AND carries a
-    # min-width so it overflows (and scrolls) on narrow viewports instead of
-    # compressing columns and clipping the actions cell.
-    assert "<div class=\"table-wrap\"><table class=\"status-list\">" in html
+def test_coding_zone_partitions_agents_and_archive_by_kind(html):
+    # Cards are the coding agents; the collapsible archive is the coding archive.
+    assert "const codingAgents = agents.filter(a => a.kind === 'coding');" in html
+    assert "(data.archived || []).filter(s => s.kind === 'coding'" in html
+
+
+def test_coding_archive_is_collapsible_and_scrolls(html):
+    # The archive is a collapsible <details> holding the archive-list table,
+    # which sits in the scrolling .table-wrap AND carries a min-width so it
+    # overflows (and scrolls) instead of clipping the actions cell.
+    assert "<div class=\"table-wrap\"><table class=\"archive-list\">" in html
     assert ".table-wrap { overflow-x: auto; }" in html
-    assert ".table-wrap table.status-list { min-width: 760px; }" in html
+    assert "table.archive-list {" in html and "min-width: 820px;" in html
 
 
-def test_status_list_cost_column_respects_framing(html):
-    # The List view's Cost cell goes through fmtPerItemCost exactly like the
-    # cards — per-item cost renders as tokens for subscription/local (#249),
-    # plan-tier framing is never re-derived in JS (#110/#241).
-    assert "<td>${fmtPerItemCost(a.cost_today, _costVal(a, true), framing)}</td>" in html
+def test_status_archive_cost_column_respects_framing(html):
+    # The archive Cost cell routes through the /status framing block (#17/#249),
+    # never a raw dollar.
+    assert "<td>${fmtFramedDollar(s.total_cost_usd, data.framing)}</td>" in html
 
 
 # --- #249: "% of cycle" is window-level; per-item cost must render as tokens -- #
@@ -795,13 +804,12 @@ def test_per_item_cost_helper_renders_tokens_for_subscription_local(html):
 
 
 def test_per_item_cost_surfaces_use_the_helper_not_framed_dollar(html):
-    # Every per-item dollar cell — Traces list, Status cards, StatusListTable,
-    # span-detail, and the per-trace total — uses fmtPerItemCost, not the
-    # window-aggregate fmtFramedDollar. Guards against a regression reintroducing
-    # "% of cycle" at per-row granularity (the #249 bug: "466.7% of cycle").
+    # Every per-item dollar cell — Traces list, Status cards, span-detail, and
+    # the per-trace total — uses fmtPerItemCost, not the window-aggregate
+    # fmtFramedDollar. Guards against a regression reintroducing "% of cycle" at
+    # per-row granularity (the #249 bug: "466.7% of cycle").
     assert "${fmtPerItemCost(t.cost_usd, _costVal(t, true), framing)}" in html        # traces list
     assert "${fmtPerItemCost(a.cost_today, _costVal(a, true), data.framing)}" in html  # status card
-    assert "<td>${fmtPerItemCost(a.cost_today, _costVal(a, true), framing)}</td>" in html  # status list
     assert "${fmtPerItemCost(sel.cost_usd, _costVal(sel, true), framing)}" in html     # span detail
     assert "fmtPerItemCost(wfTotalCost, wfTotalInOut, framing)" in html                # trace total
     # these per-item surfaces must NOT call fmtFramedDollar on the row value
@@ -995,3 +1003,46 @@ def test_analytics_tool_dim_no_cost_metric_empty_state(html):
     # one-click recovery actions
     assert "onClick=${() => setFilter('metric', 'events')}>Switch to Events" in html
     assert "setFilter('group_by', 'model')" in html
+
+
+# --- #306: StatusView coding archive lives in the coding zone --------------- #
+def test_status_coding_archive_renders_in_coding_zone(html):
+    # The coding archive is a collapsible <details> inside the coding zone,
+    # gated only on there being coding archive rows — not on any view mode. The
+    # empty-active case still shows the archive (and a "No active coding
+    # sessions" note) rather than blanking the page.
+    start = html.index("function StatusView")
+    end = html.index("function TracesListView", start)
+    view = html[start:end]
+
+    # The coding zone renders whenever there are coding agents OR coding archive.
+    assert "${(codingAgents.length || codingArchived.length) ? html`" in view
+    # The archive is its own collapsible block keyed on ended-at.
+    assert "${codingArchived.length > 0 ? html`" in view
+    assert "keyed on ended-at · method still openable" in view
+    # Empty-active note shown when there are no active coding sessions.
+    assert "No active coding sessions" in view
+    # No leftover view-toggle machinery.
+    assert "viewMode" not in view
+
+
+# --- #306: right-click to rename a session card ----------------------------- #
+def test_status_card_right_click_rename_wiring(html):
+    # The coding-session card title is right-click-renamable: an onContextMenu
+    # handler enters an inline edit state, and submitting POSTs to the label
+    # endpoint via the authed apiPost helper (not window.prompt).
+    start = html.index("function StatusView")
+    end = html.index("function TracesListView", start)
+    view = html[start:end]
+
+    # Inline edit state + autofocus ref (no window.prompt).
+    assert "const [editingId, setEditingId] = useState(null)" in view
+    assert "window.prompt" not in view
+    # Right-click ANYWHERE on the card enters edit mode (not just the title, so
+    # the browser's native context menu never wins), and the ✎ is left-click.
+    assert 'class="card clickable" onContextMenu=${startEdit}' in view
+    assert 'class="rename-pencil" onClick=${startEdit}' in view
+    # Submit persists via the authed POST helper to the /label endpoint.
+    assert "apiPost('/sessions/' + encodeURIComponent(a.session_id) + '/label'" in view
+    # Discoverability affordance on the title.
+    assert "or right-click to rename" in view

--- a/tests/unit/test_logs_converter.py
+++ b/tests/unit/test_logs_converter.py
@@ -517,3 +517,24 @@ def test_parse_log_records_unknown_event_skipped():
     assert ingested == 0
     assert rejections == []
     pipeline.process.assert_not_called()
+
+
+def test_parse_log_records_extracts_service_namespace():
+    """service.namespace on the resource is stamped onto every synthesized span."""
+    record = make_claude_code_api_request_log(session_id="s-ns")
+    body = {
+        "resourceLogs": [{
+            "resource": {"attributes": [
+                {"key": "service.name", "value": {"stringValue": "claude-code-harness"}},
+                {"key": "service.namespace", "value": {"stringValue": "aquanode"}},
+            ]},
+            "scopeLogs": [{"logRecords": [record]}],
+        }],
+    }
+    pipeline = MagicMock()
+    parse_log_records(body, pipeline)
+
+    pipeline.process.assert_called_once()
+    span = pipeline.process.call_args[0][0]
+    assert span.service_namespace == "aquanode"
+    assert span.agent_id == "claude-code-harness"

--- a/tests/unit/test_models.py
+++ b/tests/unit/test_models.py
@@ -55,7 +55,7 @@ class TestSessionRecord:
         with patch("tokenjam.utils.time_parse.utcnow", return_value=now):
             assert session.effective_status == "active"
 
-    def test_effective_status_active_stale_becomes_stale(self):
+    def test_effective_status_active_quiet_becomes_idle(self):
         now = datetime(2026, 3, 28, 12, 10, 0, tzinfo=timezone.utc)
         session = SessionRecord(
             session_id="s1",
@@ -64,7 +64,21 @@ class TestSessionRecord:
             ended_at=datetime(2026, 3, 28, 12, 3, 0, tzinfo=timezone.utc),
             status="active",
         )
-        # 7 minutes since last activity > 5 minute threshold
+        # 7 min since last activity: past the 5-min active window, well within
+        # the 4h idle window -> idle (not stale).
+        with patch("tokenjam.utils.time_parse.utcnow", return_value=now):
+            assert session.effective_status == "idle"
+
+    def test_effective_status_active_old_becomes_stale(self):
+        now = datetime(2026, 3, 28, 17, 10, 0, tzinfo=timezone.utc)
+        session = SessionRecord(
+            session_id="s1",
+            agent_id="a1",
+            started_at=datetime(2026, 3, 28, 12, 0, 0, tzinfo=timezone.utc),
+            ended_at=datetime(2026, 3, 28, 12, 3, 0, tzinfo=timezone.utc),
+            status="active",
+        )
+        # >5h since last activity, beyond the 4h idle window -> stale.
         with patch("tokenjam.utils.time_parse.utcnow", return_value=now):
             assert session.effective_status == "stale"
 
@@ -76,9 +90,77 @@ class TestSessionRecord:
             started_at=datetime(2026, 3, 28, 12, 0, 0, tzinfo=timezone.utc),
             status="active",
         )
-        # 10 minutes since started_at, no ended_at
+        # 10 min since started_at, no ended_at -> idle (within the 4h window).
         with patch("tokenjam.utils.time_parse.utcnow", return_value=now):
-            assert session.effective_status == "stale"
+            assert session.effective_status == "idle"
+
+    def test_effective_status_closed_unchanged(self):
+        session = SessionRecord(
+            session_id="s1",
+            agent_id="a1",
+            started_at=datetime(2026, 3, 28, 12, 0, 0, tzinfo=timezone.utc),
+            status="closed",
+        )
+        assert session.effective_status == "closed"
+
+    def test_status_at_honours_custom_idle_window(self):
+        now = datetime(2026, 3, 28, 12, 30, 0, tzinfo=timezone.utc)
+        session = SessionRecord(
+            session_id="s1",
+            agent_id="a1",
+            started_at=datetime(2026, 3, 28, 12, 0, 0, tzinfo=timezone.utc),
+            ended_at=datetime(2026, 3, 28, 12, 3, 0, tzinfo=timezone.utc),
+            status="active",
+        )
+        # 27 min gap. With a 10-min idle window it is stale; the default 4h
+        # window keeps it idle.
+        with patch("tokenjam.utils.time_parse.utcnow", return_value=now):
+            assert session.status_at(timedelta(minutes=10)) == "stale"
+            assert session.status_at(timedelta(hours=4)) == "idle"
+
+    def _idle_session(self, now):
+        """An 'active' session whose spans went quiet 30 min ago (-> stale at a
+        10-min idle window, idle at the default)."""
+        return SessionRecord(
+            session_id="s1",
+            agent_id="a1",
+            started_at=now - timedelta(hours=1),
+            ended_at=now - timedelta(minutes=30),
+            status="active",
+        )
+
+    def test_transcript_mtime_rescues_idle_to_active(self):
+        now = datetime(2026, 3, 28, 12, 30, 0, tzinfo=timezone.utc)
+        session = self._idle_session(now)
+        fresh = now - timedelta(minutes=1)  # transcript touched 1 min ago
+        with patch("tokenjam.utils.time_parse.utcnow", return_value=now):
+            # Spans are stale, but the transcript is fresh -> live.
+            assert session.status_with_transcript_mtime(fresh) == "active"
+
+    def test_transcript_mtime_stale_does_not_rescue(self):
+        now = datetime(2026, 3, 28, 12, 30, 0, tzinfo=timezone.utc)
+        session = self._idle_session(now)
+        old = now - timedelta(minutes=20)  # transcript also went quiet
+        with patch("tokenjam.utils.time_parse.utcnow", return_value=now):
+            assert session.status_with_transcript_mtime(old) == "idle"
+
+    def test_transcript_mtime_none_is_unaffected(self):
+        # Non-CC sessions (no transcript) pass through the span-derived status.
+        now = datetime(2026, 3, 28, 12, 30, 0, tzinfo=timezone.utc)
+        session = self._idle_session(now)
+        with patch("tokenjam.utils.time_parse.utcnow", return_value=now):
+            assert session.status_with_transcript_mtime(None) == "idle"
+
+    def test_transcript_mtime_never_revives_closed(self):
+        # A fresh transcript must not resurrect an explicitly-closed session.
+        now = datetime(2026, 3, 28, 12, 30, 0, tzinfo=timezone.utc)
+        session = SessionRecord(
+            session_id="s1", agent_id="a1",
+            started_at=now - timedelta(hours=1), status="closed",
+        )
+        fresh = now - timedelta(minutes=1)
+        with patch("tokenjam.utils.time_parse.utcnow", return_value=now):
+            assert session.status_with_transcript_mtime(fresh) == "closed"
 
 
 class TestEnums:

--- a/tests/unit/test_onboard_first_run.py
+++ b/tests/unit/test_onboard_first_run.py
@@ -120,9 +120,10 @@ def _isolated_claude_code(monkeypatch, tmp_path):
 def _run_claude_code(tmp_path, plan_choice: str):
     runner = CliRunner()
     with runner.isolated_filesystem(temp_dir=tmp_path):
-        # plan_choice then daily budget "0".
+        # --project skips the interactive project-name prompt; then plan_choice
+        # then daily budget "0".
         return runner.invoke(
-            cmd_onboard, ["--claude-code", "--no-daemon"],
+            cmd_onboard, ["--claude-code", "--no-daemon", "--project", "testproj"],
             input=f"{plan_choice}\n0\n", obj={},
         )
 

--- a/tests/unit/test_session_label.py
+++ b/tests/unit/test_session_label.py
@@ -1,0 +1,194 @@
+"""Tests for session renames (#306): the DB overlay helpers, the
+POST /api/v1/sessions/{id}/label endpoint, and its precedence + surfacing in
+/status.
+
+A rename is a dashboard action persisted to the `session_labels` table
+(migration 15) and overlaid onto the /status tile/archive label — beating the
+OTel service.instance.id but NOT a config `[session_labels]` entry.
+"""
+from __future__ import annotations
+
+import httpx
+import pytest
+
+from tokenjam.api.app import create_app
+from tokenjam.core.config import (
+    ApiAuthConfig,
+    ApiConfig,
+    SecurityConfig,
+    TjConfig,
+)
+from tokenjam.core.db import (
+    InMemoryBackend,
+    delete_session_label,
+    get_session_labels,
+    set_session_label,
+)
+from tokenjam.core.ingest import IngestPipeline
+from tests.factories import make_llm_span
+
+
+INGEST_SECRET = "test-secret-token"
+
+
+# ── DB helpers: set / get / delete round-trip ──────────────────────────────
+
+def test_label_helpers_round_trip():
+    db = InMemoryBackend()
+    try:
+        # Empty to start.
+        assert get_session_labels(db.conn) == {}
+
+        set_session_label(db, "sid-1", "alpha")
+        set_session_label(db, "sid-2", "beta")
+        assert get_session_labels(db.conn) == {"sid-1": "alpha", "sid-2": "beta"}
+
+        # Re-labeling upserts (no duplicate PK error, new value wins).
+        set_session_label(db, "sid-1", "alpha-renamed")
+        assert get_session_labels(db.conn)["sid-1"] == "alpha-renamed"
+
+        # Delete removes just that row; idempotent second delete is a no-op.
+        delete_session_label(db, "sid-1")
+        delete_session_label(db, "sid-1")
+        assert get_session_labels(db.conn) == {"sid-2": "beta"}
+    finally:
+        db.close()
+
+
+def test_get_session_labels_guards_none_conn():
+    assert get_session_labels(None) == {}
+
+
+# ── Endpoint + /status surfacing ───────────────────────────────────────────
+
+def _app(config, db):
+    pipeline = IngestPipeline(db=db, config=config)
+    # Two active coding sessions the /status tiles will surface.
+    pipeline.process(make_llm_span(
+        agent_id="claude-code", session_id="sess-a", conversation_id="a",
+        service_instance_id="ttys001"))
+    pipeline.process(make_llm_span(
+        agent_id="claude-code", session_id="sess-b", conversation_id="b",
+        service_instance_id="ttys002"))
+    return create_app(config=config, db=db, ingest_pipeline=pipeline)
+
+
+def _plain_config():
+    return TjConfig(
+        version="1",
+        security=SecurityConfig(ingest_secret=INGEST_SECRET),
+        api=ApiConfig(auth=ApiAuthConfig(enabled=False)),
+    )
+
+
+async def _status_labels(client) -> dict:
+    resp = await client.get("/api/v1/status")
+    assert resp.status_code == 200
+    return {a["session_id"]: a["label"] for a in resp.json()["agents"]}
+
+
+@pytest.mark.asyncio
+async def test_post_label_surfaces_in_status():
+    db = InMemoryBackend()
+    try:
+        app = _app(_plain_config(), db)
+        transport = httpx.ASGITransport(app=app)
+        async with httpx.AsyncClient(transport=transport, base_url="http://test") as c:
+            # Default label is the instance id (ttys001).
+            assert (await _status_labels(c))["sess-a"] == "ttys001"
+
+            resp = await c.post(
+                "/api/v1/sessions/sess-a/label",
+                json={"label": "my-renamed-session"},
+            )
+            assert resp.status_code == 200
+            assert resp.json() == {
+                "session_id": "sess-a", "label": "my-renamed-session"
+            }
+
+            labels = await _status_labels(c)
+            assert labels["sess-a"] == "my-renamed-session"  # rename beats ttys id
+            assert labels["sess-b"] == "ttys002"             # untouched
+    finally:
+        db.close()
+
+
+@pytest.mark.asyncio
+async def test_post_empty_label_clears_rename():
+    db = InMemoryBackend()
+    try:
+        app = _app(_plain_config(), db)
+        transport = httpx.ASGITransport(app=app)
+        async with httpx.AsyncClient(transport=transport, base_url="http://test") as c:
+            await c.post("/api/v1/sessions/sess-a/label", json={"label": "temp"})
+            assert (await _status_labels(c))["sess-a"] == "temp"
+
+            # Empty (whitespace-only) label clears -> reverts to the ttys id.
+            resp = await c.post(
+                "/api/v1/sessions/sess-a/label", json={"label": "   "}
+            )
+            assert resp.status_code == 200
+            assert resp.json() == {"session_id": "sess-a", "label": None}
+            assert (await _status_labels(c))["sess-a"] == "ttys001"
+    finally:
+        db.close()
+
+
+@pytest.mark.asyncio
+async def test_config_label_wins_over_db_rename():
+    db = InMemoryBackend()
+    try:
+        config = TjConfig(
+            version="1",
+            security=SecurityConfig(ingest_secret=INGEST_SECRET),
+            api=ApiConfig(auth=ApiAuthConfig(enabled=False)),
+            session_labels={"sess-a": "config-wins"},
+        )
+        app = _app(config, db)
+        transport = httpx.ASGITransport(app=app)
+        async with httpx.AsyncClient(transport=transport, base_url="http://test") as c:
+            resp = await c.post(
+                "/api/v1/sessions/sess-a/label", json={"label": "db-rename"}
+            )
+            assert resp.status_code == 200
+            # DB row is written, but the config entry still wins in /status.
+            assert get_session_labels(db.conn)["sess-a"] == "db-rename"
+            labels = await _status_labels(c)
+            assert labels["sess-a"] == "config-wins"
+            # A session with no config entry uses the DB rename.
+            await c.post("/api/v1/sessions/sess-b/label", json={"label": "b-rename"})
+            assert (await _status_labels(c))["sess-b"] == "b-rename"
+    finally:
+        db.close()
+
+
+@pytest.mark.asyncio
+async def test_label_stripped_and_truncated():
+    db = InMemoryBackend()
+    try:
+        app = _app(_plain_config(), db)
+        transport = httpx.ASGITransport(app=app)
+        async with httpx.AsyncClient(transport=transport, base_url="http://test") as c:
+            resp = await c.post(
+                "/api/v1/sessions/sess-a/label",
+                json={"label": "  " + "x" * 200 + "  "},
+            )
+            assert resp.status_code == 200
+            stored = resp.json()["label"]
+            assert stored == "x" * 120           # stripped + truncated to 120
+            assert get_session_labels(db.conn)["sess-a"] == "x" * 120
+    finally:
+        db.close()
+
+
+@pytest.mark.asyncio
+async def test_post_label_rejects_non_dict_body():
+    db = InMemoryBackend()
+    try:
+        app = _app(_plain_config(), db)
+        transport = httpx.ASGITransport(app=app)
+        async with httpx.AsyncClient(transport=transport, base_url="http://test") as c:
+            resp = await c.post("/api/v1/sessions/sess-a/label", json=["not", "a", "dict"])
+            assert resp.status_code == 400
+    finally:
+        db.close()

--- a/tests/unit/test_status_sdk.py
+++ b/tests/unit/test_status_sdk.py
@@ -1,0 +1,224 @@
+"""Tests for the /status SDK-services zone: per-minute sparkline series
+(`sdk_service_series`) + the last-seen-keyed lifecycle (`_build_sdk_services`)
+and the coding/sdk `kind` tag on the status route.
+"""
+from __future__ import annotations
+
+from datetime import timedelta
+
+import httpx
+import pytest
+
+from tokenjam.api.app import create_app
+from tokenjam.api.routes.status import _build_sdk_services
+from tokenjam.core.config import ApiAuthConfig, ApiConfig, SecurityConfig, TjConfig
+from tokenjam.core.db import InMemoryBackend, sdk_service_series
+from tokenjam.core.ingest import IngestPipeline
+from tokenjam.utils.time_parse import utcnow
+from tests.factories import make_llm_span, make_session
+
+
+# ── sdk_service_series (per-minute buckets + zero-fill) ─────────────────────
+
+def test_series_buckets_and_zero_fills():
+    db = InMemoryBackend()
+    try:
+        now = utcnow()
+        # Two spans in the current minute: one ok, one error, $0.01 each.
+        db.insert_span(make_llm_span(agent_id="svc-x", cost_usd=0.01,
+                                     status="ok", start_time=now))
+        db.insert_span(make_llm_span(agent_id="svc-x", cost_usd=0.01,
+                                     status="error", start_time=now))
+        window_start = now - timedelta(minutes=24)
+        out = sdk_service_series(db.conn, ["svc-x"], window_start, now, slots=24)
+        s = out["svc-x"]
+
+        assert len(s["cost_per_min"]) == 24
+        assert len(s["calls_per_min"]) == 24
+        assert len(s["err_pct_per_min"]) == 24
+        # The current minute is the last slot.
+        assert s["calls_per_min"][-1] == 2
+        assert s["cost_per_min"][-1] == pytest.approx(0.02)
+        assert s["err_pct_per_min"][-1] == pytest.approx(50.0)
+        # Earlier slots are a flatline.
+        assert s["calls_per_min"][0] == 0
+        assert s["err_pct_per_min"][0] == 0.0
+        # Window totals.
+        assert s["window_calls"] == 2
+        assert s["window_errors"] == 1
+        assert s["window_cost"] == pytest.approx(0.02)
+        assert s["last_seen"] is not None
+    finally:
+        db.close()
+
+
+def test_series_flatline_when_no_recent_spans():
+    db = InMemoryBackend()
+    try:
+        now = utcnow()
+        old = now - timedelta(days=2)
+        db.insert_span(make_llm_span(agent_id="svc-old", cost_usd=0.5,
+                                     start_time=old))
+        window_start = now - timedelta(minutes=24)
+        out = sdk_service_series(db.conn, ["svc-old"], window_start, now, slots=24)
+        s = out["svc-old"]
+
+        assert s["calls_per_min"] == [0] * 24
+        assert s["err_pct_per_min"] == [0.0] * 24
+        assert s["window_calls"] == 0
+        # last_seen comes from an all-history query, not the sparkline window.
+        assert s["last_seen"] is not None
+    finally:
+        db.close()
+
+
+def test_series_empty_for_no_agents():
+    db = InMemoryBackend()
+    try:
+        now = utcnow()
+        assert sdk_service_series(db.conn, [], now - timedelta(minutes=24), now) == {}
+    finally:
+        db.close()
+
+
+# ── _build_sdk_services (lifecycle state machine + kind) ────────────────────
+
+def test_build_classifies_live_quiet_dormant_and_excludes_coding():
+    db = InMemoryBackend()
+    try:
+        now = utcnow()
+        db.insert_span(make_llm_span(agent_id="svc-live",
+                                     start_time=now, cost_usd=0.01))
+        db.insert_span(make_llm_span(agent_id="svc-quiet",
+                                     start_time=now - timedelta(minutes=20),
+                                     cost_usd=0.01))
+        db.insert_span(make_llm_span(agent_id="svc-dormant",
+                                     start_time=now - timedelta(minutes=45),
+                                     cost_usd=0.01))
+        # An interactive coding agent must NOT appear in the SDK zone.
+        db.insert_span(make_llm_span(agent_id="claude-code-x",
+                                     start_time=now, cost_usd=0.01))
+        agent_ids = ["svc-live", "svc-quiet", "svc-dormant", "claude-code-x"]
+
+        out = _build_sdk_services(db, None, agent_ids, now)
+        by = {s["agent_id"]: s for s in out}
+
+        assert "claude-code-x" not in by
+        assert by["svc-live"]["state"] == "live"
+        assert by["svc-quiet"]["state"] == "went_quiet"
+        assert by["svc-dormant"]["state"] == "long_dormant"
+        assert all(s["kind"] == "sdk" for s in out)
+        # Ordering: live first, then went_quiet, then long_dormant.
+        assert [s["state"] for s in out] == ["live", "went_quiet", "long_dormant"]
+        # Series ride along.
+        assert len(by["svc-live"]["cost_per_min"]) == 24
+    finally:
+        db.close()
+
+
+def test_build_computes_err_rate_and_req_per_min():
+    db = InMemoryBackend()
+    try:
+        now = utcnow()
+        # 3 calls this minute, 1 an error -> err_rate 33.3%, req/min = 3/24.
+        db.insert_span(make_llm_span(agent_id="svc-e", start_time=now,
+                                     status="ok", cost_usd=0.01))
+        db.insert_span(make_llm_span(agent_id="svc-e", start_time=now,
+                                     status="ok", cost_usd=0.01))
+        db.insert_span(make_llm_span(agent_id="svc-e", start_time=now,
+                                     status="error", cost_usd=0.01))
+        out = _build_sdk_services(db, None, ["svc-e"], now)
+        svc = out[0]
+        assert svc["err_rate"] == pytest.approx(100.0 / 3)
+        assert svc["req_per_min"] == pytest.approx(3 / 24)
+        assert svc["window_cost"] == pytest.approx(0.03)
+    finally:
+        db.close()
+
+
+def test_build_excludes_beyond_discovery_window():
+    db = InMemoryBackend()
+    try:
+        now = utcnow()
+        db.insert_span(make_llm_span(agent_id="svc-ancient",
+                                     start_time=now - timedelta(days=10),
+                                     cost_usd=0.01))
+        assert _build_sdk_services(db, None, ["svc-ancient"], now) == []
+    finally:
+        db.close()
+
+
+# ── /status route end-to-end (kind + sdk_services) ─────────────────────────
+
+@pytest.fixture
+def _cfg():
+    return TjConfig(
+        version="1",
+        security=SecurityConfig(ingest_secret="test-secret"),
+        api=ApiConfig(auth=ApiAuthConfig(enabled=False)),
+    )
+
+
+@pytest.fixture
+def _db():
+    backend = InMemoryBackend()
+    yield backend
+    backend.close()
+
+
+@pytest.fixture
+def _client(_cfg, _db):
+    pipeline = IngestPipeline(db=_db, config=_cfg)
+    app = create_app(config=_cfg, db=_db, ingest_pipeline=pipeline)
+    transport = httpx.ASGITransport(app=app)
+    return httpx.AsyncClient(transport=transport, base_url="http://test")
+
+
+async def test_status_route_returns_sdk_services_live(_db, _client):
+    now = utcnow()
+    _db.insert_span(make_llm_span(agent_id="svc-checkout",
+                                  start_time=now, cost_usd=0.02))
+    resp = await _client.get("/api/v1/status")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert "sdk_services" in data
+    svc = [s for s in data["sdk_services"] if s["agent_id"] == "svc-checkout"]
+    assert svc, data["sdk_services"]
+    assert svc[0]["kind"] == "sdk"
+    assert svc[0]["state"] == "live"
+    assert len(svc[0]["cost_per_min"]) == 24
+
+
+async def test_status_route_tags_coding_kind_on_archive(_db, _client):
+    now = utcnow()
+    _db.upsert_session(make_session(
+        agent_id="claude-code-tokenjam", session_id="sess-1", status="closed",
+        input_tokens=1000, output_tokens=200, tool_call_count=5,
+        started_at=now - timedelta(hours=1), ended_at=now - timedelta(minutes=30),
+    ))
+    resp = await _client.get("/api/v1/status")
+    data = resp.json()
+    arch = [a for a in data["archived"] if a["agent_id"] == "claude-code-tokenjam"]
+    assert arch, data["archived"]
+    assert arch[0]["kind"] == "coding"
+
+
+async def test_status_archive_filters_zero_signal_zombies(_db, _client):
+    # A terminal that opened and did nothing (0 tokens, 0 tool calls) carries no
+    # method/cost, so it must not clutter the archive. A session with any signal
+    # is kept.
+    now = utcnow()
+    _db.upsert_session(make_session(
+        agent_id="claude-code-zombie", session_id="z-1", status="closed",
+        input_tokens=0, output_tokens=0, tool_call_count=0,
+        started_at=now - timedelta(hours=2), ended_at=now - timedelta(hours=1),
+    ))
+    _db.upsert_session(make_session(
+        agent_id="claude-code-real", session_id="r-1", status="closed",
+        input_tokens=500, output_tokens=100, tool_call_count=3,
+        started_at=now - timedelta(hours=2), ended_at=now - timedelta(hours=1),
+    ))
+    resp = await _client.get("/api/v1/status")
+    archived_ids = {a["agent_id"] for a in resp.json()["archived"]}
+    assert "claude-code-real" in archived_ids
+    assert "claude-code-zombie" not in archived_ids

--- a/tokenjam/api/middleware.py
+++ b/tokenjam/api/middleware.py
@@ -13,7 +13,9 @@ class IngestAuthMiddleware(BaseHTTPMiddleware):
     Returns 401 with JSON error if secret is wrong or missing.
     """
 
-    PROTECTED_PATHS = {"/api/v1/spans", "/v1/logs", "/v1/traces"}
+    PROTECTED_PATHS = {
+        "/api/v1/spans", "/api/v1/sessions/close", "/v1/logs", "/v1/traces",
+    }
 
     async def dispatch(self, request: Request, call_next):  # type: ignore[override]
         if request.method == "POST" and request.url.path in self.PROTECTED_PATHS:

--- a/tokenjam/api/routes/logs.py
+++ b/tokenjam/api/routes/logs.py
@@ -8,7 +8,12 @@ from typing import Any
 
 from tokenjam.core.ingest import IngestPipeline, SpanRejectedError
 from tokenjam.core.models import NormalizedSpan, SpanKind, SpanStatus
-from tokenjam.otel.semconv import ClaudeCodeEvents, CodexEvents, GenAIAttributes
+from tokenjam.otel.semconv import (
+    ClaudeCodeEvents,
+    CodexEvents,
+    GenAIAttributes,
+    ResourceAttributes,
+)
 from tokenjam.utils.ids import new_span_id
 from tokenjam.api.routes.spans import _otlp_value, _safe_int
 
@@ -512,6 +517,15 @@ def parse_log_records(
                     span = converter(attrs, resource_attrs, timestamp_ns)
                     if span is None:
                         continue
+                    # service.namespace / service.instance.id are resource-level
+                    # attrs (project + terminal); stamp them on every span the
+                    # converter built.
+                    span.service_namespace = resource_attrs.get(
+                        ResourceAttributes.SERVICE_NAMESPACE
+                    )
+                    span.service_instance_id = resource_attrs.get(
+                        ResourceAttributes.SERVICE_INSTANCE_ID
+                    )
                     pipeline.process(span)
                     ingested += 1
                 except SpanRejectedError as exc:

--- a/tokenjam/api/routes/sessions.py
+++ b/tokenjam/api/routes/sessions.py
@@ -1,21 +1,35 @@
-"""GET /api/v1/sessions — session enumeration (one row per session).
+"""Session routes.
 
-Unlike /status (which collapses to one record per agent via
-`ORDER BY started_at DESC LIMIT 1`), this route returns every matching
-session, so a single agent running multiple concurrent sessions is fully
-represented. The MCP `list_active_sessions` tool proxies here in serve mode
-so its output matches the direct-DB path (#35).
+GET /api/v1/sessions — session enumeration (one row per session). Unlike
+/status (which collapses to one record per agent via
+`ORDER BY started_at DESC LIMIT 1`), this route returns every matching session,
+so a single agent running multiple concurrent sessions is fully represented.
+The MCP `list_active_sessions` tool proxies here in serve mode so its output
+matches the direct-DB path (#35).
+
+POST /api/v1/sessions/close — mark a terminal's sessions closed. Claude Code
+emits no "session closed" telemetry, so tj can't passively know a terminal
+exited. The `claude` shell wrapper installed by `tj onboard --claude-code`
+reports the exit explicitly by POSTing here (via `tj session-end`) when
+`claude` returns or is interrupted. This is a write endpoint gated by the same
+ingest Bearer auth as POST /api/v1/spans (see IngestAuthMiddleware.PROTECTED_PATHS),
+so it is not additionally gated by the read-side API key.
+
+POST /api/v1/sessions/{id}/label — set (or clear) a user-supplied display name
+for a session (the dashboard's right-click rename). API-key gated.
 """
 from __future__ import annotations
 
 from fastapi import APIRouter, Depends, Request
+from fastapi.responses import JSONResponse
 
 from tokenjam.api.deps import require_api_key
+from tokenjam.core.db import delete_session_label, set_session_label
 
-router = APIRouter(dependencies=[Depends(require_api_key)])
+router = APIRouter()
 
 
-@router.get("/sessions")
+@router.get("/sessions", dependencies=[Depends(require_api_key)])
 async def list_sessions(
     request: Request,
     status: str | None = None,
@@ -61,3 +75,86 @@ async def list_sessions(
         for r in rows
     ]
     return {"sessions": sessions, "count": len(sessions)}
+
+
+@router.post("/sessions/close")
+async def close_sessions(request: Request) -> JSONResponse:
+    """Close all active sessions matching an instance_id and/or session_id.
+
+    Body: ``{"instance_id": "<id>"}`` and/or ``{"session_id": "<id>"}`` —
+    at least one is required. Idempotent: closing already-closed sessions is a
+    no-op. Returns ``{"closed": <count>}``.
+    """
+    try:
+        body = await request.json()
+    except Exception:
+        return JSONResponse(status_code=400, content={"error": "Invalid JSON body"})
+
+    if not isinstance(body, dict):
+        return JSONResponse(
+            status_code=400, content={"error": "Expected a JSON object"}
+        )
+
+    instance_id = body.get("instance_id")
+    session_id = body.get("session_id")
+    if not instance_id and not session_id:
+        return JSONResponse(
+            status_code=400,
+            content={"error": "Provide instance_id and/or session_id"},
+        )
+
+    db = request.app.state.db
+    closed = 0
+    if instance_id:
+        closed += db.close_sessions_by_instance(instance_id)
+    if session_id:
+        closed += db.close_session_by_id(session_id)
+
+    return JSONResponse(status_code=200, content={"closed": closed})
+
+
+# Max length of a user-supplied session label; longer input is truncated.
+MAX_SESSION_LABEL_LEN = 120
+
+
+@router.post(
+    "/sessions/{session_id}/label",
+    dependencies=[Depends(require_api_key)],
+)
+async def set_session_label_endpoint(
+    request: Request, session_id: str
+) -> JSONResponse:
+    """Set (or clear) a user-supplied display name for a session.
+
+    Body: ``{"label": "<str>"}``. The label is stripped and truncated to
+    ``MAX_SESSION_LABEL_LEN``; an empty (or whitespace-only) label CLEARS any
+    existing rename, reverting the card to its default (service.instance.id ->
+    short session id). The /status route overlays this onto the tile/archive
+    label, taking precedence over the OTel instance id but NOT over a config
+    ``[session_labels]`` entry (see ``status._session_label``).
+
+    Dashboard action gated by ``require_api_key`` (the UI's ``apiPost`` sends the
+    Bearer api key) — deliberately NOT added to the ingest-secret PROTECTED_PATHS.
+    Returns ``{"session_id": ..., "label": <str|None>}`` (None when cleared).
+    """
+    try:
+        body = await request.json()
+    except Exception:
+        return JSONResponse(status_code=400, content={"error": "Invalid JSON body"})
+
+    if not isinstance(body, dict):
+        return JSONResponse(
+            status_code=400, content={"error": "Expected a JSON object"}
+        )
+
+    label = (body.get("label") or "").strip()[:MAX_SESSION_LABEL_LEN]
+    db = request.app.state.db
+    if not label:
+        delete_session_label(db, session_id)
+        return JSONResponse(
+            status_code=200, content={"session_id": session_id, "label": None}
+        )
+    set_session_label(db, session_id, label)
+    return JSONResponse(
+        status_code=200, content={"session_id": session_id, "label": label}
+    )

--- a/tokenjam/api/routes/status.py
+++ b/tokenjam/api/routes/status.py
@@ -1,19 +1,238 @@
-"""GET /api/v1/status — agent status overview."""
+"""GET /api/v1/status — agent status overview + session archive."""
 from __future__ import annotations
+
+from datetime import timedelta, timezone
 
 from fastapi import APIRouter, Depends, Request
 
 from tokenjam.api.deps import require_api_key
-from tokenjam.core.db import _row_to_session, session_active_seconds
+from tokenjam.core.alerts import is_interactive_coding_agent
+from tokenjam.core.db import (
+    _row_to_session,
+    get_session_labels,
+    sdk_service_series,
+    session_active_seconds,
+)
 from tokenjam.core.framing import (
     WindowSummary,
     compute_framing,
     plan_determination_mix,
 )
-from tokenjam.core.models import AlertFilters
+from tokenjam.core.models import (
+    SESSION_IDLE_THRESHOLD,
+    SESSION_STALE_THRESHOLD,
+    AlertFilters,
+    SessionRecord,
+)
 from tokenjam.utils.time_parse import utcnow
 
 router = APIRouter(dependencies=[Depends(require_api_key)])
+
+# Max current (active/idle) tiles to surface per agent. Extra concurrent
+# terminals beyond this are reported via the per-tile `overflow` count rather
+# than silently dropped.
+MAX_SESSION_TILES = 6
+# How many archived (closed/stale) sessions to return, most-recent first.
+ARCHIVE_LIMIT = 50
+# Scan this many times ARCHIVE_LIMIT candidates so the 0-signal zombie filter
+# can still surface up to ARCHIVE_LIMIT sessions that did real work.
+ARCHIVE_CANDIDATE_FACTOR = 6
+
+# --- SDK-services zone (non-interactive agents) -----------------------------
+# An SDK service never "closes" — it just stops emitting telemetry. So its
+# lifecycle is keyed on last-seen, not an explicit end:
+#   live         : seen within LIVE_WINDOW           -> Prometheus panel
+#   went_quiet   : silent for LIVE..QUIET_WINDOW     -> inactive list, amber
+#                  (was steady, just stopped — possible outage)
+#   long_dormant : silent beyond QUIET_WINDOW        -> inactive list, muted
+# A silent service is ambiguous (decommissioned / idle / crashed), so the UI
+# surfaces last-seen and flags the recently-quiet case for a human to check.
+SDK_LIVE_WINDOW = SESSION_STALE_THRESHOLD          # 5 min
+SDK_QUIET_WINDOW = timedelta(minutes=30)
+# Only surface SDK services seen within this window at all (keeps the inactive
+# list bounded; older services age out entirely).
+SDK_DISCOVERY_WINDOW = timedelta(days=7)
+SDK_SERVICES_LIMIT = 50
+# Per-minute sparkline resolution for the live services panel.
+SDK_SPARKLINE_SLOTS = 24
+_SDK_STATE_RANK = {"live": 0, "went_quiet": 1, "long_dormant": 2}
+
+
+def _session_label(
+    session_id: str | None,
+    instance_id: str | None,
+    session_labels: dict[str, str],
+    db_labels: dict[str, str] | None = None,
+) -> str | None:
+    """Human display name for a session's terminal.
+
+    Priority: config [session_labels] exact match -> config prefix match ->
+    DB rename (dashboard right-click -> POST /sessions/{id}/label) -> OTel
+    service.instance.id (durable, set at launch) -> None (UI falls back to the
+    short session id). The dashboard rename beats the ttys… instance id, but a
+    config [session_labels] entry still wins over a rename.
+    """
+    if session_id and session_labels:
+        if session_id in session_labels:
+            return session_labels[session_id]
+        for key, label in session_labels.items():
+            if session_id.startswith(key):
+                return label
+    if db_labels and session_id and session_id in db_labels:
+        return db_labels[session_id]
+    return instance_id
+
+
+def _idle_threshold(config) -> timedelta:
+    """Configured idle window ([sessions] idle_minutes), else the default."""
+    if config is not None:
+        return timedelta(minutes=config.session_idle_minutes)
+    return SESSION_IDLE_THRESHOLD
+
+
+def _project_for(config, agent_id: str) -> str | None:
+    """Server-side project fallback ([agents.<id>].project) for an agent."""
+    if config is None:
+        return None
+    agent_cfg = config.agents.get(agent_id)
+    return agent_cfg.project if agent_cfg else None
+
+
+def _build_archive(
+    db,
+    config,
+    session_labels: dict[str, str],
+    idle_threshold: timedelta,
+    cutoff,
+    agent_id: str | None,
+    db_labels: dict[str, str] | None = None,
+) -> list[dict]:
+    """Closed + stale sessions, most-recent first, capped at ARCHIVE_LIMIT.
+
+    Stale = an 'active' session whose last activity is older than the idle
+    window (a zombie that was never explicitly closed). Closed = a session
+    explicitly ended via /api/v1/sessions/close.
+    """
+    if not hasattr(db, "conn"):
+        return []
+
+    clause = (
+        "status = 'closed' "
+        "OR (status = 'active' AND COALESCE(ended_at, started_at) <= $1)"
+    )
+    params: list = [cutoff]
+    sql = f"SELECT * FROM sessions WHERE ({clause})"
+    if agent_id:
+        params.append(agent_id)
+        sql += f" AND agent_id = ${len(params)}"
+    # Fetch more candidates than we return: 0-signal zombie terminals are
+    # dropped below, so scan a wider window to still surface up to ARCHIVE_LIMIT
+    # sessions that did real work.
+    params.append(ARCHIVE_LIMIT * ARCHIVE_CANDIDATE_FACTOR)
+    sql += f" ORDER BY COALESCE(ended_at, started_at) DESC LIMIT ${len(params)}"
+
+    rows = db.conn.execute(sql, params).fetchall()
+    cols = [d[0] for d in db.conn.description]
+    archived: list[dict] = []
+    for r in rows:
+        s = _row_to_session(r, cols)
+        namespace = s.service_namespace or _project_for(config, s.agent_id)
+        # Drop 0-signal zombies: a terminal that opened and did nothing (no
+        # tokens, no tool calls, no cost) carries no method worth reviewing.
+        total_cost_usd = float(s.total_cost_usd) if s.total_cost_usd is not None else 0.0
+        if (s.input_tokens == 0 and s.output_tokens == 0
+                and s.tool_call_count == 0 and total_cost_usd == 0):
+            continue
+        archived.append({
+            "agent_id": s.agent_id,
+            "kind": "coding" if is_interactive_coding_agent(s.agent_id) else "sdk",
+            "namespace": namespace,
+            "session_id": s.session_id,
+            "label": _session_label(
+                s.session_id, s.service_instance_id, session_labels, db_labels
+            ),
+            "status": s.status_at(idle_threshold),
+            "input_tokens": s.input_tokens,
+            "output_tokens": s.output_tokens,
+            "tool_call_count": s.tool_call_count,
+            "total_cost_usd": (
+                float(s.total_cost_usd) if s.total_cost_usd is not None else 0.0
+            ),
+            "started_at": s.started_at.isoformat() if s.started_at else None,
+            "last_span_time": s.ended_at.isoformat() if s.ended_at else None,
+        })
+        if len(archived) >= ARCHIVE_LIMIT:
+            break
+    return archived
+
+
+def _build_sdk_services(db, config, agent_ids: list[str], now) -> list[dict]:
+    """SDK (non-interactive) agents seen recently, each with per-minute cost /
+    error sparkline series + a live/went_quiet/long_dormant lifecycle keyed on
+    last-seen. Best-effort: any failure degrades to [] rather than 500-ing the
+    whole /status route.
+    """
+    conn = getattr(db, "conn", None)
+    if conn is None:
+        return []
+    try:
+        sdk_ids = [a for a in agent_ids if not is_interactive_coding_agent(a)]
+        if not sdk_ids:
+            return []
+        window_start = now - timedelta(minutes=SDK_SPARKLINE_SLOTS)
+        series = sdk_service_series(
+            conn, sdk_ids, window_start, now, slots=SDK_SPARKLINE_SLOTS
+        )
+        discovery_cutoff = now - SDK_DISCOVERY_WINDOW
+
+        services: list[dict] = []
+        for aid in sdk_ids:
+            s = series.get(aid) or {}
+            last_seen = s.get("last_seen")
+            if last_seen is None:
+                continue
+            if last_seen.tzinfo is None:
+                last_seen = last_seen.replace(tzinfo=timezone.utc)
+            if last_seen < discovery_cutoff:
+                continue
+
+            gap = now - last_seen
+            if gap <= SDK_LIVE_WINDOW:
+                state = "live"
+            elif gap <= SDK_QUIET_WINDOW:
+                state = "went_quiet"
+            else:
+                state = "long_dormant"
+
+            window_calls = s.get("window_calls", 0)
+            window_errors = s.get("window_errors", 0)
+            err_rate = (window_errors / window_calls * 100.0) if window_calls else 0.0
+            # Average request rate over the sparkline window (req/min).
+            req_per_min = window_calls / SDK_SPARKLINE_SLOTS
+
+            services.append({
+                "agent_id": aid,
+                "kind": "sdk",
+                "namespace": _project_for(config, aid),
+                "state": state,
+                "last_seen": last_seen.isoformat(),
+                "today_cost": db.get_daily_cost(aid, now.date()),
+                "cost_per_min": s.get("cost_per_min", []),
+                "calls_per_min": s.get("calls_per_min", []),
+                "err_pct_per_min": s.get("err_pct_per_min", []),
+                "req_per_min": req_per_min,
+                "err_rate": err_rate,
+                "window_cost": s.get("window_cost", 0.0),
+            })
+
+        # Live first, then went_quiet, then long_dormant; each newest-seen first.
+        # Stable sort: order by last_seen desc, then by state rank (ISO strings
+        # sort chronologically, so reverse=True gives newest-first).
+        services.sort(key=lambda x: x["last_seen"], reverse=True)
+        services.sort(key=lambda x: _SDK_STATE_RANK[x["state"]])
+        return services[:SDK_SERVICES_LIMIT]
+    except Exception:
+        return []
 
 
 @router.get("/status")
@@ -22,6 +241,17 @@ async def get_status(
     agent_id: str | None = None,
 ) -> dict:
     db = request.app.state.db
+    config = getattr(request.app.state, "config", None)
+    session_labels = dict(config.session_labels) if config else {}
+    # Dashboard renames (POST /sessions/{id}/label), fetched once and overlaid on
+    # every tile/archive label below (config entries still win, see
+    # _session_label). Single query for all overrides.
+    db_labels = get_session_labels(getattr(db, "conn", None))
+    idle_threshold = _idle_threshold(config)
+    now = utcnow()
+    # Sessions whose last activity is newer than this are "current" (active or
+    # idle) and get a tile; older active sessions are stale -> archive only.
+    current_cutoff = now - idle_threshold
 
     # Discover agent IDs
     if agent_id:
@@ -38,57 +268,93 @@ async def get_status(
         agent_ids = []
 
     has_active_alerts = False
-    agents_data = []
+    agents_data: list[dict] = []
 
     for aid in agent_ids:
-        session = None
-
-        # Check for active session first, then fall back to latest completed
+        # Current tiles: active sessions (one per live terminal) whose last
+        # activity is within the idle window. Closed/completed/stale sessions
+        # never become a current tile — they live only in the archive.
+        sessions: list[SessionRecord] = []
         if hasattr(db, "conn"):
-            active_rows = db.conn.execute(
+            rows = db.conn.execute(
                 "SELECT * FROM sessions WHERE agent_id = $1 AND status = 'active' "
-                "ORDER BY started_at DESC LIMIT 1",
-                [aid],
+                "AND COALESCE(ended_at, started_at) > $2 "
+                "ORDER BY COALESCE(ended_at, started_at) DESC",
+                [aid, current_cutoff],
             ).fetchall()
-            if active_rows:
+            if rows:
                 cols = [d[0] for d in db.conn.description]
-                session = _row_to_session(active_rows[0], cols)
+                sessions = [_row_to_session(r, cols) for r in rows]
 
-        if session is None:
-            sessions = db.get_completed_sessions(aid, limit=1)
-            if sessions:
-                session = sessions[0]
+        today_cost = db.get_daily_cost(aid, now.date())
 
-        # Active (compute) time = sum of span durations for the session.
-        # Distinct from the wall-clock duration_seconds below — see issue #147.
-        active_seconds = None
-        if session is not None and hasattr(db, "conn"):
-            active_seconds = session_active_seconds(db.conn, session.session_id)
-
-        today_cost = db.get_daily_cost(aid, utcnow().date())
-
-        # Active (unacknowledged, unsuppressed) alerts
+        # Active (unacknowledged, unsuppressed) alerts for this agent.
         alerts = db.get_alerts(AlertFilters(agent_id=aid, unread=True, limit=50))
         active_alerts = [a for a in alerts if not a.acknowledged and not a.suppressed]
         if active_alerts:
             has_active_alerts = True
 
-        agent_data = {
-            "agent_id": aid,
-            "status": session.status if session else "idle",
-            "session_id": session.session_id if session else None,
-            "cost_today": today_cost,
-            "input_tokens": session.input_tokens if session else 0,
-            "output_tokens": session.output_tokens if session else 0,
-            "tool_call_count": session.tool_call_count if session else 0,
-            "error_count": session.error_count if session else 0,
-            "active_alerts": len(active_alerts),
-            "duration_seconds": session.duration_seconds if session else None,
-            "active_seconds": active_seconds,
-            "started_at": session.started_at.isoformat() if session and session.started_at else None,
-            "total_cost_usd": float(session.total_cost_usd) if session and session.total_cost_usd is not None else 0.0,
-        }
-        agents_data.append(agent_data)
+        if not sessions:
+            # No active/idle session — contribute no current tile.
+            continue
+
+        configured_project = _project_for(config, aid)
+        # Cap tiles by recency; surface (don't silently drop) the overflow.
+        overflow = max(0, len(sessions) - MAX_SESSION_TILES)
+        shown = sessions[:MAX_SESSION_TILES]
+        multi = len(shown) > 1
+        for session in shown:
+            namespace = session.service_namespace or configured_project
+            # Active (compute) time = sum of span durations for the session.
+            # Distinct from the wall-clock duration_seconds — see issue #147.
+            active_seconds = None
+            if hasattr(db, "conn"):
+                active_seconds = session_active_seconds(db.conn, session.session_id)
+            # When several sessions share one agent, attribute alerts per
+            # session; otherwise use the agent-level count (covers alerts that
+            # carry no session_id).
+            if multi:
+                sess_alerts = sum(
+                    1 for a in active_alerts if a.session_id == session.session_id
+                )
+            else:
+                sess_alerts = len(active_alerts)
+            agents_data.append({
+                "agent_id": aid,
+                "kind": "coding" if is_interactive_coding_agent(aid) else "sdk",
+                "namespace": namespace,
+                "status": session.status_at(idle_threshold),
+                "session_id": session.session_id,
+                "label": _session_label(
+                    session.session_id, session.service_instance_id,
+                    session_labels, db_labels,
+                ),
+                "cost_today": today_cost,
+                "total_cost_usd": (
+                    float(session.total_cost_usd)
+                    if session.total_cost_usd is not None else 0.0
+                ),
+                "input_tokens": session.input_tokens,
+                "output_tokens": session.output_tokens,
+                "tool_call_count": session.tool_call_count,
+                "error_count": session.error_count,
+                "active_alerts": sess_alerts,
+                "duration_seconds": session.duration_seconds,
+                "active_seconds": active_seconds,
+                "started_at": (
+                    session.started_at.isoformat() if session.started_at else None
+                ),
+                "last_span_time": (
+                    session.ended_at.isoformat() if session.ended_at else None
+                ),
+                # Per-agent count of current sessions hidden by the tile cap.
+                "overflow": overflow,
+            })
+
+    # SDK-services zone: non-interactive agents with per-minute sparkline series
+    # + a last-seen-keyed lifecycle. Separate from the coding tiles above, which
+    # are session-backed interactive terminals.
+    sdk_services = _build_sdk_services(db, config, agent_ids, now)
 
     # Plan-tier framing block so the agent cards' "Cost today" figure suppresses
     # / reframes raw dollars for subscription / local users (#191) — the web UI
@@ -102,8 +368,15 @@ async def get_status(
         WindowSummary(plan_tier_mix=mix, sessions=sum(mix.values())),
     )
 
+    archived = _build_archive(
+        db, config, session_labels, idle_threshold, current_cutoff, agent_id,
+        db_labels,
+    )
+
     return {
         "agents": agents_data,
+        "archived": archived,
+        "sdk_services": sdk_services,
         "has_active_alerts": has_active_alerts,
         "framing": framing.to_dict(),
     }

--- a/tokenjam/cli/cmd_onboard.py
+++ b/tokenjam/cli/cmd_onboard.py
@@ -38,16 +38,20 @@ from tokenjam.utils.formatting import console
               help="Plan tier for the provider being onboarded. Skips the "
                    "interactive plan prompt when set. Choices: api / pro / "
                    "max_5x / max_20x (Anthropic), plus / team / enterprise (OpenAI).")
+@click.option("--project", "project_override", default=None,
+              help="Project name to group this repo under in the dashboard "
+                   "(OTel service.namespace — e.g. all Aquanodeio/* repos under "
+                   "'aquanode'). Defaults to the git org. Used with --claude-code.")
 @click.pass_context
 def cmd_onboard(ctx: click.Context, claude_code: bool, codex: bool, budget: float | None,
                 install_daemon: bool, no_daemon: bool, force: bool,
-                reconfigure: bool, plan: str | None) -> None:
+                reconfigure: bool, plan: str | None, project_override: str | None) -> None:
     """Interactive setup wizard for tj."""
     # Branded welcome moment (#240) — shown once at the top of every onboard
     # flow (plain / --claude-code / --codex) before any prompt or config check.
     print_welcome_banner()
     if claude_code:
-        _onboard_claude_code(ctx, budget, no_daemon, force, reconfigure, plan)
+        _onboard_claude_code(ctx, budget, no_daemon, force, reconfigure, plan, project_override)
         return
     if codex:
         _onboard_codex(ctx, budget, no_daemon, force, reconfigure, plan)
@@ -325,6 +329,7 @@ def _onboard_claude_code(
     force: bool,
     reconfigure: bool = False,
     plan_override: str | None = None,
+    project_override: str | None = None,
 ) -> None:
     """Configure Claude Code to send telemetry to tj."""
     from tokenjam.core.config import (
@@ -340,6 +345,17 @@ def _onboard_claude_code(
 
     project_name = _derive_project_name()
     agent_id = f"claude-code-{project_name}"
+    # Project name = OTel service.namespace, the key the dashboard groups by.
+    # A meta-repo (e.g. git repo "harness" holding all of "aquanode") wants a
+    # human project name, so prompt with the repo name as default. --project
+    # skips the prompt for non-interactive use.
+    if project_override:
+        namespace = project_override
+    else:
+        namespace = click.prompt(
+            "Project name (groups related repos under one dashboard tile)",
+            default=project_name, show_default=True,
+        ).strip() or project_name
 
     # Plan-first (#240): resolve the plan tier before prompting for the daily
     # budget — "How do you pay?" is the more important, more natural opener.
@@ -347,6 +363,9 @@ def _onboard_claude_code(
         config = load_config(str(global_config_path))
         if agent_id not in config.agents:
             config.agents[agent_id] = AgentConfig()
+        # Server-side project mapping so already-running sessions group by
+        # project without restarting the agent (see AgentConfig.project).
+        config.agents[agent_id].project = namespace
 
         existing_plan = (
             config.budgets["anthropic"].plan
@@ -406,7 +425,7 @@ def _onboard_claude_code(
                 usd = ceiling
         budget = _prompt_daily_budget(budget)
         daily_usd = budget if budget and budget > 0 else None
-        agents = {agent_id: AgentConfig(budget=BudgetConfig(daily_usd=daily_usd))}
+        agents = {agent_id: AgentConfig(budget=BudgetConfig(daily_usd=daily_usd), project=namespace)}
         config = TjConfig(
             version="1",
             agents=agents,
@@ -534,8 +553,15 @@ def _onboard_claude_code(
         except (json_mod.JSONDecodeError, OSError):
             project_settings = {}
 
+    # The `claude` shell wrapper (installed below) now owns
+    # OTEL_RESOURCE_ATTRIBUTES, exporting a distinct service.instance.id per
+    # terminal. Claude Code's settings.json `env` block OVERRIDES shell env, so
+    # a value hardcoded here would clobber the wrapper's per-terminal value and
+    # silently collapse every terminal back into one dashboard tile. Do not
+    # write it, and delete any pre-existing one to migrate older setups (other
+    # env keys are left untouched).
     project_env: dict = project_settings.get("env", {})
-    project_env["OTEL_RESOURCE_ATTRIBUTES"] = f"service.name={agent_id}"
+    removed_resource_attr = project_env.pop("OTEL_RESOURCE_ATTRIBUTES", None) is not None
     project_settings["env"] = project_env
     project_settings_path.write_text(json_mod.dumps(project_settings, indent=2) + "\n")
 
@@ -579,6 +605,12 @@ def _onboard_claude_code(
         )
         zshrc.write_text(updated)
 
+    # --- Per-terminal naming: install the `claude` shell wrapper ---
+    # Tags each terminal with a distinct service.instance.id so concurrent
+    # Claude Code sessions render as separate dashboard tiles, without the user
+    # hand-editing their shell rc. Idempotent across re-onboards.
+    wrapper_files = _install_claude_wrapper()
+
     want_daemon = not no_daemon
     _finish_onboard_serve(
         str(config_path.resolve()),
@@ -594,7 +626,22 @@ def _onboard_claude_code(
     console.print("[bold green]Claude Code observability configured.[/bold green]")
     console.print(f"  Global settings:     {global_settings_path}")
     console.print(f"  Project settings:    {project_settings_path}")
+    if removed_resource_attr:
+        console.print(
+            "  [yellow]Removed a hardcoded OTEL_RESOURCE_ATTRIBUTES from project "
+            "settings[/yellow] (the claude wrapper now sets it per terminal)."
+        )
     console.print("  Shell env:           ~/.zshrc (harness-compatible endpoint)")
+    if wrapper_files:
+        console.print(
+            f"  claude wrapper:      {', '.join(wrapper_files)} "
+            "(per-terminal naming)"
+        )
+        console.print(
+            "  [dim]The claude wrapper controls OTEL_RESOURCE_ATTRIBUTES per "
+            "terminal (service.instance.id); project settings.json no longer "
+            "sets it.[/dim]"
+        )
     console.print(f"  Agent ID:            {agent_id}")
     if budget and budget > 0:
         console.print(f"  Daily budget:        ${budget:.2f}")
@@ -624,6 +671,11 @@ def _onboard_claude_code(
         _warn_manual_serve_restart(stopped_for_db=stopped_for_db, no_daemon=True)
         console.print("[dim]Start the server:[/dim]  tj serve")
     _print_restart_banner("Claude Code")
+    console.print(
+        "[dim]Open a new terminal, then launch with[/dim]  claude  "
+        "[dim](each terminal becomes its own dashboard tile;[/dim] "
+        "claude --as <name> [dim]to label it).[/dim]"
+    )
     console.print(f"[dim]After restarting, run:[/dim]  tj status --agent {agent_id}")
 
 
@@ -1216,6 +1268,107 @@ def _sync_secret_to_claude_code(secret: str) -> bool:
     settings["env"] = env
     settings_path.write_text(json_mod.dumps(settings, indent=2) + "\n")
     return True
+
+
+_WRAPPER_MARKER = "# tj per-terminal naming"
+_WRAPPER_END_MARKER = "# end tj per-terminal naming"
+
+
+def _claude_wrapper_block() -> str:
+    """Return the idempotent ``claude`` shell-wrapper block.
+
+    The wrapper tags each terminal with a distinct ``service.instance.id`` so
+    concurrent Claude Code sessions show as separate dashboard tiles. It:
+
+    - consumes an optional ``--as <name>`` flag and passes the rest through,
+    - derives the instance id from ``--as`` else the tty basename else
+      ``unknown``,
+    - exports ``OTEL_RESOURCE_ATTRIBUTES`` (project attrs from
+      ``tj otel-resource-attrs`` + the instance id),
+    - runs the real binary via ``command claude`` so it never recurses,
+    - reports the session closed (``tj session-end``) when claude exits or is
+      interrupted, so the dashboard archives the tile (Claude Code emits no
+      close event of its own). Best-effort and idempotent.
+
+    Written portably so it works in both zsh and bash.
+    """
+    return (
+        f"{_WRAPPER_MARKER}\n"
+        f"# Tags each terminal with a distinct service.instance.id so concurrent\n"
+        f"# Claude Code sessions appear as separate TokenJam dashboard tiles.\n"
+        f"# Override the label with: claude --as <name>\n"
+        f"claude() {{\n"
+        f'  local _tj_as=""\n'
+        f"  local -a _tj_args=()\n"
+        f'  while [ "$#" -gt 0 ]; do\n'
+        f'    case "$1" in\n'
+        f'      --as) _tj_as="$2"; shift 2 ;;\n'
+        f'      --as=*) _tj_as="${{1#--as=}}"; shift ;;\n'
+        f'      *) _tj_args+=("$1"); shift ;;\n'
+        f"    esac\n"
+        f"  done\n"
+        f'  local _tj_inst="$_tj_as"\n'
+        f'  if [ -z "$_tj_inst" ]; then\n'
+        f'    local _tj_tty\n'
+        f'    _tj_tty="$(tty 2>/dev/null)"\n'
+        f'    case "$_tj_tty" in\n'
+        f'      /dev/*) _tj_inst="${{_tj_tty#/dev/}}"; _tj_inst="${{_tj_inst//\\//-}}" ;;\n'
+        f"    esac\n"
+        f"  fi\n"
+        f'  [ -z "$_tj_inst" ] && _tj_inst="unknown"\n'
+        f'  export OTEL_RESOURCE_ATTRIBUTES="$(tj otel-resource-attrs),service.instance.id=$_tj_inst"\n'
+        f"  # Report this terminal's session closed on exit/interrupt so the\n"
+        f"  # dashboard archives its tile. Idempotent — double-fire is harmless.\n"
+        f"  trap 'tj session-end --instance \"$_tj_inst\" >/dev/null 2>&1 || true' INT TERM HUP\n"
+        f'  command claude "${{_tj_args[@]}}"\n'
+        f"  local _tj_status=$?\n"
+        f"  trap - INT TERM HUP\n"
+        f'  tj session-end --instance "$_tj_inst" >/dev/null 2>&1 || true\n'
+        f"  return $_tj_status\n"
+        f"}}\n"
+        f"{_WRAPPER_END_MARKER}\n"
+    )
+
+
+def _install_claude_wrapper() -> list[str]:
+    """Install the idempotent ``claude`` wrapper into the user's shell rc files.
+
+    Always writes ``~/.zshrc`` (created if absent); also writes ``~/.bashrc``
+    only when it already exists. Re-running replaces the existing block in place
+    (matched between the begin/end markers) so onboards never duplicate it.
+
+    Returns the list of rc files that were written.
+    """
+    import re as _re
+
+    block = _claude_wrapper_block()
+    written: list[str] = []
+
+    zshrc = Path.home() / ".zshrc"
+    zshrc.touch(exist_ok=True)
+    targets = [zshrc]
+    bashrc = Path.home() / ".bashrc"
+    if bashrc.exists():
+        targets.append(bashrc)
+
+    for rc in targets:
+        text = rc.read_text()
+        if _WRAPPER_MARKER not in text:
+            with rc.open("a") as f:
+                # Ensure a blank line before the block for readability.
+                f.write(("" if text.endswith("\n") or not text else "\n") + "\n" + block)
+        else:
+            # Replace the existing block (begin marker .. end marker) in place.
+            updated = _re.sub(
+                _re.escape(_WRAPPER_MARKER) + r".*?" + _re.escape(_WRAPPER_END_MARKER) + r"\n",
+                block,
+                text,
+                flags=_re.DOTALL,
+            )
+            rc.write_text(updated)
+        written.append(str(rc))
+
+    return written
 
 
 def _derive_project_name() -> str:

--- a/tokenjam/cli/cmd_otel.py
+++ b/tokenjam/cli/cmd_otel.py
@@ -1,0 +1,37 @@
+from __future__ import annotations
+
+import click
+
+from tokenjam.cli.cmd_onboard import _derive_project_name
+
+
+@click.command("otel-resource-attrs")
+@click.pass_context
+def cmd_otel_resource_attrs(ctx: click.Context) -> None:
+    """Print this project's OTel resource attributes on a single line.
+
+    Emits e.g. ``service.name=claude-code-myrepo,service.namespace=myproject``.
+
+    The per-terminal ``claude`` shell wrapper installed by
+    ``tj onboard --claude-code`` shells out to this command and appends a
+    ``service.instance.id=<terminal>`` so concurrent terminals show as
+    distinct tiles on the dashboard while keeping the project's
+    ``service.name`` / ``service.namespace``.
+
+    Output goes to stdout as a single bare line with no markup so it is safe
+    to embed in ``OTEL_RESOURCE_ATTRIBUTES="$(tj otel-resource-attrs),..."``.
+    """
+    # Same derivation tj onboard uses: git remote repo name, else cwd dir name.
+    # So agent id == service.name == claude-code-<repo>.
+    agent_id = f"claude-code-{_derive_project_name()}"
+    attrs = f"service.name={agent_id}"
+
+    # Append service.namespace only when this repo's agent has a project set in
+    # config (written by `tj onboard --claude-code`). No config / no project =>
+    # service.name only.
+    config = ctx.obj["config"]
+    agent_cfg = config.agents.get(agent_id)
+    if agent_cfg is not None and agent_cfg.project:
+        attrs += f",service.namespace={agent_cfg.project}"
+
+    click.echo(attrs)

--- a/tokenjam/cli/cmd_session_end.py
+++ b/tokenjam/cli/cmd_session_end.py
@@ -1,0 +1,61 @@
+"""`tj session-end` — report a terminal's Claude Code session(s) as closed.
+
+Called best-effort by the `claude` shell wrapper when `claude` exits or is
+interrupted. It POSTs to the running daemon's /api/v1/sessions/close endpoint
+so the dashboard can move that terminal's tile to the archive immediately
+(Claude Code emits no "session closed" telemetry of its own).
+
+Talks to the daemon over HTTP, never the DB (it is in `no_db_commands`). It
+must NEVER break the user's shell, so any failure (daemon down, network error)
+exits 0 silently; pass -v to surface what happened.
+"""
+from __future__ import annotations
+
+import json as json_mod
+import urllib.error
+import urllib.request
+
+import click
+
+_REQUEST_TIMEOUT_S = 2.0
+
+
+@click.command("session-end")
+@click.option("--instance", default=None,
+              help="service.instance.id of the terminal whose sessions to close")
+@click.option("--session", default=None,
+              help="session_id to close (alternative/addition to --instance)")
+@click.pass_context
+def cmd_session_end(ctx: click.Context, instance: str | None, session: str | None) -> None:
+    """Mark a terminal's active sessions as closed (best-effort, over HTTP)."""
+    if not instance and not session:
+        raise click.UsageError("Provide --instance and/or --session.")
+
+    config = ctx.obj["config"]
+    verbose = ctx.obj.get("verbose", False)
+
+    payload: dict[str, str] = {}
+    if instance:
+        payload["instance_id"] = instance
+    if session:
+        payload["session_id"] = session
+
+    url = f"http://{config.api.host}:{config.api.port}/api/v1/sessions/close"
+    headers = {"Content-Type": "application/json"}
+    secret = config.security.ingest_secret
+    if secret:
+        headers["Authorization"] = f"Bearer {secret}"
+
+    request = urllib.request.Request(
+        url, data=json_mod.dumps(payload).encode("utf-8"),
+        headers=headers, method="POST",
+    )
+    try:
+        with urllib.request.urlopen(request, timeout=_REQUEST_TIMEOUT_S) as resp:
+            if verbose:
+                body = resp.read().decode("utf-8", errors="replace")
+                click.echo(f"session-end: {resp.status} {body}")
+    except (urllib.error.URLError, OSError, ValueError) as exc:
+        # Daemon may be down / unreachable. Best-effort: never break the shell.
+        if verbose:
+            click.echo(f"session-end: skipped ({exc})", err=True)

--- a/tokenjam/cli/main.py
+++ b/tokenjam/cli/main.py
@@ -40,7 +40,10 @@ def cli(ctx: click.Context, config_path: str | None, output_json: bool,
         config.storage.path = db_path
 
     # Commands that don't need a database connection
-    no_db_commands = {"stop", "uninstall", "onboard", "mcp", "demo", "policy", "proxy", "summarize", "pricing"}
+    no_db_commands = {
+        "stop", "uninstall", "onboard", "mcp", "demo", "policy",
+        "proxy", "summarize", "pricing", "otel-resource-attrs", "session-end",
+    }
     invoked = ctx.invoked_subcommand
     if invoked in no_db_commands:
         ctx.obj["config"] = config
@@ -105,6 +108,8 @@ from tokenjam.cli.cmd_report import cmd_report  # noqa: E402
 from tokenjam.cli.cmd_policy import cmd_policy  # noqa: E402
 from tokenjam.cli.cmd_pricing import cmd_pricing  # noqa: E402
 from tokenjam.cli.cmd_proxy import cmd_proxy  # noqa: E402
+from tokenjam.cli.cmd_otel import cmd_otel_resource_attrs  # noqa: E402
+from tokenjam.cli.cmd_session_end import cmd_session_end  # noqa: E402
 
 cli.add_command(cmd_onboard, name="onboard")
 cli.add_command(cmd_status, name="status")
@@ -127,6 +132,8 @@ cli.add_command(cmd_report, name="report")
 cli.add_command(cmd_policy, name="policy")
 cli.add_command(cmd_pricing, name="pricing")
 cli.add_command(cmd_proxy, name="proxy")
+cli.add_command(cmd_otel_resource_attrs, name="otel-resource-attrs")
+cli.add_command(cmd_session_end, name="session-end")
 
 # cmd_drift is provided by task 05 — register if available
 try:

--- a/tokenjam/core/alerts.py
+++ b/tokenjam/core/alerts.py
@@ -45,6 +45,23 @@ _FAILURE_RATE_THRESHOLD = 0.20
 _FAILURE_RATE_CHECK_INTERVAL = 5
 _SESSION_DURATION_DEFAULT = 3600  # seconds
 
+# Agent-id prefixes for interactive coding agents (Claude Code / Codex): a
+# heterogeneous, arg-less, human-driven workload. Distinguished from SDK
+# services so the dashboard can split coding sessions from long-lived services.
+_INTERACTIVE_AGENT_PREFIXES = ("claude-code", "codex")
+
+
+def is_interactive_coding_agent(agent_id: str | None) -> bool:
+    """True for Claude Code / Codex agents (interactive, heterogeneous, no args).
+
+    Used to classify a /status agent as a coding session vs an SDK service,
+    keyed on the agent id rather than session-id presence (which is unreliable —
+    ingest mints session_ids for SDK spans too).
+    """
+    if not agent_id:
+        return False
+    return any(agent_id.startswith(p) for p in _INTERACTIVE_AGENT_PREFIXES)
+
 
 # ── Cooldown tracker ───────────────────────────────────────────────────────
 

--- a/tokenjam/core/config.py
+++ b/tokenjam/core/config.py
@@ -41,6 +41,11 @@ class AgentConfig:
     sensitive_actions: list[SensitiveAction] = field(default_factory=list)
     output_schema:    str | None           = None
     drift:            DriftConfig          = field(default_factory=DriftConfig)
+    # Project this agent rolls up under in the dashboard (server-side fallback
+    # for OTel service.namespace). Lets already-running sessions group by
+    # project without restarting the agent — the mapping is applied by tj, so
+    # no service.namespace needs to arrive on the wire.
+    project:          str | None           = None
 
 
 @dataclass
@@ -237,6 +242,15 @@ class TjConfig:
     summarize: SummarizeConfig        = field(default_factory=SummarizeConfig)
     budgets:  dict[str, ProviderBudget] = field(default_factory=dict)
     policies: list[PolicyConfig]      = field(default_factory=list)
+    # Manual session_id -> human label overrides ([session_labels] in TOML).
+    # Keys may be a full session_id or a prefix (e.g. the 8-char short id shown
+    # on the dashboard). Lets you name already-running terminals immediately;
+    # for durable naming prefer OTel service.instance.id.
+    session_labels: dict[str, str]    = field(default_factory=dict)
+    # Idle window (minutes) for the session lifecycle ([sessions] idle_minutes).
+    # An active session quieter than SESSION_STALE_THRESHOLD (5 min) but within
+    # this window renders as "idle"; beyond it as "stale" (archived). 4h default.
+    session_idle_minutes: int         = 240
     # Path to the config file on disk; set by load_config() so that relative
     # paths in the config (e.g. output_schema) can be resolved correctly.
     config_path: Path | None          = field(default=None, repr=False, compare=False)
@@ -383,6 +397,7 @@ def _parse(raw: dict) -> TjConfig:
             sensitive_actions=sensitive_actions,
             output_schema=agent_raw.get("output_schema"),
             drift=drift,
+            project=agent_raw.get("project"),
         )
 
     storage_raw = raw.get("storage", {})
@@ -494,6 +509,8 @@ def _parse(raw: dict) -> TjConfig:
             params=dict(pol_raw.get("params", {})),
         ))
 
+    sessions_raw = raw.get("sessions", {})
+
     return TjConfig(
         version=raw.get("version", "1"),
         defaults=defaults,
@@ -508,6 +525,10 @@ def _parse(raw: dict) -> TjConfig:
         summarize=summarize,
         budgets=budgets,
         policies=policies,
+        session_labels=dict(raw.get("session_labels", {})),
+        session_idle_minutes=int(
+            sessions_raw.get("idle_minutes", TjConfig.session_idle_minutes)
+        ),
     )
 
 
@@ -533,6 +554,11 @@ def _serialise(config: TjConfig) -> dict:
     d = _dc_to_dict(config)
     # `budgets` (dataclass field) maps to `[budget.*]` (TOML key); strip raw form.
     d.pop("budgets", None)
+
+    # `session_idle_minutes` (scalar field) maps to the `[sessions]` table.
+    idle_minutes = d.pop("session_idle_minutes", None)
+    if idle_minutes is not None:
+        d["sessions"] = {"idle_minutes": idle_minutes}
 
     # agents is a dict of str -> AgentConfig, handle specially
     agents_out = {}

--- a/tokenjam/core/db.py
+++ b/tokenjam/core/db.py
@@ -56,6 +56,8 @@ class StorageBackend(Protocol):
     def upsert_baseline(self, baseline: DriftBaseline) -> None: ...
     def get_session(self, session_id: str) -> SessionRecord | None: ...
     def get_session_by_conversation(self, conversation_id: str) -> SessionRecord | None: ...
+    def close_sessions_by_instance(self, instance_id: str) -> int: ...
+    def close_session_by_id(self, session_id: str) -> int: ...
     def get_traces(self, filters: TraceFilters) -> list[TraceRecord]: ...
     def count_traces(self, filters: TraceFilters) -> int: ...
     def get_trace_spans(self, trace_id: str) -> list[NormalizedSpan]: ...
@@ -305,6 +307,45 @@ MIGRATIONS: list[tuple[int, str]] = [
         "ALTER TABLE spans ADD COLUMN IF NOT EXISTS request_params JSON;\n"
         "ALTER TABLE spans ADD COLUMN IF NOT EXISTS request_tools  JSON"
     )),
+    # Migration 8: service_namespace on sessions — the OTel service.namespace
+    # the session's service rolls up under (the dashboard's "project" grouping
+    # key). Nullable; sessions whose telemetry carried no namespace stay NULL.
+    (8, "ALTER TABLE sessions ADD COLUMN IF NOT EXISTS service_namespace TEXT"),
+    # Migration 9: service_instance_id on sessions — the per-terminal label
+    # (OTel service.instance.id) used as the session's display name.
+    (9, "ALTER TABLE sessions ADD COLUMN IF NOT EXISTS service_instance_id TEXT"),
+    # Migration 10: repair ended_at on already-closed sessions. A prior bug in
+    # close_session(s) advanced ended_at to the close time, so a session closed
+    # days after its last span showed a "Last seen" of the close moment instead
+    # of its real last activity. Recompute ended_at from the session's actual
+    # spans (max of end_time / start_time), but only LOWER it — never touch
+    # sessions whose ended_at already matches or precedes their last span.
+    # Idempotent: re-running finds nothing left to correct.
+    (10, (
+        "UPDATE sessions AS s "
+        "SET ended_at = sub.max_ts "
+        "FROM (SELECT session_id, MAX(COALESCE(end_time, start_time)) AS max_ts "
+        "      FROM spans GROUP BY session_id) AS sub "
+        "WHERE s.session_id = sub.session_id "
+        "  AND s.status = 'closed' "
+        "  AND sub.max_ts IS NOT NULL "
+        "  AND (s.ended_at IS NULL OR s.ended_at > sub.max_ts)"
+    )),
+    # Migration 11: session_labels — a user-supplied display name for a session,
+    # set from the dashboard by right-clicking a session card (POST
+    # /api/v1/sessions/{id}/label). One row per session (session_id PRIMARY KEY);
+    # the /status route overlays these onto the tile/archive label, taking
+    # precedence over the OTel service.instance.id but NOT over a config
+    # [session_labels] entry (see status._session_label). Persisting to the DB
+    # (rather than editing the config TOML) keeps renames a runtime dashboard
+    # action that survives restarts without a config write.
+    (11, (
+        "CREATE TABLE IF NOT EXISTS session_labels (\n"
+        "    session_id  TEXT PRIMARY KEY,\n"
+        "    label       TEXT NOT NULL,\n"
+        "    updated_at  TIMESTAMPTZ NOT NULL\n"
+        ")"
+    )),
 ]
 
 
@@ -395,6 +436,8 @@ def _row_to_session(row: tuple, columns: list[str]) -> SessionRecord:
         tool_call_count=d.get("tool_call_count") or 0,
         error_count=d.get("error_count") or 0,
         plan_tier=d.get("plan_tier") or "unknown",
+        service_namespace=d.get("service_namespace"),
+        service_instance_id=d.get("service_instance_id"),
     )
 
 
@@ -416,6 +459,133 @@ def session_active_seconds(conn, session_id: str) -> float | None:
     if not row or row[0] is None:
         return None
     return float(row[0]) / 1000.0
+
+
+def _resolve_conn(db_or_conn):
+    """Return the underlying cursor for a backend, or the conn passed as-is.
+
+    ``set_session_label`` / ``delete_session_label`` accept either a backend
+    (whose per-thread ``.conn`` cursor is used) or a raw DuckDB connection (which
+    has no ``.conn`` attr, so it passes through unchanged).
+    """
+    return getattr(db_or_conn, "conn", db_or_conn)
+
+
+def set_session_label(db_or_conn, session_id: str, label: str) -> None:
+    """Upsert a user-supplied display name for a session (migration 11).
+
+    DuckDB has no portable UPSERT here, so this DELETEs any prior row then
+    INSERTs the fresh one — idempotent (a re-label overwrites). ``updated_at`` is
+    stamped via ``utcnow()`` (Critical Rule 9). Parameterised SQL only (Critical
+    Rule 7: no f-string SQL).
+    """
+    conn = _resolve_conn(db_or_conn)
+    now = utcnow()
+    conn.execute("DELETE FROM session_labels WHERE session_id = $1", [session_id])
+    conn.execute(
+        "INSERT INTO session_labels (session_id, label, updated_at) "
+        "VALUES ($1, $2, $3)",
+        [session_id, label, now],
+    )
+
+
+def delete_session_label(db_or_conn, session_id: str) -> None:
+    """Remove a session's user-supplied display name (migration 11). Idempotent."""
+    conn = _resolve_conn(db_or_conn)
+    conn.execute("DELETE FROM session_labels WHERE session_id = $1", [session_id])
+
+
+def get_session_labels(conn) -> dict[str, str]:
+    """All session -> user label overlays as a dict (migration 11).
+
+    One SELECT so the /status route fetches every override in a single query.
+    Guards a ``None`` conn (a non-DB backend) -> ``{}``.
+    """
+    if conn is None:
+        return {}
+    rows = conn.execute("SELECT session_id, label FROM session_labels").fetchall()
+    return {r[0]: r[1] for r in rows if r[0] is not None and r[1] is not None}
+
+
+def sdk_service_series(
+    conn, agent_ids: list[str], window_start, now, *, slots: int = 24
+) -> dict[str, dict]:
+    """Per-minute cost / calls / error% series + last_seen for the given agents.
+
+    Buckets `spans` by minute over the last `slots` minutes ending at `now`,
+    zero-filled to a fixed-length grid so every agent yields exactly `slots`
+    points (a flatline for services that emitted nothing recently). Also returns
+    window totals (for req/min + err-rate) and `last_seen` across ALL history —
+    a long-dormant service last emitted days ago, outside the sparkline window.
+
+    Powers the /status SDK-services zone (Prometheus-style sparklines). Returns
+    {} when `conn` is None or no agents are given. Each agent maps to:
+        {cost_per_min, calls_per_min, err_pct_per_min: [slots],
+         window_cost, window_calls, window_errors, last_seen}
+    """
+    if conn is None or not agent_ids:
+        return {}
+
+    # Fixed minute grid: slot i covers [grid[i], grid[i] + 60s); grid[-1] is the
+    # minute containing `now`. Epoch-second keys match the SQL bucket below.
+    base = int(now.timestamp() // 60) * 60
+    grid = [base - (slots - 1 - i) * 60 for i in range(slots)]
+    index = {ts: i for i, ts in enumerate(grid)}
+
+    result: dict[str, dict] = {
+        aid: {
+            "cost_per_min": [0.0] * slots,
+            "calls_per_min": [0] * slots,
+            "err_pct_per_min": [0.0] * slots,
+            "window_cost": 0.0,
+            "window_calls": 0,
+            "window_errors": 0,
+            "last_seen": None,
+        }
+        for aid in agent_ids
+    }
+
+    # IN (…) with per-id placeholders — a controlled small list; all values bound
+    # (never interpolated), matching the codebase's dynamic-placeholder style.
+    ph = ", ".join(f"${i + 2}" for i in range(len(agent_ids)))
+    rows = conn.execute(
+        f"""
+        SELECT agent_id,
+               CAST(epoch(date_trunc('minute', start_time AT TIME ZONE 'UTC')) AS BIGINT) AS b,
+               COALESCE(SUM(cost_usd), 0.0)                  AS cost,
+               COUNT(*) FILTER (WHERE status_code = 'error') AS errors,
+               COUNT(*)                                      AS calls
+        FROM spans
+        WHERE start_time >= $1 AND agent_id IN ({ph})
+        GROUP BY agent_id, b
+        """,
+        [window_start, *agent_ids],
+    ).fetchall()
+    for aid, b, cost, errors, calls in rows:
+        r = result[aid]
+        r["window_cost"] += float(cost or 0.0)
+        r["window_calls"] += int(calls or 0)
+        r["window_errors"] += int(errors or 0)
+        slot = index.get(int(b))
+        if slot is None:
+            continue
+        r["cost_per_min"][slot] = float(cost or 0.0)
+        r["calls_per_min"][slot] = int(calls or 0)
+        r["err_pct_per_min"][slot] = (
+            float(errors) / calls * 100.0 if calls else 0.0
+        )
+
+    ph1 = ", ".join(f"${i + 1}" for i in range(len(agent_ids)))
+    seen_rows = conn.execute(
+        f"SELECT agent_id, MAX(COALESCE(end_time, start_time)) "
+        f"FROM spans WHERE agent_id IN ({ph1}) GROUP BY agent_id",
+        [*agent_ids],
+    ).fetchall()
+    for aid, last_seen in seen_rows:
+        if aid in result:
+            result[aid]["last_seen"] = last_seen
+
+    return result
 
 
 def _int_or_none(val: object) -> int | None:
@@ -717,8 +887,9 @@ class DuckDBBackend:
             INSERT INTO sessions (
                 session_id, agent_id, conversation_id, started_at, ended_at,
                 status, total_cost_usd, input_tokens, output_tokens, cache_tokens,
-                tool_call_count, error_count, plan_tier
-            ) VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12,$13)
+                tool_call_count, error_count, plan_tier, service_namespace,
+                service_instance_id
+            ) VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12,$13,$14,$15)
             ON CONFLICT (session_id) DO UPDATE SET
                 ended_at = COALESCE(EXCLUDED.ended_at, sessions.ended_at),
                 status = EXCLUDED.status,
@@ -732,14 +903,17 @@ class DuckDBBackend:
                     WHEN COALESCE(sessions.plan_tier, 'unknown') != 'unknown'
                     THEN sessions.plan_tier
                     ELSE EXCLUDED.plan_tier
-                END
+                END,
+                service_namespace = COALESCE(EXCLUDED.service_namespace, sessions.service_namespace),
+                service_instance_id = COALESCE(EXCLUDED.service_instance_id, sessions.service_instance_id)
             """,
             [
                 session.session_id, session.agent_id, session.conversation_id,
                 session.started_at, session.ended_at, session.status,
                 session.total_cost_usd, session.input_tokens, session.output_tokens,
                 session.cache_tokens, session.tool_call_count, session.error_count,
-                session.plan_tier,
+                session.plan_tier, session.service_namespace,
+                session.service_instance_id,
             ],
         )
 
@@ -811,6 +985,54 @@ class DuckDBBackend:
             return None
         cols = [d[0] for d in cur.description]
         return _row_to_session(rows[0], cols)
+
+    def close_sessions_by_instance(self, instance_id: str) -> int:
+        """Mark all currently-active sessions for a terminal as 'closed'.
+
+        Returns the number closed. Idempotent: already-closed/completed rows are
+        not matched (status='active' filter), so re-closing is a no-op (0).
+        ended_at is the session's last-activity time ("Last seen" in the UI), so
+        closing must NOT advance it — a session closed long after its last span
+        still last had telemetry at that span. Only stamp ended_at when it's
+        NULL (a session that never recorded an end gets the close time).
+        """
+        now = utcnow()
+        count_row = self.conn.execute(
+            "SELECT COUNT(*) FROM sessions "
+            "WHERE service_instance_id = $1 AND status = 'active'",
+            [instance_id],
+        ).fetchone()
+        count = count_row[0] if count_row else 0
+        if count:
+            self.conn.execute(
+                "UPDATE sessions SET status = 'closed', "
+                "ended_at = COALESCE(ended_at, $2) "
+                "WHERE service_instance_id = $1 AND status = 'active'",
+                [instance_id, now],
+            )
+        return count
+
+    def close_session_by_id(self, session_id: str) -> int:
+        """Mark a single active session as 'closed'. Idempotent (see above).
+
+        Preserves ended_at (last-activity / "Last seen"); only stamps it when
+        NULL. Closing is not telemetry, so it must not advance last-seen.
+        """
+        now = utcnow()
+        count_row = self.conn.execute(
+            "SELECT COUNT(*) FROM sessions "
+            "WHERE session_id = $1 AND status = 'active'",
+            [session_id],
+        ).fetchone()
+        count = count_row[0] if count_row else 0
+        if count:
+            self.conn.execute(
+                "UPDATE sessions SET status = 'closed', "
+                "ended_at = COALESCE(ended_at, $2) "
+                "WHERE session_id = $1 AND status = 'active'",
+                [session_id, now],
+            )
+        return count
 
     def _trace_filter_where(self, filters: TraceFilters) -> tuple[str, list[object], int]:
         clauses: list[str] = []
@@ -1034,9 +1256,14 @@ class DuckDBBackend:
         )
 
     def get_completed_sessions(self, agent_id: str, limit: int) -> list[SessionRecord]:
+        # Order by last activity (ended_at), not start time. A short fragment
+        # that *started* later must not hide a long-running session that was
+        # still active afterwards — otherwise the status tile shows a 40s blip
+        # instead of the real multi-hour session. Falls back to started_at when
+        # ended_at is NULL.
         cur = self.conn.execute(
             "SELECT * FROM sessions WHERE agent_id = $1 AND status = 'completed' "
-            "ORDER BY started_at DESC LIMIT $2",
+            "ORDER BY COALESCE(ended_at, started_at) DESC LIMIT $2",
             [agent_id, limit],
         )
         rows = cur.fetchall()

--- a/tokenjam/core/ingest.py
+++ b/tokenjam/core/ingest.py
@@ -198,10 +198,22 @@ class IngestPipeline:
 
         # 5. Session upsert (update running totals)
         session = self._build_or_update_session(span)
-        self.db.upsert_session(session)
 
-        # 5b. Complete session when invoke_agent span ends
-        if span.name == GenAIAttributes.SPAN_INVOKE_AGENT and span.end_time:
+        # 5b. Session lifecycle.
+        #
+        # A session is "completed" only when we see a *real* session-wrapping
+        # invoke_agent span — one whose end_time is strictly after its
+        # start_time. The SDK `@watch()` path emits exactly that: one span that
+        # brackets the whole agent run.
+        #
+        # The Claude Code / Codex logs path instead maps each `user_prompt`
+        # event to a zero-duration invoke_agent span (end_time == start_time)
+        # that marks the *start* of a turn, not the end of the session.
+        # Treating those markers as completions was the bug: every live session
+        # was force-completed on its first prompt (so the dashboard showed
+        # active work as "completed" with 0 duration), and the drift/alert
+        # session-end hooks fired on every single turn.
+        if self._is_session_end(span):
             session.status = "completed"
             self.db.upsert_session(session)
             if self.drift_detector and span.agent_id:
@@ -214,9 +226,34 @@ class IngestPipeline:
                     self.alert_engine.evaluate_session_end(session)
                 except Exception as exc:
                     logger.warning("AlertEngine session-end hook failed: %s", exc)
+        else:
+            # Any other span is ongoing activity. Streaming telemetry (the logs
+            # path) never sends an explicit end event, so a session that keeps
+            # receiving spans is still alive — re-activate a record that was
+            # previously (mis)marked completed. Genuinely idle sessions are
+            # surfaced as "stale" at read time via
+            # SessionRecord.effective_status (SESSION_STALE_THRESHOLD).
+            if session.status != "active":
+                session.status = "active"
+            self.db.upsert_session(session)
 
         # 6. Post-ingest hooks (never let hook errors kill the pipeline)
         self._run_hooks(span)
+
+    @staticmethod
+    def _is_session_end(span: NormalizedSpan) -> bool:
+        """True when the span is a real session-wrapping invoke_agent span.
+
+        Distinguishes the SDK `@watch()` session span (real duration) from the
+        zero-duration invoke_agent markers the Claude Code / Codex logs path
+        emits at the start of every turn (end_time == start_time).
+        """
+        return (
+            span.name == GenAIAttributes.SPAN_INVOKE_AGENT
+            and span.end_time is not None
+            and span.start_time is not None
+            and span.end_time > span.start_time
+        )
 
     def _resolve_session(self, span: NormalizedSpan) -> NormalizedSpan:
         """
@@ -268,6 +305,16 @@ class IngestPipeline:
                 resolved = self._resolve_plan_tier(span.billing_account)
                 if resolved != "unknown":
                     existing.plan_tier = resolved
+            # Late-resolve service_namespace: from the span if it now carries
+            # one, otherwise from the agent's configured project (server-side
+            # fallback for agents that never send service.namespace).
+            if existing.service_namespace is None:
+                resolved_ns = span.service_namespace or self._resolve_project(span.agent_id)
+                if resolved_ns:
+                    existing.service_namespace = resolved_ns
+            # Late-resolve the per-terminal instance id (display label).
+            if existing.service_instance_id is None and span.service_instance_id:
+                existing.service_instance_id = span.service_instance_id
             return existing
 
         # New session
@@ -286,7 +333,21 @@ class IngestPipeline:
             tool_call_count=1 if span.tool_name else 0,
             error_count=1 if span.status_code == SpanStatus.ERROR else 0,
             plan_tier=plan_tier,
+            service_namespace=span.service_namespace or self._resolve_project(span.agent_id),
+            service_instance_id=span.service_instance_id,
         )
+
+    def _resolve_project(self, agent_id: str | None) -> str | None:
+        """Project name configured for this agent (``[agents.<id>].project``).
+
+        Server-side fallback for service.namespace so sessions group by project
+        even when the agent never sends service.namespace on the wire (e.g. an
+        already-running Claude Code session whose env was fixed at startup).
+        """
+        if not agent_id:
+            return None
+        agent_cfg = self.config.agents.get(agent_id)
+        return agent_cfg.project if agent_cfg else None
 
     def _resolve_plan_tier(self, billing_account: str | None) -> str:
         """

--- a/tokenjam/core/models.py
+++ b/tokenjam/core/models.py
@@ -4,8 +4,13 @@ from datetime import datetime, timedelta
 from enum import Enum
 from typing import Any
 
-# Sessions with no spans for this long are considered stale (zombie).
+# Sessions with no spans for this long are no longer "active" (live terminal).
 SESSION_STALE_THRESHOLD = timedelta(minutes=5)
+# Default idle window: active sessions quieter than the stale threshold but
+# within this window are "idle" (paused, likely to resume); beyond it they are
+# "stale" (zombie). Overridable per-install via [sessions] idle_minutes, applied
+# at the status route — effective_status itself stays config-free.
+SESSION_IDLE_THRESHOLD = timedelta(hours=4)
 
 
 class Severity(str, Enum):
@@ -86,6 +91,13 @@ class NormalizedSpan:
     # strip_captured_content() in core/ingest.py. Round-trip via JSON columns.
     request_params: dict[str, Any] | None = None
     request_tools:  dict[str, Any] | None = None
+    # OTel service.namespace — the logical "project" this service rolls up
+    # under (e.g. all Aquanodeio/* repos -> "aquanode"). Transient on the span;
+    # persisted on the session it creates so the dashboard can group by it.
+    service_namespace: str | None  = None
+    # OTel service.instance.id — the per-terminal/process label (e.g.
+    # "founder-os"). Persisted on the session for use as its display name.
+    service_instance_id: str | None = None
 
 
 @dataclass
@@ -108,6 +120,13 @@ class SessionRecord:
     # default to "unknown" — `tj optimize` suppresses dollar figures for those.
     # Valid values: see VALID_PLAN_TIERS in tokenjam.otel.semconv.
     plan_tier:       str          = "unknown"
+    # OTel service.namespace — the logical "project" this session's service
+    # rolls up under (e.g. repo `Aquanodeio/harness` -> namespace "aquanode").
+    # Drives dashboard grouping. None when the telemetry carried no namespace.
+    service_namespace: str | None = None
+    # OTel service.instance.id — the per-terminal label (e.g. "founder-os").
+    # Used as the session's display name when set; None otherwise.
+    service_instance_id: str | None = None
 
     @property
     def duration_seconds(self) -> float | None:
@@ -117,14 +136,63 @@ class SessionRecord:
 
     @property
     def effective_status(self) -> str:
-        """Return 'stale' for zombie sessions whose process was killed."""
+        """Lifecycle tier for the dashboard (pure: uses module-default windows).
+
+        Tiers:
+          closed     -> explicitly ended (status='closed')
+          completed  -> wrapped by a real session span (status='completed')
+          active     -> last activity within SESSION_STALE_THRESHOLD (5 min)
+          idle       -> within SESSION_IDLE_THRESHOLD (default 4h)
+          stale      -> older than the idle window (zombie)
+
+        The status route honours the configurable [sessions] idle_minutes via
+        status_at(); this property stays config-free for use everywhere else.
+        """
+        return self.status_at(SESSION_IDLE_THRESHOLD)
+
+    def status_at(self, idle_threshold: timedelta = SESSION_IDLE_THRESHOLD) -> str:
+        """effective_status with a caller-supplied idle window.
+
+        Separate from the property so the status route can apply a config-driven
+        idle window while effective_status itself remains pure.
+        """
         if self.status != "active":
+            # closed / completed (or any other terminal state) pass through.
             return self.status
         from tokenjam.utils.time_parse import utcnow
         last_activity = self.ended_at or self.started_at
-        if last_activity and (utcnow() - last_activity) > SESSION_STALE_THRESHOLD:
-            return "stale"
-        return "active"
+        if not last_activity:
+            return "active"
+        gap = utcnow() - last_activity
+        if gap <= SESSION_STALE_THRESHOLD:
+            return "active"
+        if gap <= idle_threshold:
+            return "idle"
+        return "stale"
+
+    def status_with_transcript_mtime(
+        self,
+        transcript_mtime: datetime | None,
+        idle_threshold: timedelta = SESSION_IDLE_THRESHOLD,
+    ) -> str:
+        """status_at, but rescued to 'active' by a fresh transcript mtime.
+
+        Claude Code spans are backfilled periodically, so a *live* CC session
+        can drift to ``idle``/``stale`` once its last backfilled span ages past
+        the stale threshold — even though its on-disk transcript is still being
+        appended to. When the deterministic status is idle/stale and the
+        transcript was modified within ``SESSION_STALE_THRESHOLD``, report
+        ``active`` instead. Terminal states (closed/completed) and genuinely
+        active sessions pass through untouched, so non-CC sessions (which have
+        no transcript: ``transcript_mtime is None``) are unaffected.
+        """
+        base = self.status_at(idle_threshold)
+        if base not in ("idle", "stale") or transcript_mtime is None:
+            return base
+        from tokenjam.utils.time_parse import utcnow
+        if utcnow() - transcript_mtime <= SESSION_STALE_THRESHOLD:
+            return "active"
+        return base
 
     @property
     def pricing_mode(self) -> str:

--- a/tokenjam/otel/otlp_parsing.py
+++ b/tokenjam/otel/otlp_parsing.py
@@ -14,7 +14,7 @@ from datetime import datetime, timezone
 from typing import Any
 
 from tokenjam.core.models import NormalizedSpan, SpanKind, SpanStatus
-from tokenjam.otel.semconv import GenAIAttributes, TjAttributes
+from tokenjam.otel.semconv import GenAIAttributes, ResourceAttributes, TjAttributes
 from tokenjam.utils.ids import new_span_id
 
 
@@ -183,6 +183,8 @@ def parse_otlp_span(raw: dict, resource_attrs: dict[str, Any]) -> NormalizedSpan
             attrs.get(TjAttributes.BILLING_ACCOUNT)
             or provider_to_billing_account(provider)
         ),
+        service_namespace=attrs.get(ResourceAttributes.SERVICE_NAMESPACE),
+        service_instance_id=attrs.get(ResourceAttributes.SERVICE_INSTANCE_ID),
     )
 
 

--- a/tokenjam/otel/provider.py
+++ b/tokenjam/otel/provider.py
@@ -14,7 +14,7 @@ from opentelemetry.trace import SpanKind as OtelSpanKind
 
 from tokenjam.core.models import NormalizedSpan, SpanStatus, SpanKind
 from tokenjam.core.config import TjConfig
-from tokenjam.otel.semconv import GenAIAttributes, TjAttributes
+from tokenjam.otel.semconv import GenAIAttributes, ResourceAttributes, TjAttributes
 
 if TYPE_CHECKING:
     from tokenjam.core.ingest import IngestPipeline
@@ -89,6 +89,13 @@ def convert_otel_span(otel_span: ReadableSpan) -> NormalizedSpan:
     # Map gen_ai.provider.name values to billing_account (provider-only).
     billing_account = attrs.pop(TjAttributes.BILLING_ACCOUNT, None) or _provider_to_billing_account(provider)
 
+    # service.namespace is a resource attribute (set on the TracerProvider /
+    # OTEL_RESOURCE_ATTRIBUTES), not a span attribute.
+    resource = getattr(otel_span, "resource", None)
+    resource_attrs = dict(resource.attributes) if resource and resource.attributes else {}
+    service_namespace = resource_attrs.get(ResourceAttributes.SERVICE_NAMESPACE)
+    service_instance_id = resource_attrs.get(ResourceAttributes.SERVICE_INSTANCE_ID)
+
     # Convert int tokens to int (OTel may store as strings)
     if input_tokens is not None:
         input_tokens = int(input_tokens)
@@ -161,6 +168,8 @@ def convert_otel_span(otel_span: ReadableSpan) -> NormalizedSpan:
         attributes=attrs,
         events=events,
         billing_account=billing_account,
+        service_namespace=service_namespace,
+        service_instance_id=service_instance_id,
     )
 
 

--- a/tokenjam/otel/semconv.py
+++ b/tokenjam/otel/semconv.py
@@ -143,6 +143,19 @@ class CodexEvents:
     OUTPUT    = "output"
 
 
+class ResourceAttributes:
+    """OTel standard resource attributes (set per process / service)."""
+    SERVICE_NAME      = "service.name"
+    # Logical grouping above service.name. tj uses it as the "project" a
+    # service belongs to, so the dashboard can roll up every repo under one
+    # project tile (e.g. all `Aquanodeio/*` repos -> namespace "aquanode").
+    SERVICE_NAMESPACE = "service.namespace"
+    # Per-instance identifier (one process / terminal). tj uses it as the
+    # human label for a session's terminal (e.g. "founder-os") when set at
+    # launch via OTEL_RESOURCE_ATTRIBUTES.
+    SERVICE_INSTANCE_ID = "service.instance.id"
+
+
 class TjAttributes:
     """tj-specific span attributes (non-standard extensions)."""
     COST_USD         = "tokenjam.cost_usd"

--- a/tokenjam/ui/index.html
+++ b/tokenjam/ui/index.html
@@ -226,15 +226,45 @@ code, .mono {
   font-weight: 600;
   font-size: 14px;
 }
+/* Right-click-to-rename affordance on a session card title (#306). */
+.rename-title { cursor: context-menu; }
+.rename-pencil {
+  margin-left: 6px;
+  font-size: 11px;
+  color: var(--text-dim);
+  opacity: 0;
+  cursor: pointer;
+  transition: opacity 0.12s ease, color 0.12s ease;
+}
+.card:hover .rename-pencil { opacity: 0.6; }
+.rename-pencil:hover { opacity: 1; color: var(--brand); }
+.rename-input {
+  background: var(--surface);
+  border: 1px solid var(--border);
+  color: var(--text);
+  padding: 2px 6px;
+  border-radius: 5px;
+  font-family: 'Geist Mono', monospace;
+  font-weight: 600;
+  font-size: 14px;
+  min-width: 0;
+  flex: 1 1 auto;
+  max-width: 220px;
+}
+.rename-input:focus { outline: none; border-color: var(--brand); }
 .status-dot {
   width: 8px; height: 8px; border-radius: 50%;
   display: inline-block;
 }
 .status-dot.active { background: var(--success); }
 .status-dot.completed { background: var(--success); }
-.status-dot.idle { background: var(--text-dim); }
+.status-dot.idle { background: var(--warn); }
 .status-dot.error { background: var(--error); }
-.status-dot.stale { background: var(--warn); }
+.status-dot.stale { background: var(--warn); opacity: 0.6; }
+.status-dot.closed { background: var(--text-dim); }
+.status-dot.dormant { background: var(--text-faint); }
+.status-dot.quiet { background: var(--warn); box-shadow: 0 0 0 0 rgba(245,166,35,0.5); animation: pulse-amber 2.4s infinite; }
+@keyframes pulse-amber { 0% { box-shadow: 0 0 0 0 rgba(245,166,35,0.5); } 70% { box-shadow: 0 0 0 6px rgba(245,166,35,0); } 100% { box-shadow: 0 0 0 0 rgba(245,166,35,0); } }
 .card-row {
   display: flex;
   justify-content: space-between;
@@ -327,6 +357,12 @@ tr.clickable { cursor: pointer; }
 tr.clickable:hover td { background: rgba(var(--accent-rgb),0.06); }
 td.chevron { color: var(--text-dim); font-size: 14px; text-align: center; width: 24px; }
 tr.clickable:hover td.chevron { color: var(--accent); }
+/* Status-list row actions: unify the two secondary links (View cost / View
+   traces) into one inline group with consistent spacing, clearly subordinate
+   to the now-clickable row. Mirrors the .card-links link treatment. */
+.row-actions { display: inline-flex; gap: 14px; }
+.row-actions a { font-family: 'Geist Mono', monospace; font-size: 12px; color: var(--brand); text-decoration: none; }
+.row-actions a:hover { text-decoration: underline; }
 
 /* Badges */
 .badge {
@@ -340,10 +376,81 @@ tr.clickable:hover td.chevron { color: var(--accent); }
 .badge-ok, .badge-completed { background: rgba(12,228,144,0.15); color: var(--success); }
 .badge-error { background: rgba(238,0,0,0.15); color: var(--error); }
 .badge-active { background: rgba(12,228,144,0.15); color: var(--success); }
-.badge-stale { background: rgba(245,166,35,0.15); color: var(--warn); }
+.badge-idle { background: rgba(245,166,35,0.15); color: var(--warn); }
+.badge-stale { background: rgba(245,166,35,0.12); color: var(--warn); }
+.badge-closed { background: rgba(140,140,140,0.15); color: var(--text-dim); }
 .badge-critical { background: rgba(238,0,0,0.15); color: var(--error); }
 .badge-warning { background: rgba(245,166,35,0.15); color: var(--warn); }
 .badge-info { background: rgba(61,142,255,0.15); color: var(--info); }
+
+/* Split zones — Status screen (#306) */
+.zone-head { display: flex; align-items: baseline; gap: 10px; margin: 4px 0 14px; }
+.zone-title { font-family: 'Geist', sans-serif; font-size: 16px; font-weight: 700; color: var(--text); }
+.zone-sub { font-family: 'Geist Mono', monospace; font-size: 11px; color: var(--text-dim); }
+.zone-count { margin-left: auto; font-family: 'Geist Mono', monospace; font-size: 11px; color: var(--text-faint); }
+.section-gap { height: 28px; }
+.card-foot { margin-top: 12px; padding-top: 10px; border-top: 1px solid var(--border); font-family: 'Geist Mono', monospace; font-size: 11px; color: var(--brand); display: flex; align-items: center; gap: 6px; }
+.card.clickable:hover .card-foot { color: var(--accent); }
+
+/* Collapsible archive / inactive block */
+details.archive-block { margin-top: 14px; border: 1px solid var(--border); border-radius: 8px; background: var(--surface); overflow: hidden; }
+details.archive-block > summary { list-style: none; cursor: pointer; display: flex; align-items: center; gap: 10px; padding: 11px 14px; background: var(--surface2); font-family: 'Geist Mono', monospace; font-size: 11px; color: var(--text-dim); text-transform: uppercase; letter-spacing: 0.5px; }
+details.archive-block > summary::-webkit-details-marker { display: none; }
+details.archive-block > summary .tw { color: var(--text-faint); font-size: 9px; transition: transform 0.15s; display: inline-block; }
+details.archive-block[open] > summary .tw { transform: rotate(90deg); }
+details.archive-block > summary .a-count { color: var(--text-faint); }
+details.archive-block > summary .a-hint { margin-left: auto; text-transform: none; letter-spacing: 0; color: var(--text-faint); }
+details.archive-block .table-wrap { border-top: 1px solid var(--border); }
+table.archive-list { width: 100%; border-collapse: collapse; font-family: 'Geist Mono', monospace; font-size: 13px; min-width: 820px; }
+table.archive-list th { text-align: left; padding: 9px 14px; color: var(--text-faint); font-weight: 500; font-size: 10px; text-transform: uppercase; letter-spacing: 0.5px; border-bottom: 1px solid var(--border); white-space: nowrap; }
+table.archive-list td { padding: 11px 14px; border-bottom: 1px solid var(--border); white-space: nowrap; color: var(--text-dim); }
+table.archive-list tr:last-child td { border-bottom: none; }
+table.archive-list tr.clickable:hover td { background: rgba(var(--accent-rgb),0.04); }
+table.archive-list .a-id { color: var(--text); }
+
+/* SDK services panel (Prometheus-style rows) */
+.panel { background: var(--surface); border: 1px solid var(--border); border-radius: 8px; overflow: hidden; }
+.panel-head { display: flex; align-items: center; gap: 10px; padding: 10px 14px; border-bottom: 1px solid var(--border); background: var(--surface2); font-family: 'Geist Mono', monospace; font-size: 11px; color: var(--text-dim); text-transform: uppercase; letter-spacing: 0.5px; }
+.panel-head .grip { color: var(--text-faint); }
+.panel-head .range { margin-left: auto; text-transform: none; letter-spacing: 0; }
+.panel-head .range-tag { padding: 2px 7px; border: 1px solid var(--border); border-radius: 5px; color: var(--text-dim); }
+.svc-row { display: grid; grid-template-columns: 200px 82px 1fr 90px 120px; align-items: center; gap: 16px; padding: 12px 14px; border-bottom: 1px solid var(--border); transition: background 0.12s; }
+.svc-row:last-child { border-bottom: none; }
+.svc-row.clickable { cursor: pointer; }
+.svc-row.clickable:hover { background: rgba(var(--accent-rgb),0.03); }
+.svc-name { font-family: 'Geist Mono', monospace; font-size: 13px; display: flex; align-items: center; gap: 8px; color: var(--text); }
+.svc-metric { font-family: 'Geist Mono', monospace; font-size: 13px; color: var(--text); }
+.svc-metric .unit { color: var(--text-dim); font-size: 10px; }
+.metric-label { font-family: 'Geist Mono', monospace; font-size: 9px; color: var(--text-faint); text-transform: uppercase; letter-spacing: 0.4px; }
+.spark-wrap { display: flex; align-items: center; gap: 12px; }
+.spark-col { display: flex; flex-direction: column; gap: 2px; }
+.spark-lab { font-family: 'Geist Mono', monospace; font-size: 9px; color: var(--text-faint); text-transform: uppercase; letter-spacing: 0.3px; }
+.err-good { color: var(--success); }
+.err-warn { color: var(--warn); }
+.err-bad { color: var(--error); }
+.svc-empty { padding: 16px 14px; font-family: 'Geist Mono', monospace; font-size: 12px; color: var(--text-dim); }
+
+/* Inactive services list */
+.inactive-list { border-top: 1px solid var(--border); }
+.inact-row { display: grid; grid-template-columns: 220px 150px 1fr 176px auto; align-items: center; gap: 16px; padding: 13px 14px; border-bottom: 1px solid var(--border); transition: background 0.12s; }
+.inact-row:last-child { border-bottom: none; }
+.inact-row.clickable { cursor: pointer; }
+.inact-row.clickable:hover { background: rgba(var(--accent-rgb),0.03); }
+.inact-name { font-family: 'Geist Mono', monospace; font-size: 13px; display: flex; align-items: center; gap: 8px; color: var(--text-dim); }
+.inact-row.quiet .inact-name { color: var(--text); }
+.inact-row.quiet { background: rgba(245,166,35,0.035); }
+.inact-seen { font-family: 'Geist Mono', monospace; font-size: 12px; color: var(--text-faint); }
+.inact-flat { display: flex; align-items: center; gap: 10px; }
+.inact-flat .svg-flat { flex-shrink: 0; }
+.inact-flatline { font-family: 'Geist Mono', monospace; font-size: 11px; color: var(--text-faint); font-style: italic; }
+.inact-meta { font-family: 'Geist Mono', monospace; font-size: 12px; color: var(--text-dim); text-align: right; white-space: nowrap; }
+.inact-meta .unit { color: var(--text-faint); font-size: 10px; }
+.inact-tag { font-family: 'Geist Mono', monospace; font-size: 10px; font-weight: 700; text-transform: uppercase; letter-spacing: 0.4px; padding: 3px 9px; border-radius: 6px; white-space: nowrap; }
+.tag-dormant { background: rgba(237,237,237,0.06); color: var(--text-faint); border: 1px solid var(--border); }
+.tag-quiet { background: rgba(245,166,35,0.13); color: var(--warn); border: 1px solid rgba(245,166,35,0.35); }
+.inact-actions { display: inline-flex; gap: 12px; }
+.inact-actions a { font-family: 'Geist Mono', monospace; font-size: 12px; color: var(--brand); text-decoration: none; cursor: pointer; }
+.inact-actions a:hover { text-decoration: underline; }
 
 /* Filters */
 .filters {
@@ -1527,61 +1634,121 @@ function dominantSplit(costSegs) {
 }
 
 // ============================
-// Status List Table (#241)
+// SDK Services zone (#306)
 // ============================
-// The List alternative to the Status cards: one row per agent in a columned
-// table — Agent · Status · Cost today · Tokens · Tool calls · Elapsed · Actions.
-// The Cost cell goes through fmtPerItemCost(framing) exactly like the cards do:
-// per-item cost is rendered as TOKENS for subscription/local users (not "% of
-// cycle", which is a window-level aggregate — #249) and as dollars for api. The
-// suppression decision is never re-derived here. Reuses the existing
-// .table-wrap/table CSS; no new lib.
-function StatusListTable({ agents, framing }) {
+// Non-interactive SDK agents render as Prometheus-style rows: name + status
+// dot, cost/day, a cost/min sparkline + a smaller err% sparkline, err-rate and
+// req/min. Services that stopped emitting telemetry drop into a collapsible
+// "Inactive" list keyed on last-seen — went_quiet (amber: recently silent →
+// possible outage) vs long_dormant (muted: silent for a while). Reuses the
+// shared Sparkline + fmtAgo + fmtFramedDollar; introduces no new palette.
+function _sdkErrClass(pct) {
+  return pct > 0.5 ? 'err-bad' : pct > 0 ? 'err-warn' : 'err-good';
+}
+function _sdkErrColor(pct) {
+  return pct > 0.5 ? 'var(--error)' : pct > 0 ? 'var(--warn)' : 'var(--success)';
+}
+function _flatlineSvg(color) {
+  return html`<svg class="svg-flat" width="120" height="24" viewBox="0 0 120 24" preserveAspectRatio="none">
+    <line x1="0" y1="12" x2="120" y2="12" stroke=${color} stroke-width="1.2" stroke-dasharray="3 3"></line>
+  </svg>`;
+}
+function SdkServicesPanel({ services, framing }) {
+  const live = services.filter(s => s.state === 'live');
+  const inactive = services.filter(s => s.state !== 'live');
+  const openTraces = (aid) => { location.hash = '#/traces?agent_id=' + encodeURIComponent(aid); };
+
+  const svcRow = (s) => {
+    const errPct = s.err_rate || 0;
+    return html`
+      <div class="svc-row clickable" title="Open service traces & cost"
+           onClick=${() => openTraces(s.agent_id)}>
+        <div class="svc-name"><span class="status-dot live"></span>${s.agent_id}</div>
+        <div class="svc-metric">$${(s.today_cost || 0).toFixed(2)}<span class="unit">/day</span></div>
+        <div class="spark-wrap">
+          <div class="spark-col" style="flex:1;min-width:1px">
+            <span class="spark-lab">cost / min</span>
+            <${Sparkline} values=${s.cost_per_min} color="var(--brand)" width=${220} height=${30} />
+          </div>
+          <div class="spark-col" style="width:110px">
+            <span class="spark-lab">error %</span>
+            <${Sparkline} values=${s.err_pct_per_min} color=${_sdkErrColor(errPct)} width=${110} height=${30} />
+          </div>
+        </div>
+        <div class="svc-metric ${_sdkErrClass(errPct)}">${errPct.toFixed(1)}%<div class="metric-label">err rate</div></div>
+        <div class="svc-metric" style="text-align:right">~${Math.round(s.req_per_min || 0)}<span class="unit"> req/min</span></div>
+      </div>`;
+  };
+
+  const inactRow = (s) => {
+    const quiet = s.state === 'went_quiet';
+    const dotCls = quiet ? 'quiet' : 'dormant';
+    const tagCls = quiet ? 'tag-quiet' : 'tag-dormant';
+    const tag = quiet ? 'went quiet' : 'long-dormant';
+    const flatColor = quiet ? 'var(--warn)' : 'var(--text-faint)';
+    const extra = quiet ? ('was ~' + Math.round(s.req_per_min || 0) + ' req/min') : 'no data in 24h';
+    const seen = (quiet ? 'went quiet ' : 'last seen ') + fmtAgo(s.last_seen);
+    return html`
+      <div class=${'inact-row clickable ' + (quiet ? 'quiet' : 'dormant')}
+           title=${quiet ? 'Was steady and just stopped — check for an incident' : 'Long silent — likely decommissioned'}
+           onClick=${() => openTraces(s.agent_id)}>
+        <div class="inact-name"><span class="status-dot ${dotCls}"></span>${s.agent_id}</div>
+        <div><span class=${'inact-tag ' + tagCls}>${tag}</span></div>
+        <div class="inact-flat">${_flatlineSvg(flatColor)}<span class="inact-flatline">${extra}</span></div>
+        <div class="inact-meta"><span class="inact-seen">${seen}</span><br/>$${(s.today_cost || 0).toFixed(2)}<span class="unit"> today</span></div>
+        <div class="inact-actions">
+          <a href=${'#/traces?agent_id=' + encodeURIComponent(s.agent_id)} onClick=${e => e.stopPropagation()}>Traces</a>
+          <a href=${'#/cost?agent_id=' + encodeURIComponent(s.agent_id)} onClick=${e => e.stopPropagation()}>Cost</a>
+        </div>
+      </div>`;
+  };
+
   return html`
-    <div class="table-wrap"><table class="status-list">
-      <thead><tr>
-        <th>Agent</th>
-        <th>Status</th>
-        <th>Cost today <span class="info-btn">i<span class="info-tip">Estimated from token usage. If you're on a subscription plan (e.g. Claude Max), your actual spend may differ.</span></span></th>
-        <th>Tokens (in / out)</th>
-        <th>Tool calls</th>
-        <th>Elapsed <span class="info-btn">i<span class="info-tip">Wall-clock from session start to last activity. Resumed Claude Code sessions span days.</span></span></th>
-        <th></th>
-      </tr></thead>
-      <tbody>
-        ${agents.map(a => html`
-          <tr>
-            <td class="mono"><span class="status-dot ${a.status}" style="margin-right:7px"></span>${a.agent_id}</td>
-            <td><span class="badge badge-${a.status}">${a.status}</span></td>
-            <td>${fmtPerItemCost(a.cost_today, _costVal(a, true), framing)}</td>
-            <td>${fmtTokens(a.input_tokens)} / ${fmtTokens(a.output_tokens)}</td>
-            <td>${a.tool_call_count}${a.error_count ? ' (' + a.error_count + ' failed)' : ''}</td>
-            <td>${a.duration_seconds != null ? fmtDurLong(a.duration_seconds * 1000) : '-'}</td>
-            <td style="white-space:nowrap">
-              <a href=${'#/cost?agent_id=' + encodeURIComponent(a.agent_id)}>View cost →</a>
-              <a href=${'#/traces?agent_id=' + encodeURIComponent(a.agent_id)} style="margin-left:10px">View traces →</a>
-            </td>
-          </tr>
-        `)}
-      </tbody>
-    </table></div>`;
+    <div class="panel">
+      <div class="panel-head">
+        <span class="grip">⣿</span>
+        <span>SDK agents / services · cost & error rate</span>
+        <span class="range"><span class="range-tag">last 24m · 1m step</span></span>
+      </div>
+      <div>
+        ${live.length ? live.map(svcRow) : html`<div class="svc-empty">No SDK services live right now</div>`}
+      </div>
+    </div>
+    ${inactive.length ? html`
+      <details class="archive-block" open>
+        <summary>
+          <span class="tw">▶</span>
+          <span>Inactive</span>
+          <span class="a-count">(no telemetry in 24h) · ${inactive.length}</span>
+          <span class="a-hint">keyed on last-seen · a silent service may be an outage</span>
+        </summary>
+        <div class="inactive-list">${inactive.map(inactRow)}</div>
+      </details>` : null}
+  `;
 }
 
 // ============================
 // Status View
 // ============================
 function StatusView({ params }) {
-  // Optional single-agent filter via URL (#112). Filtered client-side since
-  // /status returns every agent.
-  // View mode (Cards | List) also lives in the URL (#241): `#/status?view=cards`.
-  // List is the default (the more useful scan view, #263) and is omitted from
-  // the URL; choosing Cards carries `?view=cards`.
-  const DEFAULTS = { view: 'list', agent_id: '' };
-  const agentId = readParam(params, 'agent_id', DEFAULTS.agent_id);
-  const viewMode = readParam(params, 'view', DEFAULTS.view, v => ['cards', 'list'].includes(v));
-  const setView = (v) => navigate('status', { agent_id: agentId, view: v }, DEFAULTS);
+  // Optional single-agent filter via URL (#112), filtered client-side.
+  // The Status screen is two content-defined zones (#306): coding sessions
+  // (bounded work → archived list) and SDK services (unbounded telemetry →
+  // inactive list). Content, not a user toggle, decides what renders.
+  const agentId = readParam(params, 'agent_id', '');
   const [data, setData] = useState(null);
   const [alerts, setAlerts] = useState([]);
+  // Inline session-card rename (#306): which session's title is being edited,
+  // its working value, and a ref so the input autofocuses + selects on open.
+  const [editingId, setEditingId] = useState(null);
+  const [editValue, setEditValue] = useState('');
+  const renameRef = useRef(null);
+  useLayoutEffect(() => {
+    if (editingId && renameRef.current) {
+      renameRef.current.focus();
+      renameRef.current.select();
+    }
+  }, [editingId]);
 
   const load = useCallback(async () => {
     const [s, a] = await Promise.all([
@@ -1595,33 +1762,80 @@ function StatusView({ params }) {
   useEffect(() => { load(); const t = setInterval(load, 5000); return () => clearInterval(t); }, [load]);
 
   if (!data) return html`<div class="empty">Loading...</div>`;
-  if (!data.agents.length) return html`<div class="empty">No agents found. Run an agent with ${'`@watch()`'} to start recording.<code>pip install tokenjam && tj onboard</code></div>`;
+  const sdkServices = data.sdk_services || [];
+  if (!data.agents.length && !(data.archived || []).length && !sdkServices.length) return html`<div class="empty">No agents found. Run an agent with ${'`@watch()`'} to start recording.<code>pip install tokenjam && tj onboard</code></div>`;
 
   const agents = agentId ? data.agents.filter(a => a.agent_id === agentId) : data.agents;
+  // Coding zone = interactive coding agents (cards) + coding archive.
+  // SDK zone = data.sdk_services, rendered by SdkServicesPanel. The two zones
+  // are content-defined, not a user-selected view (#306).
+  const codingAgents = agents.filter(a => a.kind === 'coding');
+  const codingArchived = (data.archived || []).filter(s => s.kind === 'coding' && (!agentId || s.agent_id === agentId));
 
-  return html`
-    <div class="page-title">Status</div>
-    <div style="display:flex;align-items:center;gap:12px;margin:-14px 0 16px">
-      <div style="font-size:12px;color:var(--text-dim);font-family:'Geist Mono',monospace">
-        ${agentId
-          ? html`Filtered to <span class="mono">${agentId}</span> · <a href="#/status" style="color:var(--brand)">show all</a>`
-          : (viewMode === 'list' ? 'Click on an agent row for details' : 'Click on an agent tile for details')}
-      </div>
-      <div class="view-toggle" style="margin-left:auto" role="tablist" aria-label="Status view mode">
-        <button class=${viewMode === 'cards' ? 'active' : ''} aria-pressed=${viewMode === 'cards'} onClick=${() => setView('cards')}>Cards</button>
-        <button class=${viewMode === 'list' ? 'active' : ''} aria-pressed=${viewMode === 'list'} onClick=${() => setView('list')}>List</button>
-      </div>
-    </div>
-    ${viewMode === 'list'
-      ? StatusListTable({ agents, framing: data.framing })
-      : html`<div class="cards">
-      ${agents.map(a => html`
-        <div class="card">
+  // Group coding tiles by project (service.namespace). Agents whose telemetry
+  // carried no namespace fall under "Ungrouped".
+  const UNGROUPED = ' ungrouped';
+  const groups = {};
+  for (const a of codingAgents) {
+    const key = a.namespace || UNGROUPED;
+    (groups[key] = groups[key] || []).push(a);
+  }
+  const groupKeys = Object.keys(groups).sort((x, y) =>
+    x === UNGROUPED ? 1 : y === UNGROUPED ? -1 : x.localeCompare(y));
+  // Only show project headers when at least one agent has a real namespace.
+  const showHeadings = groupKeys.some(k => k !== UNGROUPED);
+
+  // Per-group count of current sessions hidden by the per-agent tile cap.
+  // `overflow` is duplicated across an agent's tiles, so dedupe by agent_id.
+  const groupOverflow = (key) => {
+    const seen = {};
+    let total = 0;
+    for (const a of groups[key]) {
+      if (a.overflow && !seen[a.agent_id]) { seen[a.agent_id] = 1; total += a.overflow; }
+    }
+    return total;
+  };
+
+  // Coding-session tile. The whole card is clickable through to the session
+  // detail (or traces when there's no session_id yet). Cost goes through the
+  // shared fmtPerItemCost(framing) path (#249). A footer echoes the openable
+  // method surfaces (Map / Approach / Timeline live as tabs on the detail page).
+  // Persist a right-click rename, then refresh immediately (don't wait for the
+  // 5s poll). An empty value clears the rename (backend reverts to the default).
+  const submitRename = async (a) => {
+    const value = editValue.trim();
+    setEditingId(null);
+    try {
+      await apiPost('/sessions/' + encodeURIComponent(a.session_id) + '/label', { label: value });
+      await load();
+    } catch (e) { /* leave the existing name; a transient failure isn't fatal */ }
+  };
+
+  const agentCard = (a) => {
+    const displayName = a.label || a.agent_id;
+    const isEditing = a.session_id && editingId === a.session_id;
+    const startEdit = a.session_id
+      ? (e) => { e.preventDefault(); e.stopPropagation(); setEditValue(displayName); setEditingId(a.session_id); }
+      : null;
+    return html`
+        <div class="card clickable" onContextMenu=${startEdit} onClick=${() => { if (isEditing) return; location.hash = a.session_id ? '#/sessions/' + a.session_id : '#/traces'; }}>
           <div class="card-header">
             <span class="status-dot ${a.status}"></span>
-            ${a.agent_id}
+            ${isEditing
+              ? html`<input ref=${renameRef} class="rename-input" value=${editValue}
+                  onClick=${e => e.stopPropagation()}
+                  onInput=${e => setEditValue(e.target.value)}
+                  onBlur=${() => submitRename(a)}
+                  onKeyDown=${e => {
+                    e.stopPropagation();
+                    if (e.key === 'Enter') { e.preventDefault(); submitRename(a); }
+                    else if (e.key === 'Escape') { e.preventDefault(); setEditingId(null); }
+                  }} />`
+              : html`<span class="rename-title" title=${a.session_id ? 'Click ✎ or right-click to rename' : null} onContextMenu=${startEdit}>${displayName}${a.session_id ? html`<span class="rename-pencil" onClick=${startEdit} title="Rename">✎</span>` : null}</span>`}
             <span class="badge badge-${a.status}" style="margin-left:auto">${a.status}</span>
           </div>
+          ${a.label ? html`<div class="card-row"><span class="label">Agent</span><span class="value" style="font-family:'Geist Mono',monospace;font-size:12px">${a.agent_id}</span></div>` : null}
+          ${a.session_id ? html`<div class="card-row"><span class="label">Session</span><span class="value" style="font-family:'Geist Mono',monospace;font-size:12px">${a.session_id.slice(0, 8)}</span></div>` : null}
           <div class="card-row"><span class="label">Cost today <span class="info-btn">i<span class="info-tip">Estimated from token usage. If you're on a subscription plan (e.g. Claude Max), your actual spend may differ.</span></span></span><span class="value">${fmtPerItemCost(a.cost_today, _costVal(a, true), data.framing)}</span></div>
           <div class="card-row"><span class="label">Tokens</span><span class="value">${fmtTokens(a.input_tokens)} in / ${fmtTokens(a.output_tokens)} out</span></div>
           <div class="card-row"><span class="label">Tool calls</span><span class="value">${a.tool_call_count}${a.error_count ? ' (' + a.error_count + ' failed)' : ''}</span></div>
@@ -1629,14 +1843,86 @@ function StatusView({ params }) {
           ${a.duration_seconds != null ? html`<div class="card-row"><span class="label">Elapsed <span class="info-btn">i<span class="info-tip">Wall-clock from session start to last activity. Resumed Claude Code sessions span days, so this can be far larger than Active time.</span></span></span><span class="value">${fmtDurLong(a.duration_seconds * 1000)}</span></div>` : null}
           ${a.last_span_time ? html`<div class="card-row"><span class="label">Last seen</span><span class="value">${fmtAgo(a.last_span_time)}</span></div>` : null}
           ${a.active_alerts > 0 ? html`<div class="card-row"><span class="label">Alerts</span><span class="value" style="color:var(--error)">${a.active_alerts} active</span></div>` : null}
-          <div class="card-links">
-            <a href=${'#/cost?agent_id=' + encodeURIComponent(a.agent_id)}>View cost →</a>
-            <a href=${'#/traces?agent_id=' + encodeURIComponent(a.agent_id)}>View traces →</a>
-          </div>
+          <div class="card-foot">→ Map / Approach / Timeline</div>
+        </div>`;
+  };
+
+  // Archived coding-session row (mock parity): dot · session+badge · cost ·
+  // tokens · duration (derived from started_at→last_span_time) · tool calls ·
+  // ended-ago · Map/Approach/Timeline. The whole row opens the frozen session.
+  const archRow = (s) => {
+    const dur = (s.started_at && s.last_span_time)
+      ? fmtDurLong(new Date(s.last_span_time).getTime() - new Date(s.started_at).getTime())
+      : '-';
+    const endedLabel = (s.status === 'stale' ? 'last activity ' : 'ended ') + fmtAgo(s.last_span_time || s.started_at);
+    return html`
+      <tr class=${s.session_id ? 'clickable' : ''} onClick=${() => { if (s.session_id) location.hash = '#/sessions/' + s.session_id; }}>
+        <td><span class="status-dot ${s.status}"></span></td>
+        <td class="a-id">${s.label || (s.session_id ? s.session_id.slice(0, 8) : '-')} <span class="badge badge-${s.status}" style="margin-left:4px">${s.status}</span></td>
+        <td>${fmtFramedDollar(s.total_cost_usd, data.framing)}</td>
+        <td>${fmtTokens(s.input_tokens)} / ${fmtTokens(s.output_tokens)}</td>
+        <td>${dur}</td>
+        <td>${s.tool_call_count != null ? s.tool_call_count : '-'}</td>
+        <td>${endedLabel}</td>
+        <td class="row-actions">
+          ${s.session_id ? html`
+            <a href=${'#/sessions/' + s.session_id} onClick=${e => e.stopPropagation()}>Map</a>
+            <a href=${'#/sessions/' + s.session_id} onClick=${e => e.stopPropagation()}>Approach</a>
+            <a href=${'#/sessions/' + s.session_id} onClick=${e => e.stopPropagation()}>Timeline</a>` : null}
+        </td>
+      </tr>`;
+  };
+
+  return html`
+    <div class="page-title">Status</div>
+    <div style="font-size:12px;color:var(--text-dim);margin:-14px 0 18px;font-family:'Geist Mono',monospace">
+      ${agentId
+        ? html`Filtered to <span class="mono">${agentId}</span> · <a href="#/status" style="color:var(--brand)">show all</a>`
+        : 'Two zones — coding sessions (bounded work) and SDK services (unbounded telemetry).'}
+    </div>
+
+    ${(codingAgents.length || codingArchived.length) ? html`
+      <div class="zone-head">
+        <span class="zone-title">Coding sessions</span>
+        <span class="zone-sub">bounded work · active → idle → stale → closed</span>
+        <span class="zone-count">${codingAgents.length} active · ${codingArchived.length} archived</span>
+      </div>
+      ${codingAgents.length ? groupKeys.map(key => html`
+        ${(showHeadings || groupOverflow(key) > 0) ? html`
+          <div style="display:flex;align-items:baseline;gap:10px;margin:18px 0 10px;font-family:'Geist Mono',monospace">
+            <span style="font-size:13px;font-weight:600;color:var(--text)">${key === UNGROUPED ? 'Ungrouped' : key}</span>
+            <span style="font-size:12px;color:var(--text-dim)">${groups[key].length} session${groups[key].length > 1 ? 's' : ''} · ${fmtCost(Object.values(groups[key].reduce((m, a) => (m[a.agent_id] = a.cost_today || 0, m), {})).reduce((s, c) => s + c, 0))} today${groupOverflow(key) > 0 ? ' · +' + groupOverflow(key) + ' more' : ''}</span>
+          </div>` : null}
+        <div class="cards">
+          ${groups[key].map(agentCard)}
         </div>
-      `)}
-    </div>`}
+      `) : html`
+        <div style="font-size:12px;color:var(--text-dim);margin:8px 0 4px;font-family:'Geist Mono',monospace">No active coding sessions</div>`}
+
+      ${codingArchived.length > 0 ? html`
+        <details class="archive-block">
+          <summary>
+            <span class="tw">▶</span>
+            <span>Archived</span>
+            <span class="a-count">(closed / stale) · ${codingArchived.length}</span>
+            <span class="a-hint">keyed on ended-at · method still openable</span>
+          </summary>
+          <div class="table-wrap"><table class="archive-list">
+            <thead><tr><th></th><th>Session</th><th>Cost</th><th>Tokens (in / out)</th><th>Duration</th><th>Tool calls</th><th>Ended</th><th></th></tr></thead>
+            <tbody>
+              ${codingArchived.map(archRow)}
+            </tbody>
+          </table></div>
+        </details>` : null}
+    ` : null}
+
+    ${sdkServices.length ? html`
+      <div class="section-gap"></div>
+      <${SdkServicesPanel} services=${sdkServices} framing=${data.framing} />
+    ` : null}
+
     ${alerts.length > 0 ? html`
+      <div class="section-gap"></div>
       <div class="page-title" style="font-size:14px;margin-top:8px">Recent Alerts</div>
       <div class="table-wrap"><table>
         <thead><tr><th>Time</th><th>Severity</th><th>Type</th><th>Title</th><th>Agent</th></tr></thead>


### PR DESCRIPTION
Carved from #306 as **PR 1 of 5** — a focused split of the session-status dashboard branch. This one delivers the root bug fix + the honest session lifecycle model it enables.

## Root fix
Claude Code / Codex export OTLP **logs**, not traces — so each `user_prompt` turn produces a zero-duration `invoke_agent` span (`end_time == start_time`). `ingest` mistook that for a session **completion**, so every live session force-completed on its first prompt (dashboard showed active work as "completed" with 0 duration, and it tripped drift/alert false-positives). Completion is now gated on **real duration** (`end_time > start_time`); a non-end span **re-activates** a mistakenly-completed session.

## Lifecycle model (built on the fix)
- **Tiers** active / idle / stale / closed via `SessionRecord.status_at()` (5 min stale, 4h idle default), with a transcript-mtime rescue for live-but-span-quiet sessions.
- **Explicit close** — `POST /api/v1/sessions/close` + `tj session-end` (preserves `ended_at` / "Last seen"; only stamps status).
- **Project grouping** — OTel `service.namespace` + a server-side `agent→project` fallback (groups already-running sessions without a restart).
- **Display labels** — `service.instance.id` + manual overrides (right-click rename) + `tj otel-resource-attrs`.
- **Split-zones Status** — coding sessions (cards + archived) vs SDK services (per-minute cost/err sparklines); 0-signal "zombie" sessions filtered from the archive.

## Migrations
`8` service_namespace · `9` service_instance_id · `10` ended_at repair · `11` session_labels (renumbered contiguous from main's current max of 7).

## Notes for the series
- **Decoupled from later PRs:** the `capture_session_method` snapshot on close, the `session_token_cost_rollup` (#18) used by the zombie filter, and the `core.transcript` mtime-rescue are all deferred — PR1's close endpoint just closes; the zombie filter uses stored token/cost. #18 lands in the cost PR; method-capture in the Approach/Map/Timeline PR.
- `uv.lock` (introduced on the branch, untracked on `main`) is intentionally **not** included here.

## Tests
Full suite green: **1400 passed, 1 skipped** (`pytest tests/unit tests/synthetic tests/agents tests/integration`). `ruff check` clean; `index.html` module validated with `node --check`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
