### PR TITLE
fix: guard Lens KPI "% vs prev" deltas against near-empty prior window

### DIFF
--- a/tests/unit/test_lens_ui_regression.py
+++ b/tests/unit/test_lens_ui_regression.py
@@ -1830,3 +1830,29 @@ def test_map_phase_bands_split_at_idle_breaks(html):
     assert "const phaseSegs = []" in html
     assert "labelSeg: si === widest" in html
     assert "usePhaseSegs ? phaseSegs : phaseBands" in html
+
+
+# --- #396: KPI "% vs prev" delta must not blow up on a near-empty prior ----- #
+def test_trend_chip_guards_zero_baseline_with_new(html):
+    # A fresh onboard + 30-day backfill compares the current window against the
+    # near-empty pre-backfill period, so cost_delta_pct explodes (e.g. ▲140980%).
+    # TrendChip must show "new" when the prior window is thin, not the figure.
+    assert "function TrendChip({ pct, prevThin })" in html
+    assert "prevThin && pct != null && pct > 0" in html
+    assert "▲ new" in html
+    # The Cost/Dashboard call site derives prevThin from the prior window's
+    # session count and passes it through.
+    assert "const trendPrevThin" in html
+    assert "compare.previous.sessions" in html
+    assert "prevThin=${trendPrevThin}" in html
+
+
+def test_delta_pct_capped_to_avoid_four_digit_percentages(html):
+    # Genuinely-large-but-finite deltas are capped at ">999%" so a tiny (nonzero)
+    # prior baseline can't render "140980.0%". Both KPI chips route through the
+    # shared formatter — neither re-implements the raw toFixed.
+    assert "function fmtDeltaPct(pct)" in html
+    assert "DELTA_PCT_CEILING" in html
+    assert "'>999%'" in html
+    # The old unguarded raw-percentage render is gone from both chips.
+    assert "${Math.abs(pct).toFixed(1)}% vs prev" not in html

--- a/tokenjam/ui/index.html
+++ b/tokenjam/ui/index.html
@@ -5216,13 +5216,28 @@ function PlanBadge({ framing }) {
   `)}`;
 }
 
-// Trend chip: ▲ (up, red) / ▼ (down, green) with a percentage.
-function TrendChip({ pct }) {
+// Cap absurd-but-finite deltas so a near-empty prior window can't render a
+// four-digit percentage (#262/#396). Above the ceiling we show ">999%" instead
+// of e.g. "140980.0%", which reads as a broken number on a cost tool.
+const DELTA_PCT_CEILING = 999;
+function fmtDeltaPct(pct) {
+  const mag = Math.abs(pct);
+  return mag > DELTA_PCT_CEILING ? '>999%' : mag.toFixed(1) + '%';
+}
+
+// Trend chip: ▲ (up, red) / ▼ (down, green) with a percentage. When the prior
+// window is empty/thin (`prevThin`, a fresh backfill's sliver period, #262) the
+// % is arithmetic noise — show "new" instead of a blown-up figure.
+function TrendChip({ pct, prevThin }) {
+  if (prevThin && pct != null && pct > 0) {
+    return html`<span class="trend-chip" style="color:var(--error)"
+      title="The prior window had little or no data, so a percentage change would be misleading.">▲ new</span>`;
+  }
   if (pct == null) return null;
   const up = pct > 0;
   const arrow = pct === 0 ? '·' : up ? '▲' : '▼';
   const color = pct === 0 ? 'var(--text-dim)' : up ? 'var(--error)' : 'var(--success)';
-  return html`<span class="trend-chip" style="color:${color}">${arrow} ${Math.abs(pct).toFixed(1)}% vs prev</span>`;
+  return html`<span class="trend-chip" style="color:${color}">${arrow} ${fmtDeltaPct(pct)} vs prev</span>`;
 }
 
 // Signed period-over-period delta chip for KPI tiles (#217). `cost`=true uses
@@ -5242,7 +5257,7 @@ function DeltaChip({ pct, cost, prevThin }) {
   const color = cost
     ? (pct === 0 ? 'var(--text-dim)' : up ? 'var(--error)' : 'var(--success)')
     : 'var(--text-dim)';
-  return html`<span class="delta-chip" style="color:${color}">${arrow} ${Math.abs(pct).toFixed(1)}% vs prev</span>`;
+  return html`<span class="delta-chip" style="color:${color}">${arrow} ${fmtDeltaPct(pct)} vs prev</span>`;
 }
 
 // Inline-SVG sparkline (#217) — lightweight + offline; avoids spinning up a
@@ -5490,6 +5505,10 @@ function CostView({ params }) {
   }
 
   const trendPct = compare ? (useTokens ? compare.tokens_delta_pct : compare.cost_delta_pct) : null;
+  // A near-empty prior window (a fresh backfill's sliver period, #262) makes the
+  // % arithmetic noise. Use its session count as the "did anything happen" proxy
+  // so TrendChip shows "new" instead of e.g. ▲140980% on a first-run compare.
+  const trendPrevThin = !!(compare && compare.previous) && (compare.previous.sessions || 0) < 2;
   const totalDisplay = useTokens ? (fmtTokens(totalTokens) + ' tokens') : fmtFramedDollar(total, framing);
   const tableMode = groupBy === 'total' ? 'day' : groupBy;
   const totalIn = rows.reduce((s, r) => s + (r.input_tokens || 0), 0);
@@ -5530,7 +5549,7 @@ function CostView({ params }) {
           <div class="chart-title">Spend over time ${groupBy === 'model' ? 'by model' : groupBy === 'agent' ? 'by agent' : ''} ${useTokens ? '(tokens)' : ''}</div>
           <div class="chart-meta">
             <span class="chart-total">${totalDisplay}</span>
-            <${TrendChip} pct=${trendPct} />
+            <${TrendChip} pct=${trendPct} prevThin=${trendPrevThin} />
           </div>
         </div>
         ${loading ? html`<div class="shimmer" style="height:160px"></div>`


### PR DESCRIPTION
The Dashboard and Analytics KPI cards render period-over-period "% vs prev" deltas that blow up to absurd values (e.g. "▲ 140980.0% vs prev") when the prior period's value is near zero. This hits the first-run path directly: `tj onboard` backfills ~30 days of history, so the current window compares against the near-empty period before the backfill, and `(cur - prev) / prev * 100` explodes. For a cost tool built on credible numbers, that reads as broken.

## Summary
- `TrendChip` (Dashboard/Cost view) gains a `prevThin` guard and shows **"▲ new"** instead of an exploded percentage when the prior window is empty/thin.
- A shared `fmtDeltaPct()` caps any finite delta above 999% to **">999%"**, so a tiny-but-nonzero prior baseline can't render a four-digit percentage.
- Both KPI chips (`TrendChip` + Analytics `DeltaChip`) route through the shared formatter — neither re-implements the raw `toFixed` render.

## Root cause + fix
The Analytics `DeltaChip` already softened the zero-baseline case via the #262 `prevThin` guard ("vs partial prior window"). But the Dashboard/Cost `TrendChip` had **no** such guard, and neither chip capped a genuinely-large-but-finite delta produced by a tiny-nonzero baseline (the "140980%" class).

- `TrendChip` now takes a `prevThin` prop, derived on the Cost view from `compare.previous.sessions < 2` — the same "did anything happen" proxy Analytics already uses. When thin and the delta is positive, it renders "▲ new" (keeps the up arrow + attention color).
- `fmtDeltaPct()` is the single formatter both chips call; it caps at `DELTA_PCT_CEILING = 999` → ">999%".

This is why every new user saw it: onboard → 30-day backfill → the current window's compare runs against the sliver period before the backfill → division by ~0.

## Tests / Verification
- `tests/unit/test_lens_ui_regression.py`: two new static-grep guards — one asserts the `TrendChip` zero-baseline "▲ new" branch + Cost call-site wiring, one asserts the `>999%` cap and that the old unguarded raw-percentage render is gone from both chips.
- `python3 -m pytest tests/unit/test_lens_ui_regression.py tests/unit/test_ui_offline.py -q` → **193 passed**.
- `node --check` on the extracted `<script type="module">` block parses cleanly.
- Offline-safe (Critical Rule 18): no new external loads.

## What's NOT in this PR
- No change to the backend `/cost/compare` contract — `cost_delta_pct` already returns `null` when the prior cost is exactly 0 (cost.py); this PR handles the tiny-nonzero and thin-session cases in the UI where the exploded figures actually surface.
- The Analytics `DeltaChip` keeps its existing "vs partial prior window" thin message (clearer in that denser context); only its raw-percentage formatting is routed through the new cap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)