### PR TITLE
Fix #85: tj onboard detects project stack for tailored instrument snippet

### DIFF
--- a/tests/unit/test_onboard_detect.py
+++ b/tests/unit/test_onboard_detect.py
@@ -1,0 +1,188 @@
+"""Project-stack detection for the bare `tj onboard` outro (#85)."""
+from __future__ import annotations
+
+from tokenjam.cli.onboard_detect import (
+    declared_package_names,
+    detect_stack,
+    install_hint,
+)
+
+
+def _write(tmp_path, name, content):
+    (tmp_path / name).write_text(content)
+
+
+# --- declared_package_names: pyproject.toml ---------------------------------
+
+
+def test_pep621_dependencies_are_detected(tmp_path):
+    _write(tmp_path, "pyproject.toml", """
+[project]
+dependencies = ["langchain>=0.2", "requests==2.31.0"]
+""")
+    names = declared_package_names(tmp_path)
+    assert "langchain" in names
+    assert "requests" in names
+
+
+def test_pep621_optional_dependencies_are_detected(tmp_path):
+    _write(tmp_path, "pyproject.toml", """
+[project]
+dependencies = []
+[project.optional-dependencies]
+agents = ["crewai>=0.28"]
+""")
+    assert "crewai" in declared_package_names(tmp_path)
+
+
+def test_poetry_dependencies_are_detected_and_python_excluded(tmp_path):
+    _write(tmp_path, "pyproject.toml", """
+[tool.poetry.dependencies]
+python = "^3.11"
+openai = "^1.0"
+""")
+    names = declared_package_names(tmp_path)
+    assert "openai" in names
+    assert "python" not in names
+
+
+def test_poetry_group_dependencies_are_detected(tmp_path):
+    _write(tmp_path, "pyproject.toml", """
+[tool.poetry.group.dev.dependencies]
+pytest = "^8.0"
+""")
+    assert "pytest" in declared_package_names(tmp_path)
+
+
+def test_malformed_pyproject_does_not_raise(tmp_path):
+    _write(tmp_path, "pyproject.toml", "not [ valid toml")
+    assert declared_package_names(tmp_path) == set()
+
+
+# --- declared_package_names: requirements*.txt ------------------------------
+
+
+def test_requirements_txt_names_are_extracted_with_version_specifiers(tmp_path):
+    _write(tmp_path, "requirements.txt", """
+# a comment
+boto3>=1.34
+litellm==1.40.0
+-e ./local-pkg
+git+https://example.com/foo.git
+https://example.com/bar.whl
+""")
+    names = declared_package_names(tmp_path)
+    assert "boto3" in names
+    assert "litellm" in names
+    assert not any("local-pkg" in n or "foo" in n or "bar" in n for n in names)
+
+
+def test_multiple_requirements_files_are_all_scanned(tmp_path):
+    _write(tmp_path, "requirements.txt", "openai\n")
+    _write(tmp_path, "requirements-dev.txt", "pyautogen\n")
+    names = declared_package_names(tmp_path)
+    assert "openai" in names
+    assert "pyautogen" in names
+
+
+def test_extras_bracket_is_stripped_from_requirement_name(tmp_path):
+    _write(tmp_path, "requirements.txt", "llama-index[vector-stores]>=0.10\n")
+    assert "llama-index" in declared_package_names(tmp_path)
+
+
+# --- declared_package_names: setup.cfg --------------------------------------
+
+
+def test_setup_cfg_install_requires_is_detected(tmp_path):
+    _write(tmp_path, "setup.cfg", """
+[options]
+install_requires =
+    anthropic>=0.25
+    ag2
+""")
+    names = declared_package_names(tmp_path)
+    assert "anthropic" in names
+    assert "ag2" in names
+
+
+def test_setup_cfg_extras_require_is_detected(tmp_path):
+    _write(tmp_path, "setup.cfg", """
+[options.extras_require]
+langgraph =
+    langgraph>=0.1
+""")
+    assert "langgraph" in declared_package_names(tmp_path)
+
+
+# --- normalization -----------------------------------------------------------
+
+
+def test_names_are_pep503_normalized(tmp_path):
+    _write(tmp_path, "requirements.txt", "Google_Generativeai==0.5\n")
+    assert "google-generativeai" in declared_package_names(tmp_path)
+
+
+def test_empty_project_dir_yields_no_names(tmp_path):
+    assert declared_package_names(tmp_path) == set()
+
+
+# --- detect_stack: end-to-end matching --------------------------------------
+
+
+def test_no_manifests_yields_no_matches(tmp_path):
+    assert detect_stack(tmp_path) == []
+
+
+def test_langchain_dependency_yields_langchain_match(tmp_path):
+    _write(tmp_path, "requirements.txt", "langchain>=0.2\n")
+    matches = detect_stack(tmp_path)
+    keys = [m.key for m in matches]
+    assert keys == ["langchain"]
+    m = matches[0]
+    assert m.patch_call == "patch_langchain()"
+    assert "patch_langchain" in m.import_line
+    assert install_hint(m) == "pip install 'tokenjam[langchain]'"
+
+
+def test_provider_without_extra_has_no_install_hint(tmp_path):
+    _write(tmp_path, "requirements.txt", "anthropic>=0.25\n")
+    matches = detect_stack(tmp_path)
+    assert matches[0].key == "anthropic"
+    assert install_hint(matches[0]) is None
+
+
+def test_multiple_matches_are_ordered_providers_then_frameworks_alphabetically(tmp_path):
+    _write(tmp_path, "requirements.txt", "openai\nlanggraph\nanthropic\ncrewai\n")
+    matches = detect_stack(tmp_path)
+    keys = [m.key for m in matches]
+    assert keys == ["anthropic", "openai", "crewai", "langgraph"]
+
+
+def test_google_genai_and_generativeai_both_map_to_gemini_without_duplicate(tmp_path):
+    _write(tmp_path, "requirements.txt", "google-genai\ngoogle-generativeai\n")
+    matches = detect_stack(tmp_path)
+    assert [m.key for m in matches] == ["gemini"]
+
+
+def test_llama_index_variants_both_map_to_llamaindex_without_duplicate(tmp_path):
+    _write(tmp_path, "requirements.txt", "llama-index\nllama-index-core\n")
+    matches = detect_stack(tmp_path)
+    assert [m.key for m in matches] == ["llamaindex"]
+
+
+def test_autogen_fork_ag2_is_detected(tmp_path):
+    _write(tmp_path, "requirements.txt", "ag2>=0.3\n")
+    matches = detect_stack(tmp_path)
+    assert [m.key for m in matches] == ["autogen"]
+
+
+def test_litellm_detected_alongside_providers(tmp_path):
+    _write(tmp_path, "requirements.txt", "litellm\nopenai\nanthropic\n")
+    matches = detect_stack(tmp_path)
+    keys = {m.key for m in matches}
+    assert {"litellm", "openai", "anthropic"} <= keys
+
+
+def test_unrelated_dependencies_yield_no_matches(tmp_path):
+    _write(tmp_path, "requirements.txt", "flask\nrequests\nnumpy\n")
+    assert detect_stack(tmp_path) == []

--- a/tests/unit/test_onboard_stack_detection.py
+++ b/tests/unit/test_onboard_stack_detection.py
@@ -1,0 +1,74 @@
+"""Bare `tj onboard` prints a stack-tailored instrument-your-agent snippet (#85).
+
+Previously the outro always printed the same hardcoded `patch_anthropic()` +
+`@watch()` snippet regardless of the project's actual dependencies. These
+tests exercise the wiring in `cmd_onboard.py` end-to-end via the CLI, on top
+of the pure-logic coverage in `test_onboard_detect.py`.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+from click.testing import CliRunner
+
+from tokenjam.cli.cmd_onboard import cmd_onboard
+
+
+@pytest.fixture(autouse=True)
+def _no_existing_config(monkeypatch):
+    monkeypatch.setattr("tokenjam.cli.cmd_onboard.find_config_file", lambda: None)
+
+
+def _run(tmp_path, manifest_name=None, manifest_text=None):
+    runner = CliRunner()
+    with runner.isolated_filesystem(temp_dir=tmp_path):
+        if manifest_name:
+            Path(manifest_name).write_text(manifest_text)
+        res = runner.invoke(cmd_onboard, ["--no-daemon", "--budget", "0"], obj={})
+        return res
+
+
+def test_unknown_stack_falls_back_to_generic_anthropic_snippet(tmp_path):
+    res = _run(tmp_path)
+    assert res.exit_code == 0, res.output
+    assert "from tokenjam.sdk.integrations.anthropic import patch_anthropic" in res.output
+    assert "patch_anthropic()" in res.output
+
+
+def test_langchain_project_prints_langchain_snippet_and_extra(tmp_path):
+    res = _run(tmp_path, "requirements.txt", "langchain>=0.2\n")
+    assert res.exit_code == 0, res.output
+    assert "patch_langchain()" in res.output
+    assert "from tokenjam.sdk.integrations.langchain import patch_langchain" in res.output
+    assert "pip install 'tokenjam[langchain]'" in res.output
+    # Generic Anthropic snippet should not also be shown once a match is found.
+    assert "patch_anthropic()" not in res.output
+
+
+def test_openai_pyproject_project_prints_openai_snippet(tmp_path):
+    res = _run(tmp_path, "pyproject.toml", '[project]\ndependencies = ["openai>=1.0"]\n')
+    assert res.exit_code == 0, res.output
+    assert "patch_openai()" in res.output
+    assert "from tokenjam.sdk.integrations.openai import patch_openai" in res.output
+
+
+def test_multiple_matches_all_printed(tmp_path):
+    res = _run(tmp_path, "requirements.txt", "anthropic\ncrewai\n")
+    assert res.exit_code == 0, res.output
+    assert "patch_anthropic()" in res.output
+    assert "patch_crewai()" in res.output
+
+
+def test_litellm_with_providers_prints_supersedes_note(tmp_path):
+    res = _run(tmp_path, "requirements.txt", "litellm\nopenai\n")
+    assert res.exit_code == 0, res.output
+    assert "patch_litellm()" in res.output
+    assert "supersede" in res.output.lower() or "alone covers" in res.output.lower()
+
+
+def test_litellm_alone_has_no_supersedes_note(tmp_path):
+    res = _run(tmp_path, "requirements.txt", "litellm\n")
+    assert res.exit_code == 0, res.output
+    assert "patch_litellm()" in res.output
+    assert "alone covers" not in res.output.lower()

--- a/tokenjam/cli/cmd_onboard.py
+++ b/tokenjam/cli/cmd_onboard.py
@@ -12,6 +12,7 @@ import click
 from rich.markup import escape
 
 from tokenjam.cli.banner import print_welcome_banner
+from tokenjam.cli.onboard_detect import SdkMatch, detect_stack, install_hint
 from tokenjam.core.config import find_config_file
 from tokenjam.utils.formatting import console
 
@@ -175,6 +176,66 @@ def _unwire_claude_resume_brief_hook(settings: dict) -> bool:
         if not hooks:
             settings.pop("hooks", None)
     return True
+
+
+def _print_generic_instrument_snippet() -> None:
+    """The one-size-fits-all Anthropic snippet — fallback when detection finds nothing."""
+    console.print("[dim]     from tokenjam.sdk import watch[/dim]")
+    console.print("[dim]     from tokenjam.sdk.integrations.anthropic import patch_anthropic[/dim]")
+    console.print()
+    console.print("[dim]     patch_anthropic()[/dim]")
+    console.print()
+    console.print('[dim]     @watch(agent_id="my-agent")[/dim]')
+    console.print("[dim]     def run(task):[/dim]")
+    console.print("[dim]         ...[/dim]")
+
+
+def _print_matched_instrument_snippet(match: SdkMatch) -> None:
+    """One detected SDK/framework's tailored `patch_*()` + `@watch()` snippet."""
+    console.print(f"[dim]     # {match.label}[/dim]")
+    console.print("[dim]     from tokenjam.sdk import watch[/dim]")
+    console.print(f"[dim]     {match.import_line}[/dim]")
+    console.print()
+    console.print(f"[dim]     {match.patch_call}[/dim]")
+    console.print()
+    console.print('[dim]     @watch(agent_id="my-agent")[/dim]')
+    console.print("[dim]     def run(task):[/dim]")
+    console.print("[dim]         ...[/dim]")
+    hint = install_hint(match)
+    if hint:
+        console.print()
+        # escape(): the extras bracket (e.g. "tokenjam[langchain]") would
+        # otherwise be swallowed as Rich markup — same class of bug as #157.
+        console.print(f"[dim]     {escape(hint)}[/dim]")
+
+
+def _print_instrument_agent_snippet() -> None:
+    """Print the bare-onboard "instrument your agent" snippet (issue #85).
+
+    Detects the current project's declared LLM provider SDKs / agent
+    frameworks (via `onboard_detect.detect_stack`) and prints a tailored
+    `patch_*()` call + install hint per match, instead of always assuming
+    Anthropic. Falls back to the generic Anthropic snippet when nothing is
+    detected (unchanged from pre-#85 behavior).
+    """
+    matches = detect_stack(".")
+    if not matches:
+        _print_generic_instrument_snippet()
+        return
+    for i, match in enumerate(matches):
+        if i > 0:
+            console.print()
+        _print_matched_instrument_snippet(match)
+    if any(m.key == "litellm" for m in matches) and len(matches) > 1:
+        console.print()
+        console.print(
+            "[dim]     # Note: patch_litellm() alone covers every provider "
+            "it routes — the individual[/dim]"
+        )
+        console.print(
+            "[dim]     # provider patches above are only needed for calls "
+            "made outside LiteLLM.[/dim]"
+        )
 
 
 @click.command("onboard")
@@ -375,14 +436,7 @@ retention_days = 90
     console.print()
     console.print("  1. Instrument your agent:")
     console.print()
-    console.print("[dim]     from tokenjam.sdk import watch[/dim]")
-    console.print("[dim]     from tokenjam.sdk.integrations.anthropic import patch_anthropic[/dim]")
-    console.print()
-    console.print("[dim]     patch_anthropic()[/dim]")
-    console.print()
-    console.print('[dim]     @watch(agent_id="my-agent")[/dim]')
-    console.print("[dim]     def run(task):[/dim]")
-    console.print("[dim]         ...[/dim]")
+    _print_instrument_agent_snippet()
     console.print()
     console.print("  2. Run your agent \u2014 spans are recorded automatically")
     console.print()

--- a/tokenjam/cli/onboard_detect.py
+++ b/tokenjam/cli/onboard_detect.py
@@ -1,0 +1,235 @@
+"""Best-effort SDK / agent-framework detection for `tj onboard`'s bare-onboard
+outro (#85).
+
+Bare `tj onboard` (no `--claude-code`/`--codex`) prints one hardcoded
+`patch_anthropic()` + `@watch()` snippet regardless of the project's actual
+stack. This scans the project's dependency manifests for known LLM provider
+SDKs and agent frameworks so the outro can print the *tailored* `patch_*()`
+call, import path, and `tokenjam[extra]` install hint instead.
+
+Manifest-only by design: it never imports or executes project code, so it
+can't be fooled by conditional imports and can't crash on a project with
+import side effects. Detection is necessarily incomplete (a project can
+declare deps in a lockfile-only or Pipfile flow this doesn't read) — that's
+fine, the caller always has the generic snippet as a fallback.
+"""
+from __future__ import annotations
+
+import configparser
+import re
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+
+if sys.version_info >= (3, 11):
+    import tomllib
+else:
+    import tomli as tomllib  # type: ignore[no-redef]
+
+
+@dataclass(frozen=True)
+class SdkMatch:
+    """One detected provider SDK or agent framework, with its onboard advice."""
+
+    key: str
+    label: str
+    kind: str  # "provider" | "framework"
+    import_line: str
+    patch_call: str
+    extra: str | None  # tokenjam[<extra>] name, or None when no extra applies
+
+
+# Public patch functions, from tokenjam/sdk/integrations/*.py — keep these in
+# sync with that package; a renamed patch_* function or extra silently makes
+# the onboard advice wrong (fail-open, no test catches a typo in the string
+# itself, only that *some* string got printed).
+_PROVIDERS: tuple[SdkMatch, ...] = (
+    SdkMatch("anthropic", "Anthropic", "provider",
+             "from tokenjam.sdk.integrations.anthropic import patch_anthropic",
+             "patch_anthropic()", None),
+    SdkMatch("openai", "OpenAI", "provider",
+             "from tokenjam.sdk.integrations.openai import patch_openai",
+             "patch_openai()", None),
+    SdkMatch("gemini", "Gemini", "provider",
+             "from tokenjam.sdk.integrations.gemini import patch_gemini",
+             "patch_gemini()", None),
+    SdkMatch("bedrock", "Bedrock", "provider",
+             "from tokenjam.sdk.integrations.bedrock import patch_bedrock",
+             "patch_bedrock()", None),
+    SdkMatch("litellm", "LiteLLM", "provider",
+             "from tokenjam.sdk.integrations.litellm import patch_litellm",
+             "patch_litellm()", "litellm"),
+)
+
+_FRAMEWORKS: tuple[SdkMatch, ...] = (
+    SdkMatch("langchain", "LangChain", "framework",
+             "from tokenjam.sdk.integrations.langchain import patch_langchain",
+             "patch_langchain()", "langchain"),
+    SdkMatch("langgraph", "LangGraph", "framework",
+             "from tokenjam.sdk.integrations.langgraph import patch_langgraph",
+             "patch_langgraph()", None),
+    SdkMatch("crewai", "CrewAI", "framework",
+             "from tokenjam.sdk.integrations.crewai import patch_crewai",
+             "patch_crewai()", "crewai"),
+    SdkMatch("autogen", "AutoGen", "framework",
+             "from tokenjam.sdk.integrations.autogen import patch_autogen",
+             "patch_autogen()", "autogen"),
+    SdkMatch("llamaindex", "LlamaIndex", "framework",
+             "from tokenjam.sdk.integrations.llamaindex import patch_llamaindex",
+             "patch_llamaindex()", None),
+)
+
+_ALL_MATCHES: dict[str, SdkMatch] = {m.key: m for m in (*_PROVIDERS, *_FRAMEWORKS)}
+
+# PEP 503 normalized declared-dependency name -> detection key. Several
+# distribution names can map to one key (both Google SDKs, both llama-index
+# dists, autogen's pyautogen/ag2 fork).
+_PACKAGE_TO_KEY: dict[str, str] = {
+    "anthropic": "anthropic",
+    "openai": "openai",
+    "google-generativeai": "gemini",
+    "google-genai": "gemini",
+    "boto3": "bedrock",
+    "litellm": "litellm",
+    "langchain": "langchain",
+    "langchain-core": "langchain",
+    "langgraph": "langgraph",
+    "crewai": "crewai",
+    "pyautogen": "autogen",
+    "ag2": "autogen",
+    "llama-index": "llamaindex",
+    "llama-index-core": "llamaindex",
+}
+
+_NAME_RE = re.compile(r"^\s*([A-Za-z0-9_.\-]+)")
+
+
+def _normalize(name: str) -> str:
+    """PEP 503 normalize: lowercase, collapse runs of -/_/. to a single '-'."""
+    return re.sub(r"[-_.]+", "-", name.strip().lower())
+
+
+def _requirement_name(line: str) -> str | None:
+    """Bare package name from one requirements.txt-style line, or None."""
+    line = line.split("#", 1)[0].strip()
+    if not line or line.startswith(("-", "git+", "http://", "https://")):
+        return None
+    m = _NAME_RE.match(line)
+    if not m:
+        return None
+    return m.group(1).split("[", 1)[0]
+
+
+def _names_from_pyproject(path: Path) -> set[str]:
+    try:
+        data = tomllib.loads(path.read_text())
+    except (OSError, tomllib.TOMLDecodeError):
+        return set()
+    names: set[str] = set()
+
+    project = data.get("project", {}) or {}
+    for dep in project.get("dependencies", []) or []:
+        if isinstance(dep, str):
+            n = _requirement_name(dep)
+            if n:
+                names.add(n)
+    for deps in (project.get("optional-dependencies", {}) or {}).values():
+        for dep in deps or []:
+            if isinstance(dep, str):
+                n = _requirement_name(dep)
+                if n:
+                    names.add(n)
+
+    poetry = ((data.get("tool", {}) or {}).get("poetry", {}) or {})
+    for section in ("dependencies", "dev-dependencies"):
+        for name in (poetry.get(section, {}) or {}):
+            if name.lower() != "python":
+                names.add(name)
+    for group in (poetry.get("group", {}) or {}).values():
+        for name in (group.get("dependencies", {}) or {}):
+            if name.lower() != "python":
+                names.add(name)
+
+    return names
+
+
+def _names_from_requirements(path: Path) -> set[str]:
+    names: set[str] = set()
+    try:
+        text = path.read_text()
+    except OSError:
+        return names
+    for line in text.splitlines():
+        n = _requirement_name(line)
+        if n:
+            names.add(n)
+    return names
+
+
+def _names_from_setup_cfg(path: Path) -> set[str]:
+    names: set[str] = set()
+    parser = configparser.ConfigParser()
+    try:
+        parser.read(path)
+    except configparser.Error:
+        return names
+    if parser.has_option("options", "install_requires"):
+        for line in parser.get("options", "install_requires").splitlines():
+            n = _requirement_name(line)
+            if n:
+                names.add(n)
+    if parser.has_section("options.extras_require"):
+        for _extra_name, raw in parser.items("options.extras_require"):
+            for line in raw.splitlines():
+                n = _requirement_name(line)
+                if n:
+                    names.add(n)
+    return names
+
+
+def declared_package_names(project_dir: str | Path = ".") -> set[str]:
+    """Every dependency name declared across this project's manifests.
+
+    PEP-503 normalized (lowercase, `-`/`_`/`.` collapsed). Reads
+    `pyproject.toml` (PEP 621 `[project]` + Poetry `[tool.poetry]`),
+    `requirements*.txt`, and `setup.cfg` at the project root — no recursion,
+    no lockfiles.
+    """
+    root = Path(project_dir)
+    names: set[str] = set()
+
+    pyproject = root / "pyproject.toml"
+    if pyproject.is_file():
+        names |= _names_from_pyproject(pyproject)
+
+    for req_file in sorted(root.glob("requirements*.txt")):
+        names |= _names_from_requirements(req_file)
+
+    setup_cfg = root / "setup.cfg"
+    if setup_cfg.is_file():
+        names |= _names_from_setup_cfg(setup_cfg)
+
+    return {_normalize(n) for n in names}
+
+
+def detect_stack(project_dir: str | Path = ".") -> list[SdkMatch]:
+    """Detect known LLM provider SDKs / agent frameworks declared in this project.
+
+    Returns matches in a stable order (providers before frameworks, each
+    alphabetical by key) so the onboard outro's advice order never depends on
+    manifest iteration order. Empty when nothing recognized is declared —
+    callers fall back to the generic snippet in that case.
+    """
+    declared = declared_package_names(project_dir)
+    found_keys = {key for name, key in _PACKAGE_TO_KEY.items() if name in declared}
+    return sorted(
+        (_ALL_MATCHES[k] for k in found_keys),
+        key=lambda m: (0 if m.kind == "provider" else 1, m.key),
+    )
+
+
+def install_hint(match: SdkMatch) -> str | None:
+    """The `pip install tokenjam[...]` hint for a match, or None if no extra applies."""
+    if match.extra is None:
+        return None
+    return f"pip install 'tokenjam[{match.extra}]'"


### PR DESCRIPTION
Bare `tj onboard` (no `--claude-code`/`--codex`) always printed the same hardcoded `patch_anthropic()` + `@watch()` snippet in its outro, regardless of the project's actual stack. A LangChain user got no `patch_langchain()` pointer, an OpenAI-only user got an Anthropic snippet, and nobody was told which `tokenjam[extra]` to install.

## Summary
- New module `tokenjam/cli/onboard_detect.py`: manifest-only detector (no imports, no code execution) that scans `pyproject.toml` (PEP 621 `[project]` deps + optional-deps, and Poetry `[tool.poetry]` deps/group-deps), `requirements*.txt`, and `setup.cfg` for known LLM provider SDKs (Anthropic, OpenAI, Gemini, Bedrock, LiteLLM) and agent frameworks (LangChain, LangGraph, CrewAI, AutoGen/ag2, LlamaIndex).
- Wires detection into `tokenjam/cli/cmd_onboard.py`'s bare-onboard "Instrument your agent" outro: prints the exact `patch_*()` call, import path, and `pip install 'tokenjam[extra]'` hint for each match. Multiple matches all print. LiteLLM detected alongside other providers adds a note that `patch_litellm()` alone covers what it routes. Nothing detected → unchanged generic Anthropic snippet.
- Patch function names / extras cross-checked against `tokenjam/sdk/integrations/*.py` and `pyproject.toml`'s `[project.optional-dependencies]` so the printed advice is exact (not guessed). Several provider SDKs (anthropic, openai, google-genai/generativeai, boto3) and some frameworks (langgraph, llama-index) have no dedicated `tokenjam[extra]` — the tool doesn't bundle those as dependencies, so no install hint is printed for them, only the import + patch call.

## Tests / Verification
- `tests/unit/test_onboard_detect.py` (21 tests): pure-logic coverage of manifest parsing (PEP 621, Poetry, requirements.txt edge cases like `-e`/git/http refs and extras brackets, setup.cfg `install_requires`/`extras_require`), PEP 503 name normalization, and `detect_stack()` matching/ordering/dedup (e.g. `google-genai` + `google-generativeai` both map to one `gemini` match, `ag2` maps to `autogen`).
- `tests/unit/test_onboard_stack_detection.py` (6 tests): end-to-end via `CliRunner.invoke(cmd_onboard, ...)` against a temp project dir — asserts the fallback generic snippet, per-provider/framework tailored snippets, the extras install hint, and the LiteLLM-supersedes note (present only when LiteLLM + another match are both detected).
- Full suite: `pytest tests/unit/ tests/synthetic/ tests/agents/ tests/integration/` → 1975 passed, 1 skipped (pre-existing skip, unrelated).
- `ruff check` and `mypy` clean on all touched/new files.

## What's NOT in this PR
- Top-level import scanning (ticket mentioned this as optional) — manifest scanning alone covers the common case and never needs to execute project code. A future ticket could add it as a secondary signal for projects with undeclared/dev-installed deps.
- No new `cli/onboard/` package split — per the ticket's explicit instruction, that's reserved for a separate ticket splitting up `cmd_onboard.py`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)