### PR TITLE
[feature] Add summarize analyzer (Track A recoverable signal)

### DIFF
--- a/tests/unit/test_optimize_summarize.py
+++ b/tests/unit/test_optimize_summarize.py
@@ -1,0 +1,100 @@
+"""Track A summarize analyzer — filesystem-derived recoverable finding.
+
+The analyzer reasons over the summarize scan (filesystem), not telemetry, so the
+scan is monkeypatched to a controlled ScanResult. Asserts the #111 recoverable
+contract: tokens summed from candidates, usd deliberately None (tokens-only), an
+explicit basis, and a clean report_to_dict/report_from_dict round-trip.
+"""
+from __future__ import annotations
+
+from datetime import timedelta
+
+import pytest
+
+from tokenjam.core.config import TjConfig
+from tokenjam.core.db import InMemoryBackend
+from tokenjam.core.optimize import build_report
+from tokenjam.core.optimize.runner import report_from_dict, report_to_dict
+from tokenjam.core.summarize.candidates import Candidate, ScanResult
+from tokenjam.utils.time_parse import utcnow
+
+
+@pytest.fixture
+def db():
+    backend = InMemoryBackend()
+    yield backend
+    backend.close()
+
+
+def _window():
+    return utcnow() - timedelta(days=30), utcnow() + timedelta(hours=1)
+
+
+def _cand(path: str, saved: int, *, is_prompt: bool = True, scope: str = "repo") -> Candidate:
+    return Candidate(
+        path=path, prose_words=saved * 3, total_chars=saved * 12,
+        protected_blocks=0, est_tokens_saved=saved, pricing_mode="api",
+        scope=scope, is_prompt=is_prompt,
+    )
+
+
+def _patch_scan(monkeypatch, cands: list[Candidate]) -> None:
+    result = ScanResult(candidates=cands, root=".", recursive=False,
+                        globals_checked=0, walk_capped=False, note="")
+    monkeypatch.setattr(
+        "tokenjam.core.summarize.candidates.list_candidates",
+        lambda **kw: result,
+    )
+
+
+def _run(db) -> object:
+    since, until = _window()
+    report = build_report(db=db, config=TjConfig(version="1"),
+                          since=since, until=until, findings=["summarize"])
+    return report.findings["summarize"]
+
+
+def test_sums_per_call_tokens_drops_zero_saving(db, monkeypatch):
+    _patch_scan(monkeypatch, [
+        _cand("./CLAUDE.md", 410),
+        _cand("./AGENTS.md", 300),
+        _cand("./docs/x.md", 0, is_prompt=False),   # no saving → dropped
+    ])
+    f = _run(db)
+    assert f.files == 2
+    assert f.estimated_recoverable_tokens == 710
+    assert f.estimated_recoverable_usd is None       # tokens-only by design
+    assert f.estimate_confidence == "heuristic"
+    assert f.estimate_basis                          # explicit basis required by contract
+    assert {c.path for c in f.candidates} == {"./CLAUDE.md", "./AGENTS.md"}
+
+
+def test_empty_scan_yields_no_tokens_but_keeps_basis(db, monkeypatch):
+    _patch_scan(monkeypatch, [])
+    f = _run(db)
+    assert f.files == 0
+    assert f.estimated_recoverable_tokens is None
+    assert f.estimated_recoverable_usd is None
+    assert f.estimate_basis
+
+
+def test_scan_error_never_breaks_the_report(db, monkeypatch):
+    def boom(**kw):
+        raise OSError("disk gone")
+    monkeypatch.setattr("tokenjam.core.summarize.candidates.list_candidates", boom)
+    f = _run(db)
+    assert f.files == 0 and f.estimated_recoverable_tokens is None
+
+
+def test_finding_round_trips(db, monkeypatch):
+    _patch_scan(monkeypatch, [_cand("./CLAUDE.md", 410)])
+    since, until = _window()
+    report = build_report(db=db, config=TjConfig(version="1"),
+                          since=since, until=until, findings=["summarize"])
+    payload = report_to_dict(report)
+    assert payload["findings"]["summarize"]["estimated_recoverable_tokens"] == 410
+    assert payload["findings"]["summarize"]["estimated_recoverable_usd"] is None
+    back = report_from_dict(payload).findings["summarize"]
+    assert back.files == 1
+    assert back.estimated_recoverable_tokens == 410
+    assert back.candidates[0].path == "./CLAUDE.md"

--- a/tests/unit/test_optimize_summarize.py
+++ b/tests/unit/test_optimize_summarize.py
@@ -18,6 +18,7 @@ from tokenjam.core.optimize import build_report
 from tokenjam.core.optimize.runner import report_from_dict, report_to_dict
 from tokenjam.core.summarize.candidates import Candidate, ScanResult
 from tokenjam.utils.time_parse import utcnow
+from tests.factories import make_llm_span, make_session
 
 
 @pytest.fixture
@@ -48,7 +49,16 @@ def _patch_scan(monkeypatch, cands: list[Candidate]) -> None:
     )
 
 
+def _seed_window(db) -> None:
+    """One qualifying LLM call in the window so the analyzer runs — it
+    window-guards on a dead window (no telemetry → no per-call saving to attach).
+    Content is irrelevant; the finding is filesystem-derived."""
+    db.upsert_session(make_session(session_id="s0"))
+    db.insert_span(make_llm_span(session_id="s0", start_time=utcnow() - timedelta(days=1)))
+
+
 def _run(db) -> object:
+    _seed_window(db)
     since, until = _window()
     report = build_report(db=db, config=TjConfig(version="1"),
                           since=since, until=until, findings=["summarize"])
@@ -68,6 +78,28 @@ def test_sums_per_call_tokens_drops_zero_saving(db, monkeypatch):
     assert f.estimate_confidence == "heuristic"
     assert f.estimate_basis                          # explicit basis required by contract
     assert {c.path for c in f.candidates} == {"./CLAUDE.md", "./AGENTS.md"}
+    # Mandatory honesty caveat carried as the field default (Rule 14).
+    assert "meaning may change" in f.caveat
+    # Prose reduction %s computed server-side (_cand sets total_chars = saved*12,
+    # so source tokens = saved*3 → every file reduces ~33%). Per-file + aggregate.
+    assert all(c.reduction_pct == 33 for c in f.candidates)
+    assert f.reduction_pct == 33
+    assert f.avg_reduction_pct == 33
+
+
+def test_dead_window_contributes_nothing(db, monkeypatch):
+    # No telemetry in the window → no per-call saving to attach; the analyzer must
+    # NOT scan the filesystem and must emit no recoverable figure (#211 invariant).
+    def must_not_run(**kw):
+        raise AssertionError("summarize scan ran on a dead telemetry window")
+    monkeypatch.setattr("tokenjam.core.summarize.candidates.list_candidates", must_not_run)
+    since, until = _window()   # empty db → total_tokens == 0
+    report = build_report(db=db, config=TjConfig(version="1"),
+                          since=since, until=until, findings=["summarize"])
+    f = report.findings["summarize"]
+    assert f.files == 0
+    assert f.estimated_recoverable_tokens is None
+    assert f.reduction_pct is None
 
 
 def test_empty_scan_yields_no_tokens_but_keeps_basis(db, monkeypatch):
@@ -91,14 +123,21 @@ def test_scan_error_never_breaks_the_report(db, monkeypatch, caplog):
 
 
 def test_finding_round_trips(db, monkeypatch):
+    _seed_window(db)
     _patch_scan(monkeypatch, [_cand("./CLAUDE.md", 410)])
     since, until = _window()
     report = build_report(db=db, config=TjConfig(version="1"),
                           since=since, until=until, findings=["summarize"])
     payload = report_to_dict(report)
-    assert payload["findings"]["summarize"]["estimated_recoverable_tokens"] == 410
-    assert payload["findings"]["summarize"]["estimated_recoverable_usd"] is None
+    sd = payload["findings"]["summarize"]
+    assert sd["estimated_recoverable_tokens"] == 410
+    assert sd["estimated_recoverable_usd"] is None
+    assert "meaning may change" in sd["caveat"]       # caveat survives serialization
+    assert sd["reduction_pct"] == 33 and sd["avg_reduction_pct"] == 33
     back = report_from_dict(payload).findings["summarize"]
     assert back.files == 1
     assert back.estimated_recoverable_tokens == 410
     assert back.candidates[0].path == "./CLAUDE.md"
+    assert back.candidates[0].reduction_pct == 33     # per-file % survives the round-trip
+    assert "meaning may change" in back.caveat        # and the caveat survives the ctor
+    assert back.reduction_pct == 33 and back.avg_reduction_pct == 33

--- a/tests/unit/test_optimize_summarize.py
+++ b/tests/unit/test_optimize_summarize.py
@@ -7,6 +7,7 @@ explicit basis, and a clean report_to_dict/report_from_dict round-trip.
 """
 from __future__ import annotations
 
+import logging
 from datetime import timedelta
 
 import pytest
@@ -78,12 +79,15 @@ def test_empty_scan_yields_no_tokens_but_keeps_basis(db, monkeypatch):
     assert f.estimate_basis
 
 
-def test_scan_error_never_breaks_the_report(db, monkeypatch):
+def test_scan_error_never_breaks_the_report(db, monkeypatch, caplog):
     def boom(**kw):
         raise OSError("disk gone")
     monkeypatch.setattr("tokenjam.core.summarize.candidates.list_candidates", boom)
-    f = _run(db)
+    with caplog.at_level(logging.DEBUG, logger="tokenjam.core.optimize.analyzers.summarize"):
+        f = _run(db)
     assert f.files == 0 and f.estimated_recoverable_tokens is None
+    # the swallow must leave a trail (not silent) so a real regression is diagnosable
+    assert any("scan failed" in r.message for r in caplog.records)
 
 
 def test_finding_round_trips(db, monkeypatch):

--- a/tokenjam/core/optimize/analyzers/summarize.py
+++ b/tokenjam/core/optimize/analyzers/summarize.py
@@ -18,10 +18,13 @@ usage-ranked/amortized path is deferred. Every user-visible string says
 """
 from __future__ import annotations
 
+import logging
 from dataclasses import dataclass, field
 
 from tokenjam.core.optimize.registry import register
 from tokenjam.core.optimize.types import AnalyzerContext
+
+logger = logging.getLogger(__name__)
 
 # Surfaced verbatim next to the recoverable figure (contract requires an explicit
 # basis; states the filesystem/per-call basis so it isn't mistaken for a
@@ -76,6 +79,13 @@ def run(ctx: AnalyzerContext) -> None:
     try:
         scan = list_candidates(config=ctx.config)  # read-only, never writes
     except Exception:
+        # Empty finding on any scan failure so a filesystem hiccup never breaks the
+        # optimize report — but log it: a silent broad-swallow would hide a real
+        # code/config regression in list_candidates as if it were a benign hiccup.
+        logger.debug(
+            "summarize analyzer: candidate scan failed; returning empty finding",
+            exc_info=True,
+        )
         ctx.report.findings["summarize"] = finding
         return
 

--- a/tokenjam/core/optimize/analyzers/summarize.py
+++ b/tokenjam/core/optimize/analyzers/summarize.py
@@ -1,0 +1,99 @@
+"""
+Summarize analyzer — surfaces static prompt files worth summarizing (Track A).
+
+Unlike the other analyzers, this one reasons over the **filesystem**, not
+telemetry: it runs the read-only, catalog-default summarize scan
+(`core/summarize/candidates.list_candidates`) and reports the per-call
+prompt-token reduction available by summarizing those files' prose. It carries
+the #111 recoverable-savings contract so the Overview waste band and the
+`/cost/components` overlay pick it up with no UI change (registry-driven).
+
+Honesty discipline (Critical Rule 14 + `core/summarize/estimate.py`): the figure
+we can stand behind from a file alone is **tokens**. A per-call dollar amount at
+default rates is noise, and the meaningful *amortized* dollar needs a real
+per-file call count (telemetry) we don't have — so `estimated_recoverable_usd`
+is left `None` (the contract's "no estimate available for this state"), and the
+usage-ranked/amortized path is deferred. Every user-visible string says
+"estimated" / "review before applying" — never "saves you".
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+
+from tokenjam.core.optimize.registry import register
+from tokenjam.core.optimize.types import AnalyzerContext
+
+# Surfaced verbatim next to the recoverable figure (contract requires an explicit
+# basis; states the filesystem/per-call basis so it isn't mistaken for a
+# telemetry-window figure like the other analyzers).
+SUMMARIZE_ESTIMATE_BASIS = (
+    "Per-call prompt-token reduction from a read-only filesystem scan of catalog "
+    "prompt files (CLAUDE.md / AGENTS.md / globals); prose is summarized, structure "
+    "kept verbatim. Realized on every call that sends the cached prompt — NOT "
+    "multiplied by this window's calls (that amortized figure needs per-file usage "
+    "telemetry). Advisory; review each rewrite before applying."
+)
+
+
+@dataclass
+class SummarizeCandidate:
+    """One summarizable prompt file (mirrors core/summarize Candidate, trimmed)."""
+
+    path: str
+    kind: str          # "prompt" | "other"
+    scope: str         # global | project | repo | path
+    est_tokens_saved: int
+    total_chars: int = 0   # source size, so the UI can render an avg-reduction % (DEC-032 tile)
+
+
+@dataclass
+class SummarizeFinding:
+    """Filesystem-derived summarize opportunity, on the #111 recoverable contract.
+
+    Tokens-only by design (see module docstring): `estimated_recoverable_usd`
+    stays None until a usage-ranked (telemetry) path lands.
+    """
+
+    candidates: list[SummarizeCandidate] = field(default_factory=list)
+    files: int = 0
+    estimated_recoverable_usd: float | None = None
+    estimated_recoverable_tokens: int | None = None
+    estimate_basis: str = ""
+    estimate_confidence: str = "heuristic"
+
+
+@register("summarize")
+def run(ctx: AnalyzerContext) -> None:
+    """Attach a SummarizeFinding: catalog-default candidates + per-call token saving.
+
+    Reasons over the filesystem (config-driven scan), not `ctx.conn`. The scan is
+    catalog-default (a handful of known prompt files) so it's cheap enough for the
+    polling Overview; a filesystem hiccup never breaks the optimize report.
+    """
+    from tokenjam.core.summarize.candidates import list_candidates
+
+    finding = SummarizeFinding(estimate_basis=SUMMARIZE_ESTIMATE_BASIS)
+    try:
+        scan = list_candidates(config=ctx.config)  # read-only, never writes
+    except Exception:
+        ctx.report.findings["summarize"] = finding
+        return
+
+    finding.candidates = [
+        SummarizeCandidate(
+            path=c.path,
+            kind="prompt" if c.is_prompt else "other",
+            scope=c.scope,
+            est_tokens_saved=c.est_tokens_saved,
+            total_chars=c.total_chars,
+        )
+        for c in scan.candidates
+        if c.est_tokens_saved > 0
+    ]
+    finding.files = len(finding.candidates)
+    if finding.candidates:
+        finding.estimated_recoverable_tokens = sum(
+            c.est_tokens_saved for c in finding.candidates
+        )
+        # estimated_recoverable_usd intentionally left None — see module docstring.
+    ctx.report.findings["summarize"] = finding

--- a/tokenjam/core/optimize/analyzers/summarize.py
+++ b/tokenjam/core/optimize/analyzers/summarize.py
@@ -8,13 +8,21 @@ prompt-token reduction available by summarizing those files' prose. It carries
 the #111 recoverable-savings contract so the Overview waste band and the
 `/cost/components` overlay pick it up with no UI change (registry-driven).
 
+Window-guarded: like every other recoverable finding, it contributes nothing on
+a dead telemetry window (`ctx.summary.total_tokens == 0`). A window with no calls
+has no per-call saving to attach a recoverable figure to, and surfacing one would
+break the empty-window overlay invariant (#211) — a dead window must show no
+recoverable waste. The filesystem scan is skipped entirely until the window shows
+activity.
+
 Honesty discipline (Critical Rule 14 + `core/summarize/estimate.py`): the figure
 we can stand behind from a file alone is **tokens**. A per-call dollar amount at
 default rates is noise, and the meaningful *amortized* dollar needs a real
 per-file call count (telemetry) we don't have — so `estimated_recoverable_usd`
 is left `None` (the contract's "no estimate available for this state"), and the
 usage-ranked/amortized path is deferred. Every user-visible string says
-"estimated" / "review before applying" — never "saves you".
+"estimated" / "review before applying" — never "saves you"; the mandatory
+`caveat` names summary's one risk (meaning may change, structure won't).
 """
 from __future__ import annotations
 
@@ -23,6 +31,7 @@ from dataclasses import dataclass, field
 
 from tokenjam.core.optimize.registry import register
 from tokenjam.core.optimize.types import AnalyzerContext
+from tokenjam.core.summarize.detect import CHARS_PER_TOKEN
 
 logger = logging.getLogger(__name__)
 
@@ -37,6 +46,14 @@ SUMMARIZE_ESTIMATE_BASIS = (
     "telemetry). Advisory; review each rewrite before applying."
 )
 
+# Mandatory caveat (Rule 14) — carried as the dataclass default like the other
+# recoverable findings' caveats (MODEL_DOWNGRADE_CAVEAT etc.) so no surface can
+# drop it. Names summary's ONE risk: structure is guaranteed (restore-by-id),
+# meaning is not.
+SUMMARIZE_HONESTY_CAVEAT = (
+    "Structure is guaranteed; meaning may change — review each rewrite before applying."
+)
+
 
 @dataclass
 class SummarizeCandidate:
@@ -46,7 +63,8 @@ class SummarizeCandidate:
     kind: str          # "prompt" | "other"
     scope: str         # global | project | repo | path
     est_tokens_saved: int
-    total_chars: int = 0   # source size, so the UI can render an avg-reduction % (DEC-032 tile)
+    total_chars: int = 0     # source size (feeds the aggregate reduction %)
+    reduction_pct: int = 0   # per-file prose reduction %, computed server-side (no JS chars/4)
 
 
 @dataclass
@@ -63,6 +81,25 @@ class SummarizeFinding:
     estimated_recoverable_tokens: int | None = None
     estimate_basis: str = ""
     estimate_confidence: str = "heuristic"
+    caveat: str = SUMMARIZE_HONESTY_CAVEAT
+    # Prose-reduction %s computed server-side (single source of truth — the Lens
+    # screen renders these instead of re-deriving chars/CHARS_PER_TOKEN in JS):
+    #   reduction_pct     = aggregate saved ÷ source tokens across all candidates
+    #   avg_reduction_pct = mean of the per-file reduction %s
+    reduction_pct: int | None = None
+    avg_reduction_pct: int | None = None
+
+
+def _src_tokens(total_chars: int) -> int:
+    """Source-token estimate for a file's raw size, on the shared chars→tokens
+    constant (not a magic /4) so the % matches the rest of the pipeline."""
+    return round(total_chars / CHARS_PER_TOKEN)
+
+
+def _reduction_pct(est_tokens_saved: int, total_chars: int) -> int:
+    """Per-file prose reduction % (saved ÷ source tokens), on the shared basis."""
+    src = _src_tokens(total_chars)
+    return round(est_tokens_saved / src * 100) if src > 0 else 0
 
 
 @register("summarize")
@@ -73,9 +110,18 @@ def run(ctx: AnalyzerContext) -> None:
     catalog-default (a handful of known prompt files) so it's cheap enough for the
     polling Overview; a filesystem hiccup never breaks the optimize report.
     """
+    finding = SummarizeFinding(estimate_basis=SUMMARIZE_ESTIMATE_BASIS)
+
+    # Window-guard: a dead telemetry window has no calls to realize a per-call
+    # saving against, so — like every recoverable finding — contribute nothing
+    # rather than leak a filesystem figure into the empty-window overlay (#211).
+    # Also skips the scan entirely on an idle window.
+    if ctx.summary.total_tokens == 0:
+        ctx.report.findings["summarize"] = finding
+        return
+
     from tokenjam.core.summarize.candidates import list_candidates
 
-    finding = SummarizeFinding(estimate_basis=SUMMARIZE_ESTIMATE_BASIS)
     try:
         scan = list_candidates(config=ctx.config)  # read-only, never writes
     except Exception:
@@ -96,6 +142,7 @@ def run(ctx: AnalyzerContext) -> None:
             scope=c.scope,
             est_tokens_saved=c.est_tokens_saved,
             total_chars=c.total_chars,
+            reduction_pct=_reduction_pct(c.est_tokens_saved, c.total_chars),
         )
         for c in scan.candidates
         if c.est_tokens_saved > 0
@@ -106,4 +153,15 @@ def run(ctx: AnalyzerContext) -> None:
             c.est_tokens_saved for c in finding.candidates
         )
         # estimated_recoverable_usd intentionally left None — see module docstring.
+        # Prose-reduction %s, computed here so the UI has a single compute path:
+        #   reduction_pct     = token-weighted aggregate (saved ÷ source tokens)
+        #   avg_reduction_pct = mean of the per-file reduction %s
+        total_src = sum(_src_tokens(c.total_chars) for c in finding.candidates)
+        if total_src > 0:
+            finding.reduction_pct = round(
+                finding.estimated_recoverable_tokens / total_src * 100
+            )
+        finding.avg_reduction_pct = round(
+            sum(c.reduction_pct for c in finding.candidates) / len(finding.candidates)
+        )
     ctx.report.findings["summarize"] = finding

--- a/tokenjam/core/optimize/runner.py
+++ b/tokenjam/core/optimize/runner.py
@@ -36,6 +36,7 @@ ANALYZER_ORDER: list[str] = [
     "reuse",
     "trim",
     "subagent",
+    "summarize",
 ]
 
 THIN_DATA_DAYS = 7
@@ -332,6 +333,10 @@ def _build_finding_constructors() -> dict:
         SubagentRightsizingFinding,
         SubagentRow,
     )
+    from tokenjam.core.optimize.analyzers.summarize import (
+        SummarizeCandidate,
+        SummarizeFinding,
+    )
     from tokenjam.core.optimize.types import ReuseCluster, ReuseFinding
 
     def _cache_efficacy(d: dict) -> CacheEfficacyFinding:
@@ -434,6 +439,17 @@ def _build_finding_constructors() -> dict:
             estimate_confidence=d.get("estimate_confidence", "heuristic"),
         )
 
+    def _summarize(d: dict) -> SummarizeFinding:
+        cands = [SummarizeCandidate(**c) for c in d.get("candidates") or []]
+        return SummarizeFinding(
+            candidates=cands,
+            files=int(d.get("files", 0)),
+            estimated_recoverable_usd=d.get("estimated_recoverable_usd"),
+            estimated_recoverable_tokens=d.get("estimated_recoverable_tokens"),
+            estimate_basis=d.get("estimate_basis", ""),
+            estimate_confidence=d.get("estimate_confidence", "heuristic"),
+        )
+
     return {
         "cache": _cache_efficacy,
         "cache-recommend": _cache_recommend,
@@ -441,6 +457,7 @@ def _build_finding_constructors() -> dict:
         "reuse": _reuse,
         "trim": _prompt_bloat,
         "subagent": _subagent,
+        "summarize": _summarize,
     }
 
 

--- a/tokenjam/core/optimize/runner.py
+++ b/tokenjam/core/optimize/runner.py
@@ -334,6 +334,7 @@ def _build_finding_constructors() -> dict:
         SubagentRow,
     )
     from tokenjam.core.optimize.analyzers.summarize import (
+        SUMMARIZE_HONESTY_CAVEAT,
         SummarizeCandidate,
         SummarizeFinding,
     )
@@ -448,6 +449,9 @@ def _build_finding_constructors() -> dict:
             estimated_recoverable_tokens=d.get("estimated_recoverable_tokens"),
             estimate_basis=d.get("estimate_basis", ""),
             estimate_confidence=d.get("estimate_confidence", "heuristic"),
+            caveat=d.get("caveat", SUMMARIZE_HONESTY_CAVEAT),
+            reduction_pct=d.get("reduction_pct"),
+            avg_reduction_pct=d.get("avg_reduction_pct"),
         )
 
     return {


### PR DESCRIPTION
This PR registers a new summarize optimize analyzer that surfaces static
prompt files worth summarizing and reports the per-call prompt-token reduction
available. It carries the #111 recoverable-savings contract, so the Overview
waste band and the /cost/components overlay pick it up registry-driven — no UI
change in this PR.

This is the read-only cost signal for the shipped tj summarize feature
(#354–357): the analyzer runs the same catalog-default, read-only scan
(core/summarize/candidates.list_candidates) the CLI/MCP already use, and sums
each file's est_tokens_saved.

How
- New core/optimize/analyzers/summarize.py: @register("summarize") ->
  SummarizeFinding (+ SummarizeCandidate), on the recoverable contract.
- runner.py: append "summarize" to ANALYZER_ORDER and add its from_dict
  constructor.
- Tests: sum / drop-zero-savings / empty scan / scan-error-swallowed /
  round-trip.

Notes for review
1. New side-effect class in the registry: unlike the other analyzers (which
   read ctx.conn telemetry), this one reasons over the filesystem. It runs the
   same read-only scan the tj summarize CLI uses, but at catalog-default scope
   only (a handful of known prompt files/locations), so it's cheap for the
   polling Overview. The scan function also supports repo/recursive discovery
   and re-scan, but this analyzer deliberately doesn't pass those (see What's
   NOT in this PR). It's try/except-guarded — a filesystem hiccup returns an
   empty finding, never breaks the optimize report.
2. Scan cwd: the scan reflects the process cwd + ~/ globals. Correct for the
   tj optimize CLI; under the long-running daemon it reflects the daemon's cwd
   (a known limitation, flagged not fixed here). For v1, non-catalog locations
   are surfaced via the tj summarize CLI (which takes path/recursive/repo);
   wiring that breadth into the analyzer is deferred.

What's NOT in this PR
- No API routes, no UI — analyzer / cost-signal only.
- No outbound calls, no writes — the scan is read-only.
- No dollar/amortized figure (deferred until a telemetry-ranked path lands).
- Catalog-default scope only — repo/recursive discovery and re-scan exist in
  the scan/CLI but aren't wired into the analyzer (deferred).

The API (reads/apply), the outbound run surface, and the Lens UI follow as
separate PRs.
