### PR TITLE
feat: add Prove (tokenjam-bench) nudge to onboard + tokenmaxx

### DIFF
--- a/tests/unit/test_cmd_tokenmaxx.py
+++ b/tests/unit/test_cmd_tokenmaxx.py
@@ -191,6 +191,20 @@ def test_card_surfaces_reclaimable_quota_not_spend(db):
     assert "tj context" in out
 
 
+def test_card_nudges_proving_savings_hold_with_bench(db):
+    # The panel footer nudges the user to *prove* the savings hold with
+    # tokenjam-bench — honest framing ("hold", never "guaranteed"/"certified").
+    _seed_overhead_heavy(db, plan_tier="max_5x")
+    result = _invoke(db, _config("max_5x"))
+    assert result.exit_code == 0, result.output
+    out = result.output
+    assert "Prove your savings hold" in out
+    assert "pip install tokenjam-bench" in out
+    # The bench CTA itself must not overclaim.
+    assert "certified" not in out.lower()
+    assert "guaranteed savings hold" not in out.lower()
+
+
 def test_api_plan_shows_implied_dollars_as_secondary_only(db):
     # API users DO get a dollar calibration line — but demoted, labeled
     # "Implied API value", never the headline (mirrors quota-audit #5).

--- a/tests/unit/test_onboard_first_run.py
+++ b/tests/unit/test_onboard_first_run.py
@@ -31,9 +31,12 @@ def test_welcome_banner_shows_brand_version_and_value_prop(capsys):
 def test_nudge_leads_with_no_restart_wins(capsys):
     _print_next_steps_nudge(has_data=True, days=30)
     out = capsys.readouterr().out
-    # The three high-wow, no-restart commands.
-    for cmd in ("tj tokenmaxx", "tj optimize", "tj serve"):
+    # The high-wow, no-restart commands + the bench "prove" nudge.
+    for cmd in ("tj tokenmaxx", "tj optimize", "tjb", "tj serve"):
         assert cmd in out, out
+    # Prove step: honest framing (holds, never "guaranteed") + install hint.
+    assert "prove a cheaper model still holds" in out
+    assert "pip install tokenjam-bench" in out
     assert "already loaded" in out
     assert "last 30 days" in out
 

--- a/tokenjam/cli/cmd_onboard.py
+++ b/tokenjam/cli/cmd_onboard.py
@@ -304,6 +304,9 @@ retention_days = 90
     console.print("[dim]     tj traces          [/dim]# span history")
     console.print("[dim]     tj serve           [/dim]# web UI at http://127.0.0.1:7391/")
     console.print()
+    console.print("  4. Prove a cheaper model still holds:")
+    console.print("[dim]     pip install tokenjam-bench[/dim]  # then: tjb")
+    console.print()
 
     if not want_daemon:
         _warn_manual_serve_restart(stopped_for_db=stopped_for_db, no_daemon=True)
@@ -392,6 +395,7 @@ def _print_next_steps_nudge(*, has_data: bool, days: int | None = None) -> None:
     console.print()
     console.print("  [bold]tj tokenmaxx[/bold]   [dim]your shareable spend tier[/dim]")
     console.print("  [bold]tj optimize[/bold]    [dim]cost-saving candidates from your usage[/dim]")
+    console.print("  [bold]tjb[/bold]            [dim]prove a cheaper model still holds (pip install tokenjam-bench)[/dim]")
     console.print("  [bold]tj serve[/bold]       [dim]open Lens (web UI) at http://127.0.0.1:7391/[/dim]")
     console.print()
 

--- a/tokenjam/cli/cmd_tokenmaxx.py
+++ b/tokenjam/cli/cmd_tokenmaxx.py
@@ -287,6 +287,11 @@ def _render(
         action.append("tj optimize", style="bold green")
         action.append(" for the full savings report.")
 
+    # ── Prove line — nudge to verify the savings hold, never "guaranteed". ──
+    prove = Text("🔬 ")
+    prove.append("Prove your savings hold: ", style="dim")
+    prove.append("pip install tokenjam-bench", style="bold green")
+
     panel_body = Group(
         headline,
         Text(""),
@@ -295,6 +300,7 @@ def _render(
         body,
         Text(""),
         action,
+        prove,
     )
 
     title = ("[bold]TokenJam Quota Wrapped — Weekly Recap[/bold]" if weekly


### PR DESCRIPTION
Completes the Analyze → Prove → Enforce funnel in TokenJam's onboarding and tokenmaxx surfaces. Both walked observe → optimize but never pointed users at the *prove* step — confirming a downsize candidate holds before switching. tokenjam-bench (the `tjb` CLI) is that step.

## Summary
- Onboard next-steps (`_print_next_steps_nudge`, the `--claude-code`/`--codex` path): one line after `tj optimize` pointing at `tjb` + `pip install tokenjam-bench`, matching the existing column alignment + Rich `[bold]`/`[dim]` styling.
- Onboard plain-SDK path (the `tj status` / `tj traces` / `tj serve` telemetry block): the same prove line as a "4. Prove a cheaper model still holds" step, for consistency.
- tokenmaxx panel footer (`cmd_tokenmaxx.py`): a "Prove your savings hold: `pip install tokenjam-bench`" CTA line inside the bordered, screenshot-friendly Panel.

## Bench command confirmed
Verified against the local + public `github.com/Metabuilder-Labs/tokenjam-bench` repo (README + CLI). Package is `tokenjam-bench`, CLI is `tjb` (not `tjbench`). The zero-flag entry point is `tjb run` (offline proof); a specific swap is `tjb run --original <model> --candidate <model>` / `--benchmark <suite>`. Both surfaces use the install-first framing (`pip install tokenjam-bench`, then `tjb`) since that is the README's own entry point, and the nudges are intentionally minimal (one line) rather than teaching flags.

## Honesty framing
Per Critical Rule 14 the copy says "prove … holds" / "prove your savings hold" — never "guaranteed", "certified", or "safe". Per Critical Rule 6 no hardcoded unicode bullets (Rich handles formatting).

## Rendered output

Onboard next-steps:
```
▸ Next steps  your last 30 days already loaded — these work right now:

  tj tokenmaxx   your shareable spend tier
  tj optimize    cost-saving candidates from your usage
  tjb            prove a cheaper model still holds (pip install tokenjam-bench)
  tj serve       open Lens (web UI) at http://127.0.0.1:7391/
```

tokenmaxx panel footer (inside the Panel):
```
│  💡 98.0% of cycle tokens sits in 1 compactable session. Run tj context to   │
│  see where to reclaim it.                                                    │
│  🔬 Prove your savings hold: pip install tokenjam-bench                      │
```

## Tests / Verification
- `tests/unit/test_onboard_first_run.py::test_nudge_leads_with_no_restart_wins` — asserts `tjb`, "prove a cheaper model still holds", and "pip install tokenjam-bench" are present.
- `tests/unit/test_cmd_tokenmaxx.py::test_card_nudges_proving_savings_hold_with_bench` — asserts the panel CTA is present and does not overclaim ("certified" absent).
- `ruff check tokenjam/` clean; `pytest tests/unit/ tests/integration/` → 1780 passed.

## What's NOT in this PR
- No docs / README changes — issues #333/#335 scoped this to the two CLI surfaces only.
- No teaching of `tjb` flags — the nudge is deliberately one line; the bench README owns the full usage.

Closes #333
Closes #335

🤖 Generated with [Claude Code](https://claude.com/claude-code)