### PR TITLE
docs: fix onboard drift (#89), add 11 missing CLI commands (#90), document subagent analyzer (#91)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -412,6 +412,7 @@ Key runtime dependency: `pytz` is required by DuckDB for `TIMESTAMPTZ` column ha
   - [`cache.md`](docs/optimize/cache.md) — `cache` (current caching ratio) + `cache-recommend` (Anthropic-only breakpoint suggestions)
   - [`script.md`](docs/optimize/script.md) — `script` clustering by `(tool_name, arg_shape)` signature (file: `workflow_restructure.py`)
   - [`trim.md`](docs/optimize/trim.md) — LLMLingua-2 token-significance classifier (`trim`, file: `prompt_bloat.py`), install + capture requirements, performance numbers
+  - [`subagent.md`](docs/optimize/subagent.md) — per-subagent right-sizing (`subagent`, file: `subagent_rightsizing.py`), Claude Code-only (keys off `sub_agent_id`, populated only by CC backfill)
 - **[AGENTS.md](AGENTS.md)** — codebase conventions for contributors (referenced from the top-level README).
 - **Backfill adapters** — `docs/backfill/overview.md` lists the four sources (`claude-code` / `langfuse` / `helicone` / `otlp`) with the partnership-posture framing; per-adapter pages document modes (URL / file), field mapping, idempotency, and v1 limitations.
 - **[docs/policy/overview.md](docs/policy/overview.md)** — read-only preview of the unified policy surface (`tj policy list`). Notes that the `add` / `edit` / `apply` subcommands and the underlying `[policy]` config migration land next sprint.

--- a/docs/claude-code-integration.md
+++ b/docs/claude-code-integration.md
@@ -11,13 +11,15 @@ tj status --agent claude-code-<project>
 
 `tj onboard --claude-code` does everything in one shot:
 - Creates a shared config at `~/.config/tj/config.toml` (one config for all your projects)
-- Writes OTLP exporter vars to `~/.claude/settings.json` so Claude Code sends telemetry automatically
-- Tags this project's sessions by writing `OTEL_RESOURCE_ATTRIBUTES=service.name=claude-code-<project>` to `.claude/settings.json`
+- Writes OTLP exporter vars to the **global** `~/.claude/settings.json` so Claude Code sends telemetry automatically
+- Installs a `claude` shell wrapper into `~/.zshrc` (and `~/.bashrc` if it exists) that tags each terminal with a distinct `service.instance.id` — derived from `--as <name>` if you pass it, else the tty — so concurrent terminals render as separate dashboard tiles. The wrapper calls `tj otel-resource-attrs` for the project's `service.name`/`service.namespace`, appends the per-terminal id, and reports the session closed (`tj session-end`) when `claude` exits so its tile archives
+- **Removes** any hardcoded `OTEL_RESOURCE_ATTRIBUTES` previously written to this project's `.claude/settings.json` — that value would override the wrapper's per-terminal env (Claude Code's `settings.json` `env` block wins over shell env) and collapse every terminal back into one dashboard tile
 - Wires the **zero-token statusline** into `~/.claude/settings.json` (`"statusLine": {"type": "command", "command": "tj statusline"}`) — non-destructively; an existing statusLine you (or another tool) authored is left untouched
+- Wires a **SessionStart resume-brief hook** (`tj resume-brief --from-hook`) so a resumed or post-compaction session is handed its prior method (task, progress, dead ends, working files) as `additionalContext` instead of re-investigating — also zero token cost, also non-destructive of any existing `SessionStart` hook
 - Installs a background daemon (launchd on macOS, systemd on Linux) to keep `tj serve` alive across restarts
 - Adds Docker harness-compatible OTLP env vars to `~/.zshrc`
 
-**Claude Code must be restarted** after running `tj onboard --claude-code` for the new `settings.json` env vars to take effect.
+**Claude Code must be restarted** after running `tj onboard --claude-code` for the new `settings.json` env vars to take effect. Restarting your terminal (or opening a new one) picks up the updated shell wrapper and rc-file env vars.
 
 ## Adding a second (or third) project
 

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -326,7 +326,7 @@ Key flag: `--off` on `killswitch` releases pass-through mode.
 
 ## Integration entrypoints
 
-These are wired by `tj onboard --claude-code` and invoked by Claude Code itself (via hooks / the statusline / the shell wrapper), not typically run by hand — documented here for completeness and troubleshooting.
+These are wired by `tj onboard --claude-code` (except `tj hook cap-output`, which is opt-in) and invoked by Claude Code itself (via hooks / the statusline / the shell wrapper), not typically run by hand — documented here for completeness and troubleshooting.
 
 ### `tj statusline`
 

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -27,6 +27,20 @@ tj onboard --budget 5.00    # set daily budget during setup
 tj onboard --force          # overwrite existing config
 ```
 
+### `tj quickstart`
+
+Zero-install, zero-config first run. Reads the same `~/.claude/projects/*.jsonl` files ccusage does — no pip env, no config, no daemon, no on-disk DB (a transient in-memory backend). Shows quota composition (re-read vs. net-new work) and a session timeline, then points at `tj onboard` to go deeper.
+
+```bash
+tj quickstart
+tj quickstart --since 7d
+tj quickstart --full          # lift the first-run cap (default: most-recent 300 sessions)
+tj quickstart --root <path>   # override the Claude Code projects root
+tj quickstart --json
+```
+
+Key flags: `--since`, `--root`, `--full`, `--json`.
+
 ### `tj doctor`
 
 Health check — validates config, database connectivity, ingest secret, and alert channel reachability.
@@ -68,6 +82,43 @@ tj cost --group-by day      # group by day
 tj cost --group-by agent    # group by agent
 tj cost --group-by tool     # group by tool
 ```
+
+### `tj context`
+
+Diagnose where your Claude Code quota goes: what share of tokens is re-reading prior context (conversation history, CLAUDE.md, tool output) vs. net-new work, plus recurring inclusions (capture-gated) and `/compact` candidates. Subscription plans see a token-share/quota headline; API plans see dollars as a secondary line. Needs a direct DB connection or a running `tj serve` (computed server-side when the daemon holds the write lock).
+
+```bash
+tj context
+tj context --since 7d --agent my-agent
+tj context --json
+```
+
+Key flags: `--since`, `--agent`, `--json`.
+
+### `tj quota-audit`
+
+Retroactive audit of your Opus quota: which past Opus sessions were structurally Sonnet-shaped (small input/output, few tool calls)? Reports the percent of Opus quota reclaimable, example sessions to spot-check, and an optional tuned routing-config export. Quota-share framing, never a dollar "saving" claim. Needs a direct DB connection (can't run against a live `tj serve`).
+
+```bash
+tj quota-audit
+tj quota-audit --since 30d --agent my-agent
+tj quota-audit --export-config claude-code
+tj quota-audit --json
+```
+
+Key flags: `--since`, `--agent`, `--export-config`, `--json`.
+
+### `tj savings`
+
+Show tokens reclaimed by the `tj hook cap-output` output-trim hook (estimated, char/4 — the "prove" half of tj's measure → act → prove loop; `tj context` is the "measure" half). Reads the append-only JSONL sink, never the DB.
+
+```bash
+tj savings
+tj savings --session <session_id>
+tj savings --json
+```
+
+Key flags: `--session`, `--json`.
 
 ### `tj alerts`
 
@@ -181,6 +232,18 @@ tj tokenmaxx --json
 
 Key flags: `--since`, `--json`.
 
+### `tj pricing`
+
+Read-only inspection of the resolved model pricing table — one row per `(provider, model)` with input/output/cache-read/cache-write rates in USD per million tokens, plus a `source` column (`override` vs. `packaged`).
+
+```bash
+tj pricing list
+tj pricing list --model claude-opus
+tj pricing list --json
+```
+
+Key flags: `--model`, `--json`.
+
 ### `tj backfill`
 
 Ingest historical telemetry from local Claude Code logs or external observability exports.
@@ -209,6 +272,25 @@ tj report --reuse my-agent --no-open
 ```
 
 Key flags: `--trim [agent_id]`, `--reuse [agent_id]`, `--since`, `--no-open`.
+
+### `tj summarize`
+
+Structure-aware prompt summarization (advisory). `list` scans for prompt files worth summarizing and estimates the per-call token saving (read-only). `prep` wraps a prompt's structure behind verbatim markers and emits it for a model to rewrite — `--via claude-p` or `--via api` runs the rewrite for you in one shot. `check` verifies a rewrite preserved every structure block (a hard gate) and stages it. `apply` writes a staged rewrite back to the file (default dry-run; `--go` writes, with a backup); `undo` restores from that backup.
+
+```bash
+tj summarize list
+tj summarize list --recursive --json
+tj summarize prep path/to/prompt.md
+tj summarize prep path/to/prompt.md --via claude-p
+tj summarize check path/to/prompt.md --summary rewrite.md --prepped-hash <hash>
+tj summarize apply path/to/prompt.md
+tj summarize apply --go
+tj summarize undo path/to/prompt.md --go
+```
+
+Subcommands: `list`, `prep`, `check`, `apply`, `undo`.
+
+Key flags: `list` — `--recursive`, `--repo`, `--no-global`, `--ext`, `--min-prose`, `--json`; `prep` — `--via claude-p|api`, `--ratio`, `--json`; `check` — `--summary`, `--prepped-hash`, `--json`; `apply`/`undo` — `--go`, `--dry-run`, `--json`.
 
 ### `tj policy`
 
@@ -241,6 +323,59 @@ tj proxy killswitch --off
 Subcommands: `enable`, `disable`, `status`, `killswitch`.
 
 Key flag: `--off` on `killswitch` releases pass-through mode.
+
+## Integration entrypoints
+
+These are wired by `tj onboard --claude-code` and invoked by Claude Code itself (via hooks / the statusline / the shell wrapper), not typically run by hand — documented here for completeness and troubleshooting.
+
+### `tj statusline`
+
+Zero-model-token status line for Claude Code. Reads the session payload JSON Claude Code pipes on stdin and prints one line: model, session token total, and the re-read share (cache-read ÷ total tokens), with a `/compact` nudge once re-reading dominates. Runs out-of-band after each turn — never enters the model's context, so it costs no quota. Wired into `~/.claude/settings.json`'s `statusLine` by `tj onboard --claude-code`.
+
+```bash
+tj statusline   # reads payload JSON on stdin; not meant to be typed interactively
+```
+
+### `tj resume-brief`
+
+Hands a resuming (or post-compaction) session a compact brief of its prior method — task, progress, dead ends, working files — instead of re-investigating. Deterministic, no LLM, zero in-loop token cost. `tj onboard --claude-code` wires `--from-hook` into a `SessionStart` hook automatically.
+
+```bash
+tj resume-brief --from-hook       # SessionStart-hook mode: reads session_id/transcript_path from stdin
+tj resume-brief --session <id>
+tj resume-brief --transcript <path>
+tj resume-brief --last            # manual: most recently active session by mtime
+```
+
+Key flags: `--from-hook`, `--session`, `--transcript`, `--last` (exactly one is expected).
+
+### `tj hook`
+
+Claude Code hook entrypoints installed out-of-band by `tj onboard`. Currently one subcommand, `cap-output`: a `PostToolUse` hook that trims a bloated tool output before it enters context (fail-open — any error leaves the original output untouched). Default-off; opt in via `[hooks.output_cap].enabled = true` then re-run `tj onboard --claude-code`.
+
+```bash
+tj hook cap-output   # reads the PostToolUse event JSON on stdin
+```
+
+### `tj otel-resource-attrs`
+
+Prints this project's OTel resource attributes (`service.name=claude-code-<repo>[,service.namespace=<project>]`) on one bare line. Called by the `claude` shell wrapper (installed by `tj onboard --claude-code`) to build each terminal's `OTEL_RESOURCE_ATTRIBUTES`, appending a per-terminal `service.instance.id`.
+
+```bash
+tj otel-resource-attrs
+```
+
+### `tj session-end`
+
+Reports a terminal's Claude Code session(s) as closed, so the dashboard archives that tile immediately (Claude Code emits no close event of its own). Called best-effort by the `claude` shell wrapper on exit/interrupt; talks to the running daemon over HTTP and never touches the DB directly. Always exits 0 — a failure here must never break the user's shell.
+
+```bash
+tj session-end --instance <terminal-id>
+tj session-end --session <session_id>
+tj session-end -v --instance <terminal-id>   # -v surfaces what happened on failure
+```
+
+Key flags: `--instance`, `--session` (at least one required).
 
 ### `tj demo`
 

--- a/docs/optimize/cache.md
+++ b/docs/optimize/cache.md
@@ -65,3 +65,4 @@ this is the right level.
 - [Downsize](downsize.md) — flag sessions whose shape matches a cheaper-model candidate
 - [Script](script.md) — find workflows that look like deterministic shell scripts
 - [Trim](trim.md) — identify low-significance tokens in captured prompts
+- [Subagent](subagent.md) — per-subagent cost breakdown and right-sizing candidates (Claude Code only)

--- a/docs/optimize/downsize.md
+++ b/docs/optimize/downsize.md
@@ -44,3 +44,4 @@ JSON output mirrors the same data with top-level `plan` and `pricing_mode` field
 - [Cache](cache.md) — measure and improve prompt-cache usage
 - [Script](script.md) — find workflows that look like deterministic shell scripts
 - [Trim](trim.md) — identify low-significance tokens in captured prompts
+- [Subagent](subagent.md) — the same over-powered heuristic, scoped to subagents instead of whole sessions

--- a/docs/optimize/script.md
+++ b/docs/optimize/script.md
@@ -87,3 +87,4 @@ it claims structural identity, which is a different (and weaker) thing.
 - [Downsize](downsize.md) — flag sessions whose shape matches a cheaper-model candidate
 - [Cache](cache.md) — measure and improve prompt-cache usage
 - [Trim](trim.md) — identify low-significance tokens in captured prompts
+- [Subagent](subagent.md) — per-subagent cost breakdown and right-sizing candidates (Claude Code only)

--- a/docs/optimize/subagent.md
+++ b/docs/optimize/subagent.md
@@ -1,0 +1,73 @@
+# Subagent
+
+Product name: **Subagent right-sizing**. Internal/CLI name: `subagent`.
+
+```bash
+tj optimize subagent
+```
+
+Claude Code spawns subagents (the Task tool), and their turns are stored under
+the parent session. Folded into one parent total, a heavy research session's
+subagent spend hides where the tokens actually went — on a real session tj
+measured 66% of spend across ~147 subagents, invisible above the DB. This
+analyzer breaks a window's cost down per subagent and flags two structural
+right-sizing candidates.
+
+## Claude Code only
+
+The analyzer groups spans by `(session_id, sub_agent_id)`. `sub_agent_id` is
+populated only by the Claude Code backfill path (derived from the on-disk
+transcript's `agentId` / `isSidechain` fields) — spans from other runtimes
+(Codex, the Python SDK, generic OTLP) carry `NULL` and are silently excluded.
+See [agent-capability-matrix.md](../agent-capability-matrix.md) for the full
+per-persona capability breakdown; subagent right-sizing has no row there today
+because no other persona populates the column yet.
+
+## What it flags
+
+Each `(session, sub_agent_id)` group with `cost_usd >= $0.05` (a noise floor —
+trivially small spend isn't worth a recommendation regardless of shape) is
+checked against two independent structural criteria:
+
+| Flag | Criteria |
+|---|---|
+| `over_powered` | Ran on a premium (Opus-tier — model name contains `opus`) model, produced fewer than 2,000 output tokens, and made 5 or fewer tool calls. Mirrors the [Downsize](downsize.md) heuristic, scoped to one subagent. |
+| `over_provisioned` | Was handed a large context — input + cache-read tokens ≥ 50,000 — yet produced fewer than 2,000 output tokens. The prompt it was dispatched with is likely larger than the task needed. |
+
+A single subagent can carry both flags. Thresholds live as module constants in
+`tokenjam/core/optimize/analyzers/subagent_rightsizing.py` (`SMALL_OUTPUT_TOKENS`,
+`FEW_TOOL_CALLS`, `CONTEXT_HEAVY_TOKENS`, `MIN_FLAG_COST_USD`).
+
+It reads aggregate token counts only — no content capture required.
+
+## Output
+
+The finding reports, for the window:
+
+- `total_subagents` / `sessions_with_subagents` — how many subagents ran and across how many sessions
+- `subagent_cost_usd` / `subagent_tokens` and `percent_of_cost` — how much of the window's total cost ran inside subagents at all, before any flagging
+- `flagged_cost_usd` — spend concentrated in the flagged (candidate) subagents
+- `rows` — the top 25 subagents by cost (aggregates are computed over all subagents in the window; only the rendered/serialized list is capped)
+- `flagged` — the top 25 flagged candidates by cost, each carrying its `flags` list
+
+Rendering follows the same plan-tier-aware convention as the rest of `tj optimize`: `api` plans see the dollar share, subscription/local/unknown plans see the token share instead.
+
+## Estimate basis / confidence
+
+Candidate-only in v1 — `estimated_recoverable_usd` and `estimated_recoverable_tokens` are deliberately `None`; the analyzer surfaces the spend sitting in flagged subagents (`flagged_cost_usd`) rather than assert a guaranteed recovery. `estimate_confidence` is `"heuristic"` and `estimate_basis` reads:
+
+> spend concentrated in structurally-flagged subagents (premium model with little output, or large context with little output); review before re-dispatching — no guaranteed saving
+
+`confidence` on the finding itself is `structural` (Rule 14, honesty discipline) — the mandatory caveat, surfaced in every render mode:
+
+> Candidate-flagging heuristic, not a quality judgment. Review the flagged subagents before changing how you dispatch them or which model they use.
+
+As with [Downsize](downsize.md), the analyzer never claims the flagged subagent's task would have succeeded on a cheaper model or with a smaller prompt — only that its structural shape matches a class worth a closer look.
+
+## See also
+
+- [Downsize](downsize.md) — the same over-powered heuristic, scoped to whole sessions instead of subagents
+- [Cache](cache.md) — measure and improve prompt-cache usage
+- [Script](script.md) — find workflows that look like deterministic shell scripts
+- [Trim](trim.md) — identify low-significance tokens in captured prompts
+- [agent-capability-matrix.md](../agent-capability-matrix.md) — why this analyzer is Claude Code-only today

--- a/docs/optimize/trim.md
+++ b/docs/optimize/trim.md
@@ -84,3 +84,4 @@ the region removed. The caveat surfaces this in every report.
 - [Downsize](downsize.md) — flag sessions whose shape matches a cheaper-model candidate
 - [Cache](cache.md) — measure and improve prompt-cache usage
 - [Script](script.md) — find workflows that look like deterministic shell scripts
+- [Subagent](subagent.md) — per-subagent cost breakdown and right-sizing candidates (Claude Code only)


### PR DESCRIPTION
Fixes three docs tickets in one PR — all verified against the current `cli/*.py` source, not assumed.

## Summary
- **#89** — `docs/claude-code-integration.md`'s onboarding section still described the old behavior (writing `OTEL_RESOURCE_ATTRIBUTES` directly into project `.claude/settings.json`). Rewrote it to match `cmd_onboard.py`: `tj onboard --claude-code` installs a `claude` shell wrapper (in `~/.zshrc`/`~/.bashrc`) that tags each terminal via `tj otel-resource-attrs` + a per-terminal `service.instance.id`, and actively **removes** any hardcoded `OTEL_RESOURCE_ATTRIBUTES` left over from older onboards (it would override the wrapper's per-terminal env and collapse every terminal into one dashboard tile). Also documented the `SessionStart` resume-brief hook wired alongside the statusline, which the page never mentioned at all.
- **#90** — `docs/cli-reference.md` was missing 11 registered commands: `context`, `quota-audit`, `quickstart`, `savings`, `pricing`, `summarize`, `statusline`, `resume-brief`, `hook`, `otel-resource-attrs`, `session-end`. Cross-checked the full command list against `cli/main.py`'s registrations — no other undocumented commands found (checked for a hinted `ping` / `onboard --verify` from a maybe-merged PR #410; that PR hasn't landed on `origin/main` as of this branch, so nothing further to add). Every flag documented was sourced from each `cmd_*.py`'s Click options — grouped the five hook/statusline/wrapper-invoked commands under a new "Integration entrypoints" heading since they're not meant to be run by hand.
- **#91** — `docs/optimize/subagent.md` didn't exist, the only analyzer without a dedicated product page. Wrote it following the sibling docs' structure (product name, criteria table, output fields, estimate basis/confidence, "See also"), sourced from `core/optimize/analyzers/subagent_rightsizing.py` and `cmd_optimize.py`'s `_render_subagent`. Documents why it's Claude Code-only (keys off `sub_agent_id`, populated only by the CC backfill path) with a link to `agent-capability-matrix.md`. Cross-linked it from the other four `docs/optimize/*.md` siblings and added it to `CLAUDE.md`'s "Optimize product pages" index (which was also missing it).

## Verification
- Read `cli/cmd_onboard.py` end-to-end (the `_onboard_claude_code` path, the `claude` wrapper installer, `_wire_claude_resume_brief_hook`) to confirm the new copy matches actual behavior.
- Diffed the full command registration list in `cli/main.py` against every `### `tj ...`` heading in `docs/cli-reference.md` — 33 headings + inline `tj trace`, matching all 35 registered subcommands (including the conditional `drift`).
- Read every new/changed `cmd_*.py` file's Click options directly rather than guessing flags.
- Verified every markdown relative link in the changed files resolves to a real file (no broken links introduced).

## What's NOT in this PR
- Did not touch `README.md` — PR #406 (open) rewrites it and adds `docs/getting-started.md` + `docs/first-hour.md`; editing it here would conflict.
- Did not add `docs/optimize/reuse.md` to `CLAUDE.md`'s optimize-pages index — that page already existed before this PR but was already missing from the index; out of scope for these three tickets, worth its own quick follow-up ticket.
- Did not investigate whether a `tj backfill codex` adapter or Codex statusline support has since landed — `docs/agent-capability-matrix.md` already tracks that as a separate open investigation and wasn't part of this brief.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>