### PR TITLE
[feature] Add summarize API surface (reads + guarded apply/undo)

### DIFF
--- a/tests/integration/test_summarize_api.py
+++ b/tests/integration/test_summarize_api.py
@@ -3,10 +3,14 @@ staged / backups + apply / undo.
 
 Core scan + staging + apply are exercised by their own unit tests; here we prove
 the routes wire to core, shape the payloads, and (capabilities) reflect the host
-honestly. list_candidates / session / apply / backup are monkeypatched for
-determinism — no real writes.
+honestly. Most tests monkeypatch list_candidates / session / apply for
+determinism; the real-core apply tests at the end drive `POST /apply` end-to-end
+against a temp file (no mocks) to close that seam — the drift/owner/symlink/backup
+guards must hold through the route, not just in the unit tests.
 """
 from __future__ import annotations
+
+import re
 
 import httpx
 import pytest
@@ -22,6 +26,9 @@ from tokenjam.core.config import (
 from tokenjam.core.db import InMemoryBackend
 from tokenjam.core.ingest import IngestPipeline
 from tokenjam.core.summarize.candidates import Candidate, ScanResult
+
+PROSE = "Always act carefully and never drop a required step when you respond. " * 30
+_MARKER_RE = re.compile(r'<tj-keep id="\d+"[^>]*?(?:/>|>.*?</tj-keep>)', re.DOTALL)
 
 
 @pytest.fixture
@@ -160,3 +167,39 @@ async def test_undo_ok_and_drift_returns_409(client, monkeypatch):
     assert ok.status_code == 200 and ok.json()["restored"] is True
     bad = await client.post("/api/v1/summarize/undo", json={"path": "./drifted.md", "go": True})
     assert bad.status_code == 409
+
+
+# ---- real-core apply through the route (no mocks — closes the monkeypatch seam) ----
+
+def _stage_real(config, tmp_path, name="CLAUDE.md"):
+    """Write a real prompt file and stage a structure-preserving rewrite via core
+    (prep/check live in the run PR, so we stage directly and drive WRITE via /apply)."""
+    from tokenjam.core.summarize import session
+    p = tmp_path / name
+    p.write_text(PROSE + "\n```\nkeep = 'me'\n```\n", encoding="utf-8")
+    prep = session.prepare(path=str(p))
+    summary = "Be careful; never skip a step. " + " ".join(_MARKER_RE.findall(prep.wrapped_prompt))
+    verdict = session.check(config, str(p), summary, prep.source_sha256)
+    assert verdict.staged
+    return p
+
+
+async def test_apply_go_writes_and_backs_up_real_core(client, config, tmp_path):
+    from tokenjam.core.summarize import backup, session
+    p = _stage_real(config, tmp_path)
+    before = p.read_text()
+    r = (await client.post("/api/v1/summarize/apply", json={"path": str(p), "go": True})).json()
+    assert r["dry_run"] is False
+    assert [a["path"] for a in r["applied"]] == [str(p)] and r["skipped"] == []
+    assert p.read_text() != before                       # file was rewritten
+    assert any(b["source_path"] == str(p) for b in backup.list_backups(config))   # backup written
+    assert session.list_staged(config) == []             # staging cleared after apply
+
+
+async def test_apply_skips_drift_through_route_real_core(client, config, tmp_path):
+    p = _stage_real(config, tmp_path)
+    p.write_text("hand-edited after staging\n", encoding="utf-8")   # drift
+    r = (await client.post("/api/v1/summarize/apply", json={"path": str(p), "go": True})).json()
+    assert r["applied"] == []
+    assert any("changed since check" in s["reason"] for s in r["skipped"])
+    assert p.read_text() == "hand-edited after staging\n"           # never overwritten

--- a/tests/integration/test_summarize_api.py
+++ b/tests/integration/test_summarize_api.py
@@ -1,0 +1,162 @@
+"""Summarize API surface (Track B, in-process): capabilities / candidates /
+staged / backups + apply / undo.
+
+Core scan + staging + apply are exercised by their own unit tests; here we prove
+the routes wire to core, shape the payloads, and (capabilities) reflect the host
+honestly. list_candidates / session / apply / backup are monkeypatched for
+determinism — no real writes.
+"""
+from __future__ import annotations
+
+import httpx
+import pytest
+
+from tokenjam.api.app import create_app
+from tokenjam.core.config import (
+    ApiAuthConfig,
+    ApiConfig,
+    SecurityConfig,
+    StorageConfig,
+    TjConfig,
+)
+from tokenjam.core.db import InMemoryBackend
+from tokenjam.core.ingest import IngestPipeline
+from tokenjam.core.summarize.candidates import Candidate, ScanResult
+
+
+@pytest.fixture
+def db():
+    backend = InMemoryBackend()
+    yield backend
+    backend.close()
+
+
+@pytest.fixture
+def config(tmp_path):
+    # storage.path's parent drives session.summary_root → point it at tmp so
+    # /staged reads an empty temp dir, never the real ~/.tj/summary.
+    return TjConfig(
+        version="1",
+        security=SecurityConfig(ingest_secret="s"),
+        api=ApiConfig(auth=ApiAuthConfig(enabled=False)),
+        storage=StorageConfig(path=str(tmp_path / "telemetry.duckdb")),
+    )
+
+
+@pytest.fixture
+def client(config, db):
+    pipeline = IngestPipeline(db=db, config=config)
+    app = create_app(config=config, db=db, ingest_pipeline=pipeline)
+    return httpx.AsyncClient(transport=httpx.ASGITransport(app=app), base_url="http://test")
+
+
+async def test_capabilities_manual_always_on_dead_paths_flagged(client, monkeypatch):
+    monkeypatch.delenv("TJ_ANTHROPIC_API_KEY", raising=False)
+    monkeypatch.setattr("shutil.which", lambda name: None)   # no `claude` on host
+    caps = (await client.get("/api/v1/summarize/capabilities")).json()
+    assert caps["manual"]["available"] is True
+    assert caps["api"]["available"] is False and caps["api"]["reason"]
+    assert caps["claude_p"]["available"] is False and caps["claude_p"]["reason"]
+
+
+async def test_capabilities_api_enabled_when_key_present(client, monkeypatch):
+    monkeypatch.setenv("TJ_ANTHROPIC_API_KEY", "sk-test")
+    caps = (await client.get("/api/v1/summarize/capabilities")).json()
+    assert caps["api"]["available"] is True and caps["api"]["reason"] == ""
+
+
+async def test_candidates_returns_scan_dict(client, monkeypatch):
+    fake = ScanResult(
+        candidates=[Candidate(
+            path="./CLAUDE.md", prose_words=1000, total_chars=4000, protected_blocks=1,
+            est_tokens_saved=410, pricing_mode="api", scope="repo", is_prompt=True,
+        )],
+        root=".", recursive=False, globals_checked=0, walk_capped=False, note="",
+    )
+    monkeypatch.setattr("tokenjam.core.summarize.candidates.list_candidates", lambda **kw: fake)
+    body = (await client.get("/api/v1/summarize/candidates")).json()
+    assert body["count"] == 1
+    c = body["candidates"][0]
+    assert c["path"] == "./CLAUDE.md" and c["kind"] == "prompt" and c["est_tokens_saved"] == 410
+
+
+async def test_staged_empty_by_default(client):
+    r = await client.get("/api/v1/summarize/staged")
+    assert r.status_code == 200
+    assert r.json() == {"staged": []}
+
+
+async def test_staged_lists_and_reads_one(client, monkeypatch):
+    monkeypatch.setattr(
+        "tokenjam.core.summarize.session.list_staged",
+        lambda config: [{"path": "./CLAUDE.md", "est_tokens_saved": 410}],
+    )
+    monkeypatch.setattr(
+        "tokenjam.core.summarize.session.read_staged",
+        lambda config, path: {"path": path, "diff": "@@ ... @@"} if path == "./CLAUDE.md" else None,
+    )
+    listed = (await client.get("/api/v1/summarize/staged")).json()
+    assert listed["staged"][0]["path"] == "./CLAUDE.md"
+    one = (await client.get("/api/v1/summarize/staged", params={"path": "./CLAUDE.md"})).json()
+    assert one["staged"][0]["diff"] == "@@ ... @@"
+    miss = (await client.get("/api/v1/summarize/staged", params={"path": "./nope.md"})).json()
+    assert miss["staged"] == []
+
+
+async def test_backups_empty_by_default(client):
+    r = await client.get("/api/v1/summarize/backups")
+    assert r.status_code == 200
+    assert r.json() == {"backups": []}
+
+
+async def test_backups_lists_undoable_records(client, monkeypatch):
+    monkeypatch.setattr(
+        "tokenjam.core.summarize.backup.list_backups",
+        lambda config: [
+            {"source_path": "./CLAUDE.md", "applied_at": "2026-07-04T12:00:00", "undoable": True, "reason": ""},
+            {"source_path": "./AGENTS.md", "applied_at": "2026-07-04T12:01:00",
+             "undoable": False, "reason": "changed since apply — undo would lose newer edits"},
+        ],
+    )
+    got = (await client.get("/api/v1/summarize/backups")).json()["backups"]
+    assert got[0]["source_path"] == "./CLAUDE.md" and got[0]["undoable"] is True
+    assert got[1]["undoable"] is False and "changed since apply" in got[1]["reason"]
+
+
+async def test_apply_defaults_dry_run_and_passes_go_through(client, monkeypatch):
+    seen: dict = {}
+
+    def fake_apply(config, path=None, *, go=False):
+        seen["path"], seen["go"] = path, go
+        return {"applied": [path] if (go and path) else [], "skipped": [], "dry_run": not go}
+
+    monkeypatch.setattr("tokenjam.core.summarize.apply.apply_staged", fake_apply)
+    dry = (await client.post("/api/v1/summarize/apply", json={"path": "./CLAUDE.md"})).json()
+    assert seen == {"path": "./CLAUDE.md", "go": False} and dry["dry_run"] is True
+    wrote = (await client.post("/api/v1/summarize/apply", json={"path": "./CLAUDE.md", "go": True})).json()
+    assert seen["go"] is True and wrote["applied"] == ["./CLAUDE.md"]
+
+
+async def test_apply_all_when_path_omitted(client, monkeypatch):
+    captured: dict = {}
+    monkeypatch.setattr(
+        "tokenjam.core.summarize.apply.apply_staged",
+        lambda config, path=None, *, go=False: captured.update(path=path) or {"applied": [], "skipped": [], "dry_run": not go},
+    )
+    await client.post("/api/v1/summarize/apply", json={})
+    assert captured["path"] is None   # omitted → apply all staged
+
+
+async def test_undo_ok_and_drift_returns_409(client, monkeypatch):
+    from tokenjam.core.summarize.session import SummarizeRefused
+
+    def fake_undo(config, path, *, go=False):
+        if path == "./drifted.md":
+            raise SummarizeRefused("file changed since backup")
+        return {"path": path, "restored": go, "dry_run": not go}
+
+    monkeypatch.setattr("tokenjam.core.summarize.apply.undo", fake_undo)
+    ok = await client.post("/api/v1/summarize/undo", json={"path": "./CLAUDE.md", "go": True})
+    assert ok.status_code == 200 and ok.json()["restored"] is True
+    bad = await client.post("/api/v1/summarize/undo", json={"path": "./drifted.md", "go": True})
+    assert bad.status_code == 409

--- a/tests/unit/test_summarize_backup.py
+++ b/tests/unit/test_summarize_backup.py
@@ -1,0 +1,71 @@
+"""Unit tests for backup.list_backups (the Lens 'undo' preflight).
+
+Backups land under a tmp storage dir (never the real ~/.tj). The point: the
+``undoable`` flag must mirror exactly what ``undo`` will actually allow —
+including the edge cases from the #424 review (missing gzip blob → a dead Undo
+button; broken symlink mislabelled as "file no longer exists").
+"""
+from __future__ import annotations
+
+import pytest
+
+from tokenjam.core.config import StorageConfig, TjConfig
+from tokenjam.core.summarize import backup
+
+
+@pytest.fixture
+def cfg(tmp_path):
+    return TjConfig(version="1", storage=StorageConfig(path=str(tmp_path / "t.duckdb")))
+
+
+def _applied(cfg, tmp_path, name="CLAUDE.md", original="old body\n", output="new body\n"):
+    """Simulate an applied file: current file == the applied output, with a backup saved."""
+    p = tmp_path / name
+    p.write_text(output, encoding="utf-8")
+    backup.save(cfg, str(p), original=original, output=output, est_tokens_saved=42)
+    return str(p), p
+
+
+def test_empty_when_no_backups(cfg):
+    assert backup.list_backups(cfg) == []
+
+
+def test_undoable_when_file_matches_applied_output(cfg, tmp_path):
+    sp, _ = _applied(cfg, tmp_path)
+    (rec,) = backup.list_backups(cfg)
+    assert rec["source_path"] == sp
+    assert rec["undoable"] is True and rec["reason"] == ""
+    assert rec["est_tokens_saved"] == 42
+
+
+def test_not_undoable_when_file_changed_since_apply(cfg, tmp_path):
+    _, p = _applied(cfg, tmp_path)
+    p.write_text("hand-edited since apply\n", encoding="utf-8")
+    (rec,) = backup.list_backups(cfg)
+    assert rec["undoable"] is False and "changed since apply" in rec["reason"]
+
+
+def test_not_undoable_when_backup_blob_missing(cfg, tmp_path):
+    # meta.json present but the .orig.gz gone (manual delete / cleanup tooling):
+    # undo() would 409, so the preflight must report undoable=False, not a dead button.
+    sp, _ = _applied(cfg, tmp_path)
+    backup._orig_path(cfg, sp).unlink()
+    (rec,) = backup.list_backups(cfg)
+    assert rec["undoable"] is False and rec["reason"] == "backup file missing"
+
+
+def test_symlink_reason_takes_precedence_over_missing(cfg, tmp_path):
+    # is_symlink() is checked before exists() (which follows links), so a broken
+    # symlink at the source path reads as "symlink…", not "file no longer exists".
+    _, p = _applied(cfg, tmp_path)
+    p.unlink()
+    p.symlink_to(tmp_path / "nowhere.md")   # broken symlink
+    (rec,) = backup.list_backups(cfg)
+    assert rec["undoable"] is False and "symlink" in rec["reason"]
+
+
+def test_not_undoable_when_file_gone(cfg, tmp_path):
+    _, p = _applied(cfg, tmp_path)
+    p.unlink()
+    (rec,) = backup.list_backups(cfg)
+    assert rec["undoable"] is False and rec["reason"] == "file no longer exists"

--- a/tokenjam/api/app.py
+++ b/tokenjam/api/app.py
@@ -83,6 +83,7 @@ def create_app(
     from tokenjam.api.routes.version import router as version_router, health_router
     from tokenjam.api.routes.policy import router as policy_router
     from tokenjam.api.routes.loop import router as loop_router
+    from tokenjam.api.routes.summarize import router as summarize_router
 
     app.include_router(spans_router, prefix="/api/v1")
     app.include_router(traces_router, prefix="/api/v1")
@@ -103,6 +104,7 @@ def create_app(
     app.include_router(version_router, prefix="/api/v1")
     app.include_router(policy_router, prefix="/api/v1")  # /policy/* enforcement reads (#223)
     app.include_router(loop_router, prefix="/api/v1")  # /annotations, /expectations (#53)
+    app.include_router(summarize_router, prefix="/api/v1")  # /summarize/* reads + apply/undo (Track B)
     app.include_router(health_router)  # /health — no prefix, for uptime probes
     app.include_router(metrics_router)  # /metrics — no prefix
     app.include_router(otlp_router)  # /v1/traces, /v1/metrics, /v1/logs — no prefix

--- a/tokenjam/api/routes/summarize.py
+++ b/tokenjam/api/routes/summarize.py
@@ -1,0 +1,142 @@
+"""/api/v1/summarize/* — the in-process summarize surface (Track B).
+
+Reads for the Lens Summarize screen, plus the guarded apply/undo writes:
+  * /summarize/capabilities — which run engines actually work on THIS host, so the
+    UI offers only live paths (never a dead "API" when no key is set).
+  * /summarize/candidates   — the read-only scan (core `list_candidates`).
+  * /summarize/staged       — staged rewrite records (source hash, restored text,
+    diff, produced_by, est_tokens_saved) for the review/apply cockpit.
+  * /summarize/backups      — applied files that still have a gzip backup (Undo).
+  * /summarize/apply, /undo — guarded writes via core (owner + hash-drift +
+    symlink-refuse + gzip backup); DRY-RUN by default, go=true to write.
+
+All call core in-process (like `/optimize` → `build_report`); nothing shells out
+to `tj`. Routes are sync `def` so their filesystem/DB work runs in Starlette's
+threadpool rather than blocking the event loop. The OUTBOUND run/prep/check
+endpoints live in their own route module.
+"""
+from __future__ import annotations
+
+import os
+import shutil
+from typing import Any
+
+from fastapi import APIRouter, Depends, HTTPException, Query, Request
+from pydantic import BaseModel
+
+from tokenjam.api.deps import require_api_key
+
+router = APIRouter()
+
+
+def _config(request: Request):
+    config = request.app.state.config
+    if config is None:
+        raise HTTPException(
+            status_code=503, detail="Server not fully initialised (config missing)."
+        )
+    return config
+
+
+@router.get("/summarize/capabilities", dependencies=[Depends(require_api_key)])
+def get_summarize_capabilities() -> dict[str, Any]:
+    """Which run engines are usable on this host — the UI greys out dead paths.
+
+    `manual` is always available (no outbound). `api` needs the user's own
+    `TJ_ANTHROPIC_API_KEY` in the server env (its presence is the authorization).
+    `claude_p` needs the `claude` CLI on the host PATH.
+    """
+    has_key = bool(os.environ.get("TJ_ANTHROPIC_API_KEY"))
+    has_claude = shutil.which("claude") is not None
+    return {
+        "api": {
+            "available": has_key,
+            "reason": "" if has_key else "set TJ_ANTHROPIC_API_KEY to enable",
+        },
+        "claude_p": {
+            "available": has_claude,
+            "reason": "" if has_claude else "the `claude` CLI is not on this host's PATH",
+        },
+        "manual": {"available": True, "reason": ""},
+    }
+
+
+@router.get("/summarize/candidates", dependencies=[Depends(require_api_key)])
+def get_summarize_candidates(
+    request: Request,
+    path: str | None = Query(None, description="Explicit path/target to scan (widens to all .md)."),
+    recursive: bool = Query(False, description="Walk the repo/PATH for all .md."),
+    repo: bool = Query(False, description="Scope to the detected git repo root."),
+) -> dict[str, Any]:
+    """Read-only summarize scan (core `list_candidates`) — never writes."""
+    from tokenjam.core.summarize.candidates import list_candidates
+
+    scan = list_candidates(path=path, config=_config(request), recursive=recursive, repo=repo)
+    return scan.to_dict()
+
+
+@router.get("/summarize/staged", dependencies=[Depends(require_api_key)])
+def get_summarize_staged(
+    request: Request,
+    path: str | None = Query(None, description="Read one staged record by source path; omit for all."),
+) -> dict[str, Any]:
+    """Read staged rewrite records — all, or one by source path."""
+    from tokenjam.core.summarize import session
+
+    config = _config(request)
+    if path:
+        rec = session.read_staged(config, path)
+        return {"staged": [rec] if rec is not None else []}
+    return {"staged": session.list_staged(config)}
+
+
+@router.get("/summarize/backups", dependencies=[Depends(require_api_key)])
+def get_summarize_backups(request: Request) -> dict[str, Any]:
+    """Applied files that still have a gzip backup — the UI's persistent undo surface.
+
+    Each record carries an ``undoable`` flag (+ ``reason``) so the UI can offer Undo for
+    files applied in any earlier session, not just the one that applied them."""
+    from tokenjam.core.summarize.backup import list_backups
+
+    return {"backups": list_backups(_config(request))}
+
+
+# --------------------------------------------------------------------------- #
+# Mutating routes — the deliberate departure: Lens's first file-writing action.
+# Both call core directly (never re-implement the guards) so every write keeps
+# the shipped guarantees: owner-check + content-hash drift-refuse + symlink-refuse
+# + gzip backup. Default is DRY-RUN (go=false); the UI sends go=true only on an
+# explicit per-file Apply — no flag bypasses a guard.
+# --------------------------------------------------------------------------- #
+class ApplyRequest(BaseModel):
+    path: str | None = None   # one staged file, or all staged when omitted
+    go: bool = False          # false = dry-run (returns the plan, writes nothing)
+
+
+class UndoRequest(BaseModel):
+    path: str
+    go: bool = False
+
+
+@router.post("/summarize/apply", dependencies=[Depends(require_api_key)])
+def post_summarize_apply(request: Request, body: ApplyRequest) -> dict[str, Any]:
+    """Apply staged rewrite(s) to disk via core `apply_staged` (per-file guards inside).
+
+    Dry-run by default: returns `{applied, skipped, dry_run}`; drifted/unowned/symlink
+    files are skipped-with-reason, never forced.
+    """
+    from tokenjam.core.summarize.apply import apply_staged
+
+    return apply_staged(_config(request), body.path, go=body.go)
+
+
+@router.post("/summarize/undo", dependencies=[Depends(require_api_key)])
+def post_summarize_undo(request: Request, body: UndoRequest) -> dict[str, Any]:
+    """Restore a file from its backup via core `undo`; refuses (409) on drift/missing."""
+    from tokenjam.core.summarize.apply import undo
+    from tokenjam.core.summarize.session import SummarizeRefused
+
+    try:
+        return undo(_config(request), body.path, go=body.go)
+    except SummarizeRefused as exc:
+        raise HTTPException(status_code=409, detail=str(exc)) from exc

--- a/tokenjam/core/summarize/apply.py
+++ b/tokenjam/core/summarize/apply.py
@@ -79,7 +79,8 @@ def apply_staged(config: TjConfig, path: str | None = None, *, go: bool = False)
             skipped.append({"path": sp, "reason": "changed since check — re-prep it"})
             continue
         if go:
-            backup.save(config, sp, original=current, output=e["restored"])
+            backup.save(config, sp, original=current, output=e["restored"],
+                        est_tokens_saved=int(e.get("est_tokens_saved", 0) or 0))
             _atomic_write(p, e["restored"])
             clear(config, sp)
         applied.append({"path": sp, "est_tokens_saved": e["est_tokens_saved"], "diff": e["diff"]})

--- a/tokenjam/core/summarize/backup.py
+++ b/tokenjam/core/summarize/backup.py
@@ -28,8 +28,11 @@ def _meta_path(config: TjConfig, path: str) -> Path:
     return backups_dir(config) / f"{stage_key(path)}.meta.json"
 
 
-def save(config: TjConfig, path: str, original: str, output: str) -> None:
-    """Gzip the original + write the meta (one-level — replaces any prior backup for ``path``)."""
+def save(config: TjConfig, path: str, original: str, output: str, est_tokens_saved: int = 0) -> None:
+    """Gzip the original + write the meta (one-level — replaces any prior backup for ``path``).
+
+    ``est_tokens_saved`` is recorded so the Optimize box can report applied savings
+    (the read-only scan drops applied files, so their saving is otherwise lost)."""
     d = backups_dir(config)
     d.mkdir(parents=True, exist_ok=True)
     _orig_path(config, path).write_bytes(gzip.compress(original.encode("utf-8")))
@@ -38,6 +41,7 @@ def save(config: TjConfig, path: str, original: str, output: str) -> None:
             "source_path": path,
             "original_sha256": sha256(original),
             "output_sha256": sha256(output),
+            "est_tokens_saved": int(est_tokens_saved),
             "applied_at": utcnow().isoformat(),
         }, ensure_ascii=False),
         encoding="utf-8",
@@ -58,6 +62,50 @@ def recorded_output(config: TjConfig, path: str) -> str | None:
         return json.loads(f.read_text(encoding="utf-8"))["output_sha256"]
     except (OSError, json.JSONDecodeError, KeyError):
         return None
+
+
+def list_backups(config: TjConfig) -> list[dict]:
+    """Every applied file that still has a backup — the Lens 'undo' surface.
+
+    Each record: ``source_path``, ``applied_at``, plus a computed ``undoable`` flag
+    (+ ``reason`` when false). A backup is undoable iff the file still exists, is not
+    a symlink, and its CURRENT content matches what apply wrote — the same conditions
+    ``undo`` enforces, surfaced up front so the UI can show why a row can't be undone.
+    """
+    d = backups_dir(config)
+    if not d.exists():
+        return []
+    out: list[dict] = []
+    for meta_f in sorted(d.glob("*.meta.json")):
+        try:
+            meta = json.loads(meta_f.read_text(encoding="utf-8"))
+        except (OSError, json.JSONDecodeError):
+            continue
+        sp = meta.get("source_path")
+        if not sp:
+            continue
+        p = Path(sp).expanduser()
+        undoable, reason = True, ""
+        if not p.exists():
+            undoable, reason = False, "file no longer exists"
+        elif p.is_symlink():
+            undoable, reason = False, "symlink — refusing to restore through it"
+        else:
+            try:
+                current = p.read_text(encoding="utf-8")
+            except OSError:
+                undoable, reason = False, "cannot read the file"
+            else:
+                if sha256(current) != meta.get("output_sha256"):
+                    undoable, reason = False, "changed since apply — undo would lose newer edits"
+        out.append({
+            "source_path": sp,
+            "applied_at": meta.get("applied_at", ""),
+            "est_tokens_saved": int(meta.get("est_tokens_saved", 0) or 0),
+            "undoable": undoable,
+            "reason": reason,
+        })
+    return out
 
 
 def load_original(config: TjConfig, path: str, current: str | None) -> str:

--- a/tokenjam/core/summarize/backup.py
+++ b/tokenjam/core/summarize/backup.py
@@ -68,9 +68,10 @@ def list_backups(config: TjConfig) -> list[dict]:
     """Every applied file that still has a backup — the Lens 'undo' surface.
 
     Each record: ``source_path``, ``applied_at``, plus a computed ``undoable`` flag
-    (+ ``reason`` when false). A backup is undoable iff the file still exists, is not
-    a symlink, and its CURRENT content matches what apply wrote — the same conditions
-    ``undo`` enforces, surfaced up front so the UI can show why a row can't be undone.
+    (+ ``reason`` when false). A backup is undoable iff the gzip blob is present, the
+    file still exists, is not a symlink, and its CURRENT content matches what apply
+    wrote — the same conditions ``undo`` enforces, surfaced up front so the UI can
+    show why a row can't be undone.
     """
     d = backups_dir(config)
     if not d.exists():
@@ -84,12 +85,22 @@ def list_backups(config: TjConfig) -> list[dict]:
         sp = meta.get("source_path")
         if not sp:
             continue
+        # Pair the blob to THIS meta file by name — don't recompute stage_key from
+        # source_path, which resolves symlinks and would map a now-symlinked source
+        # to a different key and spuriously read as "backup file missing".
+        orig_f = meta_f.with_name(meta_f.name[: -len(".meta.json")] + ".orig.gz")
         p = Path(sp).expanduser()
         undoable, reason = True, ""
-        if not p.exists():
-            undoable, reason = False, "file no longer exists"
+        if not orig_f.exists():
+            # meta.json without its gzip blob (deleted/cleaned) — undo() would 409;
+            # report it up front rather than offering an Undo that can't run.
+            undoable, reason = False, "backup file missing"
         elif p.is_symlink():
+            # is_symlink() before exists(): exists() follows the link, so a broken
+            # symlink would otherwise be mislabelled "file no longer exists".
             undoable, reason = False, "symlink — refusing to restore through it"
+        elif not p.exists():
+            undoable, reason = False, "file no longer exists"
         else:
             try:
                 current = p.read_text(encoding="utf-8")


### PR DESCRIPTION
Adds the FastAPI surface the Lens Summarize screen reads from and applies
through — the in-process bridge to the shipped tj summarize core (#354–357).
Every route calls core directly (like /optimize → build_report); nothing shells
out to tj, and there are no outbound LLM calls in this PR.

Routes (all /api/v1, Depends(require_api_key), sync def so filesystem/DB work
runs in Starlette's threadpool):
- GET /summarize/capabilities — which run engines work on THIS host (UI greys
  out dead paths).
- GET /summarize/candidates — the read-only scan (list_candidates).
- GET /summarize/staged — staged rewrite records (all, or one by path).
- GET /summarize/backups — applied files that still have a backup (the Undo
  surface), each with a computed undoable flag + reason.
- POST /summarize/apply — apply staged rewrite(s) via core apply_staged.
- POST /summarize/undo — restore from backup via core undo.

How
- New api/routes/summarize.py + one include line in api/app.py.
- core/summarize/backup.py: add list_backups() (the undo surface) and record
  est_tokens_saved in the backup meta, so the Optimize box can report applied
  savings (the read-only scan drops applied files, so their saving is otherwise
  lost). Backward-compatible — older backups without the field read as 0.
- core/summarize/apply.py: pass est_tokens_saved through to backup.save on apply.
- Tests: 10 integration tests; core is monkeypatched (no real writes/outbound)
  to prove the routes wire to core and shape the payloads.

Notes for review
1. Lens's first file-writing action. apply/undo. Both call core (apply_staged /
   undo), never re-implement the guards, so every write keeps the shipped
   guarantees: owner-check + content-hash drift-refuse + symlink-refuse + gzip
   backup. Default is DRY-RUN (go=false, returns the plan, writes nothing); the
   UI sends go=true only on an explicit per-file Apply.
2. Backup meta gains a field. backup.save now records est_tokens_saved in
   *.meta.json (additive; readers default to 0). list_backups recomputes
   undoable from the live file (exists / not-symlink / content still matches what
   apply wrote) — the same conditions undo enforces, surfaced up front so the UI
   can explain why a row can't be undone (e.g. "changed since apply — undo would
   lose newer edits"; also file-missing / symlink / unreadable).
3. These handlers do blocking filesystem/DB I/O, so they're plain sync def —
   FastAPI offloads sync routes to a threadpool, keeping the event loop free.

What's NOT in this PR
- No outbound LLM calls. The run/prep/check endpoints (which make tj serve an
  outbound caller for the first time) are a separate, design-gated PR.
- No UI — API only.
- No new config, no telemetry/spans.

The analyzer (cost signal) is its own PR; the outbound run surface and the Lens
UI follow.
