### PR TITLE
MCP-for-CC copy, Claude 5 pricing, npx bin

### DIFF
--- a/docs/alerts.md
+++ b/docs/alerts.md
@@ -111,6 +111,6 @@ GET  /api/v1/alerts                    # list alerts (supports filtering)
 PATCH /api/v1/alerts/{id}/acknowledge  # mark alert as acknowledged
 ```
 
-## MCP (Claude Code)
+## MCP (SDK / API integrations)
 
-The MCP server exposes `list_alerts` and `acknowledge_alert` tools, so Claude Code can check and manage alerts directly within a session.
+The MCP server exposes `list_alerts` and `acknowledge_alert` tools for SDK / API integrations that already sit in the request path. It is not wired up for Claude Code or Codex (an in-loop MCP is a per-turn quota tax there, ticket #59) — those agents check alerts via `tj` CLI reports or the dashboard instead.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -95,7 +95,7 @@ tokenjam/
 ├── core/       Pure domain logic — NO imports from cli/ or api/
 ├── cli/        Click commands — imports from core/
 ├── api/        FastAPI routes — imports from core/
-├── mcp/        MCP server for Claude Code — imports from core/ and api/
+├── mcp/        MCP server for SDK / API integrations — imports from core/ and api/
 ├── otel/       OTel SDK wiring — imports from core/
 ├── sdk/        Python instrumentation SDK — imports from core/ and otel/
 │   └── integrations/   Provider and framework patches
@@ -303,9 +303,9 @@ The `TjConfig` dataclass tree in `tokenjam/core/config.py` defines the full hier
 
 ---
 
-## MCP server (Claude Code integration)
+## MCP server (SDK / API integration)
 
-`tj mcp` is a stdio-based MCP (Model Context Protocol) server that gives Claude Code direct access to TokenJam observability data. It exposes 13 tools that Claude Code can call during a session.
+`tj mcp` is a stdio-based MCP (Model Context Protocol) server that gives an SDK / API integration direct access to TokenJam observability data. It exposes 13 tools. It is **not** wired up for Claude Code or Codex — an in-loop MCP is a per-turn quota tax on subscription users (+36% measured, ticket #59); those agents get tj out-of-band via the statusline + OTel capture instead. Wire it manually only for an SDK / API integration that already sits in the request path: `claude mcp add tj --scope user -- tj mcp`.
 
 ### Dual-mode operation
 

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -256,7 +256,7 @@ Key flag: `--json`.
 
 ### `tj mcp`
 
-Start the MCP server (stdio transport for Claude Code). Registered automatically by `tj onboard --claude-code`.
+Start the MCP server (stdio transport, for SDK / API integrations). `tj onboard --claude-code` / `--codex` do **not** register it — an in-loop MCP is a per-turn quota tax on subscription users (ticket #59); wire it manually with `claude mcp add tj --scope user -- tj mcp` only if you're building an SDK / API integration.
 
 ```bash
 tj mcp

--- a/docs/harness-integration.md
+++ b/docs/harness-integration.md
@@ -37,8 +37,11 @@ harness conforms to one thin correlation id.
 
 ## Easiest setup: the `setup_harness` MCP command
 
-If you use tj's MCP server (`tj mcp`, wired via `tj onboard --claude-code`), run
-this from **inside your harness repo** in Claude Code:
+`tj onboard --claude-code` does **not** wire the MCP server (an in-loop MCP is a
+per-turn quota tax on subscription users, ticket #59) — but this one-time setup
+helper is a legitimate reason to wire it temporarily. Run
+`claude mcp add tj --scope user -- tj mcp`, then from **inside your harness
+repo** in Claude Code:
 
 - **`setup_harness(mode="instrument")`** — writes a drop-in helper
   (`.tj/run-env.sh`) that mints one run id per launch and exports
@@ -51,7 +54,10 @@ this from **inside your harness repo** in Claude Code:
   recommendation.
 
 After wiring, launch a run and confirm the workers grouped in the Runs view (or
-re-run `mode="map"`).
+re-run `mode="map"`). Once `setup_harness` has done its job, deregister the MCP
+server (`claude mcp remove tj --scope user`) to avoid paying the per-turn tax
+on unrelated sessions — the `.tj/run-env.sh` helper it wrote keeps working
+without it.
 
 ## Wiring it by hand
 

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -29,8 +29,8 @@ written to disk and no background process starts.
 **Requirements:** a Python runner — `uv` (recommended) or `pipx`. `npx tokenjam` prints
 install guidance if neither is present.
 
-When you're ready for live capture, the local dashboard, and the MCP server for
-Claude Code, install the full CLI (below) and run `tj onboard`.
+When you're ready for live capture, the local dashboard, and the zero-token
+statusline, install the full CLI (below) and run `tj onboard`.
 
 ## Base install
 

--- a/npm-wrapper/package.json
+++ b/npm-wrapper/package.json
@@ -12,7 +12,8 @@
     "directory": "npm-wrapper"
   },
   "bin": {
-    "tj": "bin/tj.js"
+    "tj": "bin/tj.js",
+    "tokenjam": "bin/tj.js"
   },
   "files": [
     "bin/tj.js",

--- a/tests/integration/test_cli.py
+++ b/tests/integration/test_cli.py
@@ -487,6 +487,35 @@ def test_doctor_mcp_wiring_checks(runner, db, config, tmp_path):
         assert "project scope" in mcp_checks[0]["message"]
 
 
+def test_doctor_mcp_wiring_message_renders_bracket_literal(runner, db, config, tmp_path):
+    """The Codex removal hint contains the literal TOML section header
+    `[mcp_servers.tj]`. In human (non-JSON) rendering, `_print_check` feeds
+    the message straight into `console.print`, and Rich treats an unescaped
+    `[...]` as a markup tag — stripping it instead of printing it (same class
+    of bug as #157 / PR #407). The console-rendered check must show the
+    bracket text verbatim."""
+    fake_home = tmp_path / "fake_home"
+    fake_home.mkdir()
+    fake_cwd = tmp_path / "fake_cwd"
+    fake_cwd.mkdir()
+
+    _clean_doctor_config(config, tmp_path)
+    config_file = tmp_path / "tokenjam.toml"
+    config_file.write_text('version = "1"\n')
+
+    codex_dir = fake_home / ".codex"
+    codex_dir.mkdir(parents=True, exist_ok=True)
+    (codex_dir / "config.toml").write_text("[mcp_servers.tj]\ncommand = 'tj'\nargs = ['mcp']\n")
+
+    with patch("pathlib.Path.home", return_value=fake_home), \
+         patch("pathlib.Path.cwd", return_value=fake_cwd), \
+         patch("shutil.which", return_value=None), \
+         patch("tokenjam.cli.cmd_doctor.find_config_file", return_value=config_file):
+        result = _invoke(runner, db, config, ["doctor"])
+
+    assert "[mcp_servers.tj]" in result.output
+
+
 # -- since flag parsing --
 
 def test_since_flag_parses_all_formats(runner, db, config):

--- a/tests/integration/test_cli.py
+++ b/tests/integration/test_cli.py
@@ -424,7 +424,10 @@ def test_doctor_mcp_wiring_checks(runner, db, config, tmp_path):
         assert statusline_checks and statusline_checks[0]["level"] == "warning"
         assert "tj onboard --claude-code" in statusline_checks[0]["message"]
 
-    # Case 3: MCP registered globally in Codex (~/.codex/config.toml) -> should be level: "ok"
+    # Case 3: MCP registered globally in Codex (~/.codex/config.toml) -> should
+    # be level "warning" (#94): Codex gets the same +36% quota-tax reasoning as
+    # Claude Code (see cmd_onboard.py's Codex path, which actively retires this
+    # legacy block), so a green check here would contradict the #59 decision.
     codex_dir = fake_home / ".codex"
     codex_dir.mkdir(parents=True, exist_ok=True)
     codex_config = codex_dir / "config.toml"
@@ -435,17 +438,20 @@ def test_doctor_mcp_wiring_checks(runner, db, config, tmp_path):
          patch("shutil.which", return_value=None), \
          patch("tokenjam.cli.cmd_doctor.find_config_file", return_value=config_file):
         result = _invoke(runner, db, config, ["doctor", "--json"])
-        assert result.exit_code == 0
+        assert result.exit_code == 1
         checks = json.loads(result.output)
         mcp_checks = [c for c in checks if c["name"] == "MCP wiring"]
-        assert mcp_checks and mcp_checks[0]["level"] == "ok"
+        assert mcp_checks and mcp_checks[0]["level"] == "warning"
         assert "Codex" in mcp_checks[0]["message"]
+        assert "#59" in mcp_checks[0]["message"]
 
     # Clean up codex file
     codex_config.unlink()
     codex_dir.rmdir()
 
-    # Case 4: MCP registered globally in Claude Code (~/.claude.json) -> should be level: "ok"
+    # Case 4: MCP registered globally in Claude Code (~/.claude.json) -> should
+    # be level "warning" (#94) — a green check for this state contradicts the
+    # #59 decision to keep MCP out of the Claude Code loop.
     claude_json = fake_home / ".claude.json"
     claude_json.write_text('{"mcpServers": {"tj": {"command": "tj"}}}')
 
@@ -454,16 +460,18 @@ def test_doctor_mcp_wiring_checks(runner, db, config, tmp_path):
          patch("shutil.which", return_value=None), \
          patch("tokenjam.cli.cmd_doctor.find_config_file", return_value=config_file):
         result = _invoke(runner, db, config, ["doctor", "--json"])
-        assert result.exit_code == 0
+        assert result.exit_code == 1
         checks = json.loads(result.output)
         mcp_checks = [c for c in checks if c["name"] == "MCP wiring"]
-        assert mcp_checks and mcp_checks[0]["level"] == "ok"
+        assert mcp_checks and mcp_checks[0]["level"] == "warning"
         assert "Claude Code" in mcp_checks[0]["message"]
+        assert "claude mcp remove tj --scope user" in mcp_checks[0]["message"]
 
     # Clean up claude json file
     claude_json.unlink()
 
-    # Case 5: MCP registered locally in project-level .mcp.json -> should be level: "ok"
+    # Case 5: MCP registered locally in project-level .mcp.json -> should be
+    # level "warning" (#94) — same quota-tax reasoning applies at project scope.
     project_mcp = fake_cwd / ".mcp.json"
     project_mcp.write_text('{"mcpServers": {"tj": {"command": "tj"}}}')
 
@@ -472,10 +480,10 @@ def test_doctor_mcp_wiring_checks(runner, db, config, tmp_path):
          patch("shutil.which", return_value=None), \
          patch("tokenjam.cli.cmd_doctor.find_config_file", return_value=config_file):
         result = _invoke(runner, db, config, ["doctor", "--json"])
-        assert result.exit_code == 0
+        assert result.exit_code == 1
         checks = json.loads(result.output)
         mcp_checks = [c for c in checks if c["name"] == "MCP wiring"]
-        assert mcp_checks and mcp_checks[0]["level"] == "ok"
+        assert mcp_checks and mcp_checks[0]["level"] == "warning"
         assert "project scope" in mcp_checks[0]["message"]
 
 

--- a/tests/unit/test_quickstart.py
+++ b/tests/unit/test_quickstart.py
@@ -150,8 +150,9 @@ def test_quickstart_renders_without_daemon_or_ondisk_db(tmp_path):
     # Both halves of the first-run value are present.
     assert "quota" in result.output.lower()
     assert "Session timeline" in result.output
-    # The opt-in "go deeper" pointer keeps the daemon path discoverable.
-    assert "tj onboard" in result.output
+    # The opt-in "go deeper" pointer prints the full pasteable install command,
+    # since the quickstart audience has no `tj` on PATH (it ran via `npx tokenjam`).
+    assert "pipx install tokenjam && tj onboard" in result.output
 
 
 def test_quickstart_json_emits_both_views(tmp_path):

--- a/tokenjam/cli/cmd_doctor.py
+++ b/tokenjam/cli/cmd_doctor.py
@@ -4,6 +4,7 @@ import json
 
 import click
 import duckdb
+from rich.markup import escape
 
 from tokenjam.core.config import find_config_file, load_config
 from tokenjam.utils.formatting import console
@@ -626,4 +627,7 @@ def _print_check(check: dict) -> None:
     icons = {"ok": "[green]\u2713[/green]", "warning": "[yellow]\u26a0[/yellow]",
              "error": "[red]\u2717[/red]", "info": "[blue]i[/blue]"}
     icon = icons.get(level, "?")
-    console.print(f"  {icon}  {check['name']}: {check['message']}")
+    # Check names/messages are plain text, not Rich markup \u2014 a literal
+    # bracketed value inside one (e.g. the `[mcp_servers.tj]` TOML section
+    # header) would otherwise be parsed as a markup tag and stripped.
+    console.print(f"  {icon}  {escape(check['name'])}: {escape(check['message'])}")

--- a/tokenjam/cli/cmd_doctor.py
+++ b/tokenjam/cli/cmd_doctor.py
@@ -515,22 +515,37 @@ def _check_mcp_wiring(config: object) -> dict:
 
     # The MCP is an SDK / API surface, not a Claude Code / Codex one (#59): an
     # in-loop MCP is a per-turn quota burden on subscription users, so its
-    # ABSENCE for a coding agent is the correct state, never a warning. If it is
-    # registered (an SDK user, or a legacy CC/Codex registration) just report it.
+    # ABSENCE for a coding agent is the correct state, never a warning. A
+    # registration found in Claude Code, Codex, or project scope is exactly
+    # the quota-tax footgun this check exists to catch (`tj onboard` hasn't
+    # written any of these since #59 — see cmd_onboard.py's Codex path,
+    # which actively retires a legacy block) — flag it, don't green-check it.
     if has_codex or has_claude or has_project:
         found_locations = []
+        removal_hints = []
         if has_codex:
             found_locations.append("Codex (global)")
+            removal_hints.append(
+                "`tj onboard --codex --reconfigure` retires the legacy "
+                "[mcp_servers.tj] block"
+            )
         if has_claude:
             found_locations.append("Claude Code (global)")
+            removal_hints.append("`claude mcp remove tj --scope user` to deregister")
         if has_project:
             found_locations.append("project scope")
+            removal_hints.append(
+                "remove the `tj` entry from .mcp.json / .claude.json in this project"
+            )
         return {
             "name": "MCP wiring",
-            "level": "ok",
+            "level": "warning",
             "message": (
-                f"MCP server registered in {', '.join(found_locations)} "
-                "(the in-request-path surface for SDK / API use)."
+                f"MCP server registered in {', '.join(found_locations)} — an "
+                "in-loop MCP is a per-turn quota tax on subscription users "
+                "(+36% measured, ticket #59), not the recommended surface for "
+                "Claude Code / Codex. Remove it: " + "; ".join(removal_hints) + ". "
+                "The MCP is meant for SDK / API integrations only."
             ),
         }
 

--- a/tokenjam/cli/cmd_quickstart.py
+++ b/tokenjam/cli/cmd_quickstart.py
@@ -18,7 +18,8 @@ Design (what makes it "zero-setup"):
       - a session timeline from :mod:`tokenjam.core.session_timeline`.
   * The output **leads with reads-your-local-logs + added-value framing** —
     "reads your ~/.claude session logs; here's where your quota actually goes" —
-    then ends on the opt-in "go deeper" pointer to ``tj onboard`` (daemon / MCP / live).
+    then ends on the opt-in "go deeper" pointer to ``tj onboard`` (daemon /
+    statusline / live capture).
 
 Because it manages its own transient DB, ``quickstart`` is registered in
 ``no_db_commands`` so the CLI never opens the on-disk DB or trips the daemon's
@@ -73,7 +74,7 @@ def cmd_quickstart(ctx: click.Context, since: str, root_path: str | None,
     no daemon, no onboarding. On a large history the first run caps at the
     most-recent sessions for speed (use `--full` for everything). Run
     `tj onboard` afterwards to go deeper (live capture, the dashboard, and the
-    MCP server for Claude Code).
+    zero-token statusline).
     """
     from pathlib import Path
 
@@ -282,8 +283,8 @@ def _render(diag, timeline, *, since: str,
     deeper = Text()
     deeper.append("Go deeper: ", style="bold")
     deeper.append("`tj onboard`", style="bold cyan")
-    deeper.append(" sets up live capture, the local dashboard, and the MCP "
-                  "server for Claude Code (the opt-in daemon path).", style="dim")
+    deeper.append(" sets up live capture, the local dashboard, and the "
+                  "zero-token statusline (the opt-in daemon path).", style="dim")
     console.print(deeper)
     console.print()
 

--- a/tokenjam/cli/cmd_quickstart.py
+++ b/tokenjam/cli/cmd_quickstart.py
@@ -281,11 +281,12 @@ def _render(diag, timeline, *, since: str,
     console.print(f"  [dim]{diag.caveat}[/dim]")
     console.print()
     deeper = Text()
-    deeper.append("Go deeper: ", style="bold")
-    deeper.append("`tj onboard`", style="bold cyan")
-    deeper.append(" sets up live capture, the local dashboard, and the "
-                  "zero-token statusline (the opt-in daemon path).", style="dim")
+    deeper.append("Go deeper", style="bold")
+    deeper.append(" — install and set up live capture, the local dashboard, "
+                  "and the zero-token statusline:", style="dim")
     console.print(deeper)
+    console.print()
+    console.print(Text("  pipx install tokenjam && tj onboard", style="bold cyan"))
     console.print()
 
 

--- a/tokenjam/core/cost.py
+++ b/tokenjam/core/cost.py
@@ -46,8 +46,9 @@ def calculate_cost(
         if key not in _UNKNOWN_MODEL_WARNED:
             _UNKNOWN_MODEL_WARNED.add(key)
             logger.warning(
-                "No pricing data for %s/%s — using default rates. "
-                "Add to tokenjam/pricing/models.toml to get accurate costs.",
+                "No pricing data for %s/%s — using default rates (cost figures "
+                "may be inaccurate). Upgrade tokenjam for current pricing, or "
+                "add an override to ~/.config/tj/pricing.toml — see `tj pricing list`.",
                 provider, model,
             )
         rates = ModelRates(

--- a/tokenjam/pricing/models.toml
+++ b/tokenjam/pricing/models.toml
@@ -46,6 +46,16 @@ output_per_mtok = 25.00
 cache_read_per_mtok = 0.50
 cache_write_per_mtok = 6.25
 
+# Claude Sonnet 5 — introductory pricing in effect through 2026-08-31 (see
+# https://platform.claude.com/docs/en/about-claude/pricing#claude-sonnet-5-introductory-pricing);
+# standard pricing ($3/$15 input/output) takes over 2026-09-01 — update this
+# row then. cache_write = 5-minute write.
+[anthropic.claude-sonnet-5]
+input_per_mtok = 2.00
+output_per_mtok = 10.00
+cache_read_per_mtok = 0.20
+cache_write_per_mtok = 2.50
+
 [anthropic.claude-sonnet-4-6]
 input_per_mtok = 3.00
 output_per_mtok = 15.00


### PR DESCRIPTION
Pre-launch polish of the published first-run experience, bundling three related tickets from a 2026-07-07 live dogfood session into one PR.

## Summary
- Removed all stale MCP-for-Claude-Code steering copy (quickstart outro + `tj doctor`'s MCP wiring check + a docs/ sweep), contradicting issue #59's measured +36% quota-tax decision.
- Added Claude Sonnet 5 to `pricing/models.toml` (was missing, causing every current transcript to print a pricing-fallback warning as line 1 of `npx tokenjam` output) and reworded that fallback warning to something an npx user can actually act on.
- Made `npm-wrapper/package.json`'s bin mapping explicit so `npx tokenjam` resolves by name instead of npm's single-bin fallback.

## #94 — stale MCP-for-Claude-Code copy contradicting #59
- `cmd_quickstart.py`: outro/docstrings now say "the zero-token statusline" instead of "the MCP server for Claude Code".
- `cmd_doctor.py`'s `_check_mcp_wiring`: a detected registration in Claude Code, Codex, **or** project scope now returns `level: warning` (with the quota-tax rationale + a concrete removal command) instead of a green `ok`. I included Codex, not just Claude Code, because `cmd_onboard.py`'s own Codex path already treats an in-loop MCP the same way (it actively retires a legacy `[mcp_servers.tj]` block on re-onboard) — this check has no config signal that can distinguish a genuine SDK-context registration from a stale/misconfigured coding-agent one, so any detected registration is exactly the footgun the check exists to catch.
- Swept `docs/` (architecture.md, alerts.md, cli-reference.md, installation.md, harness-integration.md) for the same stale "MCP = Claude Code integration" framing and corrected each to SDK/API-only framing. `harness-integration.md` claimed `tj mcp` is "wired via `tj onboard --claude-code`" — that's simply false post-#59 — so I reworded its one legitimate one-time-setup use case to the manual `claude mcp add`/`remove` flow, with a nudge to deregister afterward.

## #95 — Claude 5 pricing missing + unactionable fallback warning
- `pricing/models.toml` had Fable 5, Opus 4.8, and Haiku 4.5 rows but not Sonnet 5 — added `[anthropic.claude-sonnet-5]` using Anthropic's published introductory pricing ($2/$10 input/output, $2.50 5-minute cache write, $0.20 cache read) which is in effect through 2026-08-31 per https://platform.claude.com/docs/en/about-claude/pricing#claude-sonnet-5-introductory-pricing — with a comment flagging the 2026-09-01 step to standard $3/$15 rates so a future maintainer knows to update it.
- Reworded the "No pricing data" fallback warning in `core/cost.py` — it used to point an npx user at `tokenjam/pricing/models.toml`, an internal repo path they can't edit. Now it says to upgrade tokenjam, or add an override to `~/.config/tj/pricing.toml` (an existing, real override mechanism — see `tj pricing list`).
- **Not done:** moving the warning to print after the report instead of as line 1. It's emitted via `logging.warning()` deep inside per-span cost calculation during ingest, which runs before the report renders — deferring it would need a warning collector threaded through the ingest pipeline back up to the CLI command. That's more invasive than this PR's scope; the "Done when" criterion (no warning on current transcripts) is met by the pricing fix. Flagging as a possible follow-up.

## #87 — npx single-bin fallback
- Added an explicit `"tokenjam": "bin/tj.js"` bin alongside the existing `"tj": "bin/tj.js"` in `npm-wrapper/package.json`, so `npx tokenjam` resolves by name instead of relying on npm's implicit single-bin fallback. `bin/tj.js` only reads `process.argv`, never the invoked command name, so this is behavior-neutral — verified with `node -c` and a manual local run.
- Did not bump the wrapper's version or publish to npm. Per `CLAUDE.md`, `publish-npm.yml`'s `publish-npm-wrapper` job derives the published version from the release tag; the literal in `package.json` is only a floor for local `npm pack` sanity and isn't meant to be manually bumped per release.

## Tests / Verification
- `tests/integration/test_cli.py::test_doctor_mcp_wiring_checks` updated: cases 3/4/5 (Codex, Claude Code global, project scope) now assert `level == "warning"` and `exit_code == 1` instead of `"ok"`/`0`, matching the corrected behavior.
- Full suite: `pytest tests/unit/ tests/synthetic/ tests/agents/ tests/integration/` → 1981 passed, 1 skipped (pre-existing).
- `ruff check tokenjam/` and `mypy tokenjam/` clean.
- Live verification: built a fixture Claude Code session JSONL with `model: "claude-sonnet-5"` and ran `tj quickstart` against it via `CliRunner` — no pricing warning, cost correctly computed at the new Sonnet 5 rate ($0.0040 for 1000 in / 200 out tokens), outro shows the corrected statusline copy. Separately confirmed via `tj doctor --json` with a stubbed `~/.claude.json` MCP registration that the check now returns `level: "warning"` with the quota-tax message and removal command.
- `node -c npm-wrapper/bin/tj.js` and a JSON parse of `npm-wrapper/package.json` both pass.

## What's NOT in this PR
- The #95 warning-timing reordering (see above) — deferred, not required by the ticket's Done-when criteria.
- Any npm publish for #87 — explicitly out of scope per the brief.

🤖 Generated with [Claude Code](https://claude.com/claude-code)