### PR TITLE
Fix #373: Bedrock pricing keys never match live spans — normalize provider + model id in get_rates

### DIFF
--- a/tests/unit/test_cost.py
+++ b/tests/unit/test_cost.py
@@ -199,6 +199,68 @@ def test_calculate_cost_openai_model():
     assert cost == 2.25
 
 
+def test_get_rates_bedrock_raw_span_provider_and_model():
+    """#373: a live Bedrock span carries provider="aws.bedrock" and the raw
+    boto3 modelId (dots + trailing ":0"); the lookup must normalize both
+    onto the [aws.us-amazon-nova-micro-v1] table key."""
+    rates = get_rates("aws.bedrock", "us.amazon.nova-micro-v1:0")
+    assert rates is not None
+    assert rates.input_per_mtok == 0.035
+    assert rates.output_per_mtok == 0.14
+
+
+def test_get_rates_bedrock_litellm_provider_form():
+    """#373: LiteLLM-routed Bedrock reports provider "bedrock" and may keep
+    the "bedrock/" prefix on the model id."""
+    rates = get_rates("bedrock", "us.amazon.nova-micro-v1:0")
+    assert rates is not None
+    assert rates.input_per_mtok == 0.035
+
+    rates = get_rates("bedrock", "bedrock/us.amazon.nova-micro-v1:0")
+    assert rates is not None
+    assert rates.input_per_mtok == 0.035
+
+
+def test_get_rates_bedrock_nova_pro():
+    rates = get_rates("aws.bedrock", "us.amazon.nova-pro-v1:0")
+    assert rates is not None
+    assert rates.input_per_mtok == 0.80
+    assert rates.output_per_mtok == 3.20
+
+
+def test_get_rates_bedrock_anthropic_on_bedrock():
+    """The mid-string date in Anthropic-on-Bedrock ids must survive
+    normalization (only the trailing ":N" is stripped)."""
+    rates = get_rates("aws.bedrock", "us.anthropic.claude-opus-4-1-20250805-v1:0")
+    assert rates is not None
+    assert rates.input_per_mtok == 15.00
+    assert rates.cache_write_per_mtok == 18.75
+
+
+def test_get_rates_bedrock_version_strip_only_trailing_digits():
+    """#373: the ":N" strip applies only to a trailing ":<digits>" —
+    arbitrary colons must not make an unrelated id match."""
+    from tokenjam.core.pricing import _normalize_bedrock_model
+
+    assert _normalize_bedrock_model("us.amazon.nova-micro-v1:0") == "us-amazon-nova-micro-v1"
+    # Non-numeric / non-trailing colon segments are preserved.
+    assert _normalize_bedrock_model("us.amazon.nova-micro-v1:latest") == (
+        "us-amazon-nova-micro-v1:latest"
+    )
+    assert _normalize_bedrock_model("us.amazon.nova:0:micro") == "us-amazon-nova:0:micro"
+    # No-op normalization returns None so callers skip the second lookup.
+    assert _normalize_bedrock_model("plain-model") is None
+
+
+def test_get_rates_non_bedrock_provider_unaffected():
+    """Regression guard: non-Bedrock providers get no alias or model
+    normalization — a dotted OpenAI-ish name still misses as before."""
+    rates = get_rates("anthropic", "claude-haiku-4-5")
+    assert rates is not None
+    assert get_rates("openai", "us.amazon.nova-micro-v1:0") is None
+    assert get_rates("nonexistent", "model") is None
+
+
 def test_pricing_file_exists_at_expected_path():
     """Regression: PRICING_FILE must resolve to tokenjam/pricing/models.toml,
     not a path outside the package. A broken path causes $0.00 costs

--- a/tokenjam/core/pricing.py
+++ b/tokenjam/core/pricing.py
@@ -269,6 +269,35 @@ def _strip_date_suffix(model: str) -> str | None:
     return m.group(1) if m else None
 
 
+# Live Bedrock spans carry the provider verbatim from their ingest path —
+# "aws.bedrock" (direct boto3 via BedrockIntegration), "bedrock" (LiteLLM's
+# `bedrock/...` routing), or "aws_bedrock" — but the packaged table keys
+# Bedrock rates under [aws.*]. Mapped here for the lookup only; the stored
+# span keeps its raw provider string (#373).
+_BEDROCK_PROVIDER_ALIASES = {
+    "aws.bedrock": "aws",
+    "aws_bedrock": "aws",
+    "bedrock": "aws",
+}
+
+
+def _normalize_bedrock_model(model: str) -> str | None:
+    """Return the [aws.*] table-key form of a raw Bedrock modelId, or None.
+
+    boto3 modelIds look like "us.amazon.nova-micro-v1:0" — dotted, with a
+    trailing ":N" version — and LiteLLM-routed ids may keep a "bedrock/"
+    prefix. The table keys are dot-flattened and unversioned
+    ("us-amazon-nova-micro-v1"). Only a trailing ":<digits>" is stripped;
+    other colons are left alone. Returns None when normalization is a no-op
+    so callers skip the redundant second lookup.
+    """
+    import re as _re
+
+    normalized = model.removeprefix("bedrock/")
+    normalized = _re.sub(r":\d+$", "", normalized).replace(".", "-")
+    return normalized if normalized != model else None
+
+
 def get_rates(provider: str, model: str) -> ModelRates | None:
     """
     Return ModelRates for the given provider/model, or None if not found.
@@ -284,6 +313,11 @@ def get_rates(provider: str, model: str) -> ModelRates | None:
     trailing YYYYMMDD release-date suffix (Anthropic/OpenAI both ship dated
     variants like `claude-haiku-4-5-20251001`). This keeps the tables short
     while still pricing the dated names that flow through Claude Code logs.
+
+    Bedrock spans are normalized for the table lookup only (#373): the
+    provider aliases in _BEDROCK_PROVIDER_ALIASES map onto the table's
+    "aws" key, and the raw boto3 modelId is additionally tried in its
+    table-key form (see _normalize_bedrock_model).
     """
     base = _strip_date_suffix(model)
 
@@ -299,13 +333,25 @@ def get_rates(provider: str, model: str) -> ModelRates | None:
 
     # 2. Provider-keyed table (user [provider.model] over packaged).
     table = load_pricing_table()
-    rates = table.get(provider, {}).get(model)
+    lookup_provider = _BEDROCK_PROVIDER_ALIASES.get(provider, provider)
+    provider_models = table.get(lookup_provider, {})
+    rates = provider_models.get(model)
     if rates is not None:
         return rates
     if base is not None:
-        rates = table.get(provider, {}).get(base)
+        rates = provider_models.get(base)
         if rates is not None:
             return rates
+
+    # Bedrock: the raw boto3 modelId ("us.amazon.nova-micro-v1:0") never
+    # matches the dot-flattened, unversioned [aws.*] keys — try the
+    # normalized table-key form (#373).
+    if lookup_provider == "aws":
+        normalized = _normalize_bedrock_model(model)
+        if normalized is not None:
+            rates = provider_models.get(normalized)
+            if rates is not None:
+                return rates
 
     return None
 


### PR DESCRIPTION
Every `[aws.*]` pricing entry — the original Nova rows plus the rates added in #366/#370 — was unreachable for real Bedrock traffic, so every Bedrock call silently billed at the $0.50/$2.00 default. This makes those keys live by normalizing inside the rate lookup.

Closes #373

## Summary
- `get_rates()` now aliases provider `aws.bedrock` / `aws_bedrock` / `bedrock` → the table's `aws` key for the provider-keyed lookup.
- For that provider, it additionally tries the modelId in table-key form: strip an optional `bedrock/` prefix (LiteLLM-routed form), strip a trailing `:<digits>` version, flatten dots to hyphens (`us.amazon.nova-micro-v1:0` → `us-amazon-nova-micro-v1`).
- Lookup-only change: stored span `provider`/`model` stay raw, `models.toml` is untouched.

## Symptom, root cause, fix
**Symptom:** all Bedrock spans cost out at the default flat rate; the `[aws.*]` table entries never match.

**Root cause:** two simultaneous mismatches. Live spans carry `provider = "aws.bedrock"` (set verbatim by `BedrockIntegration`) or `"bedrock"` (LiteLLM), and `model = "us.amazon.nova-micro-v1:0"` (raw boto3 modelId). The table keys are `[aws.us-amazon-nova-micro-v1]` — provider `aws`, dots flattened, `:0` stripped. `get_rates("aws.bedrock", "us.amazon.nova-micro-v1:0")` looked under `table["aws.bedrock"]`, missed, and returned `None`.

**Fix:** normalize in `get_rates` (`tokenjam/core/pricing.py`) per the issue's preferred approach — one home covering every ingest path (direct boto3, LiteLLM-Bedrock, OTLP HTTP), slotted alongside the existing `_strip_date_suffix` fallback. The normalized model key is tried only after the exact and date-stripped forms miss, and only when the resolved provider is `aws`, so no other provider's lookup changes. The `:N` strip is anchored (`:\d+$`) — only a trailing all-digit version segment is removed; mid-string dates in Anthropic-on-Bedrock ids (`...-20250805-v1`) survive intact. No cache changes — the LRU-cached layers are untouched; only the post-load lookup logic changed.

## Tests / Verification
- `tests/unit/test_cost.py` (where `get_rates` tests live — there is no `test_pricing.py`): 6 new tests covering
  - `get_rates("aws.bedrock", "us.amazon.nova-micro-v1:0")` → packaged Nova Micro rate (0.035/0.14, non-default)
  - provider `"bedrock"` and the LiteLLM `bedrock/us.amazon...` model form
  - the existing Nova Pro entry and an Anthropic-on-Bedrock id (mid-string date preserved)
  - `:N` strip applies only to a trailing `:digits`, not `:latest` or mid-string colons
  - regression guard: non-Bedrock providers unaffected (`anthropic` still resolves; `openai` + a Bedrock id still misses; unknown pair still `None`)
- `python3 -m pytest tests/unit/ -q` → 1313 passed; `tests/integration/` → 344 passed
- `ruff check` and `mypy` clean on both touched files

## What's NOT in this PR
- **`billing_account` derivation** — untouched by design; the issue explicitly scopes this out (`provider_to_billing_account` already maps Bedrock correctly).
- **`models.toml`** — no key changes; the issue's premise is that the existing #366/#370 keys become live once the lookup normalizes.
- **Ingest-boundary normalization** (`convert_otel_span` / `otlp_parsing`) — the issue considered and rejected it (two edit sites, rewrites what users see in traces).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015e3DZGhb1R5sXX2x52Y2Ar