### PR TITLE
feat: add JSON output for budget command (#281)

### DIFF
--- a/tests/integration/test_cli.py
+++ b/tests/integration/test_cli.py
@@ -611,6 +611,18 @@ def test_budget_show_displays_defaults(runner, db, config):
     assert "5.00" in result.output  # fixture has daily_usd=5.0
 
 
+def test_budget_show_json_outputs_valid_budget_rows(runner, db, config):
+    """tj budget --json emits machine-readable rows."""
+    result = _invoke(runner, db, config, ["budget", "--json"])
+
+    assert result.exit_code == 0
+    data = json.loads(result.output)
+    test_agent = next(r for r in data if r["agent_id"] == "test-agent")
+    assert data[0]["scope"] == "defaults"
+    assert test_agent["daily_usd"] == 5.0
+    assert test_agent["effective_daily_usd"] == 5.0
+
+
 def test_budget_set_global_writes_config(runner, db, config, tmp_path):
     """tj budget --daily updates global defaults and writes config."""
     config_file = tmp_path / "config.toml"
@@ -626,6 +638,29 @@ def test_budget_set_global_writes_config(runner, db, config, tmp_path):
     assert mock_write.called
     saved_config = mock_write.call_args[0][0]
     assert saved_config.defaults.budget.daily_usd == 8.0
+
+
+def test_budget_set_json_outputs_updated_values(runner, db, config, tmp_path):
+    """tj budget --daily --json emits the updated budget values."""
+    config_file = tmp_path / "config.toml"
+    config_file.write_text("")
+
+    with patch("tokenjam.cli.main.load_config", return_value=config), \
+         patch("tokenjam.cli.main.open_db", return_value=db), \
+         patch("tokenjam.cli.cmd_budget.find_config_file", return_value=str(config_file)), \
+         patch("tokenjam.cli.cmd_budget.write_config"):
+        result = runner.invoke(cli, ["budget", "--daily", "8.0", "--json"])
+
+    assert result.exit_code == 0
+    data = json.loads(result.output)
+    assert data == {
+        "scope": "defaults",
+        "agent_id": None,
+        "daily_usd": 8.0,
+        "session_usd": None,
+        "effective_daily_usd": 8.0,
+        "effective_session_usd": None,
+    }
 
 
 def test_budget_set_agent_writes_config(runner, db, config, tmp_path):

--- a/tokenjam/cli/cmd_budget.py
+++ b/tokenjam/cli/cmd_budget.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 
+import json
 from pathlib import Path
+from typing import TypedDict
 
 import click
 
@@ -14,25 +16,37 @@ from tokenjam.core.config import (
 from tokenjam.utils.formatting import console
 
 
+class _BudgetRow(TypedDict):
+    scope: str
+    agent_id: str | None
+    daily_usd: float | None
+    session_usd: float | None
+    effective_daily_usd: float | None
+    effective_session_usd: float | None
+
+
 @click.command("budget")
 @click.option("--agent", default=None, help="Agent ID to target (omit for global defaults)")
 @click.option("--daily", "daily_usd", type=float, default=None,
               help="Daily budget in USD (0 = remove limit)")
 @click.option("--session", "session_usd", type=float, default=None,
               help="Per-session budget in USD (0 = remove limit)")
+@click.option("--json", "output_json", is_flag=True,
+              help="Emit machine-readable JSON.")
 @click.pass_context
 def cmd_budget(
     ctx: click.Context,
     agent: str | None,
     daily_usd: float | None,
     session_usd: float | None,
+    output_json: bool,
 ) -> None:
     """View or set cost budgets for agents."""
     config = ctx.obj["config"]
     writing = daily_usd is not None or session_usd is not None
 
     if not writing:
-        _show_budgets(config, ctx.obj.get("db"))
+        _show_budgets(config, ctx.obj.get("db"), output_json)
         return
 
     # Write mode — find config file on disk
@@ -61,6 +75,18 @@ def cmd_budget(
 
     write_config(config, Path(config_path_str))
 
+    if output_json:
+        effective = resolve_effective_budget(agent, config) if agent else config.defaults.budget
+        click.echo(json.dumps({
+            "scope": "agent" if agent else "defaults",
+            "agent_id": agent,
+            "daily_usd": budget.daily_usd,
+            "session_usd": budget.session_usd,
+            "effective_daily_usd": effective.daily_usd,
+            "effective_session_usd": effective.session_usd,
+        }))
+        return
+
     console.print(f"[green]\u2713[/green] Budget updated for {scope}")
     if daily_usd is not None:
         val = f"${daily_usd:.2f}" if daily_usd > 0 else "no limit"
@@ -70,7 +96,60 @@ def cmd_budget(
         console.print(f"  Session: {val}")
 
 
-def _show_budgets(config, db) -> None:
+def _budget_rows(config, db) -> list[_BudgetRow]:
+    rows: list[_BudgetRow] = [{
+        "scope": "defaults",
+        "agent_id": None,
+        "daily_usd": config.defaults.budget.daily_usd,
+        "session_usd": config.defaults.budget.session_usd,
+        "effective_daily_usd": config.defaults.budget.daily_usd,
+        "effective_session_usd": config.defaults.budget.session_usd,
+    }]
+
+    # Merge agent IDs from config + DB-observed agents. Two paths:
+    # - Direct DB: pull distinct agent_ids from sessions table.
+    # - API shim (daemon up, no db.conn): derive from recent traces.
+    #   Without this fallback, `tj budget` silently misses every agent
+    #   that hasn't been declared in tj.toml when the daemon is running
+    #   (#68 §11). Mirrors the pattern already used by cmd_status.
+    agent_ids = set(config.agents)
+    if db is not None:
+        if hasattr(db, "conn"):
+            rows_from_db = db.conn.execute(
+                "SELECT DISTINCT agent_id FROM sessions ORDER BY agent_id"
+            ).fetchall()
+            agent_ids |= {r[0] for r in rows_from_db if r[0]}
+        else:
+            try:
+                from tokenjam.core.models import TraceFilters
+                traces = db.get_traces(TraceFilters(limit=200))
+                agent_ids |= {t.agent_id for t in traces if t.agent_id}
+            except Exception:
+                # API call failed (server down, transient error) —
+                # render what we have from config rather than crash.
+                pass
+
+    for agent_id in sorted(agent_ids):
+        agent_cfg = config.agents.get(agent_id)
+        eff = resolve_effective_budget(agent_id, config)
+        rows.append({
+            "scope": "agent",
+            "agent_id": agent_id,
+            "daily_usd": agent_cfg.budget.daily_usd if agent_cfg else None,
+            "session_usd": agent_cfg.budget.session_usd if agent_cfg else None,
+            "effective_daily_usd": eff.daily_usd,
+            "effective_session_usd": eff.session_usd,
+        })
+
+    return rows
+
+
+def _show_budgets(config, db, output_json: bool = False) -> None:
+    rows = _budget_rows(config, db)
+    if output_json:
+        click.echo(json.dumps(rows))
+        return
+
     from rich.table import Table
 
     table = Table(show_header=True, header_style="bold", box=None, padding=(0, 2))
@@ -88,47 +167,21 @@ def _show_budgets(config, db) -> None:
             return f"[dim]${effective:.2f}[/dim] [dim](default)[/dim]"
         return "[dim]no limit[/dim]"
 
+    defaults = rows[0]
     table.add_row(
         "[bold]defaults[/bold]",
-        _fmt(config.defaults.budget.daily_usd),
-        _fmt(config.defaults.budget.session_usd),
+        _fmt(defaults["daily_usd"]),
+        _fmt(defaults["session_usd"]),
     )
 
-    # Merge agent IDs from config + DB-observed agents. Two paths:
-    # - Direct DB: pull distinct agent_ids from sessions table.
-    # - API shim (daemon up, no db.conn): derive from recent traces.
-    #   Without this fallback, `tj budget` silently misses every agent
-    #   that hasn't been declared in tj.toml when the daemon is running
-    #   (#68 §11). Mirrors the pattern already used by cmd_status.
-    agent_ids = set(config.agents)
-    if db is not None:
-        if hasattr(db, "conn"):
-            rows = db.conn.execute(
-                "SELECT DISTINCT agent_id FROM sessions ORDER BY agent_id"
-            ).fetchall()
-            agent_ids |= {r[0] for r in rows if r[0]}
-        else:
-            try:
-                from tokenjam.core.models import TraceFilters
-                traces = db.get_traces(TraceFilters(limit=200))
-                agent_ids |= {t.agent_id for t in traces if t.agent_id}
-            except Exception:
-                # API call failed (server down, transient error) —
-                # render what we have from config rather than crash.
-                pass
-
-    for agent_id in sorted(agent_ids):
-        agent_cfg = config.agents.get(agent_id)
-        eff = resolve_effective_budget(agent_id, config)
-        raw_daily = agent_cfg.budget.daily_usd if agent_cfg else None
-        raw_session = agent_cfg.budget.session_usd if agent_cfg else None
+    for row in rows[1:]:
         table.add_row(
-            agent_id,
-            _fmt_effective(raw_daily, eff.daily_usd),
-            _fmt_effective(raw_session, eff.session_usd),
+            str(row["agent_id"]),
+            _fmt_effective(row["daily_usd"], row["effective_daily_usd"]),
+            _fmt_effective(row["session_usd"], row["effective_session_usd"]),
         )
 
-    if not agent_ids:
+    if len(rows) == 1:
         table.add_row("[dim]no agents configured[/dim]", "", "")
 
     console.print(table)


### PR DESCRIPTION
## Summary
- Add a local `--json` flag to `tj budget`.
- Refactor budget display data into `_budget_rows()` so table and JSON output share one source.
- Emit JSON rows for view mode, including raw and effective amounts.

Closes #281