### PR TITLE
Bump version to 0.5.4

### DIFF
--- a/npm-wrapper/package.json
+++ b/npm-wrapper/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tokenjam",
-  "version": "0.5.3",
+  "version": "0.5.4",
   "description": "Zero-install launcher for TokenJam (tj) — `npx tokenjam` runs the Python CLI via uvx/pipx and prints where your Claude Code quota actually goes, no setup.",
   "keywords": ["claude-code", "ccusage", "tokens", "cost", "llm", "agents", "observability", "tokenjam"],
   "homepage": "https://tokenjam.dev",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "tokenjam"
-version = "0.5.3"
+version = "0.5.4"
 description = "TokenJam — local-first OTel-native observability for Autonomous AI agents"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/sdk-ts/package.json
+++ b/sdk-ts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tokenjam/sdk",
-  "version": "0.5.3",
+  "version": "0.5.4",
   "description": "TypeScript SDK for TokenJam — local-first observability for AI agents",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",


### PR DESCRIPTION
Routine patch release. Version bump only in this PR (`pyproject.toml`, `sdk-ts/package.json`, `npm-wrapper/package.json`); everything below already merged to `main` since v0.5.3.

## Features
- `tj ping` — proof-of-life test-span emitter to verify instrumentation is wired (#80)
- `tj onboard --verify` — first-signal onboarding verification step + `doctor` silent-case diagnosis (#80, #410)
- `tj resume-brief` — hands a resuming session its prior method, ~40–60% fewer turns to re-orient (#401)
- `tokenjam` console-script alias — bare `uvx tokenjam` / `pipx run tokenjam` now work alongside `tj`
- Project stack detection — `tj onboard` tailors its instrument snippet to the detected stack (#85, #407)
- `tj optimize` findings now ranked by reclaimable token share, with persona-aware CTAs (#97)
- `tj status` alert dedup + consistent dollar-based subscription cost framing via a shared currency formatter (#96)

## Fixes
- Daily cost API shim window bug (#348)
- Session-less OTLP spans now correctly attach to the trace's session (#409)
- Onboarding stack-detection guarded against a `UnicodeDecodeError` crash (#408)
- `verify`/`doctor` status contradiction, path wrapping, SDK doctor exit code (#102, #104, #105)
- Statusline renders human-readable token counts instead of `"0.0M tok"` (#103)

## Docs
- README restructured as convince-and-route, stale claims fixed
- Getting-started ladder + first-hour guide + real quickstart hero screenshot

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
