### PR TITLE
docs: Codex capability matrix + parity investigation (#81)

### DIFF
--- a/README.md
+++ b/README.md
@@ -258,6 +258,7 @@ tj serve               # start Lens + REST API
 | 🔁 Reuse analyzer deep-dive | [docs/optimize/reuse.md](docs/optimize/reuse.md) |
 | 🧪 Prove a downsize candidate holds (TokenJam Bench) | [tokenjam-bench](https://github.com/Metabuilder-Labs/tokenjam-bench) |
 | Claude Code & Codex integration | [docs/claude-code-integration.md](docs/claude-code-integration.md) |
+| Claude Code vs. Codex vs. SDK vs. OTLP — capability matrix | [docs/agent-capability-matrix.md](docs/agent-capability-matrix.md) |
 | Harness run grouping (governors / fan-out launchers) | [docs/harness-integration.md](docs/harness-integration.md) |
 | Python SDK reference | [docs/python-sdk.md](docs/python-sdk.md) |
 | TypeScript SDK reference | [docs/typescript-sdk.md](docs/typescript-sdk.md) |

--- a/docs/agent-capability-matrix.md
+++ b/docs/agent-capability-matrix.md
@@ -1,0 +1,46 @@
+# Agent capability matrix
+
+`tj` supports four ways of getting telemetry in: **Claude Code**, **Codex CLI**, the **Python SDK**,
+and **any OTLP-compliant agent** wired directly at the ingest endpoint. These are not equivalent —
+each persona gets a different subset of tj's surface, mostly because the upstream tool exposes a
+different set of hooks (or none). This page is the honest, per-capability breakdown, in the shape of
+[OpenTelemetry's language implementation matrix](https://opentelemetry.io/docs/languages/): rows are
+capabilities, columns are personas, cells are Yes / Partial / No with a one-line reason.
+
+Onboarding entry points: `tj onboard --claude-code` · `tj onboard --codex` · `tj onboard` (Python SDK /
+generic — see [python-sdk.md](python-sdk.md)) · no onboarding needed for generic OTLP (point your
+exporter at `tj serve`'s `/api/v1/spans`, see [framework-support.md](framework-support.md)).
+
+| Capability | Claude Code | Codex CLI | Python SDK | Generic OTLP |
+|---|---|---|---|---|
+| **Live ingest** | Yes — OTLP log events converted to spans by `api/routes/logs.py` | Yes — same converter, dedicated Codex event parsers (`api_request`, `sse_event`, `user_prompt`, `tool_decision`, `tool_result`) | Yes — in-process `@watch()` + `patch_*()` spans via `TjSpanExporter` | Yes — `POST /api/v1/spans`, any OTel GenAI-semconv-shaped payload |
+| **Historical backfill** | Yes — `tj backfill claude-code` (auto-run by `tj onboard --claude-code`) parses `~/.claude/projects/*.jsonl` | No — no `tj backfill codex` adapter exists yet; see investigation below | N/A — SDK telemetry is live-only, there's no local session log to backfill from | Partial — `tj backfill otlp --source-file <dump>` replays an OTLP JSON dump if you have one; nothing to backfill for a live-only exporter |
+| **Statusline (zero-token in-loop nudge)** | Yes — `tj onboard --claude-code` wires `tj statusline` into `~/.claude/settings.json` non-destructively | No — Codex's TUI has its own built-in `[tui].status_line` (fixed items: model, tokens, cost, git-branch, etc.) but no custom-command hook, so tj cannot inject a line into it | N/A — no TUI, the SDK is a library | N/A — depends entirely on the host agent's own UI, tj has nothing to wire |
+| **Hooks (SessionStart resume-brief / PostToolUse output-cap)** | Yes — resume-brief hook installed by default; output-cap hook is opt-in | No — Codex CLI has no hook system tj integrates with | N/A — no hook concept; equivalent is manual instrumentation via `record_llm_call()` / `record_tool_call()` | N/A |
+| **Per-terminal / per-instance identity** | Yes — the installed `claude` shell wrapper sets a distinct `service.instance.id` per terminal so concurrent sessions render as separate dashboard tiles | No — Codex hardcodes `service.name="codex_exec"` in the binary regardless of `[otel.resource]`, so **all** Codex activity across every terminal collapses into one agent tile | N/A — caller sets `agent_id` explicitly per `@watch()` call, so this is under direct code control | Partial — possible if the agent sets distinct resource attributes itself; tj does not automate this for a tool it doesn't control |
+| **Dashboard (Lens web UI)** | Yes | Yes | Yes | Yes — dashboard and analyzers are ingestion-source-agnostic; they read from the DB, not from the persona |
+| **Analyzers (downsize / cache / script / trim / reuse / budget-projection)** | Yes | Yes | Yes | Yes |
+| **MCP server (in-request-path tools)** | No, by design — an in-loop MCP measured **+36%** model-weighted quota overhead on CC subscription users (ticket #59); the statusline is the zero-cost substitute | No, by design — same reasoning; Codex has no zero-cost substitute today (see Statusline row) | Yes — the primary intended use case, tj sits in the SDK's request path already | Yes, if the host agent supports MCP tool-calling — otherwise not applicable |
+
+## Parity investigation: Codex backfill & statusline
+
+Filed as part of ticket #81 to decide whether the two Codex gaps above (backfill, statusline) are
+worth a follow-up or are structurally blocked.
+
+**Backfill — feasible, follow-up recommended.** Codex CLI writes local session transcripts to
+`~/.codex/sessions/YYYY/MM/DD/rollout-*.jsonl` (confirmed via Codex CLI docs and third-party parsers —
+e.g. `codex-trace`, "Agent Sessions" — that already read this format for session viewing/resuming).
+This is structurally the same situation as `core/backfill.py`'s existing Claude Code adapter: an
+undocumented-but-stable-enough, reverse-engineerable per-session JSONL format. A `tj backfill codex`
+adapter mirroring `ingest_claude_code()` looks buildable without any missing capability on Codex's
+side — it just hasn't been written yet. **Not implemented in this PR** (out of scope — this ticket
+only requires the decision, not the adapter); worth filing as its own ticket if wanted.
+
+**Statusline — infeasible today, revisit later.** Codex CLI does have a built-in TUI status line
+(`[tui].status_line` in `~/.codex/config.toml`, configurable via `/statusline` or the config file,
+with presets), but it is restricted to a fixed list of built-in item IDs (model, tokens, cost,
+git-branch, context usage, etc.) sourced from Codex's own internal state. There is no custom-command
+mechanism to inject an externally-computed line the way Claude Code's `statusLine: {type: "command"}`
+works — the upstream feature requests for one (`openai/codex#17827`, `#20244`) are still open/unresolved
+as of this writing. Until Codex ships a command-backed status line item, tj has no hook to wire its
+zero-token re-read/quota nudge into, and stays fully out-of-band (`tj tokenmaxx` / `tj traces` reads).

--- a/docs/claude-code-integration.md
+++ b/docs/claude-code-integration.md
@@ -77,6 +77,36 @@ The MCP server opens the DuckDB file read-only — no lock conflicts with `tj se
 
 Claude calls `setup_project`, which writes `.claude/settings.json` with `OTEL_RESOURCE_ATTRIBUTES=service.name=<project>` so spans from that project are tagged with the right agent ID.
 
+## Codex
+
+`tj onboard --codex` is a **smaller** integration than `tj onboard --claude-code` — Codex CLI exposes
+less to hook into, not because tj treats it as second-class. It wires OTel telemetry only:
+
+```bash
+tj onboard --codex
+# Restart Codex, then:
+tj tokenmaxx   # or: tj traces
+```
+
+This writes an `[otel]` block to `~/.codex/config.toml` pointing at `tj serve`'s OTLP endpoint. Codex
+CLI hardcodes `service.name="codex_exec"` in its binary regardless of `[otel.resource]`, so every Codex
+terminal's activity lands under one `codex_exec` agent tile — there is no per-project or per-terminal
+split like Claude Code gets.
+
+What `--codex` does **not** do, and why:
+- **No historical backfill** — no `tj backfill codex` adapter exists yet (Codex does write local
+  `~/.codex/sessions/*.jsonl` transcripts that look backfillable; see the investigation below).
+- **No statusline** — Codex's own TUI status line has no custom-command hook for tj to inject into.
+- **No MCP registration** — same reasoning as Claude Code: an in-loop MCP is a per-turn quota tax,
+  and Codex has no zero-cost statusline substitute to fall back on either.
+
+tj stays fully out-of-band for Codex: telemetry flows in automatically once you restart, and you read
+it with `tj tokenmaxx` / `tj traces` / the dashboard — no in-loop cost either way.
+
+See **[docs/agent-capability-matrix.md](agent-capability-matrix.md)** for the full Claude Code vs.
+Codex vs. Python SDK vs. OTLP capability breakdown, including the backfill/statusline parity
+investigation.
+
 ## Uninstalling
 
 ```bash

--- a/tokenjam/cli/cmd_onboard.py
+++ b/tokenjam/cli/cmd_onboard.py
@@ -1229,6 +1229,11 @@ def _onboard_codex(
         "Codex telemetry flows to tj automatically. Run[/dim]  tj tokenmaxx  "
         "[dim]/[/dim]  tj traces  [dim]for the deep dive.[/dim]"
     )
+    console.print(
+        "[dim]Codex gets a smaller subset of tj than Claude Code (no backfill, "
+        "no statusline, no per-terminal split) — see[/dim] "
+        "docs/agent-capability-matrix.md [dim]for the full breakdown.[/dim]"
+    )
     _print_restart_banner("Codex")
     console.print("[dim]After restarting, run:[/dim]  tj traces")
 


### PR DESCRIPTION
Fixes #81.

`tj onboard --codex` wires only OTel telemetry, and relative to `--claude-code` it lacks historical backfill, any statusline/hook surface, and per-terminal instance identity (Codex hardcodes `service.name="codex_exec"`, collapsing all Codex activity into one agent tile). None of this asymmetry was documented anywhere — users had no way to tell "not yet built" from "not possible."

## Summary
- Add `docs/agent-capability-matrix.md`: a Claude Code vs. Codex vs. Python SDK vs. generic-OTLP capability matrix (rows = capability, columns = persona, cells = yes/partial/no + one-line note — shaped after OpenTelemetry's language-status matrix). Verified cell-by-cell against `cli/cmd_onboard.py`, `api/routes/logs.py`, and `core/backfill.py`.
- Add a `## Codex` section to `docs/claude-code-integration.md` — this also fixes the README's `docs/claude-code-integration.md#codex` link, which pointed at a non-existent anchor before this PR.
- Link the new matrix from the README's Documentation table and from `_onboard_codex`'s outro text (one new `console.print` line).

## Parity investigation: Codex backfill & statusline

- **Backfill — feasible, follow-up recommended, not implemented here.** Codex CLI writes local session transcripts to `~/.codex/sessions/YYYY/MM/DD/rollout-*.jsonl` — reverse-engineerable the same way `core/backfill.py` already parses Claude Code's undocumented JSONL format (confirmed via Codex docs + third-party parsers like `codex-trace` and "Agent Sessions" that already read this format for session viewing/resuming). A `tj backfill codex` adapter mirroring `ingest_claude_code()` looks buildable without any missing capability on Codex's side.
- **Statusline — infeasible today.** Codex's TUI does have a built-in `[tui].status_line` (`~/.codex/config.toml`, configurable via `/statusline` or config, fixed items: model, tokens, cost, git-branch, context usage), but no custom-command hook to inject an externally-computed line — the upstream feature requests for one (`openai/codex#17827`, `#20244`) are still unresolved. tj has nothing to wire its zero-token re-read/quota nudge into until that ships.

Both conclusions are recorded in `docs/agent-capability-matrix.md` under "Parity investigation."

## Tests / Verification
- `pytest tests/unit/ tests/synthetic/ tests/agents/ tests/integration/` — 1948 passed, 1 skipped.
- `ruff check tokenjam/` / `mypy tokenjam/` clean on the touched file (`cmd_onboard.py`).
- `pytest tests/unit/test_onboard_codex.py` and the full onboard suite (`-k onboard`, 66 tests) pass — the new outro print line doesn't collide with any exact-stdout assertions.

## What's NOT in this PR
- No `tj backfill codex` adapter — the ticket only required recording the feasibility decision, not building it. Good candidate for a follow-up ticket.

🤖 Generated with [Claude Code](https://claude.com/claude-code)