### PR TITLE
Fix #348: bound API daily cost windows

### DIFF
--- a/tests/integration/test_storage_backend_parity.py
+++ b/tests/integration/test_storage_backend_parity.py
@@ -214,15 +214,18 @@ def _proj_baseline(baseline) -> tuple | None:
 
 
 # (invoke, project) per parity method. ``now``/``trace_id`` are bound at seed
-# time so get_daily_cost targets the seeded day and get_trace_spans a real trace.
+# time so get_daily_cost targets the seeded historical day and get_trace_spans a
+# real trace. The historical daily-cost target is load-bearing: querying today
+# would not catch an API shim that forgot to send an `until` bound.
 def _parity_specs(now, trace_id):
+    historical_day = (now - timedelta(days=3)).date()
     return {
         "get_traces": (lambda b: b.get_traces(TraceFilters(limit=100)), _proj_traces),
         "get_trace_spans": (lambda b: b.get_trace_spans(trace_id), _proj_spans),
         "get_cost_summary": (lambda b: b.get_cost_summary(CostFilters()), _proj_cost),
         "get_alerts": (lambda b: b.get_alerts(AlertFilters()), _proj_alerts),
         "get_tool_calls": (lambda b: b.get_tool_calls(AGENT, None, None), _proj_tool_calls),
-        "get_daily_cost": (lambda b: b.get_daily_cost(AGENT, now.date()), _proj_daily_cost),
+        "get_daily_cost": (lambda b: b.get_daily_cost(AGENT, historical_day), _proj_daily_cost),
         "get_baseline": (lambda b: b.get_baseline(AGENT), _proj_baseline),
     }
 
@@ -262,8 +265,8 @@ def _build_dataset(now) -> _Dataset:
             span = dataclasses.replace(span, trace_id=trace_id)
         spans.append(span)
 
-    # A span three days back — get_daily_cost(today) must exclude it (the old
-    # shim bug summed cumulatively across days).
+    # A span three days back — get_daily_cost(historical_day) must return only
+    # this span, not the cumulative total from that day through now.
     spans.append(make_llm_span(
         agent_id=AGENT, session_id=SESSION, input_tokens=500, output_tokens=100,
         cost_usd=99.0, start_time=now - timedelta(days=3),

--- a/tokenjam/core/api_backend.py
+++ b/tokenjam/core/api_backend.py
@@ -5,7 +5,7 @@ queries through the REST API.
 """
 from __future__ import annotations
 
-from datetime import date, datetime
+from datetime import date, datetime, timedelta, timezone
 from typing import Any
 
 import httpx
@@ -162,9 +162,12 @@ class ApiBackend:
         return data.get("tools", [])
 
     def get_daily_cost(self, agent_id: str, day: date) -> float:
+        start = datetime(day.year, day.month, day.day, tzinfo=timezone.utc)
+        end = start + timedelta(days=1)
         params: dict[str, str] = {
             "agent_id": agent_id,
-            "since": datetime(day.year, day.month, day.day).isoformat(),
+            "since": start.isoformat(),
+            "until": end.isoformat(),
             "group_by": "day",
         }
         data = self._get("/api/v1/cost", params)


### PR DESCRIPTION
`ApiBackend.get_daily_cost` was querying `/api/v1/cost` from the requested day's midnight through now, so historical dates could return cumulative spend instead of that single day's spend. This bounds the shim query to the requested UTC day and tightens the parity guard so the regression is caught.

## Summary
- Bound the API shim daily-cost request with both `since=<day 00:00 UTC>` and `until=<next day 00:00 UTC>`.
- Updated the storage-backend parity spec to query the seeded historical day, not today, so a missing `until` bound turns red.

## Related issue
Closes #348

## Tests / Verification
- `PYTHONPATH=/tmp/tokenjam pytest tests/integration/test_storage_backend_parity.py::test_shim_matches_db tests/integration/test_storage_backend_parity.py::test_duckdb_and_in_memory_agree -q --tb=short`
- `PYTHONPATH=/tmp/tokenjam pytest tests/integration/test_storage_backend_parity.py::test_every_protocol_method_is_classified tests/integration/test_storage_backend_parity.py::test_parity_methods_have_specs tests/integration/test_storage_backend_parity.py::test_parity_and_gap_methods_are_actually_implemented tests/integration/test_storage_backend_parity.py::test_unimplemented_methods_have_no_silent_shim -q --tb=short`
- `PYTHONPATH=/tmp/tokenjam pytest tests/unit/ tests/synthetic/ tests/agents/ tests/integration/ -q --tb=short -p no:cacheprovider` — 1916 passed
- `ruff check tokenjam/`
- `mypy tokenjam/ --show-error-codes`

## Checklist
- [x] Tests pass (`pytest tests/unit/ tests/synthetic/ tests/agents/ tests/integration/`)
- [x] Lint clean (`ruff check tokenjam/`)
- [x] Type check clean (`mypy tokenjam/`)
- [x] CLAUDE.md updated (not needed, no architecture change)
- [x] Test spans use `tests/factories.py` (not raw `NormalizedSpan`)
- [x] Requested `@anilmurty` as reviewer (or @-mentioned him above)

@anilmurty ready for review.