### PR TITLE
[feature] Add summarize run/prep/check API (outbound run surface)

### DIFF
--- a/tests/integration/test_summarize_run_api.py
+++ b/tests/integration/test_summarize_run_api.py
@@ -1,0 +1,157 @@
+"""Outbound summarize run surface: run / prep / check (Track B).
+
+`run` makes tj serve an outbound LLM caller; here delivery/session are
+monkeypatched so nothing real is called — we prove the routes normalize modes,
+serialize verdict/amortization, and map refuse/deliver failures to
+409/502/400/404. prep/check are the manual (no-outbound) path.
+"""
+from __future__ import annotations
+
+import httpx
+import pytest
+
+from tokenjam.api.app import create_app
+from tokenjam.core.config import (
+    ApiAuthConfig,
+    ApiConfig,
+    SecurityConfig,
+    StorageConfig,
+    TjConfig,
+)
+from tokenjam.core.db import InMemoryBackend
+from tokenjam.core.ingest import IngestPipeline
+
+
+@pytest.fixture
+def db():
+    backend = InMemoryBackend()
+    yield backend
+    backend.close()
+
+
+@pytest.fixture
+def config(tmp_path):
+    # storage.path's parent drives session.summary_root → point it at tmp so
+    # check() stages under a temp dir, never the real ~/.tj/summary.
+    return TjConfig(
+        version="1",
+        security=SecurityConfig(ingest_secret="s"),
+        api=ApiConfig(auth=ApiAuthConfig(enabled=False)),
+        storage=StorageConfig(path=str(tmp_path / "telemetry.duckdb")),
+    )
+
+
+@pytest.fixture
+def client(config, db):
+    pipeline = IngestPipeline(db=db, config=config)
+    app = create_app(config=config, db=db, ingest_pipeline=pipeline)
+    return httpx.AsyncClient(transport=httpx.ASGITransport(app=app), base_url="http://test")
+
+
+# ---- run / prep / check (mocked — no real outbound calls) ----
+
+def _verdict(path="./CLAUDE.md", ok=True):
+    from tokenjam.core.summarize.session import CheckVerdict
+    return CheckVerdict(
+        path=path, structure_ok=ok, reason="", integrity={}, words_before=1000,
+        words_after=550, est_tokens_saved=410, must_keep_removed=[], must_keep_added=[],
+        diff="@@ ... @@", restored="...", staged=ok, produced_by="api", note="",
+    )
+
+
+def _prep(path="./CLAUDE.md", wrapped="<wrapped>", note=""):
+    from tokenjam.core.summarize.session import PrepResult
+    return PrepResult(
+        path=path, source_sha256="abc", wrapped_prompt=wrapped, system_rules="rules",
+        prose_words=200, target_prose_words=100, protected_blocks=1, plan=[], note=note,
+    )
+
+
+async def test_run_normalizes_claude_p_and_serializes_verdict(client, monkeypatch):
+    from tokenjam.core.summarize.delivery import RunResult
+    seen: dict = {}
+
+    def fake_via(config, path, mode, *, ratio=0.5):
+        seen["mode"], seen["path"] = mode, path
+        return RunResult(verdict=_verdict(path), amortization=None, skipped_note=None, cost_unknown=False)
+
+    monkeypatch.setattr("tokenjam.core.summarize.delivery.summarize_via", fake_via)
+    r = await client.post("/api/v1/summarize/run", json={"path": "./CLAUDE.md", "mode": "claude_p"})
+    assert r.status_code == 200
+    assert seen["mode"] == "claude-p"                      # underscore normalized to hyphen
+    assert r.json()["verdict"]["est_tokens_saved"] == 410
+
+
+async def test_run_serializes_amortization(client, monkeypatch):
+    from tokenjam.core.summarize.delivery import Amortization, RunResult
+    am = Amortization(model="claude-x", rewrite_usd=0.01, saving_usd_per_call=0.002,
+                      break_even_calls=5, rates_known=True)
+    monkeypatch.setattr(
+        "tokenjam.core.summarize.delivery.summarize_via",
+        lambda config, path, mode, *, ratio=0.5: RunResult(verdict=_verdict(path), amortization=am),
+    )
+    body = (await client.post("/api/v1/summarize/run", json={"path": "./x.md", "mode": "api"})).json()
+    assert body["amortization"]["break_even_calls"] == 5 and body["amortization"]["rates_known"] is True
+
+
+async def test_run_skipped_below_gate(client, monkeypatch):
+    from tokenjam.core.summarize.delivery import RunResult
+    monkeypatch.setattr(
+        "tokenjam.core.summarize.delivery.summarize_via",
+        lambda config, path, mode, *, ratio=0.5: RunResult(verdict=None, skipped_note="too short"),
+    )
+    body = (await client.post("/api/v1/summarize/run", json={"path": "./x.md", "mode": "api"})).json()
+    assert body["verdict"] is None and body["skipped_note"] == "too short"
+
+
+async def test_run_rejects_manual_and_unknown_mode(client):
+    for m in ("manual", "bogus"):
+        r = await client.post("/api/v1/summarize/run", json={"path": "./x.md", "mode": m})
+        assert r.status_code == 400
+
+
+async def test_run_maps_refuse_409_and_delivery_502(client, monkeypatch):
+    from tokenjam.core.summarize.delivery import DeliveryError
+    from tokenjam.core.summarize.session import SummarizeRefused
+
+    def refuse(config, path, mode, *, ratio=0.5):
+        raise SummarizeRefused("changed since prep")
+
+    monkeypatch.setattr("tokenjam.core.summarize.delivery.summarize_via", refuse)
+    assert (await client.post("/api/v1/summarize/run", json={"path": "./x.md", "mode": "api"})).status_code == 409
+
+    def boom(config, path, mode, *, ratio=0.5):
+        raise DeliveryError("model down")
+
+    monkeypatch.setattr("tokenjam.core.summarize.delivery.summarize_via", boom)
+    assert (await client.post("/api/v1/summarize/run", json={"path": "./x.md", "mode": "api"})).status_code == 502
+
+
+async def test_prep_returns_wrapped_prompt_and_404_on_missing(client, monkeypatch):
+    monkeypatch.setattr("tokenjam.core.summarize.session.prepare",
+                        lambda *, path, ratio=0.5: _prep(path))
+    ok = (await client.post("/api/v1/summarize/prep", json={"path": "./CLAUDE.md"})).json()
+    assert ok["wrapped_prompt"] == "<wrapped>" and ok["source_sha256"] == "abc"
+
+    def missing(*, path, ratio=0.5):
+        raise FileNotFoundError(path)
+
+    monkeypatch.setattr("tokenjam.core.summarize.session.prepare", missing)
+    assert (await client.post("/api/v1/summarize/prep", json={"path": "./nope.md"})).status_code == 404
+
+
+async def test_check_stages_and_maps_drift_409(client, monkeypatch):
+    monkeypatch.setattr("tokenjam.core.summarize.session.check",
+                        lambda config, path, summary, source_hash, **kw: _verdict(path, ok=True))
+    ok = (await client.post("/api/v1/summarize/check",
+                            json={"path": "./CLAUDE.md", "summary": "s", "source_hash": "abc"})).json()
+    assert ok["structure_ok"] is True and ok["staged"] is True
+
+    from tokenjam.core.summarize.session import SummarizeRefused
+
+    def refuse(config, path, summary, source_hash, **kw):
+        raise SummarizeRefused("changed")
+
+    monkeypatch.setattr("tokenjam.core.summarize.session.check", refuse)
+    assert (await client.post("/api/v1/summarize/check",
+                              json={"path": "./x.md", "summary": "s", "source_hash": "abc"})).status_code == 409

--- a/tests/integration/test_summarize_run_api.py
+++ b/tests/integration/test_summarize_run_api.py
@@ -3,9 +3,13 @@
 `run` makes tj serve an outbound LLM caller; here delivery/session are
 monkeypatched so nothing real is called — we prove the routes normalize modes,
 serialize verdict/amortization, and map refuse/deliver failures to
-409/502/400/404. prep/check are the manual (no-outbound) path.
+409/502/400/404. `run` is also gated behind the `[summarize] allow_outbound_run`
+opt-in (DEC-031) — refused 403 when off. prep/check are the manual (no-outbound)
+path and need no opt-in.
 """
 from __future__ import annotations
+
+from dataclasses import replace
 
 import httpx
 import pytest
@@ -16,10 +20,13 @@ from tokenjam.core.config import (
     ApiConfig,
     SecurityConfig,
     StorageConfig,
+    SummarizeConfig,
     TjConfig,
 )
 from tokenjam.core.db import InMemoryBackend
 from tokenjam.core.ingest import IngestPipeline
+
+PROSE = "Always act carefully and never drop a required step when you respond. " * 30
 
 
 @pytest.fixture
@@ -38,6 +45,9 @@ def config(tmp_path):
         security=SecurityConfig(ingest_secret="s"),
         api=ApiConfig(auth=ApiAuthConfig(enabled=False)),
         storage=StorageConfig(path=str(tmp_path / "telemetry.duckdb")),
+        # Run tests exercise the outbound route, so opt-in is on here; the default
+        # (off) is exercised by test_run_refused_when_outbound_disabled.
+        summarize=SummarizeConfig(allow_outbound_run=True),
     )
 
 
@@ -166,3 +176,39 @@ async def test_check_stages_and_maps_drift_409(client, monkeypatch):
     monkeypatch.setattr("tokenjam.core.summarize.session.check", refuse)
     assert (await client.post("/api/v1/summarize/check",
                               json={"path": "./x.md", "summary": "s", "source_hash": "abc"})).status_code == 409
+
+
+async def test_run_refused_when_outbound_disabled(db, config):
+    # Default posture (DEC-031): outbound run is off until the user opts in, so a
+    # POST is refused 403 — no spend on a default install. Manual path is unaffected.
+    off = replace(config, summarize=SummarizeConfig(allow_outbound_run=False))
+    app = create_app(config=off, db=db, ingest_pipeline=IngestPipeline(db=db, config=off))
+    async with httpx.AsyncClient(transport=httpx.ASGITransport(app=app), base_url="http://test") as c:
+        r = await c.post("/api/v1/summarize/run", json={"path": "./x.md", "mode": "api"})
+    assert r.status_code == 403
+    assert "allow_outbound_run" in r.json()["detail"]
+
+
+async def test_check_missing_file_returns_404(client, monkeypatch):
+    # File vanished between prep and check → 404, parity with /prep and /run.
+    def gone(config, path, summary, source_hash, **kw):
+        raise FileNotFoundError(path)
+    monkeypatch.setattr("tokenjam.core.summarize.session.check", gone)
+    r = await client.post("/api/v1/summarize/check",
+                          json={"path": "./gone.md", "summary": "s", "source_hash": "abc"})
+    assert r.status_code == 404
+
+
+async def test_check_structure_fail_never_stages(client, config, tmp_path):
+    # Real core (no mock): a summary that drops a protected block fails the structure
+    # gate — the route returns structure_ok=false/staged=false and NOTHING is written
+    # to the staging store. Closes the seam where the other check tests monkeypatch core.
+    from tokenjam.core.summarize import session
+    p = tmp_path / "CLAUDE.md"
+    p.write_text(PROSE + "\n```\nkeep = 'me'\n```\n", encoding="utf-8")
+    prep = (await client.post("/api/v1/summarize/prep", json={"path": str(p)})).json()
+    broken = "Be brief."   # no <tj-keep> markers → protected block dropped → structure fails
+    v = (await client.post("/api/v1/summarize/check", json={
+        "path": str(p), "summary": broken, "source_hash": prep["source_sha256"]})).json()
+    assert v["structure_ok"] is False and v["staged"] is False
+    assert session.list_staged(config) == []

--- a/tests/integration/test_summarize_run_api.py
+++ b/tests/integration/test_summarize_run_api.py
@@ -127,6 +127,17 @@ async def test_run_maps_refuse_409_and_delivery_502(client, monkeypatch):
     assert (await client.post("/api/v1/summarize/run", json={"path": "./x.md", "mode": "api"})).status_code == 502
 
 
+async def test_run_missing_file_returns_404(client, monkeypatch):
+    # summarize_via preps first (reads the file); a missing path raises
+    # FileNotFoundError, which the route maps to 404 like /prep — not a 500.
+    def missing(config, path, mode, *, ratio=0.5):
+        raise FileNotFoundError(path)
+
+    monkeypatch.setattr("tokenjam.core.summarize.delivery.summarize_via", missing)
+    r = await client.post("/api/v1/summarize/run", json={"path": "./nope.md", "mode": "api"})
+    assert r.status_code == 404
+
+
 async def test_prep_returns_wrapped_prompt_and_404_on_missing(client, monkeypatch):
     monkeypatch.setattr("tokenjam.core.summarize.session.prepare",
                         lambda *, path, ratio=0.5: _prep(path))

--- a/tokenjam/api/app.py
+++ b/tokenjam/api/app.py
@@ -84,6 +84,7 @@ def create_app(
     from tokenjam.api.routes.policy import router as policy_router
     from tokenjam.api.routes.loop import router as loop_router
     from tokenjam.api.routes.summarize import router as summarize_router
+    from tokenjam.api.routes.summarize_run import router as summarize_run_router
 
     app.include_router(spans_router, prefix="/api/v1")
     app.include_router(traces_router, prefix="/api/v1")
@@ -105,6 +106,7 @@ def create_app(
     app.include_router(policy_router, prefix="/api/v1")  # /policy/* enforcement reads (#223)
     app.include_router(loop_router, prefix="/api/v1")  # /annotations, /expectations (#53)
     app.include_router(summarize_router, prefix="/api/v1")  # /summarize/* reads + apply/undo (Track B)
+    app.include_router(summarize_run_router, prefix="/api/v1")  # /summarize/{run,prep,check} OUTBOUND (Track B, design-gated)
     app.include_router(health_router)  # /health — no prefix, for uptime probes
     app.include_router(metrics_router)  # /metrics — no prefix
     app.include_router(otlp_router)  # /v1/traces, /v1/metrics, /v1/logs — no prefix

--- a/tokenjam/api/routes/summarize_run.py
+++ b/tokenjam/api/routes/summarize_run.py
@@ -75,6 +75,10 @@ def post_summarize_run(request: Request, body: RunRequest) -> dict[str, Any]:
         )
     try:
         result = summarize_via(_config(request), body.path, mode, ratio=body.ratio)
+    except FileNotFoundError as exc:
+        # summarize_via preps first (reads the file); a missing path is a 404, like
+        # /summarize/prep — not an unhandled 500.
+        raise HTTPException(status_code=404, detail=f"cannot read {body.path}: {exc}") from exc
     except SummarizeRefused as exc:
         raise HTTPException(status_code=409, detail=str(exc)) from exc
     except DeliveryError as exc:
@@ -97,7 +101,9 @@ def post_summarize_prep(request: Request, body: PrepRequest) -> dict[str, Any]:
         return prepare(path=body.path, ratio=body.ratio).to_dict()
     except SummarizeRefused as exc:
         raise HTTPException(status_code=409, detail=str(exc)) from exc
-    except OSError as exc:
+    except FileNotFoundError as exc:
+        # Only a missing file is a 404; other OSErrors (permission, is-a-directory)
+        # are genuine server errors and should surface as 500, not be masked as 404.
         raise HTTPException(status_code=404, detail=f"cannot read {body.path}: {exc}") from exc
 
 

--- a/tokenjam/api/routes/summarize_run.py
+++ b/tokenjam/api/routes/summarize_run.py
@@ -1,0 +1,113 @@
+"""/api/v1/summarize/{run,prep,check} — the OUTBOUND summarize run surface (Track B).
+
+Split from the read/apply surface (routes/summarize.py) on purpose: `run` makes
+`tj serve` an OUTBOUND LLM caller for the FIRST time — a posture shift the
+maintainer reserved (where the key/outbound config lives, auth-to-spend, sync vs
+async). Isolating it here lets the reads/apply layer merge while this surface
+waits on that design call.
+
+  run   = OUTBOUND (api | claude-p): prep -> deliver -> check -> stage, one file.
+  prep  = manual step 1 (NO outbound): wrap structure -> the copy-paste prompt.
+  check = manual step 2 (NO outbound): verify the pasted-back summary -> stage.
+
+Per-file by design — the UI loops `run` with a progress bar and streams results
+into the review box, so no async-job infra is needed. All call core
+(session.prepare / delivery.summarize_via / session.check) directly; nothing
+shells out to `tj`. Routes are sync `def` (blocking I/O -> Starlette threadpool).
+
+`_config` is duplicated from routes/summarize.py so this module stands alone; a
+shared helper can fold the two once both land.
+"""
+from __future__ import annotations
+
+from typing import Any
+
+from fastapi import APIRouter, Depends, HTTPException, Request
+from pydantic import BaseModel
+
+from tokenjam.api.deps import require_api_key
+
+router = APIRouter()
+
+
+def _config(request: Request):
+    config = request.app.state.config
+    if config is None:
+        raise HTTPException(
+            status_code=503, detail="Server not fully initialised (config missing)."
+        )
+    return config
+
+
+class RunRequest(BaseModel):
+    path: str
+    mode: str                  # "api" | "claude-p" ("claude_p" accepted); manual uses /prep+/check
+    ratio: float = 0.5
+
+
+class PrepRequest(BaseModel):
+    path: str
+    ratio: float = 0.5
+
+
+class CheckRequest(BaseModel):
+    path: str
+    summary: str
+    source_hash: str           # the prep's source_sha256 — check hash-guards against it
+
+
+@router.post("/summarize/run", dependencies=[Depends(require_api_key)])
+def post_summarize_run(request: Request, body: RunRequest) -> dict[str, Any]:
+    """Run the summarizer on ONE file server-side (the only OUTBOUND route).
+
+    `api` bills the user's `TJ_ANTHROPIC_API_KEY`; `claude-p` spawns the host's
+    `claude` (subscription limits). Per-file by design — the UI loops it with a
+    progress bar; results stream into the review box. `manual` is NOT here.
+    """
+    from tokenjam.core.summarize.delivery import DeliveryError, summarize_via
+    from tokenjam.core.summarize.session import SummarizeRefused
+
+    mode = body.mode.replace("_", "-")
+    if mode not in ("api", "claude-p"):
+        raise HTTPException(
+            status_code=400,
+            detail="mode must be 'api' or 'claude-p' (manual uses /summarize/prep + /summarize/check).",
+        )
+    try:
+        result = summarize_via(_config(request), body.path, mode, ratio=body.ratio)
+    except SummarizeRefused as exc:
+        raise HTTPException(status_code=409, detail=str(exc)) from exc
+    except DeliveryError as exc:
+        raise HTTPException(status_code=502, detail=str(exc)) from exc
+    return {
+        "verdict": result.verdict.to_dict() if result.verdict is not None else None,
+        "amortization": result.amortization.to_dict() if result.amortization is not None else None,
+        "skipped_note": result.skipped_note,
+        "cost_unknown": result.cost_unknown,
+    }
+
+
+@router.post("/summarize/prep", dependencies=[Depends(require_api_key)])
+def post_summarize_prep(request: Request, body: PrepRequest) -> dict[str, Any]:
+    """Manual step 1 (no outbound): wrap structure → the prompt to summarize in a new
+    session. `wrapped_prompt` is empty (with a note) when the file is below the prose gate."""
+    from tokenjam.core.summarize.session import SummarizeRefused, prepare
+
+    try:
+        return prepare(path=body.path, ratio=body.ratio).to_dict()
+    except SummarizeRefused as exc:
+        raise HTTPException(status_code=409, detail=str(exc)) from exc
+    except OSError as exc:
+        raise HTTPException(status_code=404, detail=f"cannot read {body.path}: {exc}") from exc
+
+
+@router.post("/summarize/check", dependencies=[Depends(require_api_key)])
+def post_summarize_check(request: Request, body: CheckRequest) -> dict[str, Any]:
+    """Manual step 2 (no outbound): verify the pasted-back summary + stage it if structure
+    holds. 409 if the file changed since prep (the summary was built against another version)."""
+    from tokenjam.core.summarize.session import SummarizeRefused, check
+
+    try:
+        return check(_config(request), body.path, body.summary, body.source_hash).to_dict()
+    except SummarizeRefused as exc:
+        raise HTTPException(status_code=409, detail=str(exc)) from exc

--- a/tokenjam/api/routes/summarize_run.py
+++ b/tokenjam/api/routes/summarize_run.py
@@ -67,6 +67,18 @@ def post_summarize_run(request: Request, body: RunRequest) -> dict[str, Any]:
     from tokenjam.core.summarize.delivery import DeliveryError, summarize_via
     from tokenjam.core.summarize.session import SummarizeRefused
 
+    cfg = _config(request)
+    # Conscious opt-in (DEC-031): this is the only route that spends the user's
+    # money / drives their subscription, so it stays inert until they knowingly
+    # enable it. Manual prep+check (no outbound) needs no flag.
+    if not cfg.summarize.allow_outbound_run:
+        raise HTTPException(
+            status_code=403,
+            detail="Outbound summarize run is disabled. Set `[summarize] allow_outbound_run = true` "
+                   "to enable server-side runs (they spend your API key / drive your subscription). "
+                   "The manual copy-paste flow (/summarize/prep + /summarize/check) needs no opt-in.",
+        )
+
     mode = body.mode.replace("_", "-")
     if mode not in ("api", "claude-p"):
         raise HTTPException(
@@ -74,7 +86,7 @@ def post_summarize_run(request: Request, body: RunRequest) -> dict[str, Any]:
             detail="mode must be 'api' or 'claude-p' (manual uses /summarize/prep + /summarize/check).",
         )
     try:
-        result = summarize_via(_config(request), body.path, mode, ratio=body.ratio)
+        result = summarize_via(cfg, body.path, mode, ratio=body.ratio)
     except FileNotFoundError as exc:
         # summarize_via preps first (reads the file); a missing path is a 404, like
         # /summarize/prep — not an unhandled 500.
@@ -117,3 +129,6 @@ def post_summarize_check(request: Request, body: CheckRequest) -> dict[str, Any]
         return check(_config(request), body.path, body.summary, body.source_hash).to_dict()
     except SummarizeRefused as exc:
         raise HTTPException(status_code=409, detail=str(exc)) from exc
+    except FileNotFoundError as exc:
+        # File vanished between prep and check → 404, parity with /prep and /run.
+        raise HTTPException(status_code=404, detail=f"cannot read {body.path}: {exc}") from exc

--- a/tokenjam/core/config.py
+++ b/tokenjam/core/config.py
@@ -282,8 +282,14 @@ class SummarizeConfig:
     `TJ_ANTHROPIC_API_KEY`). There is NO default: only frontier models are validated to
     preserve structure (DEC-029 / DEF-010), and a weak model just fails the structure
     check and stages nothing — so the user must choose one explicitly.
+
+    `allow_outbound_run` gates `POST /summarize/run` — the only server route that
+    spends the user's money / drives their subscription (DEC-031). Default OFF: the
+    outbound run surface is inert on a fresh install until the user knowingly turns it
+    on. The manual (prep + paste-back check) path never goes outbound and is unaffected.
     """
     api_model: str | None = None
+    allow_outbound_run: bool = False
 
 
 @dataclass
@@ -553,7 +559,10 @@ def _parse(raw: dict) -> TjConfig:
     )
     hooks = HooksConfig(output_cap=cap_output)
 
-    summarize = SummarizeConfig(api_model=raw.get("summarize", {}).get("api_model"))
+    summarize = SummarizeConfig(
+        api_model=raw.get("summarize", {}).get("api_model"),
+        allow_outbound_run=bool(raw.get("summarize", {}).get("allow_outbound_run", False)),
+    )
 
     defaults_raw = raw.get("defaults", {})
     defaults_budget_raw = defaults_raw.get("budget", {})


### PR DESCRIPTION
Adds the per-file run surface for the Lens Summarize screen: POST
/summarize/{run,prep,check}. run is outbound (api / claude-p); prep+check are
the manual, no-outbound path. Split into its own route module (summarize_run.py)
and its own PR because run makes tj serve an outbound LLM caller for the first
time.

Design gate — please confirm before merge (DEC-031)

POST /summarize/run is tj serve's first outbound call to an LLM. This reuses the
shipped CLI delivery layer's outbound conventions (TJ_ANTHROPIC_API_KEY,
presence = authorization) rather than inventing new server-side config. What's
genuinely new — and yours to decide — is the server/daemon posture: whether
that's the right home for outbound config, auth-to-spend, and sync vs async.
This PR takes the minimal stance below and is split out so the read/apply
surface can merge while this waits if needed. Current shape:
- api bills the caller's own TJ_ANTHROPIC_API_KEY (its presence in the server
  env is the authorization; the global ANTHROPIC_API_KEY is ignored, matching
  the shipped delivery layer). claude-p spawns the host's claude (subscription
  limits). manual never goes outbound.
- Per-file, sync: run handles 1 file at a time. UI loops this with a progress
  bar and streams results into review. No async-job infra, and no batching at
  this time.
- CORS (local-origin) is the only spend guard today — no per-call/per-file cost
  cap.
- Everything can be overridden.

How
- New api/routes/summarize_run.py (_config duplicated from the reads router so
  it stands alone) + one include line in api/app.py.
- Routes call core directly — session.prepare / delivery.summarize_via /
  session.check; never shell out to tj. Error mapping: 400 bad/manual mode · 404
  missing file (prep) · 409 drift/refuse · 502 model failure.
- Tests: 7 integration tests; delivery/session monkeypatched (no real outbound)
  — mode normalization, verdict/amortization serialization, skip-below-gate, and
  the 400/409/502/404 mappings.

Notes for review
1. _config is duplicated from routes/summarize.py (6 lines) so this module is
   independent of that PR. Once both land, a shared helper can fold them —
   flagged, not done, to keep the PRs decoupled.
2. Manual path has no outbound — prep returns the wrapped copy-paste prompt;
   check verifies the pasted-back summary and stages it. Only run calls out.
3. Guards live in core — run stages via the same session.check gate (structure +
   hash); nothing is applied here (apply/undo are the other PR).

What's NOT in this PR
- No outbound config model / key management / provider catalog — that's the
  design call.
- No cost cap or auth-to-spend beyond CORS.
- No UI, no analyzer.
- No async/job queue — per-file sync by design.

Stands alone as a route module (its own tests pass without the other PRs); a
complete screen needs the reads/apply PR too.
