### PR TITLE
ci: dedicated NPM_WRAPPER_TOKEN secret for the unscoped wrapper publish

### DIFF
--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -66,4 +66,9 @@ jobs:
         working-directory: npm-wrapper
         run: npm publish --access public
         env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+          # The unscoped `tokenjam` wrapper is owned by a different npm account
+          # than the @tokenjam org packages, so it publishes with its own
+          # dedicated secret (granular token scoped to just this package).
+          # NPM_TOKEN (the @tokenjam org token) cannot publish it — v0.5.3 and
+          # v0.5.4 both failed E403 on exactly that mismatch.
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_WRAPPER_TOKEN }}


### PR DESCRIPTION
The unscoped `tokenjam` npx wrapper is owned by a personal npm account (anshs), while `NPM_TOKEN` belongs to the @tokenjam org context — which is why the wrapper publish job failed `E403 Forbidden` on both v0.5.3 and v0.5.4 (the `@tokenjam/sdk` job succeeded both times with the same secret).

This points the `publish-npm-wrapper` job at a dedicated `NPM_WRAPPER_TOKEN` secret (granular token, read/write, scoped to just the `tokenjam` package). The `@tokenjam/sdk` job keeps `NPM_TOKEN` unchanged.

**Requires:** add the `NPM_WRAPPER_TOKEN` secret in repo settings before the next release.

**Note on wrapper 0.5.4:** re-running the failed v0.5.4 job would still use the workflow snapshot from the tag (old secret), so it can't ship the wrapper. Either publish 0.5.4 manually once (`cd npm-wrapper && npm version 0.5.4 --no-git-tag-version && npm publish`) or let the wrapper wait for the next release — it's version-independent at runtime, so users are unaffected either way; only the #87 bin hardening is deferred.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
