### PR TITLE
Bump version to 0.5.3

### DIFF
--- a/npm-wrapper/package.json
+++ b/npm-wrapper/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tokenjam",
-  "version": "0.5.2",
+  "version": "0.5.3",
   "description": "Zero-install launcher for TokenJam (tj) — `npx tokenjam` runs the Python CLI via uvx/pipx and prints where your Claude Code quota actually goes, no setup.",
   "keywords": ["claude-code", "ccusage", "tokens", "cost", "llm", "agents", "observability", "tokenjam"],
   "homepage": "https://tokenjam.dev",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "tokenjam"
-version = "0.5.2"
+version = "0.5.3"
 description = "TokenJam — local-first OTel-native observability for Autonomous AI agents"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/sdk-ts/package.json
+++ b/sdk-ts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tokenjam/sdk",
-  "version": "0.5.2",
+  "version": "0.5.3",
   "description": "TypeScript SDK for TokenJam — local-first observability for AI agents",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",


### PR DESCRIPTION
Release cut for 0.5.3. Bumps `pyproject.toml`, `sdk-ts/package.json`, and `npm-wrapper/package.json` to 0.5.3 (Critical Rule 15 — all publish artifacts aligned; the npm-wrapper now has a publish path via #386).

Do NOT merge until the release is ready to cut; tagging `v0.5.3` after merge fires the PyPI / npm / GHCR publish workflows.

## Headline of 0.5.3
- **Backfill dedup self-heal (#397)** — purges cross-scheme duplicate spans that inflated cost/token numbers ~2× for pre-v0.5.2 re-backfills.
- **Migration self-heal (#381)** + session dashboard / timeline / map (#371), context diagnostics (#368), zero-token statusline + MCP-for-SDK reframe (#374), close-the-loop (#380), StorageBackend parity guard (#379).
- Lens Dashboard empty-gate fix (#392) + near-zero-baseline delta formatting (#396); `[1m]`-context + current OpenAI pricing (#393); Bedrock/LiteLLM pricing (#366).
- README leads with `pipx`; competitor references scrubbed; bench "Prove" nudge in onboarding (#333/#335).

🤖 Generated with [Claude Code](https://claude.com/claude-code)