### PR TITLE
feat: add `tokenjam` console-script alias for bare uvx/pipx invocation

### DIFF
--- a/docs/installation.md
+++ b/docs/installation.md
@@ -7,7 +7,7 @@ TokenJam ships as a Python package on PyPI and a TypeScript SDK on npm. Pick the
 The fastest way to see value — **no install, no config, no daemon**:
 
 ```bash
-npx tokenjam                      # or:  uvx --from tokenjam tj
+npx tokenjam                      # or:  uvx tokenjam
 ```
 
 This runs `tj quickstart`: it reads your existing Claude Code sessions from
@@ -22,9 +22,11 @@ written to disk and no background process starts.
   launcher that shells out to the Python CLI via the first available runner
   (`uvx` → `pipx run` → an installed `tj`). All arguments pass straight through,
   so `npx tokenjam quickstart --since 7d`, `npx tokenjam optimize`, etc. all work.
-- `uvx --from tokenjam tj` runs the Python CLI directly with [uv](https://docs.astral.sh/uv/)'s
-  ephemeral runner. (The `--from tokenjam` is required because the PyPI package
-  is `tokenjam` while the command is `tj`.)
+- `uvx tokenjam` runs the Python CLI directly with [uv](https://docs.astral.sh/uv/)'s
+  ephemeral runner. (The PyPI package `tokenjam` ships both a `tj` command and a
+  `tokenjam` alias, so `uvx tokenjam` and `uvx --from tokenjam tj` are equivalent —
+  use the longer `--from` form if you're on an older tokenjam release without the
+  alias.)
 
 **Requirements:** a Python runner — `uv` (recommended) or `pipx`. `npx tokenjam` prints
 install guidance if neither is present.

--- a/npm-wrapper/bin/tj.js
+++ b/npm-wrapper/bin/tj.js
@@ -16,6 +16,11 @@
  *   3. `tj …`                      — an already-installed CLI on PATH
  *
  * If none are present we print actionable install guidance and exit non-zero.
+ *
+ * Note: tokenjam >=0.5.4 also ships a `tokenjam` console-script alias
+ * alongside `tj`, so bare `uvx tokenjam` / `pipx run tokenjam` work too. This
+ * wrapper keeps the explicit `--from tokenjam tj` / `--spec tokenjam tj` form
+ * below for back-compat with the 0.5.3 and earlier releases it also targets.
  */
 "use strict";
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -70,6 +70,7 @@ bloat     = ["llmlingua>=0.2"]
 
 [project.scripts]
 tj = "tokenjam.cli.main:cli"
+tokenjam = "tokenjam.cli.main:cli"
 
 [tool.pytest.ini_options]
 testpaths = ["tests/unit", "tests/synthetic", "tests/agents", "tests/integration"]


### PR DESCRIPTION
Users reaching for `uvx tokenjam` or `pipx run tokenjam` today hit a "no command tokenjam" error, because the package only registered the `tj` entry point — the PyPI package name (`tokenjam`) and the CLI command name (`tj`) differ. This adds a second `[project.scripts]` entry so `uvx tokenjam` / `pipx run tokenjam` / a bare `tokenjam` on PATH all resolve directly, without the `--from tokenjam tj` indirection.

## Summary
- `pyproject.toml`: register `tokenjam = "tokenjam.cli.main:cli"` alongside the existing `tj` entry point. Both point at the same `cli:cli`; `tj` remains the primary/documented command.
- `docs/installation.md`: update the two mentions of `uvx --from tokenjam tj` to the simpler `uvx tokenjam`, with a note that the `--from` form still works for anyone on an older tokenjam release without the alias.
- `npm-wrapper/bin/tj.js`: header-comment-only note that ≥0.5.4 also ships the `tokenjam` alias. Runner logic is unchanged — it still uses the explicit `--from tokenjam tj` / `--spec tokenjam tj` form, which is required for back-compat with 0.5.3 and earlier.

## Tests / Verification
- Installed editable into a scratch venv and confirmed both entry points resolve to the same CLI:
  ```
  $ /tmp/tj-alias-venv/bin/tj --version
  tj, version 0.5.3
  $ /tmp/tj-alias-venv/bin/tokenjam --version
  tokenjam, version 0.5.3
  ```
- `ruff check tokenjam/` — all checks passed.
- `node -c npm-wrapper/bin/tj.js` — syntax OK.
- Full suite (`pytest tests/unit/ tests/synthetic/ tests/agents/ tests/integration/`) — 1980 passed, 2 skipped, since `pyproject.toml` changed.
- No `.py` files were touched, so `mypy` has nothing new to check.

## What's NOT in this PR
- `README.md` is left untouched — its `uvx --from tokenjam tj` mentions are being rewritten by #406; once that merges, its `uvx --from tokenjam tj quickstart` mentions can simplify to `uvx tokenjam quickstart`.
- No entry-point test was added — the repo has no existing precedent asserting console-script registration (checked `tests/`), and the venv install/`--version` check above covers the packaging metadata directly.
- `npm-wrapper` runner logic (the `--from tokenjam tj` invocation itself) is intentionally unchanged — it must keep working against already-published 0.5.3 and earlier, which don't have the alias.

🤖 Generated with [Claude Code](https://claude.com/claude-code)