### PR TITLE
Fix #97: tj optimize ranks findings by reclaimable share + persona-aware downsize CTA

### DIFF
--- a/tests/integration/test_cli.py
+++ b/tests/integration/test_cli.py
@@ -1115,6 +1115,121 @@ def test_optimize_json_includes_plan_and_pricing_mode(runner, db, config):
         assert "monthly_tokens_freed" in data["downgrade"]
 
 
+def test_optimize_ranks_findings_by_reclaimable_share_not_registry_order(runner, db, config):
+    """#97: a downsize finding whose candidates hold a negligible share of
+    the window's tokens must not occupy the numbered ① slot ahead of a
+    finding that's actually reclaiming a meaningful fraction of the window
+    — the exact bug: "① Model downgrade: 28% of sessions match" when those
+    sessions held ~0% of the window's tokens, because downsize always
+    rendered first (ANALYZER_ORDER), not by size of the opportunity.
+    """
+    from datetime import timedelta
+    from tests.factories import make_llm_span, make_session, make_tool_span
+    from tokenjam.utils.time_parse import utcnow
+
+    now = utcnow()
+
+    # Small-opus downsize candidate: matches the structural heuristic, but
+    # its tokens are a tiny fraction of the window once the noise below is
+    # added (1_200 / ~501_200 ≈ 0.2%).
+    db.insert_span(make_llm_span(
+        agent_id="test-agent", model="claude-opus-4-7", provider="anthropic",
+        input_tokens=1000, output_tokens=200, cost_usd=0.03,
+        session_id="small-opus", start_time=now - timedelta(days=1),
+    ))
+
+    # Noise: large LLM sessions that don't match the downgrade shape (input
+    # far exceeds SMALL_INPUT_TOKENS) but dominate window.total_tokens.
+    for i in range(10):
+        db.insert_span(make_llm_span(
+            agent_id="test-agent", model="claude-sonnet-4-5", provider="anthropic",
+            input_tokens=50_000, output_tokens=1_000, cost_usd=1.0,
+            session_id=f"noise-{i}", start_time=now - timedelta(days=1),
+        ))
+
+    # Identical-signature cluster: 20 single-tool-call sessions, each with
+    # 5_000 session-level tokens — ~20% of the window, dwarfing the downsize
+    # candidate's ~0.2%. (Both the script and reuse analyzers key off this
+    # same repeated-tool-sequence signal; whichever surfaces a cluster wins
+    # the top slot — the point being it's not downsize.)
+    for i in range(20):
+        sid = f"cluster-{i}"
+        db.upsert_session(make_session(
+            agent_id="test-agent", session_id=sid,
+            input_tokens=4_000, output_tokens=1_000, total_cost_usd=0.05,
+        ))
+        tool = make_tool_span(agent_id="test-agent", tool_name="Read")
+        tool.session_id = sid
+        tool.start_time = now - timedelta(days=1)
+        db.insert_span(tool)
+
+    result = _invoke(runner, db, config, ["optimize"])
+    assert result.exit_code == 0
+    out = result.output
+
+    # The bigger reclaimable-share finding leads — not downsize, even though
+    # downsize always ran first in ANALYZER_ORDER.
+    assert "① Workflow restructure" in out or "① Reuse" in out
+    # ...and downsize no longer gets the fixed ① slot it always used to.
+    assert "① Model downgrade" not in out
+    # It's still surfaced — honesty discipline forbids a silent drop — just
+    # collapsed into the de-minimis pointer list instead of a numbered slot.
+    assert "Minor findings" in out
+    assert "Model downgrade" in out
+    assert "of window tokens" in out
+
+
+def test_optimize_downsize_cta_matches_claude_code_persona(runner, db, config):
+    """#97: a window dominated by claude-code-* sessions gets the Claude Code
+    routing CTA (route export / subagent right-sizing / /compact), not the
+    SDK-only `tjb run --original ... --candidate ...` command a subscription
+    user has no way to act on."""
+    from datetime import timedelta
+    from tests.factories import make_llm_span, make_session
+    from tokenjam.utils.time_parse import utcnow
+
+    now = utcnow()
+    db.upsert_session(make_session(
+        agent_id="claude-code-my-project", session_id="s-small", plan_tier="max_5x",
+    ))
+    db.insert_span(make_llm_span(
+        agent_id="claude-code-my-project", model="claude-opus-4-7", provider="anthropic",
+        input_tokens=1000, output_tokens=200, cost_usd=0.03,
+        session_id="s-small", start_time=now - timedelta(days=1),
+    ))
+
+    result = _invoke(runner, db, config, ["optimize"])
+    assert result.exit_code == 0
+    out = result.output
+
+    assert "tj route export --target ccr" in out
+    assert "tj optimize subagent" in out
+    assert "/compact" in out
+    # tjb is still mentioned, but only as the secondary SDK note.
+    assert "If you also run SDK agents" in out
+
+
+def test_optimize_downsize_cta_unchanged_for_sdk_persona(runner, db, config):
+    """A non-Claude-Code (SDK/API) persona keeps the original tjb CTA."""
+    from datetime import timedelta
+    from tests.factories import make_llm_span
+    from tokenjam.utils.time_parse import utcnow
+
+    db.insert_span(make_llm_span(
+        agent_id="sdk-worker", model="claude-opus-4-7", provider="anthropic",
+        input_tokens=1000, output_tokens=200, cost_usd=0.03,
+        session_id="s-small", start_time=utcnow() - timedelta(days=1),
+    ))
+
+    result = _invoke(runner, db, config, ["optimize"])
+    assert result.exit_code == 0
+    out = result.output
+
+    assert "Candidate only — prove it holds before switching:" in out
+    assert "pip install tokenjam-bench" in out
+    assert "tj route export --target ccr" not in out
+
+
 def test_cost_compare_renders_window_diff(runner, db, config):
     """`tj cost --compare previous` produces a diff report against the prior window."""
     from datetime import timedelta

--- a/tests/unit/test_framing.py
+++ b/tests/unit/test_framing.py
@@ -16,6 +16,7 @@ from tokenjam.core.framing import (
     compute_framing,
     config_declared_plan,
     config_declared_plan_labels,
+    dominant_persona,
     dominant_plan,
     pricing_mode_for,
     render_dollar,
@@ -303,3 +304,48 @@ def test_framing_to_dict_has_contract_fields():
         "qualifier_text",
     ):
         assert key in d
+
+
+# --------------------------------------------------------------------------- #
+# agent_persona_mix / dominant_persona — Claude Code vs SDK/API developer (#97)
+# --------------------------------------------------------------------------- #
+def test_agent_persona_mix_classifies_by_claude_code_prefix():
+    from unittest.mock import MagicMock
+
+    from tokenjam.core.framing import agent_persona_mix
+
+    conn = MagicMock()
+    conn.execute.return_value.fetchall.return_value = [
+        ("claude-code-my-project",), ("claude-code-other",), ("sdk-agent-x",),
+    ]
+    result = agent_persona_mix(conn, agent_id="agent-x")
+    assert result == {"claude_code": 2, "other": 1}
+    sql, params = conn.execute.call_args[0]
+    assert "agent_id = $" in sql
+    assert params == ["agent-x"]
+
+
+def test_agent_persona_mix_empty_when_no_sessions():
+    from unittest.mock import MagicMock
+
+    from tokenjam.core.framing import agent_persona_mix
+
+    conn = MagicMock()
+    conn.execute.return_value.fetchall.return_value = []
+    assert agent_persona_mix(conn) == {"claude_code": 0, "other": 0}
+
+
+@pytest.mark.parametrize("mix,expected", [
+    ({"claude_code": 9, "other": 1}, "claude-code"),
+    ({"claude_code": 1, "other": 9}, "sdk"),
+    ({"claude_code": 5, "other": 5}, "mixed"),
+])
+def test_dominant_persona_from_agent_mix(mix, expected):
+    assert dominant_persona(mix) == expected
+
+
+def test_dominant_persona_falls_back_to_declared_plan_when_mix_empty():
+    assert dominant_persona({"claude_code": 0, "other": 0}, declared_plan="max_5x") == "claude-code"
+    assert dominant_persona({"claude_code": 0, "other": 0}, declared_plan="api") == "sdk"
+    assert dominant_persona({"claude_code": 0, "other": 0}, declared_plan=None) == "unknown"
+    assert dominant_persona({}, declared_plan="pro") == "claude-code"

--- a/tokenjam/api/routes/optimize.py
+++ b/tokenjam/api/routes/optimize.py
@@ -19,7 +19,12 @@ from typing import Any
 from fastapi import APIRouter, Depends, HTTPException, Query, Request
 
 from tokenjam.api.deps import require_api_key
-from tokenjam.core.framing import WindowSummary, compute_framing, plan_tier_mix
+from tokenjam.core.framing import (
+    WindowSummary,
+    agent_persona_mix,
+    compute_framing,
+    plan_tier_mix,
+)
 from tokenjam.core.optimize import ANALYZER_REGISTRY, build_report, report_to_dict
 from tokenjam.utils.time_parse import parse_since, utcnow
 
@@ -110,6 +115,17 @@ def get_optimize(
             payload["plan_tier_mix"] = {}
     else:
         payload["plan_tier_mix"] = {}
+
+    # Agent-persona mix (#97) — same best-effort daemon-mode plumbing as
+    # plan_tier_mix above, so the CLI's downsize CTA can tell a Claude Code
+    # subscriber from an SDK/API developer whether or not the daemon is up.
+    if conn is not None:
+        try:
+            payload["agent_persona_mix"] = agent_persona_mix(conn, since_dt, until_dt, agent_id)
+        except Exception:
+            payload["agent_persona_mix"] = {}
+    else:
+        payload["agent_persona_mix"] = {}
 
     # Plan-tier framing block (#110) — built from the report window + the
     # plan-tier mix above, so the local web UI frames recoverable-savings and

--- a/tokenjam/cli/cmd_optimize.py
+++ b/tokenjam/cli/cmd_optimize.py
@@ -2,13 +2,16 @@
 from __future__ import annotations
 
 import json
+from typing import Any
 
 import click
 from rich.markup import escape as _rich_escape
 
 from tokenjam.core.framing import (
     PLAN_LABEL_AND_FEE,
+    agent_persona_mix,
     config_declared_plan,
+    dominant_persona,
     dominant_plan,
     plan_tier_mix,
     pricing_mode_for,
@@ -33,7 +36,10 @@ from tokenjam.utils.time_parse import parse_since, utcnow
 # Plan-tier framing helpers (PLAN_LABEL_AND_FEE, pricing_mode_for,
 # dominant_plan, config_declared_plan, plan_tier_mix) live in
 # tokenjam.core.framing — the single source shared with cmd_tokenmaxx and the
-# REST API. See issue #110.
+# REST API. See issue #110. agent_persona_mix / dominant_persona (also
+# framing.py) classify the window's dominant user (Claude Code subscriber vs
+# SDK/API developer) so the downsize finding's call-to-action matches the
+# levers that persona actually has — see #97.
 
 
 @click.command("optimize")
@@ -151,6 +157,10 @@ def cmd_optimize(
         # #68 §12 follow-up #29, so the CLI can render subscription /
         # local / unknown framings correctly under daemon mode.
         plan_mix = report_dict.get("plan_tier_mix") or {}
+        # Agent-persona mix (#97) — same daemon-mode plumbing as plan_mix
+        # above, so the downsize CTA matches persona whether or not the
+        # daemon is up.
+        agent_mix = report_dict.get("agent_persona_mix") or {}
     else:
         row = conn.execute(
             "SELECT COUNT(*) FROM spans WHERE model IS NOT NULL"
@@ -183,10 +193,12 @@ def cmd_optimize(
         )
 
         plan_mix = plan_tier_mix(conn, since_dt, until_dt, agent)
+        agent_mix = agent_persona_mix(conn, since_dt, until_dt, agent)
 
     dominant = dominant_plan(plan_mix)
     pricing_mode = pricing_mode_for(dominant)
     declared_plan = config_declared_plan(config)
+    persona = dominant_persona(agent_mix, declared_plan=declared_plan)
 
     # --export-config branch: write the snippet to disk and exit. Skips
     # the normal rendering path. The user reads the snippet file and
@@ -242,6 +254,8 @@ def cmd_optimize(
         payload["plan_tier_mix"] = plan_mix
         payload["plan"] = dominant
         payload["pricing_mode"] = pricing_mode
+        payload["agent_persona_mix"] = agent_mix
+        payload["persona"] = persona
         if cost_diff is not None:
             from tokenjam.cli.cmd_cost import _diff_to_dict
             payload["compare"] = _diff_to_dict(cost_diff)
@@ -267,6 +281,7 @@ def cmd_optimize(
         dominant_plan=dominant, pricing_mode=pricing_mode,
         declared_plan=declared_plan,
         requested=list(findings) if findings else None,
+        persona=persona,
     )
     if cost_diff is not None:
         from tokenjam.cli.cmd_cost import _render_diff
@@ -276,6 +291,94 @@ def cmd_optimize(
         from tokenjam.cli.cmd_cost import _render_diff_dict
         console.print("\n[bold]Window comparison[/bold]")
         _render_diff_dict(cost_diff_dict)
+
+
+# ---------------------------------------------------------------------------
+# Finding ranking (#97) — order the numbered slots by reclaimable share of
+# the window's tokens, instead of ANALYZER_ORDER (registry order).
+# ---------------------------------------------------------------------------
+
+# Minimum estimated-recoverable-token share of the window for a finding to
+# occupy a numbered slot. Below this, ranking by share is noise — a finding
+# whose analyzer merely happened to run first shouldn't outrank one that's
+# actually reclaiming a meaningful fraction of the window. Findings below the
+# threshold still render, just collapsed into the "Minor findings" pointer
+# list instead of a numbered slot.
+DE_MINIMIS_SHARE = 0.01
+
+# Display labels for the "Minor findings" collapsed pointer list — must match
+# the header text each renderer prints in its numbered form.
+_MINOR_FINDING_LABELS = {
+    "downsize":        "Model downgrade",
+    "cache":           "Cache efficacy",
+    "cache-recommend": "Cache recommend",
+    "script":          "Workflow restructure",
+    "reuse":           "Reuse",
+    "trim":            "Prompt bloat",
+    "subagent":        "Subagent right-sizing",
+}
+
+
+def _numbered_marker(n: int) -> str:
+    """Circled-digit marker for a ranked finding's slot (①, ②, … ⑳)."""
+    if 1 <= n <= 20:
+        return chr(0x2460 + n - 1)
+    return f"({n})"  # defensive — no report should ever have this many
+
+
+def _reclaimable_share(finding: Any, window_total_tokens: int) -> float | None:
+    """Estimated-recoverable-tokens share of the window, for ranking.
+
+    Returns ``None`` — not 0.0 — when the finding has no quantified estimate
+    at all (analyzer disabled, no candidates, or cache-recommend, which
+    recommends a cache_control placement rather than a token count). Those
+    findings still render in full (they're not "de-minimis", they're
+    "unranked") — only a finding with a real-but-tiny share collapses into
+    the Minor findings pointer list. Conflating the two would hide an
+    analyzer's own diagnostic empty-state message (e.g. "no tool spans in
+    this window") behind a generic pointer.
+    """
+    tokens = getattr(finding, "estimated_recoverable_tokens", None)
+    if tokens is None or window_total_tokens <= 0:
+        return None
+    return max(float(tokens), 0.0) / window_total_tokens
+
+
+def _rank_findings(
+    report: OptimizeReport, requested: list[str] | None,
+) -> list[tuple[str, float | None]]:
+    """Rank findings with something to show by reclaimable token share
+    (largest first; unranked findings — no quantified estimate — sort last).
+    Ties fall back to ANALYZER_ORDER for determinism.
+    """
+    window_tokens = report.window.total_tokens
+    order = ["downsize", *_FINDING_RENDERERS.keys()]
+    order_index = {name: i for i, name in enumerate(order)}
+
+    items: list[tuple[str, float | None]] = []
+    # Render an explicit "no candidates" empty state when the downsize
+    # analyzer ran but found nothing — the Optimize web tab does this
+    # (PR #130 / issue #126) and the CLI used to silently skip the section,
+    # which makes reviewers think the analyzer didn't run. Skip the empty
+    # state when the user asked for a different positional subset
+    # (`tj optimize cache` shouldn't mention downsize at all).
+    downsize_was_requested = (not requested) or ("downsize" in requested)
+    if report.downgrade is not None:
+        items.append(("downsize", _reclaimable_share(report.downgrade, window_tokens)))
+    elif downsize_was_requested:
+        items.append(("downsize", None))
+
+    for name, finding in (report.findings or {}).items():
+        if name not in _FINDING_RENDERERS:
+            continue
+        items.append((name, _reclaimable_share(finding, window_tokens)))
+
+    items.sort(key=lambda item: (
+        item[1] is None,
+        -(item[1] or 0.0),
+        order_index.get(item[0], len(order)),
+    ))
+    return items
 
 
 # ---------------------------------------------------------------------------
@@ -290,6 +393,7 @@ def _render_report(
     pricing_mode: str = "unknown",
     declared_plan: str | None = None,
     requested: list[str] | None = None,
+    persona: str = "unknown",
 ) -> None:
     w = report.window
     scope_tag = f", {agent}" if agent else ""
@@ -380,29 +484,58 @@ def _render_report(
     if report.notes:
         console.print()
 
-    # ----- Model-downgrade body -----
-    # Render an explicit "no candidates" empty state when the analyzer ran
-    # but found nothing — the Optimize web tab does this (PR #130 / issue
-    # #126) and the CLI used to silently skip the section, which makes
-    # reviewers think the analyzer didn't run. Skip the empty state when
-    # the user asked for a different positional subset (`tj optimize cache`
-    # shouldn't mention downsize at all).
-    downsize_was_requested = (not requested) or ("downsize" in requested)
-    if report.downgrade is not None:
-        _render_downgrade(
-            report.downgrade,
-            pricing_mode=("unknown" if all_unknown else pricing_mode),
-        )
+    # ----- Findings, ranked by reclaimable share of the window's tokens -----
+    # Findings used to render in ANALYZER_ORDER (registry order), so a
+    # nothing-burger could occupy the top numbered slot just because its
+    # analyzer happened to run first — e.g. "① Model downgrade: 28% of
+    # sessions match" when those sessions held ~0% of the window's tokens
+    # (#97). Rank by estimated_recoverable_tokens / window.total_tokens
+    # instead. Three buckets:
+    #   major    — real, meaningful share: numbered slot, full render.
+    #   unranked — no quantified estimate at all (disabled / no candidates):
+    #              full render (own empty-state message), unnumbered — same
+    #              as the historical behavior, so diagnostic detail ("no tool
+    #              spans in this window") never disappears.
+    #   minor    — real but de-minimis share: collapsed to a one-line pointer
+    #              so it can't crowd out a finding that actually matters.
+    ranked = _rank_findings(report, requested)
+    major = [item for item in ranked if item[1] is not None and item[1] >= DE_MINIMIS_SHARE]
+    unranked = [item for item in ranked if item[1] is None]
+    minor = [item for item in ranked if item[1] is not None and item[1] < DE_MINIMIS_SHARE]
+
+    def _render_finding(name: str, marker: str) -> None:
+        if name == "downsize":
+            if report.downgrade is not None:
+                _render_downgrade(
+                    report.downgrade,
+                    pricing_mode=("unknown" if all_unknown else pricing_mode),
+                    persona=persona,
+                    marker=marker,
+                )
+            else:
+                console.print(
+                    f"{_finding_header(marker, 'Model downgrade:')} "
+                    "[dim]no candidates in this window — sessions don't match "
+                    "the smaller-model shape (small input/output, few tool "
+                    "calls).[/dim]"
+                )
+        else:
+            _FINDING_RENDERERS[name](
+                report.findings[name], pricing_mode=pricing_mode, marker=marker,
+            )
+
+    for slot, (name, _share) in enumerate(major, start=1):
+        _render_finding(name, _numbered_marker(slot))
         console.print()
-    elif downsize_was_requested:
-        console.print(
-            "  [bold]① Downsize:[/bold] "
-            "[dim]no candidates in this window — sessions don't match the "
-            "smaller-model shape (small input/output, few tool calls).[/dim]"
-        )
+
+    for name, _share in unranked:
+        _render_finding(name, "")
         console.print()
 
     # ----- Budget projection -----
+    # Not part of the reclaimable-share ranking above — it's a forward-looking
+    # cap/overage exposure, not a recoverable-tokens finding, so it always
+    # renders in its own section rather than competing for a numbered slot.
     # Subscription users don't have a dollar-denominated budget projection;
     # the [budget.<provider>] section may exist as a self-imposed soft
     # ceiling, but rendering it as a hard cap would mislead. Suppress in
@@ -412,28 +545,44 @@ def _render_report(
             _render_budget(proj)
             console.print()
 
-    # ----- Wave-2 findings (cache, cache-recommend,
-    # script, trim) — these attach to report.findings
-    # rather than typed slots. Dispatch to a per-finding renderer; ignore
-    # any unknown finding names (forward-compatible with future analyzers).
-    rendered_any_wave2 = False
-    for name, finding in (report.findings or {}).items():
-        renderer = _FINDING_RENDERERS.get(name)
-        if renderer is None:
-            continue
-        renderer(finding, pricing_mode=pricing_mode)
+    # ----- Minor findings -----
+    # De-minimis-share findings stay visible (never silently dropped — the
+    # honesty discipline forbids a quiet skip) but collapsed to a one-line
+    # pointer instead of a full render, so a near-zero finding can't crowd
+    # out the ones that actually matter.
+    if minor:
+        console.print(
+            f"  [dim]Minor findings (< {DE_MINIMIS_SHARE * 100:.0f}% of window "
+            f"tokens):[/dim]"
+        )
+        for name, share in minor:
+            # `minor` is filtered to `item[1] is not None` above; the
+            # assertion below just narrows the type for mypy.
+            assert share is not None
+            label = _MINOR_FINDING_LABELS.get(name, name)
+            if name == "downsize":
+                # The exact scenario this ranking fixes (#97): the analyzer
+                # found session-shape candidates, but they hold a negligible
+                # share of the window's tokens — say so plainly rather than
+                # "no candidates" (that empty state is the `unranked` bucket,
+                # which only holds report.downgrade is None).
+                assert report.downgrade is not None
+                console.print(
+                    f"     [dim]• {label} — "
+                    f"{report.downgrade.percent_of_sessions:.0f}% of sessions "
+                    f"match, but only ~{share * 100:.1f}% of window tokens. "
+                    f"Run [bold]tj optimize downsize[/bold] for detail.[/dim]"
+                )
+            else:
+                console.print(
+                    f"     [dim]• {label} — ~{share * 100:.1f}% of window "
+                    f"tokens. Run [bold]tj optimize {name}[/bold] for "
+                    f"detail.[/dim]"
+                )
         console.print()
-        rendered_any_wave2 = True
 
-    # Only show the catch-all when truly nothing rendered. The earlier
-    # condition missed the Wave-2 findings dict, so cache /
-    # cache-recommend / script / trim were silently
-    # falling into "No candidates flagged" (issue #68 §15).
-    rendered_any = (
-        report.downgrade is not None
-        or downsize_was_requested  # we emit a "no candidates" empty state
-        or (pricing_mode == "api" and bool(report.budgets))
-        or rendered_any_wave2
+    rendered_any = bool(major) or bool(unranked) or bool(minor) or (
+        pricing_mode == "api" and bool(report.budgets)
     )
     if not rendered_any:
         console.print(
@@ -463,7 +612,12 @@ def _sampling_ci_suffix(d: DowngradeFinding) -> str:
     )
 
 
-def _render_downgrade(d: DowngradeFinding, pricing_mode: str = "api") -> None:
+def _render_downgrade(
+    d: DowngradeFinding,
+    pricing_mode: str = "api",
+    persona: str = "unknown",
+    marker: str = "①",
+) -> None:
     """
     Render the downsize finding for the given pricing mode.
 
@@ -473,9 +627,12 @@ def _render_downgrade(d: DowngradeFinding, pricing_mode: str = "api") -> None:
                     against your plan cap"
     - local:        token-only framing for capacity planning
     - unknown:      structural-only, no savings figures
+
+    `persona` picks the call-to-action at the bottom (#97) — see
+    `_render_downgrade_cta`.
     """
     console.print(
-        f"  [bold]① Model downgrade:[/bold] "
+        f"  [bold]{marker} Model downgrade:[/bold] "
         f"{d.percent_of_sessions:.0f}% of sessions match a smaller-model "
         f"candidate shape"
     )
@@ -553,17 +710,71 @@ def _render_downgrade(d: DowngradeFinding, pricing_mode: str = "api") -> None:
         f"     [yellow]![/yellow] [italic]{MODEL_DOWNGRADE_CAVEAT}[/italic]"
     )
     if d.bench_command:
+        _render_downgrade_cta(d.bench_command, persona)
+
+
+def _render_downgrade_cta(bench_command: str, persona: str) -> None:
+    """
+    Persona-aware call-to-action for the downsize finding (#97).
+
+    A Claude Code subscription user can't pass `--original`/`--candidate` to
+    pick a model per request — their real levers are exporting a routing
+    config, right-sizing subagents, and `/compact`. `tokenjam-bench` (which
+    runs the swap directly against a provider API key) is the right CTA for
+    an SDK/API developer, and only a secondary note for anyone who also runs
+    SDK agents. A mixed window shows both, labeled. Persona "sdk" and the
+    defensive "unknown" fallback both get the original, unchanged CTA.
+    """
+    console.print()
+    if persona == "claude-code":
+        console.print(
+            "     [bold]Candidate only — review before routing:[/bold]"
+        )
+        console.print(
+            "       tj route export --target ccr   "
+            "[dim]# or --target litellm[/dim]"
+        )
+        console.print(
+            "       tj optimize subagent            "
+            "[dim]# right-size subagent models/context[/dim]"
+        )
+        console.print(
+            "       /compact                        "
+            "[dim]# trim context mid-session[/dim]"
+        )
         console.print()
+        console.print(
+            "     [dim]If you also run SDK agents against these models:[/dim]"
+        )
+        console.print("       [dim]pip install tokenjam-bench[/dim]")
+        for line in bench_command.split("\n"):
+            console.print(f"       [dim]{line}[/dim]")
+    elif persona == "mixed":
+        console.print(
+            "     [bold]Candidate only — review before routing:[/bold]"
+        )
+        console.print("     [dim]Claude Code sessions:[/dim]")
+        console.print(
+            "       tj route export --target ccr   "
+            "[dim]# or --target litellm[/dim]"
+        )
+        console.print("       tj optimize subagent")
+        console.print("       /compact")
+        console.print("     [dim]SDK sessions:[/dim]")
+        console.print("       pip install tokenjam-bench")
+        for line in bench_command.split("\n"):
+            console.print(f"       {line}")
+    else:  # persona in {"sdk", "unknown"} — unchanged original CTA
         console.print(
             "     [bold]Candidate only — prove it holds before switching:[/bold]"
         )
         console.print("       pip install tokenjam-bench")
-        for line in d.bench_command.split("\n"):
+        for line in bench_command.split("\n"):
             console.print(f"       {line}")
 
 
 def _render_budget(p: BudgetProjection) -> None:
-    headline = f"  [bold]② Budget projection ({p.provider}, " \
+    headline = f"  [bold]Budget projection ({p.provider}, " \
                f"{format_cost(p.budget_usd)}/cycle):[/bold] "
 
     if not p.over_budget:
@@ -713,19 +924,29 @@ def _export_snippet(
 # dict keyed by analyzer name). _FINDING_RENDERERS at the bottom maps each
 # analyzer's registration name to the function that renders its finding.
 #
-# Each renderer takes (finding, pricing_mode=str) and prints to the global
-# `console`. Adding a new analyzer: add a renderer here and an entry in the
-# dispatch table. cmd_optimize._render_report iterates report.findings and
-# calls into here.
+# Each renderer takes (finding, pricing_mode=str, marker=str) and prints to
+# the global `console`. `marker` is the numbered slot assigned by
+# `_rank_findings` (e.g. "②") — empty when the finding rendered outside the
+# ranked list. Adding a new analyzer: add a renderer here, an entry in the
+# dispatch table, and a label in `_MINOR_FINDING_LABELS`. cmd_optimize.
+# _render_report ranks report.findings by reclaimable share and calls in here.
 
-def _render_cache_efficacy(finding, *, pricing_mode: str = "api") -> None:
+def _finding_header(marker: str, label: str) -> str:
+    """Bold header line for a ranked finding, e.g. '② Cache efficacy:'."""
+    prefix = f"{marker} " if marker else ""
+    return f"  [bold]{prefix}{label}[/bold]"
+
+
+def _render_cache_efficacy(
+    finding, *, pricing_mode: str = "api", marker: str = "",
+) -> None:
     """
     Render the cache finding — current caching-ratio table per
     (provider, model). When any rows are flagged, surface them prominently;
     otherwise show the full table dimmed so the user sees the underlying
     data even when no recommendation is warranted.
     """
-    console.print("  [bold]Cache efficacy:[/bold]")
+    console.print(_finding_header(marker, "Cache efficacy:"))
     if not finding.rows:
         console.print(
             "     [dim]No LLM spans with provider/model in this window.[/dim]"
@@ -765,13 +986,15 @@ def _render_cache_efficacy(finding, *, pricing_mode: str = "api") -> None:
         )
 
 
-def _render_cache_recommend(finding, *, pricing_mode: str = "api") -> None:
+def _render_cache_recommend(
+    finding, *, pricing_mode: str = "api", marker: str = "",
+) -> None:
     """
     Render the cache-recommend finding — Anthropic-only v1 breakpoint
     candidates. When the analyzer is disabled (capture.prompts off), surface
     the hint instead of an empty table.
     """
-    console.print("  [bold]Cache recommend:[/bold]")
+    console.print(_finding_header(marker, "Cache recommend:"))
     if not finding.enabled:
         # Hint includes the install / config instruction from the analyzer.
         # _rich_escape because the hint contains TOML section names like
@@ -821,12 +1044,14 @@ def _render_cache_recommend(finding, *, pricing_mode: str = "api") -> None:
         )
 
 
-def _render_workflow_restructure(finding, *, pricing_mode: str = "api") -> None:
+def _render_workflow_restructure(
+    finding, *, pricing_mode: str = "api", marker: str = "",
+) -> None:
     """
     Render the script (Script) finding — clusters of sessions
     matching the same (tool_name, arg_shape) signature.
     """
-    console.print("  [bold]Workflow restructure:[/bold]")
+    console.print(_finding_header(marker, "Workflow restructure:"))
     if not finding.clusters:
         if finding.sessions_examined == 0:
             console.print(
@@ -880,13 +1105,15 @@ def _render_workflow_restructure(finding, *, pricing_mode: str = "api") -> None:
         console.print(f"     [yellow]![/yellow] [italic]{finding.caveat}[/italic]")
 
 
-def _render_prompt_bloat(finding, *, pricing_mode: str = "api") -> None:
+def _render_prompt_bloat(
+    finding, *, pricing_mode: str = "api", marker: str = "",
+) -> None:
     """
     Render the trim (Trim) finding — LLMLingua-2 token-significance
     summary. When the analyzer is disabled (either capture off or extra
     not installed), surface the hint.
     """
-    console.print("  [bold]Prompt bloat:[/bold]")
+    console.print(_finding_header(marker, "Prompt bloat:"))
     if not finding.enabled:
         if finding.hint:
             # Escape Rich markup — hints can contain TOML section names
@@ -937,14 +1164,16 @@ def _render_prompt_bloat(finding, *, pricing_mode: str = "api") -> None:
     )
 
 
-def _render_reuse(finding, *, pricing_mode: str = "api") -> None:
+def _render_reuse(
+    finding, *, pricing_mode: str = "api", marker: str = "",
+) -> None:
     """
     Render the reuse (Reuse) finding — clusters of sessions whose planning
     skeleton repeats. Two recoverable numbers per cluster: cache-reuse (reuse
     the existing skeleton) and script-replacement (replace every planning call
     with a deterministic template). Framed per pricing mode.
     """
-    console.print("  [bold]Reuse:[/bold]")
+    console.print(_finding_header(marker, "Reuse:"))
     if not finding.clusters:
         console.print(
             "     [dim]No repeated planning detected above threshold "
@@ -1000,13 +1229,15 @@ def _render_reuse(finding, *, pricing_mode: str = "api") -> None:
         )
 
 
-def _render_subagent(finding, *, pricing_mode: str = "api") -> None:
+def _render_subagent(
+    finding, *, pricing_mode: str = "api", marker: str = "",
+) -> None:
     """
     Render the subagent right-sizing finding — how much of the window's cost ran
     inside subagents, plus the structurally-flagged candidates (over-powered
     model / over-provisioned context).
     """
-    console.print("  [bold]Subagent right-sizing:[/bold]")
+    console.print(_finding_header(marker, "Subagent right-sizing:"))
     if not finding.total_subagents:
         console.print(
             "     [dim]No subagent (Task-tool) activity in this window.[/dim]"

--- a/tokenjam/core/framing.py
+++ b/tokenjam/core/framing.py
@@ -531,3 +531,90 @@ def plan_determination_mix(conn: Any, agent_id: str | None = None) -> dict[str, 
     narrows to a single agent when set — the plan is per-agent, not per-window.
     """
     return plan_tier_mix(conn, None, None, agent_id)
+
+
+# ---------------------------------------------------------------------------
+# Persona detection (#97) — Claude Code subscriber vs SDK/API developer.
+# ---------------------------------------------------------------------------
+# `tj optimize`'s downsize finding used to print an SDK-only call-to-action
+# (`tjb run --original ... --candidate ...`) regardless of who was running it.
+# A Claude Code subscription user can't pick a model per request — their real
+# levers are exporting a routing config, right-sizing subagents, and
+# `/compact`. Detecting the dominant persona lets the CLI render the CTA that
+# actually matches the user's levers.
+
+# `tj onboard --claude-code` / `tj backfill claude-code` stamp every ingested
+# session's agent_id as `claude-code-<slug>` (see backfill.py
+# _agent_id_from_cwd, session_timeline.py SessionSummary.project_label) — the
+# one existing convention that distinguishes a Claude Code session from any
+# other runtime (SDK, other CLIs).
+CLAUDE_CODE_AGENT_PREFIX = "claude-code-"
+
+# A window is "claude-code" or "sdk" dominated at this threshold; between the
+# two, both audiences are meaningfully represented and the CTA should label
+# and show both rather than pick one.
+_PERSONA_DOMINANT_FRACTION = 0.8
+
+
+def agent_persona_mix(
+    conn: Any,
+    since: Any = None,
+    until: Any = None,
+    agent_id: str | None = None,
+) -> dict[str, int]:
+    """Count sessions by whether their agent_id looks like Claude Code.
+
+    Mirrors :func:`plan_tier_mix`'s query shape (same optional since/until/
+    agent_id window, same ``sessions`` table). Returns
+    ``{"claude_code": N, "other": M}``.
+    """
+    clauses: list[str] = []
+    params: list[Any] = []
+    if since is not None:
+        params.append(since)
+        clauses.append("started_at >= $" + str(len(params)))
+    if until is not None:
+        params.append(until)
+        clauses.append("started_at < $" + str(len(params)))
+    if agent_id:
+        params.append(agent_id)
+        clauses.append("agent_id = $" + str(len(params)))
+    where = (" WHERE " + " AND ".join(clauses)) if clauses else ""
+    sql = "SELECT agent_id FROM sessions" + where
+    rows = conn.execute(sql, params).fetchall()
+    mix = {"claude_code": 0, "other": 0}
+    for (aid,) in rows:
+        if aid and str(aid).startswith(CLAUDE_CODE_AGENT_PREFIX):
+            mix["claude_code"] += 1
+        else:
+            mix["other"] += 1
+    return mix
+
+
+def dominant_persona(
+    agent_mix: dict[str, int], declared_plan: str | None = None,
+) -> str:
+    """Classify the analyzed window's dominant user persona.
+
+    Returns one of ``"claude-code"``, ``"sdk"``, ``"mixed"``, ``"unknown"``.
+
+    Primary signal is the ``agent_id`` prefix (:data:`CLAUDE_CODE_AGENT_PREFIX`).
+    Falls back to the declared plan tier only when no session in the window
+    carries an identifiable agent_id (e.g. raw OTLP ingestion that never ran
+    ``tj onboard``) — a declared Claude Code subscription tier (pro / max_5x /
+    max_20x) still implies a Claude Code user even before agent-id attribution
+    exists, and a declared ``api`` plan implies an SDK/API developer.
+    """
+    total = sum(agent_mix.values())
+    if total == 0:
+        if declared_plan in {"pro", "max_5x", "max_20x"}:
+            return "claude-code"
+        if declared_plan == "api":
+            return "sdk"
+        return "unknown"
+    cc_fraction = agent_mix.get("claude_code", 0) / total
+    if cc_fraction >= _PERSONA_DOMINANT_FRACTION:
+        return "claude-code"
+    if cc_fraction <= (1 - _PERSONA_DOMINANT_FRACTION):
+        return "sdk"
+    return "mixed"


### PR DESCRIPTION
`tj optimize` had two persona-blindness bugs, observed live on a Claude Code Max-plan machine (#97).

## Summary
- Rank findings by reclaimable token share of the window instead of `ANALYZER_ORDER` (registry order), so a nothing-burger finding can no longer occupy the numbered `①` slot ahead of a finding that's actually reclaiming a meaningful fraction of the window.
- Detect the analyzed window's dominant persona (Claude Code subscriber vs SDK/API developer) and render the downsize finding's call-to-action to match the levers that persona actually has.

## #97 — Ranking
`cmd_optimize._render_report` used to iterate `report.findings` in `ANALYZER_ORDER` and always give the downsize finding a hardcoded `①`, regardless of size. The reported symptom: downsize led with "28% of sessions match" then conceded "those sessions hold ~0% of this cycle's tokens."

Fix: `_rank_findings` (`tokenjam/cli/cmd_optimize.py`) ranks every finding — downsize plus every wave-2 analyzer (`cache`, `cache-recommend`, `script`, `reuse`, `trim`, `subagent`) — by `estimated_recoverable_tokens / window.total_tokens` (the existing recoverable-savings contract, #111). Three buckets:
- **major** (share ≥ 1%): numbered slot (`①②③…`), full render, in share order.
- **unranked** (no quantified estimate — disabled analyzer, or a "no candidates" empty state): full render, unnumbered, same as the historical wave-2 behavior — so an analyzer's own diagnostic message ("no tool spans in this window") is never hidden.
- **minor** (share < 1%, but real): collapsed into a one-line "Minor findings" pointer instead of a numbered slot, so it can't crowd out the findings that matter. Still visible — never a silent drop.

Budget projection is informational (cap/overage exposure, not a reclaimable-tokens finding) so it renders in its own section, unnumbered, rather than competing in the ranking.

## #97 — Persona-aware CTA
The downsize finding's bench command always printed `tjb run --original anthropic:claude-sonnet-4-5 --candidate ...` — an SDK-developer action. A Claude Code subscription user can't set a model per request; their real levers are `tj route export`, `tj optimize subagent`, and `/compact`.

Fix: `dominant_persona` + `agent_persona_mix` (`tokenjam/core/framing.py`) classify the window via the `claude-code-<slug>` agent_id convention (`tj onboard --claude-code` / `tj backfill claude-code`), falling back to the declared plan tier (pro/max_5x/max_20x vs api) only when no session carries an identifiable agent_id. `_render_downgrade_cta` renders the matching CTA:
- **claude-code** → `tj route export --target ccr` (or litellm) + `tj optimize subagent` + `/compact`, with `tjb` as a secondary "if you also run SDK agents" note.
- **sdk** (and the defensive **unknown** fallback) → the original `tjb` CTA, unchanged.
- **mixed** → both, labeled by persona.

Same daemon-mode plumbing as `plan_tier_mix`: `/api/v1/optimize` now also returns `agent_persona_mix` (best-effort, empty on failure) so the CLI's CTA is correct whether or not `tj serve` is up.

## Tests / Verification
- `tests/unit/test_framing.py` — `agent_persona_mix` SQL/classification + `dominant_persona` (agent-mix-driven and declared-plan-fallback cases).
- `tests/integration/test_cli.py` — reproduces the exact reported bug shape (a de-minimis downsize candidate against a much bigger competing finding) and asserts it's demoted to "Minor findings," never the fixed `①`; plus CTA parity tests for claude-code / sdk personas.
- `pytest tests/unit/ tests/synthetic/ tests/agents/ tests/integration/`: 1990 passed, 1 skipped (pre-existing, unrelated).
- `ruff check` / `mypy` clean on all touched files.

## What's NOT in this PR
- `cache-recommend` has no quantified token estimate at all (it recommends a `cache_control` placement, not a token count) — it always lands in the `unranked` bucket. A future pass could give it a comparable estimate so it can compete for a numbered slot on its own merits.
- `subagent` right-sizing never populates `estimated_recoverable_usd`/`estimated_recoverable_tokens` on its finding (checked `subagent_rightsizing.py` — the fields are always `None` by construction), so it's also always `unranked` today regardless of how much spend is flagged. Filing this as a follow-up is likely worth a ticket, but left to the master's judgment on scope.
- Persona detection is per-`tj optimize` invocation, not cached/persisted — a mixed CC+SDK box always recomputes the mix from the sessions table for the requested window.

🤖 Generated with [Claude Code](https://claude.com/claude-code)