### PR TITLE
Fix #340: resolve real tj binary for daemon install fallback

### DIFF
--- a/tests/unit/test_onboard_daemon.py
+++ b/tests/unit/test_onboard_daemon.py
@@ -86,3 +86,72 @@ class TestLaunchdInstallUsesWFlag:
         assert any("load" in c and "-w" in c for c in calls), (
             f"load should use -w; calls were {calls}"
         )
+
+
+class TestTjBinaryResolution:
+    """The daemon installers must point launchd/systemd at a real `tj` binary.
+
+    Regression for #340: when `tj` is off PATH, the fallback derived the path
+    with `sys.executable.replace("/python", "/tj")`, which rewrote a
+    `python3`-named interpreter to a nonexistent `tj3` (because `/python`
+    matches inside `/python3`). The unit is written pointing at a binary that
+    doesn't exist; `launchctl load` still returns 0, so onboarding reports
+    success while `tj serve` never launches.
+    """
+
+    def test_prefers_tj_on_path(self, monkeypatch):
+        from tokenjam.cli.cmd_onboard import _resolve_tj_binary
+        monkeypatch.setattr("tokenjam.cli.cmd_onboard.shutil.which", lambda _: "/usr/local/bin/tj")
+        assert _resolve_tj_binary() == "/usr/local/bin/tj"
+
+    def test_fallback_python3_resolves_to_sibling_tj(self, monkeypatch):
+        """A `python3`-named interpreter must yield the sibling `tj`, not `tj3`."""
+        from tokenjam.cli.cmd_onboard import _resolve_tj_binary
+        monkeypatch.setattr("tokenjam.cli.cmd_onboard.shutil.which", lambda _: None)
+        monkeypatch.setattr(
+            "tokenjam.cli.cmd_onboard.sys.executable", "/opt/venv/bin/python3"
+        )
+        assert _resolve_tj_binary() == "/opt/venv/bin/tj"
+
+    def test_fallback_python311_resolves_to_sibling_tj(self, monkeypatch):
+        """A versioned `python3.11` interpreter must also yield `tj`, not `tj3.11`."""
+        from tokenjam.cli.cmd_onboard import _resolve_tj_binary
+        monkeypatch.setattr("tokenjam.cli.cmd_onboard.shutil.which", lambda _: None)
+        monkeypatch.setattr(
+            "tokenjam.cli.cmd_onboard.sys.executable", "/opt/venv/bin/python3.11"
+        )
+        assert _resolve_tj_binary() == "/opt/venv/bin/tj"
+
+    def test_launchd_plist_never_points_at_tj3(self, tmp_path, monkeypatch):
+        from tokenjam.cli.cmd_onboard import _install_launchd
+        monkeypatch.setattr("tokenjam.cli.cmd_onboard.Path.home", lambda: tmp_path)
+        monkeypatch.setattr("tokenjam.cli.cmd_onboard.shutil.which", lambda _: None)
+        monkeypatch.setattr(
+            "tokenjam.cli.cmd_onboard.sys.executable", "/opt/venv/bin/python3"
+        )
+        with patch(
+            "tokenjam.cli.cmd_onboard.subprocess.run",
+            MagicMock(return_value=MagicMock(returncode=0)),
+        ):
+            _install_launchd("/tmp/cfg.toml")
+
+        plist = (tmp_path / "Library/LaunchAgents/com.tokenjam.serve.plist").read_text()
+        assert "<string>/opt/venv/bin/tj</string>" in plist
+        assert "/tj3" not in plist
+
+    def test_systemd_unit_never_points_at_tj3(self, tmp_path, monkeypatch):
+        from tokenjam.cli.cmd_onboard import _install_systemd
+        monkeypatch.setattr("tokenjam.cli.cmd_onboard.Path.home", lambda: tmp_path)
+        monkeypatch.setattr("tokenjam.cli.cmd_onboard.shutil.which", lambda _: None)
+        monkeypatch.setattr(
+            "tokenjam.cli.cmd_onboard.sys.executable", "/opt/venv/bin/python3.11"
+        )
+        with patch(
+            "tokenjam.cli.cmd_onboard.subprocess.run",
+            MagicMock(return_value=MagicMock(returncode=0)),
+        ):
+            _install_systemd("/tmp/cfg.toml")
+
+        unit = (tmp_path / ".config/systemd/user/tokenjam.service").read_text()
+        assert "ExecStart=/opt/venv/bin/tj --config /tmp/cfg.toml serve" in unit
+        assert "/tj3" not in unit

--- a/tokenjam/cli/cmd_onboard.py
+++ b/tokenjam/cli/cmd_onboard.py
@@ -1434,8 +1434,22 @@ def _install_daemon(config_path: str) -> str | None:
         return None
 
 
+def _resolve_tj_binary() -> str:
+    """Resolve the absolute path to the ``tj`` executable for daemon units.
+
+    Prefer the copy on PATH. When ``tj`` isn't on PATH (e.g. a venv whose bin
+    dir isn't exported), fall back to the sibling ``tj`` next to the running
+    interpreter — derived by path, not string substitution. The old
+    ``sys.executable.replace("/python", "/tj")`` rewrote a ``python3``-named
+    interpreter to a nonexistent ``tj3`` (``/python`` matches inside
+    ``/python3``), so launchd/systemd pointed at a binary that doesn't exist
+    while ``launchctl load`` still returned 0 (#340).
+    """
+    return shutil.which("tj") or str(Path(sys.executable).with_name("tj"))
+
+
 def _install_launchd(config_path: str) -> str | None:
-    tj_path = shutil.which("tj") or sys.executable.replace("/python", "/tj").replace("/python3", "/tj")
+    tj_path = _resolve_tj_binary()
     plist_path = Path.home() / "Library/LaunchAgents/com.tokenjam.serve.plist"
     plist_path.parent.mkdir(parents=True, exist_ok=True)
     plist_content = f"""\
@@ -1493,7 +1507,7 @@ def _install_launchd(config_path: str) -> str | None:
 
 
 def _install_systemd(config_path: str) -> str | None:
-    tj_path = shutil.which("tj") or sys.executable.replace("/python", "/tj").replace("/python3", "/tj")
+    tj_path = _resolve_tj_binary()
     service_path = Path.home() / ".config/systemd/user/tokenjam.service"
     service_path.parent.mkdir(parents=True, exist_ok=True)
     service_content = f"""\


### PR DESCRIPTION
The daemon install fallback derived the `tj` binary path from the running interpreter with a string substitution that produced a nonexistent executable on any `python3`-named interpreter — silently breaking first-run onboarding on the fresh-install path.

## Summary
- Replace the `sys.executable.replace("/python", "/tj").replace("/python3", "/tj")` derivation in `_install_launchd` and `_install_systemd` with a shared `_resolve_tj_binary()` helper.
- Resolve the sibling binary by path: `shutil.which("tj")` first, then `str(Path(sys.executable).with_name("tj"))`.
- Add regression tests covering `python3` / `python3.11` interpreter names for the helper and both installers.

## Root cause + fix
`_install_launchd` (~line 1437) and `_install_systemd` (~line 1495) fell back, when `shutil.which("tj")` returns `None`, to `sys.executable.replace("/python", "/tj").replace("/python3", "/tj")`. The first `.replace("/python", "/tj")` matches `/python` as a **substring** of `/python3`, so an interpreter named `python3` (or `python3.11`) is rewritten to `tj3` (or `tj3.11`) — a binary that does not exist — and the second replace then has nothing left to match. Only a bare `python` basename happened to produce the correct `tj`.

The launchd plist / systemd unit is therefore written pointing at a nonexistent executable. `launchctl load -w` still returns 0, so onboarding reports the daemon installed while `tj serve` never launches and the Lens dashboard stays empty. Because this is on the fresh-install path, it silently breaks first-run onboarding for any venv whose bin dir isn't exported on PATH.

Fix derives the sibling binary by path, not string substitution — `str(Path(sys.executable).with_name("tj"))` — via a single `_resolve_tj_binary()` helper used at both install sites so they can't drift.

## Tests / Verification
- `tests/unit/test_onboard_daemon.py::TestTjBinaryResolution` — new: asserts the helper prefers `tj` on PATH, that `python3` and `python3.11` fallbacks resolve to the sibling `tj` (not `tj3`/`tj3.11`), and that the generated plist and systemd unit contain the real `/opt/venv/bin/tj` path with no `/tj3` anywhere.
- Full suite: `pytest tests/unit/ tests/integration/ -q` → **1656 passed**.
- `ruff check tokenjam/cli/cmd_onboard.py` clean; `mypy tokenjam/cli/cmd_onboard.py` clean.

## What's NOT in this PR
- No change to the launchd/systemd unit structure, load flags, or reinstall logic — scope is strictly the binary-path derivation the issue named.

Closes #340

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: anshss <noreply@github.com>