### PR TITLE
Fix #96: tj status alert dedup, subscription cost framing, shared currency formatter

### DIFF
--- a/docs/alerts.md
+++ b/docs/alerts.md
@@ -111,6 +111,6 @@ GET  /api/v1/alerts                    # list alerts (supports filtering)
 PATCH /api/v1/alerts/{id}/acknowledge  # mark alert as acknowledged
 ```
 
-## MCP (Claude Code)
+## MCP (SDK / API integrations)
 
-The MCP server exposes `list_alerts` and `acknowledge_alert` tools, so Claude Code can check and manage alerts directly within a session.
+The MCP server exposes `list_alerts` and `acknowledge_alert` tools for SDK / API integrations that already sit in the request path. It is not wired up for Claude Code or Codex (an in-loop MCP is a per-turn quota tax there, ticket #59) — those agents check alerts via `tj` CLI reports or the dashboard instead.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -95,7 +95,7 @@ tokenjam/
 ├── core/       Pure domain logic — NO imports from cli/ or api/
 ├── cli/        Click commands — imports from core/
 ├── api/        FastAPI routes — imports from core/
-├── mcp/        MCP server for Claude Code — imports from core/ and api/
+├── mcp/        MCP server for SDK / API integrations — imports from core/ and api/
 ├── otel/       OTel SDK wiring — imports from core/
 ├── sdk/        Python instrumentation SDK — imports from core/ and otel/
 │   └── integrations/   Provider and framework patches
@@ -303,9 +303,9 @@ The `TjConfig` dataclass tree in `tokenjam/core/config.py` defines the full hier
 
 ---
 
-## MCP server (Claude Code integration)
+## MCP server (SDK / API integration)
 
-`tj mcp` is a stdio-based MCP (Model Context Protocol) server that gives Claude Code direct access to TokenJam observability data. It exposes 13 tools that Claude Code can call during a session.
+`tj mcp` is a stdio-based MCP (Model Context Protocol) server that gives an SDK / API integration direct access to TokenJam observability data. It exposes 13 tools. It is **not** wired up for Claude Code or Codex — an in-loop MCP is a per-turn quota tax on subscription users (+36% measured, ticket #59); those agents get tj out-of-band via the statusline + OTel capture instead. Wire it manually only for an SDK / API integration that already sits in the request path: `claude mcp add tj --scope user -- tj mcp`.
 
 ### Dual-mode operation
 

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -256,7 +256,7 @@ Key flag: `--json`.
 
 ### `tj mcp`
 
-Start the MCP server (stdio transport for Claude Code). Registered automatically by `tj onboard --claude-code`.
+Start the MCP server (stdio transport, for SDK / API integrations). `tj onboard --claude-code` / `--codex` do **not** register it — an in-loop MCP is a per-turn quota tax on subscription users (ticket #59); wire it manually with `claude mcp add tj --scope user -- tj mcp` only if you're building an SDK / API integration.
 
 ```bash
 tj mcp

--- a/docs/harness-integration.md
+++ b/docs/harness-integration.md
@@ -37,8 +37,11 @@ harness conforms to one thin correlation id.
 
 ## Easiest setup: the `setup_harness` MCP command
 
-If you use tj's MCP server (`tj mcp`, wired via `tj onboard --claude-code`), run
-this from **inside your harness repo** in Claude Code:
+`tj onboard --claude-code` does **not** wire the MCP server (an in-loop MCP is a
+per-turn quota tax on subscription users, ticket #59) — but this one-time setup
+helper is a legitimate reason to wire it temporarily. Run
+`claude mcp add tj --scope user -- tj mcp`, then from **inside your harness
+repo** in Claude Code:
 
 - **`setup_harness(mode="instrument")`** — writes a drop-in helper
   (`.tj/run-env.sh`) that mints one run id per launch and exports
@@ -51,7 +54,10 @@ this from **inside your harness repo** in Claude Code:
   recommendation.
 
 After wiring, launch a run and confirm the workers grouped in the Runs view (or
-re-run `mode="map"`).
+re-run `mode="map"`). Once `setup_harness` has done its job, deregister the MCP
+server (`claude mcp remove tj --scope user`) to avoid paying the per-turn tax
+on unrelated sessions — the `.tj/run-env.sh` helper it wrote keeps working
+without it.
 
 ## Wiring it by hand
 

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -29,8 +29,8 @@ written to disk and no background process starts.
 **Requirements:** a Python runner — `uv` (recommended) or `pipx`. `npx tokenjam` prints
 install guidance if neither is present.
 
-When you're ready for live capture, the local dashboard, and the MCP server for
-Claude Code, install the full CLI (below) and run `tj onboard`.
+When you're ready for live capture, the local dashboard, and the zero-token
+statusline, install the full CLI (below) and run `tj onboard`.
 
 ## Base install
 

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -7,7 +7,7 @@ TokenJam ships as a Python package on PyPI and a TypeScript SDK on npm. Pick the
 The fastest way to see value — **no install, no config, no daemon**:
 
 ```bash
-npx tokenjam                      # or:  uvx --from tokenjam tj
+npx tokenjam                      # or:  uvx tokenjam
 ```
 
 This runs `tj quickstart`: it reads your existing Claude Code sessions from
@@ -22,9 +22,11 @@ written to disk and no background process starts.
   launcher that shells out to the Python CLI via the first available runner
   (`uvx` → `pipx run` → an installed `tj`). All arguments pass straight through,
   so `npx tokenjam quickstart --since 7d`, `npx tokenjam optimize`, etc. all work.
-- `uvx --from tokenjam tj` runs the Python CLI directly with [uv](https://docs.astral.sh/uv/)'s
-  ephemeral runner. (The `--from tokenjam` is required because the PyPI package
-  is `tokenjam` while the command is `tj`.)
+- `uvx tokenjam` runs the Python CLI directly with [uv](https://docs.astral.sh/uv/)'s
+  ephemeral runner. (The PyPI package `tokenjam` ships both a `tj` command and a
+  `tokenjam` alias, so `uvx tokenjam` and `uvx --from tokenjam tj` are equivalent —
+  use the longer `--from` form if you're on an older tokenjam release without the
+  alias.)
 
 **Requirements:** a Python runner — `uv` (recommended) or `pipx`. `npx tokenjam` prints
 install guidance if neither is present.

--- a/npm-wrapper/bin/tj.js
+++ b/npm-wrapper/bin/tj.js
@@ -16,6 +16,11 @@
  *   3. `tj …`                      — an already-installed CLI on PATH
  *
  * If none are present we print actionable install guidance and exit non-zero.
+ *
+ * Note: tokenjam >=0.5.4 also ships a `tokenjam` console-script alias
+ * alongside `tj`, so bare `uvx tokenjam` / `pipx run tokenjam` work too. This
+ * wrapper keeps the explicit `--from tokenjam tj` / `--spec tokenjam tj` form
+ * below for back-compat with the 0.5.3 and earlier releases it also targets.
  */
 "use strict";
 

--- a/npm-wrapper/package.json
+++ b/npm-wrapper/package.json
@@ -12,7 +12,8 @@
     "directory": "npm-wrapper"
   },
   "bin": {
-    "tj": "bin/tj.js"
+    "tj": "bin/tj.js",
+    "tokenjam": "bin/tj.js"
   },
   "files": [
     "bin/tj.js",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -70,6 +70,7 @@ bloat     = ["llmlingua>=0.2"]
 
 [project.scripts]
 tj = "tokenjam.cli.main:cli"
+tokenjam = "tokenjam.cli.main:cli"
 
 [tool.pytest.ini_options]
 testpaths = ["tests/unit", "tests/synthetic", "tests/agents", "tests/integration"]

--- a/tests/integration/test_cli.py
+++ b/tests/integration/test_cli.py
@@ -487,6 +487,35 @@ def test_doctor_mcp_wiring_checks(runner, db, config, tmp_path):
         assert "project scope" in mcp_checks[0]["message"]
 
 
+def test_doctor_mcp_wiring_message_renders_bracket_literal(runner, db, config, tmp_path):
+    """The Codex removal hint contains the literal TOML section header
+    `[mcp_servers.tj]`. In human (non-JSON) rendering, `_print_check` feeds
+    the message straight into `console.print`, and Rich treats an unescaped
+    `[...]` as a markup tag — stripping it instead of printing it (same class
+    of bug as #157 / PR #407). The console-rendered check must show the
+    bracket text verbatim."""
+    fake_home = tmp_path / "fake_home"
+    fake_home.mkdir()
+    fake_cwd = tmp_path / "fake_cwd"
+    fake_cwd.mkdir()
+
+    _clean_doctor_config(config, tmp_path)
+    config_file = tmp_path / "tokenjam.toml"
+    config_file.write_text('version = "1"\n')
+
+    codex_dir = fake_home / ".codex"
+    codex_dir.mkdir(parents=True, exist_ok=True)
+    (codex_dir / "config.toml").write_text("[mcp_servers.tj]\ncommand = 'tj'\nargs = ['mcp']\n")
+
+    with patch("pathlib.Path.home", return_value=fake_home), \
+         patch("pathlib.Path.cwd", return_value=fake_cwd), \
+         patch("shutil.which", return_value=None), \
+         patch("tokenjam.cli.cmd_doctor.find_config_file", return_value=config_file):
+        result = _invoke(runner, db, config, ["doctor"])
+
+    assert "[mcp_servers.tj]" in result.output
+
+
 # -- since flag parsing --
 
 def test_since_flag_parses_all_formats(runner, db, config):

--- a/tests/integration/test_cli.py
+++ b/tests/integration/test_cli.py
@@ -1115,6 +1115,121 @@ def test_optimize_json_includes_plan_and_pricing_mode(runner, db, config):
         assert "monthly_tokens_freed" in data["downgrade"]
 
 
+def test_optimize_ranks_findings_by_reclaimable_share_not_registry_order(runner, db, config):
+    """#97: a downsize finding whose candidates hold a negligible share of
+    the window's tokens must not occupy the numbered ① slot ahead of a
+    finding that's actually reclaiming a meaningful fraction of the window
+    — the exact bug: "① Model downgrade: 28% of sessions match" when those
+    sessions held ~0% of the window's tokens, because downsize always
+    rendered first (ANALYZER_ORDER), not by size of the opportunity.
+    """
+    from datetime import timedelta
+    from tests.factories import make_llm_span, make_session, make_tool_span
+    from tokenjam.utils.time_parse import utcnow
+
+    now = utcnow()
+
+    # Small-opus downsize candidate: matches the structural heuristic, but
+    # its tokens are a tiny fraction of the window once the noise below is
+    # added (1_200 / ~501_200 ≈ 0.2%).
+    db.insert_span(make_llm_span(
+        agent_id="test-agent", model="claude-opus-4-7", provider="anthropic",
+        input_tokens=1000, output_tokens=200, cost_usd=0.03,
+        session_id="small-opus", start_time=now - timedelta(days=1),
+    ))
+
+    # Noise: large LLM sessions that don't match the downgrade shape (input
+    # far exceeds SMALL_INPUT_TOKENS) but dominate window.total_tokens.
+    for i in range(10):
+        db.insert_span(make_llm_span(
+            agent_id="test-agent", model="claude-sonnet-4-5", provider="anthropic",
+            input_tokens=50_000, output_tokens=1_000, cost_usd=1.0,
+            session_id=f"noise-{i}", start_time=now - timedelta(days=1),
+        ))
+
+    # Identical-signature cluster: 20 single-tool-call sessions, each with
+    # 5_000 session-level tokens — ~20% of the window, dwarfing the downsize
+    # candidate's ~0.2%. (Both the script and reuse analyzers key off this
+    # same repeated-tool-sequence signal; whichever surfaces a cluster wins
+    # the top slot — the point being it's not downsize.)
+    for i in range(20):
+        sid = f"cluster-{i}"
+        db.upsert_session(make_session(
+            agent_id="test-agent", session_id=sid,
+            input_tokens=4_000, output_tokens=1_000, total_cost_usd=0.05,
+        ))
+        tool = make_tool_span(agent_id="test-agent", tool_name="Read")
+        tool.session_id = sid
+        tool.start_time = now - timedelta(days=1)
+        db.insert_span(tool)
+
+    result = _invoke(runner, db, config, ["optimize"])
+    assert result.exit_code == 0
+    out = result.output
+
+    # The bigger reclaimable-share finding leads — not downsize, even though
+    # downsize always ran first in ANALYZER_ORDER.
+    assert "① Workflow restructure" in out or "① Reuse" in out
+    # ...and downsize no longer gets the fixed ① slot it always used to.
+    assert "① Model downgrade" not in out
+    # It's still surfaced — honesty discipline forbids a silent drop — just
+    # collapsed into the de-minimis pointer list instead of a numbered slot.
+    assert "Minor findings" in out
+    assert "Model downgrade" in out
+    assert "of window tokens" in out
+
+
+def test_optimize_downsize_cta_matches_claude_code_persona(runner, db, config):
+    """#97: a window dominated by claude-code-* sessions gets the Claude Code
+    routing CTA (route export / subagent right-sizing / /compact), not the
+    SDK-only `tjb run --original ... --candidate ...` command a subscription
+    user has no way to act on."""
+    from datetime import timedelta
+    from tests.factories import make_llm_span, make_session
+    from tokenjam.utils.time_parse import utcnow
+
+    now = utcnow()
+    db.upsert_session(make_session(
+        agent_id="claude-code-my-project", session_id="s-small", plan_tier="max_5x",
+    ))
+    db.insert_span(make_llm_span(
+        agent_id="claude-code-my-project", model="claude-opus-4-7", provider="anthropic",
+        input_tokens=1000, output_tokens=200, cost_usd=0.03,
+        session_id="s-small", start_time=now - timedelta(days=1),
+    ))
+
+    result = _invoke(runner, db, config, ["optimize"])
+    assert result.exit_code == 0
+    out = result.output
+
+    assert "tj route export --target ccr" in out
+    assert "tj optimize subagent" in out
+    assert "/compact" in out
+    # tjb is still mentioned, but only as the secondary SDK note.
+    assert "If you also run SDK agents" in out
+
+
+def test_optimize_downsize_cta_unchanged_for_sdk_persona(runner, db, config):
+    """A non-Claude-Code (SDK/API) persona keeps the original tjb CTA."""
+    from datetime import timedelta
+    from tests.factories import make_llm_span
+    from tokenjam.utils.time_parse import utcnow
+
+    db.insert_span(make_llm_span(
+        agent_id="sdk-worker", model="claude-opus-4-7", provider="anthropic",
+        input_tokens=1000, output_tokens=200, cost_usd=0.03,
+        session_id="s-small", start_time=utcnow() - timedelta(days=1),
+    ))
+
+    result = _invoke(runner, db, config, ["optimize"])
+    assert result.exit_code == 0
+    out = result.output
+
+    assert "Candidate only — prove it holds before switching:" in out
+    assert "pip install tokenjam-bench" in out
+    assert "tj route export --target ccr" not in out
+
+
 def test_cost_compare_renders_window_diff(runner, db, config):
     """`tj cost --compare previous` produces a diff report against the prior window."""
     from datetime import timedelta

--- a/tests/integration/test_cli.py
+++ b/tests/integration/test_cli.py
@@ -212,6 +212,28 @@ def test_status_api_plan_keeps_raw_dollar_line(runner, db, config):
     assert "Subscription plan" not in result.output
 
 
+def test_status_subscription_plan_with_daily_limit_shows_literal_dollar_cap(runner, db):
+    """A subscription-framed agent with a per-agent `daily_usd` limit must show
+    that limit as its literal dollar amount with a `/day` qualifier, not as a
+    percentage of the monthly subscription cycle — a user-configured DAILY
+    dollar cap has no relationship to the MONTHLY cycle `render_dollar` uses
+    for framed spend. Only the spend-so-far figure stays plan-tier-framed."""
+    from tokenjam.core.config import ProviderBudget
+
+    session = make_session(agent_id="test-agent", plan_tier="max_5x")
+    db.upsert_session(session)
+    sub_config = TjConfig(
+        version="1",
+        budgets={"anthropic": ProviderBudget(plan="max_5x")},
+        agents={"test-agent": AgentConfig(budget=BudgetConfig(daily_usd=5.0))},
+    )
+
+    result = _invoke(runner, db, sub_config, ["status"])
+    assert result.exit_code == 0
+    assert "Cost today:     0.0% of cycle / $5.00/day limit" in result.output
+    assert "% of cycle limit" not in result.output
+
+
 # -- traces tests --
 
 def test_traces_json_output_is_valid_json(runner, db, config):

--- a/tests/integration/test_cli.py
+++ b/tests/integration/test_cli.py
@@ -106,14 +106,15 @@ def _seed_agent_and_session(db, agent_id="test-agent"):
     return session
 
 
-def _seed_alert(db, agent_id="test-agent", acknowledged=False, suppressed=False):
+def _seed_alert(db, agent_id="test-agent", acknowledged=False, suppressed=False,
+                 alert_type=AlertType.COST_BUDGET_DAILY, title="Daily budget exceeded"):
     """Insert an alert into the DB."""
     alert = Alert(
         alert_id=new_uuid(),
         fired_at=utcnow(),
-        type=AlertType.COST_BUDGET_DAILY,
+        type=alert_type,
         severity=Severity.WARNING,
-        title="Daily budget exceeded",
+        title=title,
         detail={"message": "Agent exceeded $5.00 daily budget"},
         agent_id=agent_id,
         acknowledged=acknowledged,
@@ -155,6 +156,60 @@ def test_status_json_includes_active_and_elapsed(runner, db, config):
     a = json.loads(result.output)["agents"][0]
     assert "active_seconds" in a and "duration_seconds" in a
     assert a["active_seconds"] == 4.0   # 4000 ms of spans
+
+
+def test_status_dedupes_duplicate_alerts_of_same_type(runner, db, config):
+    """The alert engine's in-memory dedup state (CooldownTracker,
+    `_failure_rate_fired`) resets on process restart, so the DB can
+    legitimately hold two rows for the same (type, agent) pair (#96). The
+    human-readable `tj status` render must collapse repeats into one line
+    with a count rather than printing the same alert line twice."""
+    _seed_agent_and_session(db)
+    _seed_alert(db, alert_type=AlertType.FAILURE_RATE, title="failure_rate — test-agent")
+    _seed_alert(db, alert_type=AlertType.FAILURE_RATE, title="failure_rate — test-agent")
+    result = _invoke(runner, db, config, ["status"])
+    assert result.exit_code == 1
+    assert result.output.count("failure_rate — test-agent") == 1
+    assert "×2" in result.output
+
+
+def test_status_distinct_alert_types_are_not_collapsed(runner, db, config):
+    """Two DIFFERENT alert types for the same agent must both still render —
+    dedup is keyed on (type, agent), not agent alone."""
+    _seed_agent_and_session(db)
+    _seed_alert(db, alert_type=AlertType.FAILURE_RATE, title="failure_rate — test-agent")
+    _seed_alert(db, alert_type=AlertType.RETRY_LOOP, title="retry_loop — test-agent")
+    result = _invoke(runner, db, config, ["status"])
+    assert "failure_rate — test-agent" in result.output
+    assert "retry_loop — test-agent" in result.output
+    assert "×2" not in result.output
+
+
+def test_status_subscription_plan_shows_no_raw_dollar_line(runner, db):
+    """Subscription-tier users must not see a raw '$0.00' Cost today line
+    (#96) — the workspace rule is subscription users see plan-share framing,
+    never raw spend they don't pay. Mirrors `tj cost`'s honesty note."""
+    from tokenjam.core.config import ProviderBudget
+
+    session = make_session(agent_id="test-agent", plan_tier="max_5x")
+    db.upsert_session(session)
+    sub_config = TjConfig(version="1", budgets={"anthropic": ProviderBudget(plan="max_5x")})
+
+    result = _invoke(runner, db, sub_config, ["status"])
+    assert result.exit_code == 0
+    assert "$0.00" not in result.output
+    assert "$0.000000" not in result.output
+    assert "Cost today:     0.0% of cycle" in result.output
+    assert "Subscription plan" in result.output
+
+
+def test_status_api_plan_keeps_raw_dollar_line(runner, db, config):
+    """API-billed users keep the historical raw-dollar Cost today line."""
+    _seed_agent_and_session(db)
+    result = _invoke(runner, db, config, ["status"])
+    assert result.exit_code == 0
+    assert "Cost today:     $0.00" in result.output
+    assert "Subscription plan" not in result.output
 
 
 # -- traces tests --

--- a/tests/integration/test_cli.py
+++ b/tests/integration/test_cli.py
@@ -424,7 +424,10 @@ def test_doctor_mcp_wiring_checks(runner, db, config, tmp_path):
         assert statusline_checks and statusline_checks[0]["level"] == "warning"
         assert "tj onboard --claude-code" in statusline_checks[0]["message"]
 
-    # Case 3: MCP registered globally in Codex (~/.codex/config.toml) -> should be level: "ok"
+    # Case 3: MCP registered globally in Codex (~/.codex/config.toml) -> should
+    # be level "warning" (#94): Codex gets the same +36% quota-tax reasoning as
+    # Claude Code (see cmd_onboard.py's Codex path, which actively retires this
+    # legacy block), so a green check here would contradict the #59 decision.
     codex_dir = fake_home / ".codex"
     codex_dir.mkdir(parents=True, exist_ok=True)
     codex_config = codex_dir / "config.toml"
@@ -435,17 +438,20 @@ def test_doctor_mcp_wiring_checks(runner, db, config, tmp_path):
          patch("shutil.which", return_value=None), \
          patch("tokenjam.cli.cmd_doctor.find_config_file", return_value=config_file):
         result = _invoke(runner, db, config, ["doctor", "--json"])
-        assert result.exit_code == 0
+        assert result.exit_code == 1
         checks = json.loads(result.output)
         mcp_checks = [c for c in checks if c["name"] == "MCP wiring"]
-        assert mcp_checks and mcp_checks[0]["level"] == "ok"
+        assert mcp_checks and mcp_checks[0]["level"] == "warning"
         assert "Codex" in mcp_checks[0]["message"]
+        assert "#59" in mcp_checks[0]["message"]
 
     # Clean up codex file
     codex_config.unlink()
     codex_dir.rmdir()
 
-    # Case 4: MCP registered globally in Claude Code (~/.claude.json) -> should be level: "ok"
+    # Case 4: MCP registered globally in Claude Code (~/.claude.json) -> should
+    # be level "warning" (#94) — a green check for this state contradicts the
+    # #59 decision to keep MCP out of the Claude Code loop.
     claude_json = fake_home / ".claude.json"
     claude_json.write_text('{"mcpServers": {"tj": {"command": "tj"}}}')
 
@@ -454,16 +460,18 @@ def test_doctor_mcp_wiring_checks(runner, db, config, tmp_path):
          patch("shutil.which", return_value=None), \
          patch("tokenjam.cli.cmd_doctor.find_config_file", return_value=config_file):
         result = _invoke(runner, db, config, ["doctor", "--json"])
-        assert result.exit_code == 0
+        assert result.exit_code == 1
         checks = json.loads(result.output)
         mcp_checks = [c for c in checks if c["name"] == "MCP wiring"]
-        assert mcp_checks and mcp_checks[0]["level"] == "ok"
+        assert mcp_checks and mcp_checks[0]["level"] == "warning"
         assert "Claude Code" in mcp_checks[0]["message"]
+        assert "claude mcp remove tj --scope user" in mcp_checks[0]["message"]
 
     # Clean up claude json file
     claude_json.unlink()
 
-    # Case 5: MCP registered locally in project-level .mcp.json -> should be level: "ok"
+    # Case 5: MCP registered locally in project-level .mcp.json -> should be
+    # level "warning" (#94) — same quota-tax reasoning applies at project scope.
     project_mcp = fake_cwd / ".mcp.json"
     project_mcp.write_text('{"mcpServers": {"tj": {"command": "tj"}}}')
 
@@ -472,10 +480,10 @@ def test_doctor_mcp_wiring_checks(runner, db, config, tmp_path):
          patch("shutil.which", return_value=None), \
          patch("tokenjam.cli.cmd_doctor.find_config_file", return_value=config_file):
         result = _invoke(runner, db, config, ["doctor", "--json"])
-        assert result.exit_code == 0
+        assert result.exit_code == 1
         checks = json.loads(result.output)
         mcp_checks = [c for c in checks if c["name"] == "MCP wiring"]
-        assert mcp_checks and mcp_checks[0]["level"] == "ok"
+        assert mcp_checks and mcp_checks[0]["level"] == "warning"
         assert "project scope" in mcp_checks[0]["message"]
 
 

--- a/tests/unit/test_cmd_cost.py
+++ b/tests/unit/test_cmd_cost.py
@@ -55,11 +55,16 @@ def db():
 
 
 def test_api_plan_shows_raw_dollars(db):
-    """API users see the historical raw-dollar COST rendering, unchanged."""
+    """API users see the historical raw-dollar COST rendering, unchanged.
+
+    format_cost (#96) rounds amounts >= $100 to whole dollars with thousands
+    separators, so $2599.13 renders as "$2,599" rather than the un-rounded
+    cents.
+    """
     _seed(db, plan_tier="api", cost_usd=2599.13)
     result = _invoke(db, _config("api"), ["cost", "--since", "30d", "--group-by", "model"])
     assert result.exit_code == 0, result.output
-    assert "$2599.13" in result.output          # raw dollars preserved
+    assert "$2,599" in result.output             # raw dollars preserved
     assert "% of cycle" not in result.output     # no subscription reframing
     assert "Subscription plan" not in result.output
 
@@ -70,7 +75,7 @@ def test_subscription_plan_suppresses_raw_dollars(db):
     _seed(db, plan_tier="max_5x", cost_usd=2599.13)
     result = _invoke(db, _config("max_5x"), ["cost", "--since", "30d", "--group-by", "model"])
     assert result.exit_code == 0, result.output
-    assert "$2599.13" not in result.output       # raw dollars suppressed
+    assert "$2,599" not in result.output         # raw dollars suppressed
     # render_dollar's "X% of cycle" framing (the COST column may wrap it, so
     # match the distinctive token rather than the whole phrase).
     assert "cycle" in result.output
@@ -83,5 +88,5 @@ def test_unknown_plan_keeps_dollars_with_qualifier(db):
     _seed(db, plan_tier="unknown", cost_usd=2599.13)
     result = _invoke(db, _config(None), ["cost", "--since", "30d", "--group-by", "model"])
     assert result.exit_code == 0, result.output
-    assert "$2599.13" in result.output           # dollars still shown
+    assert "$2,599" in result.output             # dollars still shown
     assert "may overstate" in result.output       # qualifier surfaced

--- a/tests/unit/test_formatting.py
+++ b/tests/unit/test_formatting.py
@@ -3,20 +3,28 @@ from tokenjam.utils.formatting import format_cost, format_tokens, severity_colou
 
 class TestFormatCost:
     def test_small_cost(self):
-        assert format_cost(0.0001) == "$0.000100"
+        assert format_cost(0.0001) == "$0.00"
 
     def test_normal_cost(self):
-        assert format_cost(0.034) == "$0.0340"
+        assert format_cost(0.034) == "$0.03"
 
     def test_zero_cost(self):
-        assert format_cost(0.0) == "$0.000000"
+        assert format_cost(0.0) == "$0.00"
 
     def test_threshold_boundary(self):
-        # Exactly 0.001 should use 4 decimal places
-        assert format_cost(0.001) == "$0.0010"
+        assert format_cost(0.001) == "$0.00"
 
-    def test_large_cost(self):
-        assert format_cost(12.50) == "$12.5000"
+    def test_sub_hundred_cost_keeps_two_decimals(self):
+        assert format_cost(12.50) == "$12.50"
+
+    def test_exactly_one_hundred_uses_whole_dollars(self):
+        assert format_cost(100.0) == "$100"
+
+    def test_large_cost_rounds_to_whole_dollars_with_separators(self):
+        assert format_cost(1042.4825) == "$1,042"
+
+    def test_very_large_cost_uses_thousands_separators(self):
+        assert format_cost(29488.0100) == "$29,488"
 
 
 class TestFormatTokens:

--- a/tests/unit/test_framing.py
+++ b/tests/unit/test_framing.py
@@ -16,6 +16,7 @@ from tokenjam.core.framing import (
     compute_framing,
     config_declared_plan,
     config_declared_plan_labels,
+    dominant_persona,
     dominant_plan,
     pricing_mode_for,
     render_dollar,
@@ -303,3 +304,48 @@ def test_framing_to_dict_has_contract_fields():
         "qualifier_text",
     ):
         assert key in d
+
+
+# --------------------------------------------------------------------------- #
+# agent_persona_mix / dominant_persona — Claude Code vs SDK/API developer (#97)
+# --------------------------------------------------------------------------- #
+def test_agent_persona_mix_classifies_by_claude_code_prefix():
+    from unittest.mock import MagicMock
+
+    from tokenjam.core.framing import agent_persona_mix
+
+    conn = MagicMock()
+    conn.execute.return_value.fetchall.return_value = [
+        ("claude-code-my-project",), ("claude-code-other",), ("sdk-agent-x",),
+    ]
+    result = agent_persona_mix(conn, agent_id="agent-x")
+    assert result == {"claude_code": 2, "other": 1}
+    sql, params = conn.execute.call_args[0]
+    assert "agent_id = $" in sql
+    assert params == ["agent-x"]
+
+
+def test_agent_persona_mix_empty_when_no_sessions():
+    from unittest.mock import MagicMock
+
+    from tokenjam.core.framing import agent_persona_mix
+
+    conn = MagicMock()
+    conn.execute.return_value.fetchall.return_value = []
+    assert agent_persona_mix(conn) == {"claude_code": 0, "other": 0}
+
+
+@pytest.mark.parametrize("mix,expected", [
+    ({"claude_code": 9, "other": 1}, "claude-code"),
+    ({"claude_code": 1, "other": 9}, "sdk"),
+    ({"claude_code": 5, "other": 5}, "mixed"),
+])
+def test_dominant_persona_from_agent_mix(mix, expected):
+    assert dominant_persona(mix) == expected
+
+
+def test_dominant_persona_falls_back_to_declared_plan_when_mix_empty():
+    assert dominant_persona({"claude_code": 0, "other": 0}, declared_plan="max_5x") == "claude-code"
+    assert dominant_persona({"claude_code": 0, "other": 0}, declared_plan="api") == "sdk"
+    assert dominant_persona({"claude_code": 0, "other": 0}, declared_plan=None) == "unknown"
+    assert dominant_persona({}, declared_plan="pro") == "claude-code"

--- a/tests/unit/test_quickstart.py
+++ b/tests/unit/test_quickstart.py
@@ -150,8 +150,9 @@ def test_quickstart_renders_without_daemon_or_ondisk_db(tmp_path):
     # Both halves of the first-run value are present.
     assert "quota" in result.output.lower()
     assert "Session timeline" in result.output
-    # The opt-in "go deeper" pointer keeps the daemon path discoverable.
-    assert "tj onboard" in result.output
+    # The opt-in "go deeper" pointer prints the full pasteable install command,
+    # since the quickstart audience has no `tj` on PATH (it ran via `npx tokenjam`).
+    assert "pipx install tokenjam && tj onboard" in result.output
 
 
 def test_quickstart_json_emits_both_views(tmp_path):

--- a/tokenjam/api/routes/optimize.py
+++ b/tokenjam/api/routes/optimize.py
@@ -19,7 +19,12 @@ from typing import Any
 from fastapi import APIRouter, Depends, HTTPException, Query, Request
 
 from tokenjam.api.deps import require_api_key
-from tokenjam.core.framing import WindowSummary, compute_framing, plan_tier_mix
+from tokenjam.core.framing import (
+    WindowSummary,
+    agent_persona_mix,
+    compute_framing,
+    plan_tier_mix,
+)
 from tokenjam.core.optimize import ANALYZER_REGISTRY, build_report, report_to_dict
 from tokenjam.utils.time_parse import parse_since, utcnow
 
@@ -110,6 +115,17 @@ def get_optimize(
             payload["plan_tier_mix"] = {}
     else:
         payload["plan_tier_mix"] = {}
+
+    # Agent-persona mix (#97) — same best-effort daemon-mode plumbing as
+    # plan_tier_mix above, so the CLI's downsize CTA can tell a Claude Code
+    # subscriber from an SDK/API developer whether or not the daemon is up.
+    if conn is not None:
+        try:
+            payload["agent_persona_mix"] = agent_persona_mix(conn, since_dt, until_dt, agent_id)
+        except Exception:
+            payload["agent_persona_mix"] = {}
+    else:
+        payload["agent_persona_mix"] = {}
 
     # Plan-tier framing block (#110) — built from the report window + the
     # plan-tier mix above, so the local web UI frames recoverable-savings and

--- a/tokenjam/cli/cmd_doctor.py
+++ b/tokenjam/cli/cmd_doctor.py
@@ -4,6 +4,7 @@ import json
 
 import click
 import duckdb
+from rich.markup import escape
 
 from tokenjam.core.config import find_config_file, load_config
 from tokenjam.utils.formatting import console
@@ -626,4 +627,7 @@ def _print_check(check: dict) -> None:
     icons = {"ok": "[green]\u2713[/green]", "warning": "[yellow]\u26a0[/yellow]",
              "error": "[red]\u2717[/red]", "info": "[blue]i[/blue]"}
     icon = icons.get(level, "?")
-    console.print(f"  {icon}  {check['name']}: {check['message']}")
+    # Check names/messages are plain text, not Rich markup \u2014 a literal
+    # bracketed value inside one (e.g. the `[mcp_servers.tj]` TOML section
+    # header) would otherwise be parsed as a markup tag and stripped.
+    console.print(f"  {icon}  {escape(check['name'])}: {escape(check['message'])}")

--- a/tokenjam/cli/cmd_doctor.py
+++ b/tokenjam/cli/cmd_doctor.py
@@ -515,22 +515,37 @@ def _check_mcp_wiring(config: object) -> dict:
 
     # The MCP is an SDK / API surface, not a Claude Code / Codex one (#59): an
     # in-loop MCP is a per-turn quota burden on subscription users, so its
-    # ABSENCE for a coding agent is the correct state, never a warning. If it is
-    # registered (an SDK user, or a legacy CC/Codex registration) just report it.
+    # ABSENCE for a coding agent is the correct state, never a warning. A
+    # registration found in Claude Code, Codex, or project scope is exactly
+    # the quota-tax footgun this check exists to catch (`tj onboard` hasn't
+    # written any of these since #59 — see cmd_onboard.py's Codex path,
+    # which actively retires a legacy block) — flag it, don't green-check it.
     if has_codex or has_claude or has_project:
         found_locations = []
+        removal_hints = []
         if has_codex:
             found_locations.append("Codex (global)")
+            removal_hints.append(
+                "`tj onboard --codex --reconfigure` retires the legacy "
+                "[mcp_servers.tj] block"
+            )
         if has_claude:
             found_locations.append("Claude Code (global)")
+            removal_hints.append("`claude mcp remove tj --scope user` to deregister")
         if has_project:
             found_locations.append("project scope")
+            removal_hints.append(
+                "remove the `tj` entry from .mcp.json / .claude.json in this project"
+            )
         return {
             "name": "MCP wiring",
-            "level": "ok",
+            "level": "warning",
             "message": (
-                f"MCP server registered in {', '.join(found_locations)} "
-                "(the in-request-path surface for SDK / API use)."
+                f"MCP server registered in {', '.join(found_locations)} — an "
+                "in-loop MCP is a per-turn quota tax on subscription users "
+                "(+36% measured, ticket #59), not the recommended surface for "
+                "Claude Code / Codex. Remove it: " + "; ".join(removal_hints) + ". "
+                "The MCP is meant for SDK / API integrations only."
             ),
         }
 

--- a/tokenjam/cli/cmd_optimize.py
+++ b/tokenjam/cli/cmd_optimize.py
@@ -2,13 +2,16 @@
 from __future__ import annotations
 
 import json
+from typing import Any
 
 import click
 from rich.markup import escape as _rich_escape
 
 from tokenjam.core.framing import (
     PLAN_LABEL_AND_FEE,
+    agent_persona_mix,
     config_declared_plan,
+    dominant_persona,
     dominant_plan,
     plan_tier_mix,
     pricing_mode_for,
@@ -33,7 +36,10 @@ from tokenjam.utils.time_parse import parse_since, utcnow
 # Plan-tier framing helpers (PLAN_LABEL_AND_FEE, pricing_mode_for,
 # dominant_plan, config_declared_plan, plan_tier_mix) live in
 # tokenjam.core.framing — the single source shared with cmd_tokenmaxx and the
-# REST API. See issue #110.
+# REST API. See issue #110. agent_persona_mix / dominant_persona (also
+# framing.py) classify the window's dominant user (Claude Code subscriber vs
+# SDK/API developer) so the downsize finding's call-to-action matches the
+# levers that persona actually has — see #97.
 
 
 @click.command("optimize")
@@ -151,6 +157,10 @@ def cmd_optimize(
         # #68 §12 follow-up #29, so the CLI can render subscription /
         # local / unknown framings correctly under daemon mode.
         plan_mix = report_dict.get("plan_tier_mix") or {}
+        # Agent-persona mix (#97) — same daemon-mode plumbing as plan_mix
+        # above, so the downsize CTA matches persona whether or not the
+        # daemon is up.
+        agent_mix = report_dict.get("agent_persona_mix") or {}
     else:
         row = conn.execute(
             "SELECT COUNT(*) FROM spans WHERE model IS NOT NULL"
@@ -183,10 +193,12 @@ def cmd_optimize(
         )
 
         plan_mix = plan_tier_mix(conn, since_dt, until_dt, agent)
+        agent_mix = agent_persona_mix(conn, since_dt, until_dt, agent)
 
     dominant = dominant_plan(plan_mix)
     pricing_mode = pricing_mode_for(dominant)
     declared_plan = config_declared_plan(config)
+    persona = dominant_persona(agent_mix, declared_plan=declared_plan)
 
     # --export-config branch: write the snippet to disk and exit. Skips
     # the normal rendering path. The user reads the snippet file and
@@ -242,6 +254,8 @@ def cmd_optimize(
         payload["plan_tier_mix"] = plan_mix
         payload["plan"] = dominant
         payload["pricing_mode"] = pricing_mode
+        payload["agent_persona_mix"] = agent_mix
+        payload["persona"] = persona
         if cost_diff is not None:
             from tokenjam.cli.cmd_cost import _diff_to_dict
             payload["compare"] = _diff_to_dict(cost_diff)
@@ -267,6 +281,7 @@ def cmd_optimize(
         dominant_plan=dominant, pricing_mode=pricing_mode,
         declared_plan=declared_plan,
         requested=list(findings) if findings else None,
+        persona=persona,
     )
     if cost_diff is not None:
         from tokenjam.cli.cmd_cost import _render_diff
@@ -276,6 +291,94 @@ def cmd_optimize(
         from tokenjam.cli.cmd_cost import _render_diff_dict
         console.print("\n[bold]Window comparison[/bold]")
         _render_diff_dict(cost_diff_dict)
+
+
+# ---------------------------------------------------------------------------
+# Finding ranking (#97) — order the numbered slots by reclaimable share of
+# the window's tokens, instead of ANALYZER_ORDER (registry order).
+# ---------------------------------------------------------------------------
+
+# Minimum estimated-recoverable-token share of the window for a finding to
+# occupy a numbered slot. Below this, ranking by share is noise — a finding
+# whose analyzer merely happened to run first shouldn't outrank one that's
+# actually reclaiming a meaningful fraction of the window. Findings below the
+# threshold still render, just collapsed into the "Minor findings" pointer
+# list instead of a numbered slot.
+DE_MINIMIS_SHARE = 0.01
+
+# Display labels for the "Minor findings" collapsed pointer list — must match
+# the header text each renderer prints in its numbered form.
+_MINOR_FINDING_LABELS = {
+    "downsize":        "Model downgrade",
+    "cache":           "Cache efficacy",
+    "cache-recommend": "Cache recommend",
+    "script":          "Workflow restructure",
+    "reuse":           "Reuse",
+    "trim":            "Prompt bloat",
+    "subagent":        "Subagent right-sizing",
+}
+
+
+def _numbered_marker(n: int) -> str:
+    """Circled-digit marker for a ranked finding's slot (①, ②, … ⑳)."""
+    if 1 <= n <= 20:
+        return chr(0x2460 + n - 1)
+    return f"({n})"  # defensive — no report should ever have this many
+
+
+def _reclaimable_share(finding: Any, window_total_tokens: int) -> float | None:
+    """Estimated-recoverable-tokens share of the window, for ranking.
+
+    Returns ``None`` — not 0.0 — when the finding has no quantified estimate
+    at all (analyzer disabled, no candidates, or cache-recommend, which
+    recommends a cache_control placement rather than a token count). Those
+    findings still render in full (they're not "de-minimis", they're
+    "unranked") — only a finding with a real-but-tiny share collapses into
+    the Minor findings pointer list. Conflating the two would hide an
+    analyzer's own diagnostic empty-state message (e.g. "no tool spans in
+    this window") behind a generic pointer.
+    """
+    tokens = getattr(finding, "estimated_recoverable_tokens", None)
+    if tokens is None or window_total_tokens <= 0:
+        return None
+    return max(float(tokens), 0.0) / window_total_tokens
+
+
+def _rank_findings(
+    report: OptimizeReport, requested: list[str] | None,
+) -> list[tuple[str, float | None]]:
+    """Rank findings with something to show by reclaimable token share
+    (largest first; unranked findings — no quantified estimate — sort last).
+    Ties fall back to ANALYZER_ORDER for determinism.
+    """
+    window_tokens = report.window.total_tokens
+    order = ["downsize", *_FINDING_RENDERERS.keys()]
+    order_index = {name: i for i, name in enumerate(order)}
+
+    items: list[tuple[str, float | None]] = []
+    # Render an explicit "no candidates" empty state when the downsize
+    # analyzer ran but found nothing — the Optimize web tab does this
+    # (PR #130 / issue #126) and the CLI used to silently skip the section,
+    # which makes reviewers think the analyzer didn't run. Skip the empty
+    # state when the user asked for a different positional subset
+    # (`tj optimize cache` shouldn't mention downsize at all).
+    downsize_was_requested = (not requested) or ("downsize" in requested)
+    if report.downgrade is not None:
+        items.append(("downsize", _reclaimable_share(report.downgrade, window_tokens)))
+    elif downsize_was_requested:
+        items.append(("downsize", None))
+
+    for name, finding in (report.findings or {}).items():
+        if name not in _FINDING_RENDERERS:
+            continue
+        items.append((name, _reclaimable_share(finding, window_tokens)))
+
+    items.sort(key=lambda item: (
+        item[1] is None,
+        -(item[1] or 0.0),
+        order_index.get(item[0], len(order)),
+    ))
+    return items
 
 
 # ---------------------------------------------------------------------------
@@ -290,6 +393,7 @@ def _render_report(
     pricing_mode: str = "unknown",
     declared_plan: str | None = None,
     requested: list[str] | None = None,
+    persona: str = "unknown",
 ) -> None:
     w = report.window
     scope_tag = f", {agent}" if agent else ""
@@ -380,29 +484,58 @@ def _render_report(
     if report.notes:
         console.print()
 
-    # ----- Model-downgrade body -----
-    # Render an explicit "no candidates" empty state when the analyzer ran
-    # but found nothing — the Optimize web tab does this (PR #130 / issue
-    # #126) and the CLI used to silently skip the section, which makes
-    # reviewers think the analyzer didn't run. Skip the empty state when
-    # the user asked for a different positional subset (`tj optimize cache`
-    # shouldn't mention downsize at all).
-    downsize_was_requested = (not requested) or ("downsize" in requested)
-    if report.downgrade is not None:
-        _render_downgrade(
-            report.downgrade,
-            pricing_mode=("unknown" if all_unknown else pricing_mode),
-        )
+    # ----- Findings, ranked by reclaimable share of the window's tokens -----
+    # Findings used to render in ANALYZER_ORDER (registry order), so a
+    # nothing-burger could occupy the top numbered slot just because its
+    # analyzer happened to run first — e.g. "① Model downgrade: 28% of
+    # sessions match" when those sessions held ~0% of the window's tokens
+    # (#97). Rank by estimated_recoverable_tokens / window.total_tokens
+    # instead. Three buckets:
+    #   major    — real, meaningful share: numbered slot, full render.
+    #   unranked — no quantified estimate at all (disabled / no candidates):
+    #              full render (own empty-state message), unnumbered — same
+    #              as the historical behavior, so diagnostic detail ("no tool
+    #              spans in this window") never disappears.
+    #   minor    — real but de-minimis share: collapsed to a one-line pointer
+    #              so it can't crowd out a finding that actually matters.
+    ranked = _rank_findings(report, requested)
+    major = [item for item in ranked if item[1] is not None and item[1] >= DE_MINIMIS_SHARE]
+    unranked = [item for item in ranked if item[1] is None]
+    minor = [item for item in ranked if item[1] is not None and item[1] < DE_MINIMIS_SHARE]
+
+    def _render_finding(name: str, marker: str) -> None:
+        if name == "downsize":
+            if report.downgrade is not None:
+                _render_downgrade(
+                    report.downgrade,
+                    pricing_mode=("unknown" if all_unknown else pricing_mode),
+                    persona=persona,
+                    marker=marker,
+                )
+            else:
+                console.print(
+                    f"{_finding_header(marker, 'Model downgrade:')} "
+                    "[dim]no candidates in this window — sessions don't match "
+                    "the smaller-model shape (small input/output, few tool "
+                    "calls).[/dim]"
+                )
+        else:
+            _FINDING_RENDERERS[name](
+                report.findings[name], pricing_mode=pricing_mode, marker=marker,
+            )
+
+    for slot, (name, _share) in enumerate(major, start=1):
+        _render_finding(name, _numbered_marker(slot))
         console.print()
-    elif downsize_was_requested:
-        console.print(
-            "  [bold]① Downsize:[/bold] "
-            "[dim]no candidates in this window — sessions don't match the "
-            "smaller-model shape (small input/output, few tool calls).[/dim]"
-        )
+
+    for name, _share in unranked:
+        _render_finding(name, "")
         console.print()
 
     # ----- Budget projection -----
+    # Not part of the reclaimable-share ranking above — it's a forward-looking
+    # cap/overage exposure, not a recoverable-tokens finding, so it always
+    # renders in its own section rather than competing for a numbered slot.
     # Subscription users don't have a dollar-denominated budget projection;
     # the [budget.<provider>] section may exist as a self-imposed soft
     # ceiling, but rendering it as a hard cap would mislead. Suppress in
@@ -412,28 +545,44 @@ def _render_report(
             _render_budget(proj)
             console.print()
 
-    # ----- Wave-2 findings (cache, cache-recommend,
-    # script, trim) — these attach to report.findings
-    # rather than typed slots. Dispatch to a per-finding renderer; ignore
-    # any unknown finding names (forward-compatible with future analyzers).
-    rendered_any_wave2 = False
-    for name, finding in (report.findings or {}).items():
-        renderer = _FINDING_RENDERERS.get(name)
-        if renderer is None:
-            continue
-        renderer(finding, pricing_mode=pricing_mode)
+    # ----- Minor findings -----
+    # De-minimis-share findings stay visible (never silently dropped — the
+    # honesty discipline forbids a quiet skip) but collapsed to a one-line
+    # pointer instead of a full render, so a near-zero finding can't crowd
+    # out the ones that actually matter.
+    if minor:
+        console.print(
+            f"  [dim]Minor findings (< {DE_MINIMIS_SHARE * 100:.0f}% of window "
+            f"tokens):[/dim]"
+        )
+        for name, share in minor:
+            # `minor` is filtered to `item[1] is not None` above; the
+            # assertion below just narrows the type for mypy.
+            assert share is not None
+            label = _MINOR_FINDING_LABELS.get(name, name)
+            if name == "downsize":
+                # The exact scenario this ranking fixes (#97): the analyzer
+                # found session-shape candidates, but they hold a negligible
+                # share of the window's tokens — say so plainly rather than
+                # "no candidates" (that empty state is the `unranked` bucket,
+                # which only holds report.downgrade is None).
+                assert report.downgrade is not None
+                console.print(
+                    f"     [dim]• {label} — "
+                    f"{report.downgrade.percent_of_sessions:.0f}% of sessions "
+                    f"match, but only ~{share * 100:.1f}% of window tokens. "
+                    f"Run [bold]tj optimize downsize[/bold] for detail.[/dim]"
+                )
+            else:
+                console.print(
+                    f"     [dim]• {label} — ~{share * 100:.1f}% of window "
+                    f"tokens. Run [bold]tj optimize {name}[/bold] for "
+                    f"detail.[/dim]"
+                )
         console.print()
-        rendered_any_wave2 = True
 
-    # Only show the catch-all when truly nothing rendered. The earlier
-    # condition missed the Wave-2 findings dict, so cache /
-    # cache-recommend / script / trim were silently
-    # falling into "No candidates flagged" (issue #68 §15).
-    rendered_any = (
-        report.downgrade is not None
-        or downsize_was_requested  # we emit a "no candidates" empty state
-        or (pricing_mode == "api" and bool(report.budgets))
-        or rendered_any_wave2
+    rendered_any = bool(major) or bool(unranked) or bool(minor) or (
+        pricing_mode == "api" and bool(report.budgets)
     )
     if not rendered_any:
         console.print(
@@ -463,7 +612,12 @@ def _sampling_ci_suffix(d: DowngradeFinding) -> str:
     )
 
 
-def _render_downgrade(d: DowngradeFinding, pricing_mode: str = "api") -> None:
+def _render_downgrade(
+    d: DowngradeFinding,
+    pricing_mode: str = "api",
+    persona: str = "unknown",
+    marker: str = "①",
+) -> None:
     """
     Render the downsize finding for the given pricing mode.
 
@@ -473,9 +627,12 @@ def _render_downgrade(d: DowngradeFinding, pricing_mode: str = "api") -> None:
                     against your plan cap"
     - local:        token-only framing for capacity planning
     - unknown:      structural-only, no savings figures
+
+    `persona` picks the call-to-action at the bottom (#97) — see
+    `_render_downgrade_cta`.
     """
     console.print(
-        f"  [bold]① Model downgrade:[/bold] "
+        f"  [bold]{marker} Model downgrade:[/bold] "
         f"{d.percent_of_sessions:.0f}% of sessions match a smaller-model "
         f"candidate shape"
     )
@@ -553,17 +710,71 @@ def _render_downgrade(d: DowngradeFinding, pricing_mode: str = "api") -> None:
         f"     [yellow]![/yellow] [italic]{MODEL_DOWNGRADE_CAVEAT}[/italic]"
     )
     if d.bench_command:
+        _render_downgrade_cta(d.bench_command, persona)
+
+
+def _render_downgrade_cta(bench_command: str, persona: str) -> None:
+    """
+    Persona-aware call-to-action for the downsize finding (#97).
+
+    A Claude Code subscription user can't pass `--original`/`--candidate` to
+    pick a model per request — their real levers are exporting a routing
+    config, right-sizing subagents, and `/compact`. `tokenjam-bench` (which
+    runs the swap directly against a provider API key) is the right CTA for
+    an SDK/API developer, and only a secondary note for anyone who also runs
+    SDK agents. A mixed window shows both, labeled. Persona "sdk" and the
+    defensive "unknown" fallback both get the original, unchanged CTA.
+    """
+    console.print()
+    if persona == "claude-code":
+        console.print(
+            "     [bold]Candidate only — review before routing:[/bold]"
+        )
+        console.print(
+            "       tj route export --target ccr   "
+            "[dim]# or --target litellm[/dim]"
+        )
+        console.print(
+            "       tj optimize subagent            "
+            "[dim]# right-size subagent models/context[/dim]"
+        )
+        console.print(
+            "       /compact                        "
+            "[dim]# trim context mid-session[/dim]"
+        )
         console.print()
+        console.print(
+            "     [dim]If you also run SDK agents against these models:[/dim]"
+        )
+        console.print("       [dim]pip install tokenjam-bench[/dim]")
+        for line in bench_command.split("\n"):
+            console.print(f"       [dim]{line}[/dim]")
+    elif persona == "mixed":
+        console.print(
+            "     [bold]Candidate only — review before routing:[/bold]"
+        )
+        console.print("     [dim]Claude Code sessions:[/dim]")
+        console.print(
+            "       tj route export --target ccr   "
+            "[dim]# or --target litellm[/dim]"
+        )
+        console.print("       tj optimize subagent")
+        console.print("       /compact")
+        console.print("     [dim]SDK sessions:[/dim]")
+        console.print("       pip install tokenjam-bench")
+        for line in bench_command.split("\n"):
+            console.print(f"       {line}")
+    else:  # persona in {"sdk", "unknown"} — unchanged original CTA
         console.print(
             "     [bold]Candidate only — prove it holds before switching:[/bold]"
         )
         console.print("       pip install tokenjam-bench")
-        for line in d.bench_command.split("\n"):
+        for line in bench_command.split("\n"):
             console.print(f"       {line}")
 
 
 def _render_budget(p: BudgetProjection) -> None:
-    headline = f"  [bold]② Budget projection ({p.provider}, " \
+    headline = f"  [bold]Budget projection ({p.provider}, " \
                f"{format_cost(p.budget_usd)}/cycle):[/bold] "
 
     if not p.over_budget:
@@ -713,19 +924,29 @@ def _export_snippet(
 # dict keyed by analyzer name). _FINDING_RENDERERS at the bottom maps each
 # analyzer's registration name to the function that renders its finding.
 #
-# Each renderer takes (finding, pricing_mode=str) and prints to the global
-# `console`. Adding a new analyzer: add a renderer here and an entry in the
-# dispatch table. cmd_optimize._render_report iterates report.findings and
-# calls into here.
+# Each renderer takes (finding, pricing_mode=str, marker=str) and prints to
+# the global `console`. `marker` is the numbered slot assigned by
+# `_rank_findings` (e.g. "②") — empty when the finding rendered outside the
+# ranked list. Adding a new analyzer: add a renderer here, an entry in the
+# dispatch table, and a label in `_MINOR_FINDING_LABELS`. cmd_optimize.
+# _render_report ranks report.findings by reclaimable share and calls in here.
 
-def _render_cache_efficacy(finding, *, pricing_mode: str = "api") -> None:
+def _finding_header(marker: str, label: str) -> str:
+    """Bold header line for a ranked finding, e.g. '② Cache efficacy:'."""
+    prefix = f"{marker} " if marker else ""
+    return f"  [bold]{prefix}{label}[/bold]"
+
+
+def _render_cache_efficacy(
+    finding, *, pricing_mode: str = "api", marker: str = "",
+) -> None:
     """
     Render the cache finding — current caching-ratio table per
     (provider, model). When any rows are flagged, surface them prominently;
     otherwise show the full table dimmed so the user sees the underlying
     data even when no recommendation is warranted.
     """
-    console.print("  [bold]Cache efficacy:[/bold]")
+    console.print(_finding_header(marker, "Cache efficacy:"))
     if not finding.rows:
         console.print(
             "     [dim]No LLM spans with provider/model in this window.[/dim]"
@@ -765,13 +986,15 @@ def _render_cache_efficacy(finding, *, pricing_mode: str = "api") -> None:
         )
 
 
-def _render_cache_recommend(finding, *, pricing_mode: str = "api") -> None:
+def _render_cache_recommend(
+    finding, *, pricing_mode: str = "api", marker: str = "",
+) -> None:
     """
     Render the cache-recommend finding — Anthropic-only v1 breakpoint
     candidates. When the analyzer is disabled (capture.prompts off), surface
     the hint instead of an empty table.
     """
-    console.print("  [bold]Cache recommend:[/bold]")
+    console.print(_finding_header(marker, "Cache recommend:"))
     if not finding.enabled:
         # Hint includes the install / config instruction from the analyzer.
         # _rich_escape because the hint contains TOML section names like
@@ -821,12 +1044,14 @@ def _render_cache_recommend(finding, *, pricing_mode: str = "api") -> None:
         )
 
 
-def _render_workflow_restructure(finding, *, pricing_mode: str = "api") -> None:
+def _render_workflow_restructure(
+    finding, *, pricing_mode: str = "api", marker: str = "",
+) -> None:
     """
     Render the script (Script) finding — clusters of sessions
     matching the same (tool_name, arg_shape) signature.
     """
-    console.print("  [bold]Workflow restructure:[/bold]")
+    console.print(_finding_header(marker, "Workflow restructure:"))
     if not finding.clusters:
         if finding.sessions_examined == 0:
             console.print(
@@ -880,13 +1105,15 @@ def _render_workflow_restructure(finding, *, pricing_mode: str = "api") -> None:
         console.print(f"     [yellow]![/yellow] [italic]{finding.caveat}[/italic]")
 
 
-def _render_prompt_bloat(finding, *, pricing_mode: str = "api") -> None:
+def _render_prompt_bloat(
+    finding, *, pricing_mode: str = "api", marker: str = "",
+) -> None:
     """
     Render the trim (Trim) finding — LLMLingua-2 token-significance
     summary. When the analyzer is disabled (either capture off or extra
     not installed), surface the hint.
     """
-    console.print("  [bold]Prompt bloat:[/bold]")
+    console.print(_finding_header(marker, "Prompt bloat:"))
     if not finding.enabled:
         if finding.hint:
             # Escape Rich markup — hints can contain TOML section names
@@ -937,14 +1164,16 @@ def _render_prompt_bloat(finding, *, pricing_mode: str = "api") -> None:
     )
 
 
-def _render_reuse(finding, *, pricing_mode: str = "api") -> None:
+def _render_reuse(
+    finding, *, pricing_mode: str = "api", marker: str = "",
+) -> None:
     """
     Render the reuse (Reuse) finding — clusters of sessions whose planning
     skeleton repeats. Two recoverable numbers per cluster: cache-reuse (reuse
     the existing skeleton) and script-replacement (replace every planning call
     with a deterministic template). Framed per pricing mode.
     """
-    console.print("  [bold]Reuse:[/bold]")
+    console.print(_finding_header(marker, "Reuse:"))
     if not finding.clusters:
         console.print(
             "     [dim]No repeated planning detected above threshold "
@@ -1000,13 +1229,15 @@ def _render_reuse(finding, *, pricing_mode: str = "api") -> None:
         )
 
 
-def _render_subagent(finding, *, pricing_mode: str = "api") -> None:
+def _render_subagent(
+    finding, *, pricing_mode: str = "api", marker: str = "",
+) -> None:
     """
     Render the subagent right-sizing finding — how much of the window's cost ran
     inside subagents, plus the structurally-flagged candidates (over-powered
     model / over-provisioned context).
     """
-    console.print("  [bold]Subagent right-sizing:[/bold]")
+    console.print(_finding_header(marker, "Subagent right-sizing:"))
     if not finding.total_subagents:
         console.print(
             "     [dim]No subagent (Task-tool) activity in this window.[/dim]"

--- a/tokenjam/cli/cmd_quickstart.py
+++ b/tokenjam/cli/cmd_quickstart.py
@@ -18,7 +18,8 @@ Design (what makes it "zero-setup"):
       - a session timeline from :mod:`tokenjam.core.session_timeline`.
   * The output **leads with reads-your-local-logs + added-value framing** —
     "reads your ~/.claude session logs; here's where your quota actually goes" —
-    then ends on the opt-in "go deeper" pointer to ``tj onboard`` (daemon / MCP / live).
+    then ends on the opt-in "go deeper" pointer to ``tj onboard`` (daemon /
+    statusline / live capture).
 
 Because it manages its own transient DB, ``quickstart`` is registered in
 ``no_db_commands`` so the CLI never opens the on-disk DB or trips the daemon's
@@ -73,7 +74,7 @@ def cmd_quickstart(ctx: click.Context, since: str, root_path: str | None,
     no daemon, no onboarding. On a large history the first run caps at the
     most-recent sessions for speed (use `--full` for everything). Run
     `tj onboard` afterwards to go deeper (live capture, the dashboard, and the
-    MCP server for Claude Code).
+    zero-token statusline).
     """
     from pathlib import Path
 
@@ -282,8 +283,8 @@ def _render(diag, timeline, *, since: str,
     deeper = Text()
     deeper.append("Go deeper: ", style="bold")
     deeper.append("`tj onboard`", style="bold cyan")
-    deeper.append(" sets up live capture, the local dashboard, and the MCP "
-                  "server for Claude Code (the opt-in daemon path).", style="dim")
+    deeper.append(" sets up live capture, the local dashboard, and the "
+                  "zero-token statusline (the opt-in daemon path).", style="dim")
     console.print(deeper)
     console.print()
 

--- a/tokenjam/cli/cmd_quickstart.py
+++ b/tokenjam/cli/cmd_quickstart.py
@@ -281,11 +281,12 @@ def _render(diag, timeline, *, since: str,
     console.print(f"  [dim]{diag.caveat}[/dim]")
     console.print()
     deeper = Text()
-    deeper.append("Go deeper: ", style="bold")
-    deeper.append("`tj onboard`", style="bold cyan")
-    deeper.append(" sets up live capture, the local dashboard, and the "
-                  "zero-token statusline (the opt-in daemon path).", style="dim")
+    deeper.append("Go deeper", style="bold")
+    deeper.append(" — install and set up live capture, the local dashboard, "
+                  "and the zero-token statusline:", style="dim")
     console.print(deeper)
+    console.print()
+    console.print(Text("  pipx install tokenjam && tj onboard", style="bold cyan"))
     console.print()
 
 

--- a/tokenjam/cli/cmd_status.py
+++ b/tokenjam/cli/cmd_status.py
@@ -4,7 +4,7 @@ import json
 
 import click
 
-from tokenjam.core.models import AlertFilters
+from tokenjam.core.models import Alert, AlertFilters
 from tokenjam.utils.formatting import console, format_cost, format_tokens, status_icon
 from tokenjam.utils.time_parse import utcnow
 
@@ -80,6 +80,8 @@ def cmd_status(ctx: click.Context, agent: str | None, output_json: bool) -> None
         if active_alerts:
             has_active_alerts = True
 
+        framing = _agent_framing(db, config, aid) if hasattr(db, "conn") else None
+
         agent_data = {
             "agent_id": aid,
             "status": session.status if session else "idle",
@@ -97,7 +99,7 @@ def cmd_status(ctx: click.Context, agent: str | None, output_json: bool) -> None
         agents_data.append(agent_data)
 
         if not output_json:
-            _print_agent_status(agent_data, active_alerts, session)
+            _print_agent_status(agent_data, active_alerts, session, framing)
 
     # Count sessions with plan_tier='unknown' so the user knows to reconfigure.
     # Informational only — exit code stays driven by alert state.
@@ -141,7 +143,92 @@ def _fmt_dur(seconds: float | None, *, coarse: bool = False) -> str:
     return f"{mins}m {s}s"
 
 
-def _print_agent_status(data: dict, active_alerts: list, session: object | None) -> None:
+def _agent_framing(db, config, agent_id: str):
+    """Plan-tier framing for one agent's Cost line (#96).
+
+    Window-independent (per #177: the pricing mode is a property of the
+    user's plan, not the selected window) — the same `plan_determination_mix`
+    + `compute_framing` pairing `tj cost` / `tj optimize` / `tj tokenmaxx`
+    already use, so `tj status` doesn't invent a fourth convention. Returns
+    None in API mode (no direct conn) — callers fall back to raw format_cost.
+    """
+    conn = getattr(db, "conn", None)
+    if conn is None:
+        return None
+    from tokenjam.core.framing import WindowSummary, compute_framing, plan_determination_mix
+
+    mix = plan_determination_mix(conn, agent_id)
+    return compute_framing(config, WindowSummary(sessions=sum(mix.values()), plan_tier_mix=mix))
+
+
+def _framing_note(framing) -> str | None:
+    """The honesty note printed under the Cost today line (#96).
+
+    Mirrors `cmd_cost._cost_note`: prefers the framing's own qualifier_text
+    (only set for mixed subscription/API session history); otherwise
+    synthesizes a concise mode note so a pure subscription/local Cost line is
+    never unexplained. api/unknown -> None (unchanged rendering, no note)."""
+    if framing is None:
+        return None
+    if framing.qualifier_text:
+        return framing.qualifier_text
+    if framing.pricing_mode == "subscription":
+        return ("Subscription plan — flat-fee billing; cost shown as share of "
+                "your monthly plan, not dollars spent.")
+    if framing.pricing_mode == "local":
+        return "Local inference — no marginal cost; dollar figures suppressed."
+    return None
+
+
+def _cost_line(data: dict, framing) -> str:
+    """Render the 'Cost today' line, plan-tier-aware (#96).
+
+    Subscription plans are flat-fee: a raw "$0.00" (or any USD figure) line
+    misrepresents metered spend the user never incurs. Mirrors the
+    subscription/local gate `cmd_cost._cost_cell` uses via
+    `core/framing.render_dollar` — known-fee subscription plans (pro /
+    max_5x / max_20x / plus) show a % of cycle; unmetered plans (team /
+    enterprise, no declared fee) and local inference show "—". API/unknown
+    keep the historical dollar rendering.
+    """
+    if framing is not None and framing.pricing_mode in ("subscription", "local"):
+        from tokenjam.core.framing import render_dollar
+        cost_str = render_dollar(data["cost_today"], framing)
+        if data["daily_limit"]:
+            cost_str += f" / {render_dollar(data['daily_limit'], framing)} limit"
+        return cost_str
+    cost_str = format_cost(data["cost_today"])
+    if data["daily_limit"]:
+        cost_str += f" / {format_cost(data['daily_limit'])} limit"
+    return cost_str
+
+
+def _dedupe_alerts(alerts: list[Alert]) -> list[tuple[Alert, int]]:
+    """Collapse repeat alerts of the same type into one (alert, count) pair (#96).
+
+    The alert engine's dedup state (CooldownTracker, `_failure_rate_fired`) is
+    in-memory only and resets on process restart, so the DB can legitimately
+    hold multiple rows for the same (type, agent) pair — the query itself
+    (`get_alerts`) is a plain `SELECT`, no join, so there's no fanout to fix
+    there. Collapse at render time instead of dropping information: keep the
+    first (most recent, since `alerts` is fired_at DESC) occurrence of each
+    type and note how many fired.
+    """
+    first_seen: dict[str, Alert] = {}
+    counts: dict[str, int] = {}
+    order: list[str] = []
+    for alert in alerts:
+        key = alert.type.value
+        if key not in first_seen:
+            first_seen[key] = alert
+            counts[key] = 0
+            order.append(key)
+        counts[key] += 1
+    return [(first_seen[key], counts[key]) for key in order]
+
+
+def _print_agent_status(data: dict, active_alerts: list, session: object | None,
+                         framing=None) -> None:
     status = data["status"]
     icon = status_icon(status)
     style = "green" if status == "active" else "dim"
@@ -150,10 +237,10 @@ def _print_agent_status(data: dict, active_alerts: list, session: object | None)
                   f"{status}")
     console.print()
 
-    cost_str = format_cost(data["cost_today"])
-    if data["daily_limit"]:
-        cost_str += f" / {format_cost(data['daily_limit'])} limit"
-    console.print(f"  Cost today:     {cost_str}")
+    console.print(f"  Cost today:     {_cost_line(data, framing)}")
+    note = _framing_note(framing)
+    if note:
+        console.print(f"  [dim]{note}[/dim]")
 
     in_tok = format_tokens(data["input_tokens"])
     out_tok = format_tokens(data["output_tokens"])
@@ -178,10 +265,11 @@ def _print_agent_status(data: dict, active_alerts: list, session: object | None)
         console.print(f"  Active session: {data['session_id']}")
 
     console.print()
-    for alert in active_alerts:
+    for alert, count in _dedupe_alerts(active_alerts):
         from tokenjam.utils.formatting import severity_colour
         colour = severity_colour(alert.severity.value)
-        console.print(f"  [{colour}]{alert.title}[/]")
+        suffix = f" ×{count}" if count > 1 else ""
+        console.print(f"  [{colour}]{alert.title}{suffix}[/]")
 
     if not active_alerts:
         console.print("  [green]No active alerts[/green]")

--- a/tokenjam/cli/cmd_status.py
+++ b/tokenjam/cli/cmd_status.py
@@ -190,16 +190,20 @@ def _cost_line(data: dict, framing) -> str:
     max_5x / max_20x / plus) show a % of cycle; unmetered plans (team /
     enterprise, no declared fee) and local inference show "—". API/unknown
     keep the historical dollar rendering.
+
+    `daily_limit` is a user-configured DAILY dollar cap (`budget.daily_usd`),
+    not a share of the monthly subscription fee — running it through
+    `render_dollar` would express a daily cap as a percentage of the wrong
+    cycle. It's always shown as its literal dollar amount with a `/day`
+    qualifier; only the spend-so-far figure is plan-tier-framed.
     """
     if framing is not None and framing.pricing_mode in ("subscription", "local"):
         from tokenjam.core.framing import render_dollar
         cost_str = render_dollar(data["cost_today"], framing)
-        if data["daily_limit"]:
-            cost_str += f" / {render_dollar(data['daily_limit'], framing)} limit"
-        return cost_str
-    cost_str = format_cost(data["cost_today"])
+    else:
+        cost_str = format_cost(data["cost_today"])
     if data["daily_limit"]:
-        cost_str += f" / {format_cost(data['daily_limit'])} limit"
+        cost_str += f" / {format_cost(data['daily_limit'])}/day limit"
     return cost_str
 
 

--- a/tokenjam/core/cost.py
+++ b/tokenjam/core/cost.py
@@ -46,8 +46,9 @@ def calculate_cost(
         if key not in _UNKNOWN_MODEL_WARNED:
             _UNKNOWN_MODEL_WARNED.add(key)
             logger.warning(
-                "No pricing data for %s/%s — using default rates. "
-                "Add to tokenjam/pricing/models.toml to get accurate costs.",
+                "No pricing data for %s/%s — using default rates (cost figures "
+                "may be inaccurate). Upgrade tokenjam for current pricing, or "
+                "add an override to ~/.config/tj/pricing.toml — see `tj pricing list`.",
                 provider, model,
             )
         rates = ModelRates(

--- a/tokenjam/core/framing.py
+++ b/tokenjam/core/framing.py
@@ -531,3 +531,90 @@ def plan_determination_mix(conn: Any, agent_id: str | None = None) -> dict[str, 
     narrows to a single agent when set — the plan is per-agent, not per-window.
     """
     return plan_tier_mix(conn, None, None, agent_id)
+
+
+# ---------------------------------------------------------------------------
+# Persona detection (#97) — Claude Code subscriber vs SDK/API developer.
+# ---------------------------------------------------------------------------
+# `tj optimize`'s downsize finding used to print an SDK-only call-to-action
+# (`tjb run --original ... --candidate ...`) regardless of who was running it.
+# A Claude Code subscription user can't pick a model per request — their real
+# levers are exporting a routing config, right-sizing subagents, and
+# `/compact`. Detecting the dominant persona lets the CLI render the CTA that
+# actually matches the user's levers.
+
+# `tj onboard --claude-code` / `tj backfill claude-code` stamp every ingested
+# session's agent_id as `claude-code-<slug>` (see backfill.py
+# _agent_id_from_cwd, session_timeline.py SessionSummary.project_label) — the
+# one existing convention that distinguishes a Claude Code session from any
+# other runtime (SDK, other CLIs).
+CLAUDE_CODE_AGENT_PREFIX = "claude-code-"
+
+# A window is "claude-code" or "sdk" dominated at this threshold; between the
+# two, both audiences are meaningfully represented and the CTA should label
+# and show both rather than pick one.
+_PERSONA_DOMINANT_FRACTION = 0.8
+
+
+def agent_persona_mix(
+    conn: Any,
+    since: Any = None,
+    until: Any = None,
+    agent_id: str | None = None,
+) -> dict[str, int]:
+    """Count sessions by whether their agent_id looks like Claude Code.
+
+    Mirrors :func:`plan_tier_mix`'s query shape (same optional since/until/
+    agent_id window, same ``sessions`` table). Returns
+    ``{"claude_code": N, "other": M}``.
+    """
+    clauses: list[str] = []
+    params: list[Any] = []
+    if since is not None:
+        params.append(since)
+        clauses.append("started_at >= $" + str(len(params)))
+    if until is not None:
+        params.append(until)
+        clauses.append("started_at < $" + str(len(params)))
+    if agent_id:
+        params.append(agent_id)
+        clauses.append("agent_id = $" + str(len(params)))
+    where = (" WHERE " + " AND ".join(clauses)) if clauses else ""
+    sql = "SELECT agent_id FROM sessions" + where
+    rows = conn.execute(sql, params).fetchall()
+    mix = {"claude_code": 0, "other": 0}
+    for (aid,) in rows:
+        if aid and str(aid).startswith(CLAUDE_CODE_AGENT_PREFIX):
+            mix["claude_code"] += 1
+        else:
+            mix["other"] += 1
+    return mix
+
+
+def dominant_persona(
+    agent_mix: dict[str, int], declared_plan: str | None = None,
+) -> str:
+    """Classify the analyzed window's dominant user persona.
+
+    Returns one of ``"claude-code"``, ``"sdk"``, ``"mixed"``, ``"unknown"``.
+
+    Primary signal is the ``agent_id`` prefix (:data:`CLAUDE_CODE_AGENT_PREFIX`).
+    Falls back to the declared plan tier only when no session in the window
+    carries an identifiable agent_id (e.g. raw OTLP ingestion that never ran
+    ``tj onboard``) — a declared Claude Code subscription tier (pro / max_5x /
+    max_20x) still implies a Claude Code user even before agent-id attribution
+    exists, and a declared ``api`` plan implies an SDK/API developer.
+    """
+    total = sum(agent_mix.values())
+    if total == 0:
+        if declared_plan in {"pro", "max_5x", "max_20x"}:
+            return "claude-code"
+        if declared_plan == "api":
+            return "sdk"
+        return "unknown"
+    cc_fraction = agent_mix.get("claude_code", 0) / total
+    if cc_fraction >= _PERSONA_DOMINANT_FRACTION:
+        return "claude-code"
+    if cc_fraction <= (1 - _PERSONA_DOMINANT_FRACTION):
+        return "sdk"
+    return "mixed"

--- a/tokenjam/pricing/models.toml
+++ b/tokenjam/pricing/models.toml
@@ -46,6 +46,16 @@ output_per_mtok = 25.00
 cache_read_per_mtok = 0.50
 cache_write_per_mtok = 6.25
 
+# Claude Sonnet 5 — introductory pricing in effect through 2026-08-31 (see
+# https://platform.claude.com/docs/en/about-claude/pricing#claude-sonnet-5-introductory-pricing);
+# standard pricing ($3/$15 input/output) takes over 2026-09-01 — update this
+# row then. cache_write = 5-minute write.
+[anthropic.claude-sonnet-5]
+input_per_mtok = 2.00
+output_per_mtok = 10.00
+cache_read_per_mtok = 0.20
+cache_write_per_mtok = 2.50
+
 [anthropic.claude-sonnet-4-6]
 input_per_mtok = 3.00
 output_per_mtok = 15.00

--- a/tokenjam/utils/formatting.py
+++ b/tokenjam/utils/formatting.py
@@ -22,9 +22,15 @@ def status_icon(status: str) -> str:
 
 
 def format_cost(usd: float) -> str:
-    if usd < 0.001:
-        return f"${usd:.6f}"
-    return f"${usd:.4f}"
+    """Format a USD amount for display (#96).
+
+    Under $100: 2 decimal places ("$12.50"). At or above $100: whole dollars
+    with thousands separators ("$1,042") — sub-dollar precision on large
+    figures (e.g. "$29488.0100") reads as false precision, not accuracy.
+    """
+    if usd >= 100:
+        return f"${usd:,.0f}"
+    return f"${usd:,.2f}"
 
 
 def format_tokens(n: int) -> str:


### PR DESCRIPTION
Fixes three `tj status` display bugs observed live on a Max-20x machine (2026-07-07 dogfood session).

## Summary
- Deduplicate repeat alert lines of the same (type, agent) pair into one line with a count.
- Subscription-tier `tj status` no longer shows a raw `$0.000000` Cost today line — it reuses the existing `core/framing` plan-tier convention (`tj cost` / `tj optimize` / `tj tokenmaxx`).
- One shared currency formatter (`format_cost` in `utils/formatting.py`) fixes inconsistent precision (`$0.000000`, `$1042.4825`, `$29488.0100`) across every `cli/` cost render.

## #1 — Duplicate alert lines
**Root cause**: query, not render. `StorageBackend.get_alerts` (`tokenjam/core/db.py:1604`) is a plain `SELECT * FROM alerts WHERE ... ORDER BY fired_at DESC` — no join, so no fanout. The duplication is a genuine data condition: the alert engine's dedup state (`CooldownTracker` and `AlertEngine._failure_rate_fired` in `tokenjam/core/alerts.py`) is **in-memory only** and resets whenever the ingest process restarts (daemon restart, or a fresh CLI-invocation process). If the same underlying condition (e.g. a session's failure rate) crosses the threshold again after a restart, a second, distinct `Alert` row is legitimately inserted for the same `(type, agent_id)` pair.

**Fix**: collapse at render time in `tokenjam/cli/cmd_status.py` (`_dedupe_alerts`) — keep the first (most recent) occurrence of each alert type and print a count suffix when there's more than one: `failure_rate — claude-code ×2`. Distinct alert types for the same agent are unaffected (verified by a dedicated test).

## #2 — `Cost today: $0.000000` shown to subscription-plan users
`tj status`'s Cost line ignored the user's declared `[budget.<provider>].plan` tier entirely — it always called the raw `format_cost`. `tj cost` / `tj optimize` / `tj tokenmaxx` already solve this exact problem via the shared `tokenjam/core/framing.py` module (`compute_framing` + `render_dollar`), so `tj status` now reuses it rather than inventing a fourth convention:
- `_agent_framing()` builds a window-independent `Framing` per agent (same `plan_determination_mix` + `compute_framing` pairing every other plan-aware CLI surface uses).
- `_cost_line()` mirrors `cmd_cost._cost_cell`'s gate: subscription/local pricing modes route through `render_dollar` (known-fee plans → `"X% of cycle"`; team/enterprise/local → `"—"`); api/unknown keep the historical dollar rendering, unchanged.
- `_framing_note()` mirrors `cmd_cost._cost_note` to surface the honesty note under the Cost line (e.g. "Subscription plan — flat-fee billing; cost shown as share of your monthly plan, not dollars spent.").

## #3 — Currency precision
`format_cost` (`tokenjam/utils/formatting.py`) previously rendered 4-6 decimal places unconditionally, producing `$0.000000`, `$1042.4825`-style outputs across status/quickstart/optimize. It's now the single shared rule: **2 decimals under $100, whole dollars with thousands separators at/above $100**. Every `cli/` module that renders a `cost_usd`-style value already imports this shared function (cmd_status, cmd_optimize, cmd_traces, cmd_quickstart, cmd_backfill, cmd_quota_audit, cmd_cost), so the fix applies everywhere with zero call-site changes.

## What's NOT in this PR
- `cmd_optimize.py` needed no changes — it already imports/uses the shared `format_cost`; its CTAs/ordering are being handled by a concurrent PR.
- Not fixing the root cause of the in-memory alert-dedup state resetting on restart (persisting `CooldownTracker`/`_failure_rate_fired` across restarts) — out of scope per the ticket brief, which asks for render-time collapse.

## Tests / Verification
- `tests/unit/test_formatting.py`: rewritten `format_cost` cases for the new 2dp/whole-dollar threshold + thousands separators.
- `tests/unit/test_cmd_cost.py`: updated 3 existing assertions for the new ≥$100 whole-dollar rendering (same honesty intent, just no un-rounded cents: `$2599.13` → `$2,599`).
- `tests/integration/test_cli.py`: new tests — same-type alert collapse with count, distinct-type alerts NOT collapsed, subscription plan shows no raw dollar line + honesty note, API tier keeps the raw dollar line unchanged.
- Full suite: `pytest tests/unit/ tests/synthetic/ tests/agents/ tests/integration/` → 1988 passed, 1 skipped.
- `ruff check` + `mypy` clean on all touched files.

Closes #96

🤖 Generated with [Claude Code](https://claude.com/claude-code)