### PR TITLE
fix(onboard): guard stack detection against UnicodeDecodeError crash

### DIFF
--- a/tests/unit/test_onboard_detect.py
+++ b/tests/unit/test_onboard_detect.py
@@ -126,6 +126,33 @@ def test_empty_project_dir_yields_no_names(tmp_path):
     assert declared_package_names(tmp_path) == set()
 
 
+# --- non-UTF-8 manifests fail open (Greptile P1 on #407) --------------------
+# read_text() raises UnicodeDecodeError on non-UTF-8 bytes. That's a ValueError
+# subclass, NOT an OSError, so the fail-open guards must catch it explicitly or
+# `tj onboard` (a default-run command) crashes.
+
+
+def test_non_utf8_requirements_fails_open(tmp_path):
+    (tmp_path / "requirements.txt").write_bytes(b"langchain>=0.2\n\xff\xfe not utf-8\n")
+    # Must not raise UnicodeDecodeError; degrades to no detection.
+    assert declared_package_names(tmp_path) == set()
+    assert detect_stack(tmp_path) == []
+
+
+def test_non_utf8_pyproject_fails_open(tmp_path):
+    (tmp_path / "pyproject.toml").write_bytes(b"[project]\ndependencies = [\xff\xfe]\n")
+    assert declared_package_names(tmp_path) == set()
+    assert detect_stack(tmp_path) == []
+
+
+def test_non_utf8_setup_cfg_fails_open(tmp_path):
+    (tmp_path / "setup.cfg").write_bytes(
+        b"[options]\ninstall_requires =\n    openai\n\xff\xfe\n"
+    )
+    assert declared_package_names(tmp_path) == set()
+    assert detect_stack(tmp_path) == []
+
+
 # --- detect_stack: end-to-end matching --------------------------------------
 
 

--- a/tokenjam/cli/cmd_onboard.py
+++ b/tokenjam/cli/cmd_onboard.py
@@ -218,7 +218,14 @@ def _print_instrument_agent_snippet() -> None:
     Anthropic. Falls back to the generic Anthropic snippet when nothing is
     detected (unchanged from pre-#85 behavior).
     """
-    matches = detect_stack(".")
+    # Stack detection is a nice-to-have outro, never load-bearing: if anything
+    # in manifest reading goes wrong (e.g. a non-UTF-8 manifest surfacing an
+    # unexpected error), degrade to the generic snippet rather than crashing
+    # a default-run command.
+    try:
+        matches = detect_stack(".")
+    except Exception:
+        matches = []
     if not matches:
         _print_generic_instrument_snippet()
         return

--- a/tokenjam/cli/onboard_detect.py
+++ b/tokenjam/cli/onboard_detect.py
@@ -123,7 +123,9 @@ def _requirement_name(line: str) -> str | None:
 def _names_from_pyproject(path: Path) -> set[str]:
     try:
         data = tomllib.loads(path.read_text())
-    except (OSError, tomllib.TOMLDecodeError):
+    except (OSError, UnicodeDecodeError, tomllib.TOMLDecodeError):
+        # UnicodeDecodeError (a ValueError, not an OSError) fires when the
+        # manifest has non-UTF-8 bytes; fail open to "no detection".
         return set()
     names: set[str] = set()
 
@@ -157,7 +159,9 @@ def _names_from_requirements(path: Path) -> set[str]:
     names: set[str] = set()
     try:
         text = path.read_text()
-    except OSError:
+    except (OSError, UnicodeDecodeError):
+        # UnicodeDecodeError (a ValueError, not an OSError) fires when the
+        # manifest has non-UTF-8 bytes; fail open to "no detection".
         return names
     for line in text.splitlines():
         n = _requirement_name(line)
@@ -171,7 +175,9 @@ def _names_from_setup_cfg(path: Path) -> set[str]:
     parser = configparser.ConfigParser()
     try:
         parser.read(path)
-    except configparser.Error:
+    except (OSError, UnicodeDecodeError, configparser.Error):
+        # UnicodeDecodeError (a ValueError, not an OSError) fires when the
+        # manifest has non-UTF-8 bytes; fail open to "no detection".
         return names
     if parser.has_option("options", "install_requires"):
         for line in parser.get("options", "install_requires").splitlines():


### PR DESCRIPTION
Stack detection for `tj onboard`'s outro crashes the whole command on a project with a non-UTF-8 manifest file. Greptile flagged this as P1 on #407 and it's real.

## The bug
`tokenjam/cli/onboard_detect.py` reads project manifests (`pyproject.toml`, `requirements*.txt`, `setup.cfg`) with `Path.read_text()`. On a file containing non-UTF-8 bytes, `read_text()` raises **`UnicodeDecodeError`** — which is a subclass of **`ValueError`, NOT `OSError`**. The existing fail-open guards were:

- `_names_from_pyproject`: `except (OSError, tomllib.TOMLDecodeError)`
- `_names_from_requirements`: `except OSError`
- `_names_from_setup_cfg`: `except configparser.Error` (configparser decodes lazily during `read()`, so it hits the same failure)

None of them catch `UnicodeDecodeError`, so the error propagates out of `detect_stack(".")` in `cmd_onboard.py` — which had **no** guard around the call — and crashes `tj onboard`, a default-run command. The stack-detection outro is only a nice-to-have; it should never be able to crash onboarding.

## The fix
- `tokenjam/cli/onboard_detect.py` — broaden all three manifest-read guards to also catch `UnicodeDecodeError`, failing open to "no detection" (a comment notes why: it's a `ValueError`, not an `OSError`).
- `tokenjam/cli/cmd_onboard.py` — wrap the `detect_stack(".")` call in `_print_instrument_agent_snippet` in a belt-and-suspenders `try/except Exception`, degrading to the generic snippet on any detection failure.

## Tests / Verification
- Added 3 regression tests to `tests/unit/test_onboard_detect.py` (`test_non_utf8_requirements_fails_open`, `test_non_utf8_pyproject_fails_open`, `test_non_utf8_setup_cfg_fails_open`) that `write_bytes` invalid UTF-8 into each manifest type and assert `declared_package_names()` / `detect_stack()` return empty rather than raising.
- Confirmed all 3 **fail** on `main` (raising the exact `UnicodeDecodeError: 'utf-8' codec can't decode byte 0xff`) and **pass** with the fix.
- `pytest tests/unit/test_onboard_detect.py tests/unit/test_onboard_stack_detection.py` → 30 passed.
- `ruff check tokenjam/` clean on both touched files.

Follow-up to #407 (Greptile P1).

🤖 Generated with [Claude Code](https://claude.com/claude-code)