### PR TITLE
Revise coding agents description in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -305,8 +305,8 @@ tj serve               # start Lens + REST API
 TokenJam is MIT, and contributions are welcome — from a one-line pricing fix to a whole new framework integration. A few easy on-ramps:
 
 - 🟢 **[Good first issues →](https://github.com/Metabuilder-Labs/tokenjam/labels/good%20first%20issue)** — scoped, newcomer-friendly tasks, ready to pick up.
-- **Bugs** - notice something off? file a bug
-- **Documentation** - struggled with something while getting started? help the next person not stumble by writing or updating documentation.
+- **Bugs** — notice something off? File a bug.
+- **Documentation** — struggled with something while getting started? Help the next person by writing or updating documentation.
 - 💸 **Model pricing** — `tokenjam/pricing/models.toml` is community-maintained. Fix a rate or add a model in a single PR — no issue needed.
 - 🔌 **Framework integrations** — provider/framework patches follow one clear pattern (`tokenjam/sdk/integrations/anthropic.py` is the reference). Open an issue first to align on approach.
 - 🤖 **Coding Agents are first-class citizens** — TokenJam is built by Humans AND AI coding agents, and contributing with one is first-class. **Claude Code:** read [CLAUDE.md](CLAUDE.md) and run `/init` to bring your agent up to speed. **Codex / other agents:** [AGENTS.md](AGENTS.md) has the critical rules.

--- a/README.md
+++ b/README.md
@@ -305,9 +305,11 @@ tj serve               # start Lens + REST API
 TokenJam is MIT, and contributions are welcome — from a one-line pricing fix to a whole new framework integration. A few easy on-ramps:
 
 - 🟢 **[Good first issues →](https://github.com/Metabuilder-Labs/tokenjam/labels/good%20first%20issue)** — scoped, newcomer-friendly tasks, ready to pick up.
+- **Bugs** - notice something off? file a bug
+- **Documentation** - struggled with something while getting started? help the next person not stumble by writing or updating documentation.
 - 💸 **Model pricing** — `tokenjam/pricing/models.toml` is community-maintained. Fix a rate or add a model in a single PR — no issue needed.
 - 🔌 **Framework integrations** — provider/framework patches follow one clear pattern (`tokenjam/sdk/integrations/anthropic.py` is the reference). Open an issue first to align on approach.
-- 🤖 **Built with coding agents** — TokenJam is built by AI coding agents, and contributing with one is first-class. **Claude Code:** read [CLAUDE.md](CLAUDE.md) and run `/init` to bring your agent up to speed. **Codex / other agents:** [AGENTS.md](AGENTS.md) has the critical rules.
+- 🤖 **Coding Agents are first-class citizens** — TokenJam is built by Humans AND AI coding agents, and contributing with one is first-class. **Claude Code:** read [CLAUDE.md](CLAUDE.md) and run `/init` to bring your agent up to speed. **Codex / other agents:** [AGENTS.md](AGENTS.md) has the critical rules.
 
 Setup and the full dev workflow are in **[CONTRIBUTING.md](CONTRIBUTING.md)**.
 

--- a/tests/integration/test_cli.py
+++ b/tests/integration/test_cli.py
@@ -307,6 +307,35 @@ def test_doctor_no_staleness_warning_when_no_spans(runner, db, config, tmp_path)
     assert not any(c["level"] == "warning" for c in checks)
 
 
+def test_doctor_onboarding_signal_info_when_silent(runner, db, config, tmp_path):
+    """Onboarded-but-zero-spans (#80) surfaces an actionable info line — never a
+    warning, so a fresh setup still exits 0."""
+    _clean_doctor_config(config, tmp_path)
+    config_file = tmp_path / "tokenjam.toml"
+    config_file.write_text('version = "1"\n')
+    with patch("tokenjam.cli.cmd_doctor.find_config_file", return_value=config_file):
+        result = _invoke(runner, db, config, ["doctor", "--json"])
+    assert result.exit_code == 0
+    checks = json.loads(result.output)
+    signal = [c for c in checks if c["name"] == "Onboarding signal"]
+    assert signal and signal[0]["level"] == "info"
+    assert "no spans" in signal[0]["message"].lower()
+
+
+def test_doctor_onboarding_signal_ok_with_spans(runner, db, config, tmp_path):
+    """Once any span exists, the onboarding-signal check goes green."""
+    _clean_doctor_config(config, tmp_path)
+    db.insert_span(make_llm_span(agent_id="test-agent", start_time=utcnow()))
+    config_file = tmp_path / "tokenjam.toml"
+    config_file.write_text('version = "1"\n')
+    with patch("tokenjam.cli.cmd_doctor.find_config_file", return_value=config_file):
+        result = _invoke(runner, db, config, ["doctor", "--json"])
+    assert result.exit_code == 0
+    checks = json.loads(result.output)
+    signal = [c for c in checks if c["name"] == "Onboarding signal"]
+    assert signal and signal[0]["level"] == "ok"
+
+
 def test_doctor_warns_on_schema_without_capture(runner, db, config, tmp_path):
     config.agents["test-agent"] = AgentConfig(output_schema="schema.json")
     config.capture.tool_outputs = False

--- a/tests/unit/test_doctor_first_signal.py
+++ b/tests/unit/test_doctor_first_signal.py
@@ -1,0 +1,80 @@
+"""Doctor's onboarded-but-silent diagnosis (#80): the after-the-fact check that
+turns a blank Status page into an actionable per-persona cause."""
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+
+from tokenjam.cli.cmd_doctor import (
+    _check_onboarding_first_signal,
+    _detect_onboarded_persona,
+)
+from tokenjam.core.db import InMemoryBackend
+from tests.factories import make_llm_span
+
+
+def _config(agent_ids=()):
+    agents = {aid: SimpleNamespace() for aid in agent_ids}
+    return SimpleNamespace(agents=agents)
+
+
+# --- persona detection ------------------------------------------------------
+
+
+def test_detects_claude_code_from_agent_id():
+    assert _detect_onboarded_persona(_config(["claude-code-myproj"])) == "claude_code"
+
+
+def test_detects_codex_from_agent_id():
+    assert _detect_onboarded_persona(_config(["codex_exec"])) == "codex"
+
+
+def test_defaults_to_sdk_when_no_runtime_marker(monkeypatch):
+    monkeypatch.setattr("tokenjam.cli.cmd_doctor._tj_statusline_wired", lambda: False)
+    assert _detect_onboarded_persona(_config([])) == "sdk"
+    assert _detect_onboarded_persona(_config(["my-agent"])) == "sdk"
+
+
+def test_detects_claude_code_from_statusline_when_no_agents(monkeypatch):
+    monkeypatch.setattr("tokenjam.cli.cmd_doctor._tj_statusline_wired", lambda: True)
+    assert _detect_onboarded_persona(_config([])) == "claude_code"
+
+
+# --- the check itself -------------------------------------------------------
+
+
+def test_flags_info_when_onboarded_but_zero_spans(monkeypatch):
+    # Info, not warning: doctor has no onboarding timestamp, so it can't tell a
+    # fresh setup from a silent one — a warning would false-alarm and flip exit 1.
+    monkeypatch.setattr("tokenjam.cli.cmd_doctor._tj_statusline_wired", lambda: False)
+    db = InMemoryBackend()
+    check = _check_onboarding_first_signal(_config(["claude-code-myproj"]), db)
+    assert check["level"] == "info"
+    assert "no spans" in check["message"].lower()
+    assert "Claude Code" in check["message"]  # per-persona cause
+
+
+def test_ok_once_a_span_exists():
+    db = InMemoryBackend()
+    db.insert_span(make_llm_span(agent_id="my-agent"))
+    check = _check_onboarding_first_signal(_config(["my-agent"]), db)
+    assert check["level"] == "ok"
+    assert "flowing" in check["message"].lower()
+
+
+def test_sdk_persona_cause_points_at_ping(monkeypatch):
+    monkeypatch.setattr("tokenjam.cli.cmd_doctor._tj_statusline_wired", lambda: False)
+    db = InMemoryBackend()
+    check = _check_onboarding_first_signal(_config([]), db)
+    assert check["level"] == "info"
+    assert "tj ping" in check["message"]
+
+
+def test_skips_in_api_fallback_mode():
+    # A backend without a `.conn` (the ApiBackend HTTP fallback) can't run the
+    # raw count query — the check must degrade to info, never error.
+    fake_db = SimpleNamespace()  # no `conn` attribute
+    check = _check_onboarding_first_signal(_config(["my-agent"]), fake_db)
+    assert check["level"] == "info"
+    assert "fallback" in check["message"].lower()

--- a/tests/unit/test_onboard_verify.py
+++ b/tests/unit/test_onboard_verify.py
@@ -1,0 +1,154 @@
+"""First-signal onboarding verification (#80): the poll primitive, per-persona
+cause strings, and the lock-aware read-backend resolver."""
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+
+from tokenjam.core.onboard_verify import (
+    VerifyResult,
+    not_confirmed_cause,
+    open_read_backend,
+    poll_for_first_span,
+)
+
+
+class _FakeBackend:
+    """Returns empty until ``arrive_after`` calls, then one trace."""
+
+    def __init__(self, arrive_after: int = 0, trace_id: str = "trace-1"):
+        self.arrive_after = arrive_after
+        self.trace_id = trace_id
+        self.calls = 0
+        self.seen_filters: list = []
+
+    def get_traces(self, filters):
+        self.calls += 1
+        self.seen_filters.append(filters)
+        if self.calls > self.arrive_after:
+            return [SimpleNamespace(trace_id=self.trace_id)]
+        return []
+
+
+# --- poll_for_first_span ----------------------------------------------------
+
+
+def test_confirms_when_a_span_arrives_immediately():
+    backend = _FakeBackend(arrive_after=0)
+    result = poll_for_first_span(
+        backend, since=None, sleep=lambda _s: None, monotonic=lambda: 0.0,
+    )
+    assert isinstance(result, VerifyResult)
+    assert result.confirmed is True
+    assert result.first_trace_id == "trace-1"
+    assert result.error is None
+
+
+def test_confirms_after_a_few_empty_polls():
+    backend = _FakeBackend(arrive_after=2)
+    ticks = iter([0.0, 1.0, 2.0, 3.0, 4.0, 5.0])
+    result = poll_for_first_span(
+        backend, since=None, interval_s=1.0,
+        sleep=lambda _s: None, monotonic=lambda: next(ticks),
+    )
+    assert result.confirmed is True
+    assert backend.calls == 3  # two empties + one hit
+
+
+def test_times_out_when_no_span_arrives():
+    backend = _FakeBackend(arrive_after=99)  # never arrives
+    # start, the >=timeout check, then the elapsed_s read on the timeout return.
+    ticks = iter([0.0, 100.0, 100.0])
+    result = poll_for_first_span(
+        backend, since=None, timeout_s=60.0,
+        sleep=lambda _s: None, monotonic=lambda: next(ticks),
+    )
+    assert result.confirmed is False
+    assert result.error is None  # a clean timeout is not an error
+
+
+def test_read_error_is_surfaced_not_raised():
+    class _Boom:
+        def get_traces(self, filters):
+            raise RuntimeError("db went away")
+
+    result = poll_for_first_span(
+        _Boom(), since=None, sleep=lambda _s: None, monotonic=lambda: 0.0,
+    )
+    assert result.confirmed is False
+    assert "db went away" in (result.error or "")
+
+
+def test_agent_id_is_passed_through_to_the_filter():
+    backend = _FakeBackend(arrive_after=0)
+    poll_for_first_span(
+        backend, since=None, agent_id="my-agent",
+        sleep=lambda _s: None, monotonic=lambda: 0.0,
+    )
+    assert backend.seen_filters[0].agent_id == "my-agent"
+
+
+# --- not_confirmed_cause ----------------------------------------------------
+
+
+def test_cause_is_persona_specific():
+    assert "restart" in not_confirmed_cause("claude_code").lower()
+    assert "Claude Code" in not_confirmed_cause("claude_code")
+    assert "Codex" in not_confirmed_cause("codex")
+    assert "tj ping" in not_confirmed_cause("sdk")
+    # Unknown persona covers both failure modes.
+    generic = not_confirmed_cause("???")
+    assert "Claude Code" in generic and "SDK" in generic
+
+
+# --- open_read_backend ------------------------------------------------------
+
+
+def _config(host="127.0.0.1", port=7391, auth_enabled=False):
+    return SimpleNamespace(
+        api=SimpleNamespace(
+            host=host, port=port,
+            auth=SimpleNamespace(enabled=auth_enabled, api_key="k"),
+        ),
+        storage=SimpleNamespace(path="/tmp/does-not-matter.db"),
+    )
+
+
+def test_prefers_the_running_daemon_over_the_db_lock(monkeypatch):
+    sentinel = object()
+    monkeypatch.setattr(
+        "tokenjam.core.api_backend.probe_api",
+        lambda host, port, api_key: sentinel,
+    )
+    backend, mode, error = open_read_backend(_config())
+    assert backend is sentinel
+    assert mode == "api"
+    assert error is None
+
+
+def test_falls_back_to_direct_when_no_daemon(monkeypatch):
+    monkeypatch.setattr(
+        "tokenjam.core.api_backend.probe_api",
+        lambda host, port, api_key: None,
+    )
+    sentinel = object()
+    monkeypatch.setattr("tokenjam.core.db.open_db", lambda storage: sentinel)
+    backend, mode, error = open_read_backend(_config())
+    assert backend is sentinel
+    assert mode == "direct"
+
+
+def test_reports_error_when_db_locked_and_no_daemon(monkeypatch):
+    monkeypatch.setattr(
+        "tokenjam.core.api_backend.probe_api",
+        lambda host, port, api_key: None,
+    )
+
+    def _locked(storage):
+        raise RuntimeError("Could not set lock on file: Conflicting lock held")
+
+    monkeypatch.setattr("tokenjam.core.db.open_db", _locked)
+    backend, mode, error = open_read_backend(_config())
+    assert backend is None
+    assert error is not None and "locked" in error.lower()

--- a/tests/unit/test_onboard_verify_cli.py
+++ b/tests/unit/test_onboard_verify_cli.py
@@ -1,0 +1,84 @@
+"""Post-onboard verification wiring (#80): the prompt gate and the runner that
+both onboarding paths call at their end."""
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+
+from tokenjam.cli import cmd_onboard
+from tokenjam.core.onboard_verify import VerifyResult
+
+
+def _config():
+    return SimpleNamespace(
+        api=SimpleNamespace(
+            host="127.0.0.1", port=7391,
+            auth=SimpleNamespace(enabled=False, api_key=None),
+        ),
+        storage=SimpleNamespace(path="/tmp/x.db"),
+    )
+
+
+def test_runner_prints_success_when_confirmed(monkeypatch, capsys):
+    closed = {"n": 0}
+    backend = SimpleNamespace(close=lambda: closed.__setitem__("n", closed["n"] + 1))
+    monkeypatch.setattr(
+        "tokenjam.core.onboard_verify.open_read_backend",
+        lambda config: (backend, "api", None),
+    )
+    monkeypatch.setattr(
+        "tokenjam.core.onboard_verify.poll_for_first_span",
+        lambda *a, **k: VerifyResult(True, 3.0, first_trace_id="t1"),
+    )
+    cmd_onboard._run_onboard_verification(_config(), "sdk", timeout_s=1.0)
+    out = capsys.readouterr().out
+    assert "Receiving telemetry" in out
+    assert closed["n"] == 1  # backend closed even on the happy path
+
+
+def test_runner_prints_persona_cause_on_timeout(monkeypatch, capsys):
+    monkeypatch.setattr(
+        "tokenjam.core.onboard_verify.open_read_backend",
+        lambda config: (SimpleNamespace(close=lambda: None), "api", None),
+    )
+    monkeypatch.setattr(
+        "tokenjam.core.onboard_verify.poll_for_first_span",
+        lambda *a, **k: VerifyResult(False, 60.0),
+    )
+    cmd_onboard._run_onboard_verification(_config(), "claude_code", timeout_s=60.0)
+    out = capsys.readouterr().out
+    assert "No telemetry yet" in out
+    assert "restart" in out.lower()  # persona-specific cause
+
+
+def test_runner_reports_when_backend_unavailable(monkeypatch, capsys):
+    monkeypatch.setattr(
+        "tokenjam.core.onboard_verify.open_read_backend",
+        lambda config: (None, None, "the database is locked"),
+    )
+    cmd_onboard._run_onboard_verification(_config(), "sdk")
+    out = capsys.readouterr().out
+    assert "Can't verify" in out
+    assert "tj serve" in out
+
+
+def test_maybe_verify_runs_directly_with_flag(monkeypatch):
+    calls = []
+    monkeypatch.setattr(
+        cmd_onboard, "_run_onboard_verification",
+        lambda config, persona: calls.append(persona),
+    )
+    cmd_onboard._maybe_verify_onboarding(_config(), persona="sdk", verify=True)
+    assert calls == ["sdk"]
+
+
+def test_maybe_verify_skips_noninteractive_without_flag(monkeypatch):
+    calls = []
+    monkeypatch.setattr(
+        cmd_onboard, "_run_onboard_verification",
+        lambda config, persona: calls.append(persona),
+    )
+    monkeypatch.setattr(cmd_onboard.sys.stdin, "isatty", lambda: False)
+    cmd_onboard._maybe_verify_onboarding(_config(), persona="sdk", verify=False)
+    assert calls == []

--- a/tests/unit/test_ping.py
+++ b/tests/unit/test_ping.py
@@ -1,0 +1,137 @@
+"""`tj ping` — SDK test-span emitter with local proof-of-life (#80).
+
+These tests exercise the command end-to-end through the real @watch()/
+record_llm_call path against a live in-process TracerProvider, with only the
+bootstrap delivery-mode and daemon confirmation stubbed (so no real daemon/DB
+is required).
+"""
+from __future__ import annotations
+
+import pytest
+from click.testing import CliRunner
+from opentelemetry import trace
+from opentelemetry.sdk.trace import TracerProvider
+
+from tokenjam.cli.cmd_ping import _ProofExporter
+from tokenjam.cli.main import cli
+
+
+@pytest.fixture(autouse=True)
+def _real_provider():
+    """Ensure a real SDK TracerProvider is the global one so the proof exporter
+    (a SimpleSpanProcessor) can attach and capture the emitted span. OTel only
+    honors the first set_tracer_provider per process, but any previously-set SDK
+    provider is equally fine — both expose add_span_processor."""
+    provider = trace.get_tracer_provider()
+    if not hasattr(provider, "add_span_processor"):
+        trace.set_tracer_provider(TracerProvider())
+
+
+@pytest.fixture(autouse=True)
+def _stub_bootstrap(monkeypatch):
+    """Don't touch a real config/DB/daemon during ping tests."""
+    monkeypatch.setattr("tokenjam.sdk.bootstrap.ensure_initialised", lambda: None)
+
+
+def _run(mode: str, monkeypatch, extra_args=None, confirm=(True, None)):
+    """Run `tj ping` with bootstrap mode stubbed and, for HTTP mode, the
+    daemon-confirmation poll stubbed to `confirm` (confirmed, error) so no
+    real daemon/DB is needed."""
+    monkeypatch.setattr("tokenjam.sdk.bootstrap.get_mode", lambda: mode)
+    monkeypatch.setattr(
+        "tokenjam.cli.cmd_ping._confirm_delivery", lambda *a, **k: confirm
+    )
+    return CliRunner().invoke(cli, ["ping", *(extra_args or [])])
+
+
+def test_proof_exporter_records_span_names():
+    exporter = _ProofExporter()
+    span = type("S", (), {"name": "llm_call"})()
+    exporter.export([span])
+    assert exporter.captured == ["llm_call"]
+
+
+def test_ping_http_mode_confirmed_delivery_exits_zero(monkeypatch):
+    result = _run("http", monkeypatch, confirm=(True, None))
+    assert result.exit_code == 0, result.output
+    assert "intercepted a test span" in result.output
+    assert "tj-ping-test" in result.output
+    assert "confirmed received" in result.output
+
+
+def test_ping_http_mode_unconfirmed_delivery_exits_nonzero(monkeypatch):
+    """force_flush() succeeding is not enough — HTTP mode must also confirm
+    the daemon actually stored the span (#410 review)."""
+    result = _run("http", monkeypatch, confirm=(False, None))
+    assert result.exit_code == 1, result.output
+    assert "not confirmed received" in result.output
+    assert "tj serve" in result.output
+
+
+def test_ping_http_mode_confirm_error_surfaces_reason(monkeypatch):
+    result = _run(
+        "http", monkeypatch, confirm=(False, "the database is locked (is tj serve running?)")
+    )
+    assert result.exit_code == 1, result.output
+    assert "not confirmed received" in result.output
+    assert "database is locked" in result.output
+
+
+def test_ping_direct_mode_reports_local_db(monkeypatch):
+    result = _run("direct", monkeypatch)
+    assert result.exit_code == 0, result.output
+    assert "intercepted a test span" in result.output
+    assert "local database" in result.output
+
+
+def test_ping_failed_mode_warns_and_exits_nonzero(monkeypatch):
+    result = _run("failed", monkeypatch)
+    assert result.exit_code == 1, result.output
+    assert "Could not reach" in result.output
+
+
+def test_ping_json_output_is_machine_readable(monkeypatch):
+    import json
+
+    result = _run("http", monkeypatch, extra_args=["--json"], confirm=(True, None))
+    assert result.exit_code == 0, result.output
+    payload = json.loads(result.output)
+    assert payload["delivery_mode"] == "http"
+    assert payload["model"] == "tj-ping-test"
+    assert payload["intercepted"] is True
+    assert payload["confirmed"] is True
+
+
+def test_ping_json_output_reports_unconfirmed(monkeypatch):
+    import json
+
+    result = _run("http", monkeypatch, extra_args=["--json"], confirm=(False, None))
+    assert result.exit_code == 1, result.output
+    payload = json.loads(result.output)
+    assert payload["confirmed"] is False
+
+
+def test_ping_honors_custom_agent_id(monkeypatch):
+    result = _run("http", monkeypatch, extra_args=["--agent", "my-real-agent"])
+    assert result.exit_code == 0, result.output
+    assert "my-real-agent" in result.output
+
+
+def test_ping_passes_agent_id_and_emission_time_to_confirm(monkeypatch):
+    """The confirmation poll must scope to this ping's own agent_id/since so it
+    can't match a stale span from an earlier run."""
+    captured = {}
+
+    def _fake_confirm(config, agent_id, since):
+        captured["agent_id"] = agent_id
+        captured["since"] = since
+        return True, None
+
+    monkeypatch.setattr("tokenjam.sdk.bootstrap.get_mode", lambda: "http")
+    monkeypatch.setattr("tokenjam.cli.cmd_ping._confirm_delivery", _fake_confirm)
+
+    result = CliRunner().invoke(cli, ["ping", "--agent", "my-real-agent"])
+
+    assert result.exit_code == 0, result.output
+    assert captured["agent_id"] == "my-real-agent"
+    assert captured["since"] is not None

--- a/tokenjam/cli/cmd_doctor.py
+++ b/tokenjam/cli/cmd_doctor.py
@@ -66,6 +66,9 @@ def cmd_doctor(ctx: click.Context, output_json: bool, repair: bool) -> None:
     # 14. Claude Code statusline wiring (issue #59) — the zero-token surface
     checks.append(_check_statusline_wiring(config))
 
+    # 15. Onboarded-but-silent — first-signal diagnosis (issue #80)
+    checks.append(_check_onboarding_first_signal(config, ctx.obj["db"]))
+
     if output_json:
         click.echo(json.dumps(checks, default=str))
     else:
@@ -602,6 +605,86 @@ def _check_statusline_wiring(config: object) -> dict:
         "message": (
             "Claude Code not detected. `tj onboard --claude-code` wires the "
             "zero-token tj statusline when you use it."
+        ),
+    }
+
+
+def _tj_statusline_wired() -> bool:
+    """True when ~/.claude/settings.json wires the tj statusline (a Claude Code
+    onboarding marker)."""
+    from pathlib import Path
+
+    settings_path = Path.home() / ".claude" / "settings.json"
+    if not settings_path.exists():
+        return False
+    try:
+        with open(settings_path, "r", encoding="utf-8") as f:
+            data = json.load(f)
+        sl = data.get("statusLine")
+        cmd = sl.get("command", "") if isinstance(sl, dict) else ""
+        return isinstance(cmd, str) and "tj statusline" in cmd
+    except Exception:
+        return False
+
+
+def _detect_onboarded_persona(config: object) -> str:
+    """Best-guess the onboarding persona from config, for a tailored cause.
+
+    Falls back to ``"sdk"`` — the fail-open path where a silent config is most
+    likely — when no Claude Code / Codex marker is present.
+    """
+    agent_ids = list(getattr(config, "agents", {}) or {})
+    if any(a.startswith("claude-code-") for a in agent_ids):
+        return "claude_code"
+    if "codex_exec" in agent_ids:
+        return "codex"
+    if _tj_statusline_wired():
+        return "claude_code"
+    return "sdk"
+
+
+def _check_onboarding_first_signal(config: object, db: object) -> dict:
+    """Diagnose the onboarded-but-zero-spans silent case (#80).
+
+    Two personas can finish onboarding "successfully" yet never emit a span: the
+    Claude Code path only starts telemetry after a restart, and the fail-open SDK
+    path swallows a typo'd agent_id / missing patch / dead daemon silently. When
+    the DB has zero spans but a config exists, surface the likely per-persona
+    cause instead of leaving the user staring at a blank Status page.
+
+    Reported at **info** level, not warning: doctor has no onboarding timestamp,
+    so it can't tell "just onboarded seconds ago" (expected empty) from "onboarded
+    long ago and silent" (the failure). Flagging every fresh setup as a warning
+    would be a false alarm and flip a clean `tj doctor` to exit 1. The info line
+    still carries the actionable per-persona cause. Complements
+    ``_check_span_staleness`` (which owns spans-exist-but-stale); this one owns the
+    spans-never-arrived case.
+    """
+    conn = getattr(db, "conn", None)
+    if conn is None:
+        return {"name": "Onboarding signal", "level": "info",
+                "message": "Skipped — CLI is running through the HTTP API "
+                           "fallback (stop `tj serve` to access the DB directly)."}
+    try:
+        row = conn.execute("SELECT COUNT(*) FROM spans").fetchone()
+    except duckdb.Error as e:
+        return {"name": "Onboarding signal", "level": "info",
+                "message": f"Skipped — could not count spans: {e}"}
+
+    total = int(row[0]) if row and row[0] is not None else 0
+    if total > 0:
+        return {"name": "Onboarding signal", "level": "ok",
+                "message": f"{total} span(s) recorded — telemetry is flowing."}
+
+    from tokenjam.core.onboard_verify import not_confirmed_cause
+
+    persona = _detect_onboarded_persona(config)
+    return {
+        "name": "Onboarding signal",
+        "level": "info",
+        "message": (
+            "Onboarded but no spans have been recorded yet. "
+            + not_confirmed_cause(persona)
         ),
     }
 

--- a/tokenjam/cli/cmd_onboard.py
+++ b/tokenjam/cli/cmd_onboard.py
@@ -271,19 +271,26 @@ def _print_instrument_agent_snippet() -> None:
               help="Project name to group this repo under in the dashboard "
                    "(OTel service.namespace — e.g. all Aquanodeio/* repos under "
                    "'aquanode'). Defaults to the git org. Used with --claude-code.")
+@click.option("--verify", is_flag=True, default=False,
+              help="After setup, poll for the first span from the newly "
+                   "configured source and report whether telemetry is flowing "
+                   "(distinguishes 'wired and receiving' from 'configured but "
+                   "silent'). Runs non-interactively; skips the prompt.")
 @click.pass_context
 def cmd_onboard(ctx: click.Context, claude_code: bool, codex: bool, budget: float | None,
                 install_daemon: bool, no_daemon: bool, force: bool,
-                reconfigure: bool, plan: str | None, project_override: str | None) -> None:
+                reconfigure: bool, plan: str | None, project_override: str | None,
+                verify: bool) -> None:
     """Interactive setup wizard for tj."""
     # Branded welcome moment (#240) — shown once at the top of every onboard
     # flow (plain / --claude-code / --codex) before any prompt or config check.
     print_welcome_banner()
     if claude_code:
-        _onboard_claude_code(ctx, budget, no_daemon, force, reconfigure, plan, project_override)
+        _onboard_claude_code(ctx, budget, no_daemon, force, reconfigure, plan,
+                             project_override, verify=verify)
         return
     if codex:
-        _onboard_codex(ctx, budget, no_daemon, force, reconfigure, plan)
+        _onboard_codex(ctx, budget, no_daemon, force, reconfigure, plan, verify=verify)
         return
     existing = find_config_file()
     if existing and not force:
@@ -471,6 +478,90 @@ retention_days = 90
     )
     console.print()
 
+    # First-signal verification (#80): the SDK is fail-open, so a typo'd
+    # agent_id / missing patch / dead daemon leaves the user silent. Reload the
+    # just-written config so the poller reads the same DB/API the daemon uses.
+    try:
+        from tokenjam.core.config import load_config as _load_written_config
+        written_config = _load_written_config(str(config_path.resolve()))
+    except Exception:
+        written_config = None
+    if written_config is not None:
+        _maybe_verify_onboarding(written_config, persona="sdk", verify=verify)
+
+
+def _maybe_verify_onboarding(config: object, *, persona: str, verify: bool) -> None:
+    """Run first-signal verification if ``--verify`` was passed, or offer it
+    interactively. No-op when neither applies (non-interactive without the flag).
+
+    ``persona`` is one of ``"sdk"``, ``"claude_code"``, ``"codex"`` and drives
+    the instruction shown and the not-confirmed cause.
+    """
+    if not verify:
+        if not sys.stdin.isatty():
+            return
+        if not click.confirm(
+            "\nVerify tj is receiving telemetry now?", default=False
+        ):
+            return
+    _run_onboard_verification(config, persona)
+
+
+def _run_onboard_verification(
+    config: object, persona: str, *, timeout_s: float = 60.0
+) -> None:
+    """Open a read-only path to spans and poll for the first one after now,
+    reporting confirmed / not-confirmed with the per-persona likely cause."""
+    from tokenjam.core.onboard_verify import (
+        not_confirmed_cause,
+        open_read_backend,
+        poll_for_first_span,
+    )
+    from tokenjam.utils.time_parse import utcnow
+
+    backend, _mode, error = open_read_backend(config)
+    if backend is None:
+        console.print(f"\n[yellow]Can't verify yet[/yellow] \u2014 {error}.")
+        console.print(
+            "Start [bold]tj serve[/bold], then run [bold]tj doctor[/bold] to check."
+        )
+        return
+
+    try:
+        since = utcnow()
+        if persona == "sdk":
+            console.print(
+                "\n[bold]Verifying\u2026[/bold] trigger one span now \u2014 run your agent, "
+                "or in another terminal run [bold]tj ping[/bold]."
+            )
+        else:
+            console.print(
+                "\n[bold]Verifying\u2026[/bold] waiting for the first telemetry. If you "
+                "haven't yet, [bold]restart[/bold] the agent runtime now."
+            )
+        console.print(f"[dim]Polling for up to {int(timeout_s)}s\u2026[/dim]")
+        result = poll_for_first_span(backend, since, timeout_s=timeout_s)
+    finally:
+        close = getattr(backend, "close", None)
+        if callable(close):
+            try:
+                close()
+            except Exception:
+                pass
+
+    if result.confirmed:
+        console.print(
+            f"[green]\u2713 Receiving telemetry![/green] First span arrived after "
+            f"{result.elapsed_s:.0f}s \u2014 you're wired up."
+        )
+    elif result.error:
+        console.print(f"[yellow]Couldn't verify[/yellow] \u2014 {result.error}.")
+    else:
+        console.print(
+            f"[yellow]\u26a0 No telemetry yet[/yellow] after {int(timeout_s)}s. "
+            + not_confirmed_cause(persona)
+        )
+
 
 _ANTHROPIC_PLAN_CHOICES = [
     ("api",      "API (per-token billing through console.anthropic.com)"),
@@ -613,6 +704,7 @@ def _onboard_claude_code(
     reconfigure: bool = False,
     plan_override: str | None = None,
     project_override: str | None = None,
+    verify: bool = False,
 ) -> None:
     """Configure Claude Code to send telemetry to tj."""
     from tokenjam.core.config import (
@@ -1041,6 +1133,8 @@ def _onboard_claude_code(
     )
     console.print(f"[dim]After restarting, run:[/dim]  tj status --agent {agent_id}")
 
+    _maybe_verify_onboarding(config, persona="claude_code", verify=verify)
+
 
 def _onboard_codex(
     ctx: click.Context,
@@ -1049,6 +1143,7 @@ def _onboard_codex(
     force: bool,
     reconfigure: bool = False,
     plan_override: str | None = None,
+    verify: bool = False,
 ) -> None:
     """Configure Codex CLI to send telemetry to tj."""
     try:
@@ -1297,6 +1392,8 @@ def _onboard_codex(
     )
     _print_restart_banner("Codex")
     console.print("[dim]After restarting, run:[/dim]  tj traces")
+
+    _maybe_verify_onboarding(config, persona="codex", verify=verify)
 
 
 def _print_restart_banner(app_name: str) -> None:

--- a/tokenjam/cli/cmd_ping.py
+++ b/tokenjam/cli/cmd_ping.py
@@ -1,0 +1,223 @@
+"""
+``tj ping`` — emit one clearly-labeled test span through the real SDK exporter
+path so an SDK user can prove their wiring without running a whole agent (#80).
+
+Modeled on Sentry's wizard-generated test event and OTel's console-exporter
+proof-of-life: the span is emitted through the same ``@watch()`` / provider-patch
+machinery real agents use, and a local in-process exporter prints a "the patch IS
+intercepting" confirmation that fires even when the daemon is down (the span is
+still captured locally). The command then reports where the span was delivered —
+a running ``tj serve`` over HTTP, or the local DuckDB.
+
+Exit code contract: 0 means delivery was *confirmed*, not merely attempted. In
+HTTP mode the span is POSTed asynchronously via ``BatchSpanProcessor``, and
+``TjHttpExporter.export()`` swallows network/auth failures into a logged
+``SpanExportResult.FAILURE`` rather than raising — so ``force_flush()`` returning
+without an exception does not mean the daemon actually stored the span. To make
+the exit code trustworthy for scripts/CI, HTTP-mode delivery is confirmed by
+polling the daemon's read API for the just-emitted span (reusing
+``onboard_verify``'s ``open_read_backend``/``poll_for_first_span``) before
+exiting 0. Direct (local DuckDB) mode writes synchronously inside
+``force_flush()`` (``TjSpanExporter.export()`` calls ``pipeline.process()``
+in-line), so a clean flush already means the span landed in the DB.
+"""
+from __future__ import annotations
+
+import json as _json
+
+import click
+
+from tokenjam.utils.formatting import console
+
+# Clearly-labeled test identity so a ping span is never mistaken for real
+# telemetry in the dashboard or analyzers.
+PING_AGENT_ID = "tj-ping"
+PING_MODEL = "tj-ping-test"
+
+# How long to wait for the daemon to confirm it stored the ping span before
+# giving up. Short: the span was already POSTed by the time we start polling,
+# so a healthy daemon confirms almost immediately.
+PING_CONFIRM_TIMEOUT_S = 8.0
+PING_CONFIRM_INTERVAL_S = 1.0
+
+
+class _ProofExporter:
+    """Minimal in-process SpanExporter that records exported spans so we can
+    print a local proof-of-life. Attached via a SimpleSpanProcessor so it fires
+    synchronously on span end, independent of network / DB delivery."""
+
+    def __init__(self) -> None:
+        self.captured: list[str] = []
+
+    def export(self, spans):  # type: ignore[no-untyped-def]
+        from opentelemetry.sdk.trace.export import SpanExportResult
+
+        for span in spans:
+            self.captured.append(span.name)
+        return SpanExportResult.SUCCESS
+
+    def shutdown(self) -> None:  # pragma: no cover - trivial
+        pass
+
+    def force_flush(self, timeout_millis: int = 30000) -> bool:  # pragma: no cover
+        return True
+
+
+@click.command("ping")
+@click.option("--agent", "agent_id", default=PING_AGENT_ID, show_default=True,
+              help="agent_id to stamp on the test span.")
+@click.option("--json", "output_json", is_flag=True,
+              help="Emit a machine-readable result instead of prose.")
+@click.pass_context
+def cmd_ping(ctx: click.Context, agent_id: str, output_json: bool) -> None:
+    """Emit a labeled test span to prove SDK instrumentation is wired up.
+
+    Exits 0 only once delivery is *confirmed* — HTTP mode polls the daemon's
+    read API for the span before exiting; exit 0 in HTTP mode never means
+    just "attempted". See the module docstring for why that distinction
+    matters.
+    """
+    config = ctx.obj["config"]
+
+    from opentelemetry import trace as trace_api
+    from opentelemetry.sdk.trace.export import SimpleSpanProcessor
+
+    from tokenjam.sdk import bootstrap
+    from tokenjam.sdk.agent import AgentSession, record_llm_call
+    from tokenjam.utils.time_parse import utcnow
+
+    bootstrap.ensure_initialised()
+
+    # Attach the local proof-of-life exporter to whichever provider bootstrap
+    # set as global. If bootstrap failed entirely there is no real provider, so
+    # the interception can't be proven — reported honestly below.
+    proof = _ProofExporter()
+    provider = trace_api.get_tracer_provider()
+    proof_attached = False
+    if hasattr(provider, "add_span_processor"):
+        provider.add_span_processor(SimpleSpanProcessor(proof))
+        proof_attached = True
+
+    # Captured before emission so the confirmation poll below only matches
+    # this ping's span, not a stale one from an earlier run.
+    since = utcnow()
+
+    # Emit one labeled test span through the real @watch()/record_llm_call path.
+    with AgentSession(agent_id=agent_id):
+        record_llm_call(
+            model=PING_MODEL,
+            provider="anthropic",
+            input_tokens=1,
+            output_tokens=1,
+        )
+
+    if hasattr(provider, "force_flush"):
+        try:
+            provider.force_flush()
+        except Exception:  # noqa: BLE001 — best-effort delivery
+            pass
+
+    mode = bootstrap.get_mode()
+    intercepted = proof_attached and bool(proof.captured)
+
+    confirmed = False
+    confirm_error: str | None = None
+    if mode == "direct":
+        # Written synchronously above (see module docstring) — no read-back
+        # needed, and re-opening the DB here would contend with the write
+        # connection this same process already holds.
+        confirmed = True
+    elif mode == "http":
+        confirmed, confirm_error = _confirm_delivery(config, agent_id, since)
+
+    if output_json:
+        console.print_json(_json.dumps({
+            "intercepted": intercepted,
+            "delivery_mode": mode,
+            "confirmed": confirmed,
+            "agent_id": agent_id,
+            "model": PING_MODEL,
+        }))
+        _exit_for_confirmation(ctx, confirmed)
+        return
+
+    if intercepted:
+        console.print(
+            "[green]✓[/green] tj intercepted a test span "
+            f"([bold]llm_call[/bold] model={PING_MODEL} agent={agent_id}) "
+            "— the SDK export path is working."
+        )
+    else:
+        console.print(
+            "[yellow]⚠[/yellow] Could not confirm local interception "
+            "(the SDK failed to initialise a tracer)."
+        )
+
+    base_url = f"http://{config.api.host}:{config.api.port}"
+    if mode == "http" and confirmed:
+        console.print(
+            f"[green]✓[/green] Delivered to [bold]tj serve[/bold] at {base_url} "
+            "(confirmed received). Run [bold]tj status[/bold] to see it."
+        )
+    elif mode == "http":
+        reason = f" ({confirm_error})" if confirm_error else ""
+        console.print(
+            f"[yellow]⚠[/yellow] Span emitted to [bold]tj serve[/bold] at {base_url} "
+            f"but not confirmed received{reason} — is [bold]tj serve[/bold] healthy? "
+            "Run [bold]tj status[/bold] to check."
+        )
+    elif mode == "direct":
+        console.print(
+            f"[green]✓[/green] Written to the local database "
+            f"([dim]{config.storage.path}[/dim]). Run [bold]tj status[/bold] to see it."
+        )
+    else:
+        console.print(
+            "[yellow]⚠[/yellow] Could not reach [bold]tj serve[/bold] or open the "
+            "local database, so the span was not stored. Start [bold]tj serve[/bold] "
+            "and re-run [bold]tj ping[/bold]."
+        )
+
+    _exit_for_confirmation(ctx, confirmed)
+
+
+def _confirm_delivery(
+    config: object, agent_id: str, since: object
+) -> tuple[bool, str | None]:
+    """Poll the daemon's read API for the just-emitted ping span.
+
+    Returns ``(confirmed, error)``. ``error`` is set only when the read path
+    itself couldn't be resolved (daemon unreachable and the local DB is
+    locked/unavailable) — a clean "didn't arrive within the timeout" is
+    ``(False, None)``.
+    """
+    from tokenjam.core.onboard_verify import open_read_backend, poll_for_first_span
+
+    backend, _mode, error = open_read_backend(config)
+    if backend is None:
+        return False, error
+
+    try:
+        result = poll_for_first_span(
+            backend,
+            since,
+            agent_id=agent_id,
+            timeout_s=PING_CONFIRM_TIMEOUT_S,
+            interval_s=PING_CONFIRM_INTERVAL_S,
+        )
+    finally:
+        close = getattr(backend, "close", None)
+        if callable(close):
+            try:
+                close()
+            except Exception:  # noqa: BLE001 — best-effort cleanup
+                pass
+
+    if result.error:
+        return False, result.error
+    return result.confirmed, None
+
+
+def _exit_for_confirmation(ctx: click.Context, confirmed: bool) -> None:
+    """Exit non-zero unless delivery was confirmed, so scripts/CI can gate on it."""
+    ctx.exit(0 if confirmed else 1)

--- a/tokenjam/cli/main.py
+++ b/tokenjam/cli/main.py
@@ -48,6 +48,9 @@ def cli(ctx: click.Context, config_path: str | None, output_json: bool,
         "proxy", "summarize", "pricing", "otel-resource-attrs", "session-end",
         "statusline",
         "quickstart",
+        # `ping` emits a test span through the SDK (which resolves its own
+        # HTTP-vs-direct path); it must not take the CLI's DuckDB lock (#80).
+        "ping",
         # `hook` fires on every tool call and must never take the DuckDB lock
         # (#61); `savings` reads the append-only JSONL sink, not the DB.
         "hook", "savings",
@@ -125,6 +128,7 @@ from tokenjam.cli.cmd_session_end import cmd_session_end  # noqa: E402
 from tokenjam.cli.cmd_statusline import cmd_statusline  # noqa: E402
 from tokenjam.cli.cmd_loop import cmd_loop  # noqa: E402
 from tokenjam.cli.cmd_resume_brief import cmd_resume_brief  # noqa: E402
+from tokenjam.cli.cmd_ping import cmd_ping  # noqa: E402
 
 cli.add_command(cmd_onboard, name="onboard")
 cli.add_command(cmd_status, name="status")
@@ -155,6 +159,7 @@ cli.add_command(cmd_session_end, name="session-end")
 cli.add_command(cmd_statusline, name="statusline")
 cli.add_command(cmd_loop, name="loop")
 cli.add_command(cmd_resume_brief, name="resume-brief")
+cli.add_command(cmd_ping, name="ping")
 
 # cmd_drift is provided by task 05 — register if available
 try:

--- a/tokenjam/core/onboard_verify.py
+++ b/tokenjam/core/onboard_verify.py
@@ -1,0 +1,166 @@
+"""
+First-signal onboarding verification (#80).
+
+Two onboarding personas can "successfully" finish setup yet never emit a single
+span, with no signal that anything is wrong:
+
+  - **SDK**: a bare ``tj onboard`` ends by printing a ``patch_anthropic()`` +
+    ``@watch()`` snippet. The SDK is deliberately fail-open, so a typo'd
+    ``agent_id``, a missing patch call, or a dead daemon produces zero spans
+    silently.
+  - **Claude Code / Codex**: telemetry only starts after the user restarts the
+    agent runtime. If they never restart, ingest never begins and nothing tells
+    them.
+
+This module provides the shared, side-effect-light polling primitive used by
+``tj onboard --verify`` (and the post-onboard prompt) to distinguish "wired and
+receiving" from "configured but silent". It is import-safe from both the CLI and
+tests, and takes no DuckDB write lock — it reads through whichever backend is
+resolved by :func:`open_read_backend` (the running daemon over HTTP when present,
+a direct read otherwise).
+"""
+from __future__ import annotations
+
+import time
+from dataclasses import dataclass
+from datetime import datetime
+from typing import Callable, Protocol
+
+from tokenjam.core.models import TraceFilters
+
+# Poll cadence defaults. ~60s total is long enough for a human to restart Claude
+# Code or run `tj ping` in another terminal, short enough to not feel hung.
+DEFAULT_TIMEOUT_S = 60.0
+DEFAULT_INTERVAL_S = 2.0
+
+
+class _ReadBackend(Protocol):
+    """The single method the poller needs — both DuckDBBackend and ApiBackend
+    satisfy this."""
+
+    def get_traces(self, filters: TraceFilters) -> list: ...
+
+
+@dataclass(frozen=True)
+class VerifyResult:
+    """Outcome of a first-span poll.
+
+    ``confirmed`` is True when at least one span arrived after ``since``.
+    ``error`` is set only when the read itself failed (e.g. the DB went away
+    mid-poll); a clean "nothing arrived within the timeout" is ``confirmed=False``
+    with ``error=None``.
+    """
+
+    confirmed: bool
+    elapsed_s: float
+    first_trace_id: str | None = None
+    error: str | None = None
+
+
+def poll_for_first_span(
+    backend: _ReadBackend,
+    since: datetime | None,
+    *,
+    agent_id: str | None = None,
+    timeout_s: float = DEFAULT_TIMEOUT_S,
+    interval_s: float = DEFAULT_INTERVAL_S,
+    sleep: Callable[[float], None] = time.sleep,
+    monotonic: Callable[[], float] = time.monotonic,
+) -> VerifyResult:
+    """Poll ``backend`` until a trace whose spans started at/after ``since``
+    appears, or ``timeout_s`` elapses.
+
+    ``agent_id`` narrows the poll to a single source when the caller knows it;
+    callers that can't reliably predict the ingested ``agent_id`` (e.g. Claude
+    Code, whose spans carry a ``service.name``-derived id that differs from the
+    ``claude-code-<project>`` config key) should leave it ``None`` and rely on
+    the ``since`` time bound.
+
+    ``sleep`` / ``monotonic`` are injectable so tests never wait real seconds.
+    """
+    start = monotonic()
+    while True:
+        try:
+            traces = backend.get_traces(
+                TraceFilters(since=since, agent_id=agent_id, limit=1)
+            )
+        except Exception as exc:  # noqa: BLE001 — surface, don't crash onboarding
+            return VerifyResult(False, monotonic() - start, error=str(exc))
+
+        if traces:
+            return VerifyResult(
+                True, monotonic() - start, first_trace_id=traces[0].trace_id
+            )
+
+        if monotonic() - start >= timeout_s:
+            return VerifyResult(False, monotonic() - start)
+
+        sleep(interval_s)
+
+
+def not_confirmed_cause(persona: str) -> str:
+    """Return the most likely reason no span arrived, phrased for the persona.
+
+    ``persona`` is one of ``"sdk"``, ``"claude_code"``, ``"codex"``; anything
+    else falls back to a generic message that covers both failure modes.
+    """
+    if persona == "claude_code":
+        return (
+            "Claude Code only starts sending telemetry after a restart. Open a "
+            "new terminal and launch `claude`, then re-run `tj doctor`. If you "
+            "already restarted, check the OTLP wiring with `tj doctor`."
+        )
+    if persona == "codex":
+        return (
+            "Codex only starts sending telemetry after a restart. Restart Codex, "
+            "then re-run `tj doctor`. If you already restarted, check the OTLP "
+            "wiring with `tj doctor`."
+        )
+    if persona == "sdk":
+        return (
+            "Make sure patch_anthropic()/@watch() actually run in your agent and "
+            "the daemon is reachable. Run `tj ping` to emit a labeled test span, "
+            "then `tj status`."
+        )
+    return (
+        "If you use Claude Code / Codex, restart it so telemetry starts. If you "
+        "use the SDK, confirm patch_*()/@watch() run and the daemon is up — try "
+        "`tj ping`."
+    )
+
+
+def open_read_backend(config) -> tuple[object | None, str | None, str | None]:
+    """Resolve a read-only path to spans without competing for the DuckDB write
+    lock.
+
+    Returns ``(backend, mode, error)`` where ``mode`` is ``"api"`` or
+    ``"direct"`` on success (``error`` None), or ``(None, None, error)`` when
+    neither path is available.
+
+    The running daemon is tried **first** (a plain HTTP GET, no lock): in the
+    default post-onboard state ``tj serve`` holds the DuckDB write lock, and the
+    poller must never take a competing lock (DuckDB is single-writer). Only when
+    no daemon answers do we open the file directly — the pre-daemon / --no-daemon
+    case, where nothing else holds the lock.
+    """
+    from tokenjam.core.api_backend import probe_api
+
+    api_key = config.api.auth.api_key if config.api.auth.enabled else None
+    api = probe_api(config.api.host, config.api.port, api_key)
+    if api is not None:
+        return api, "api", None
+
+    from tokenjam.core.db import open_db
+
+    try:
+        return open_db(config.storage), "direct", None
+    except Exception as exc:  # noqa: BLE001
+        msg = str(exc).lower()
+        if "lock" in msg or "already open" in msg or "i/o error" in msg:
+            return (
+                None,
+                None,
+                "the database is locked (is tj serve running?) and its API isn't "
+                f"reachable at http://{config.api.host}:{config.api.port}",
+            )
+        return None, None, str(exc)

--- a/tokenjam/sdk/bootstrap.py
+++ b/tokenjam/sdk/bootstrap.py
@@ -17,6 +17,16 @@ _lock = threading.Lock()
 _initialised = False
 _provider = None
 _pipeline = None
+# Where spans are being delivered after bootstrap, for surfaces (e.g. `tj ping`)
+# that want to tell the user. One of: "uninitialised", "http" (posting to a
+# running `tj serve`), "direct" (writing local DuckDB), "failed" (neither — the
+# SDK stays fail-open and drops spans).
+_mode = "uninitialised"
+
+
+def get_mode() -> str:
+    """Return the current span-delivery mode set by :func:`ensure_initialised`."""
+    return _mode
 
 
 def ensure_initialised() -> None:
@@ -24,7 +34,7 @@ def ensure_initialised() -> None:
     Idempotent bootstrap. Safe to call multiple times / from multiple threads.
     Sets up: config -> DuckDB -> IngestPipeline -> TjSpanExporter -> TracerProvider.
     """
-    global _initialised, _provider, _pipeline
+    global _initialised, _provider, _pipeline, _mode
     if _initialised:
         return
 
@@ -40,6 +50,7 @@ def ensure_initialised() -> None:
 
             # Check if tj serve is running — use HTTP exporter if so
             if _try_http_mode(config):
+                _mode = "http"
                 _initialised = True
                 atexit.register(_shutdown)
                 return
@@ -52,6 +63,7 @@ def ensure_initialised() -> None:
             pipeline = build_default_pipeline(db, config)
             _pipeline = pipeline
             _provider = build_tracer_provider(config, pipeline)
+            _mode = "direct"
             _initialised = True
 
             # Ensure spans are flushed on exit
@@ -66,11 +78,13 @@ def ensure_initialised() -> None:
                 try:
                     config = load_config()
                     if _try_http_mode(config):
+                        _mode = "http"
                         _initialised = True
                         atexit.register(_shutdown)
                         return
                 except Exception:
                     pass
+            _mode = "failed"
             logger.warning("TokenJam bootstrap failed — spans will not be recorded: %s", exc)
             _initialised = True  # Don't retry on every call
 


### PR DESCRIPTION
Updated the section on coding agents to clarify that TokenJam is built by both humans and AI coding agents.

## Summary

<!-- What does this PR do? 1-3 sentences. -->

## Related issue

<!-- Closes #N  — so the issue auto-closes on merge. One "Closes" line per issue. Omit if there's no issue. -->

## Checklist

- [ ] Tests pass (`pytest tests/unit/ tests/synthetic/ tests/agents/ tests/integration/`)
- [ ] Lint clean (`ruff check tokenjam/`)
- [ ] Type check clean (`mypy tokenjam/`)
- [ ] CLAUDE.md updated (if architecture changed)
- [ ] Test spans use `tests/factories.py` (not raw `NormalizedSpan`)
- [ ] Requested `@anilmurty` as reviewer (or @-mentioned him above)
