### PR TITLE
refresh uvx cache periodically to fix stale npx wrapper versions

### DIFF
--- a/npm-wrapper/bin/tj.js
+++ b/npm-wrapper/bin/tj.js
@@ -21,10 +21,22 @@
  * alongside `tj`, so bare `uvx tokenjam` / `pipx run tokenjam` work too. This
  * wrapper keeps the explicit `--from tokenjam tj` / `--spec tokenjam tj` form
  * below for back-compat with the 0.5.3 and earlier releases it also targets.
+ *
+ * Freshness (issue #111): `uv` reuses its cached tool environment and never
+ * re-resolves on its own, so a machine that first ran this wrapper on an old
+ * release keeps getting that release forever, even after newer ones hit
+ * PyPI. To avoid pinning stale versions indefinitely, the `uvx` branch passes
+ * `--refresh` at most once per 24h (tracked via a timestamp file — see
+ * `shouldRefresh`/`markRefreshed` below). `pipx run` isn't touched: its own
+ * cache already expires after ~14 days on its own. The installed-`tj` branch
+ * has no cache to go stale.
  */
 "use strict";
 
 const { spawnSync } = require("child_process");
+const fs = require("fs");
+const os = require("os");
+const path = require("path");
 
 // PyPI package name vs. command name differ (`tokenjam` ships the `tj` script),
 // so ephemeral runners must be told the source package explicitly.
@@ -45,6 +57,58 @@ function runners() {
   ];
 }
 
+// --- uvx cache freshness (issue #111) -------------------------------------
+//
+// Only the `uvx` runner needs this: `uv` caches a resolved tool environment
+// and reuses it forever unless told to `--refresh`, so a returning user
+// silently keeps whatever version they first resolved. Tracked with a plain
+// timestamp file rather than anything fancier — this wrapper is intentionally
+// dependency-free (stdlib `fs`/`os`/`path` only).
+
+const REFRESH_INTERVAL_MS = 24 * 60 * 60 * 1000; // 24h
+
+function refreshCacheDir() {
+  const xdgCacheHome = process.env.XDG_CACHE_HOME;
+  const base =
+    xdgCacheHome && xdgCacheHome.trim()
+      ? xdgCacheHome
+      : path.join(os.homedir(), ".cache");
+  return path.join(base, "tokenjam-npx");
+}
+
+function refreshTimestampPath() {
+  return path.join(refreshCacheDir(), "last-refresh");
+}
+
+// True if it's been >24h (or we've never refreshed / can't tell). Fails
+// open on any fs error — an unwritable/unreadable cache dir must never
+// break the wrapper, it just means we skip the freshness nudge this run.
+function shouldRefresh() {
+  try {
+    const stat = fs.statSync(refreshTimestampPath());
+    return Date.now() - stat.mtimeMs > REFRESH_INTERVAL_MS;
+  } catch {
+    return true; // no timestamp yet (or unreadable) => treat as stale
+  }
+}
+
+// Called only AFTER `uvx --refresh` has actually returned (not before we
+// spawn it). If the refresh's download is interrupted partway through
+// (network drop, Ctrl-C, OOM kill), spawnSync never returns normally, this
+// never runs, and the *next* invocation still sees a stale/missing
+// timestamp and retries `--refresh`. Writing the timestamp up front instead
+// would mark the cache "fresh" the moment we decided to refresh even if
+// that refresh never completed, silently pinning a broken/partial
+// environment for a full 24h. Best-effort/fail-open: swallow fs errors.
+function markRefreshed() {
+  try {
+    fs.mkdirSync(refreshCacheDir(), { recursive: true });
+    fs.writeFileSync(refreshTimestampPath(), String(Date.now()));
+  } catch {
+    // fail open — worst case we just try to refresh again next run
+  }
+}
+
 function main() {
   // Bare `npx tokenjam` IS the zero-install first run — route it to
   // `tj quickstart` (the quota report the docs promise). The branded home
@@ -56,10 +120,14 @@ function main() {
 
   for (const { bin, prefix } of runners()) {
     if (!has(bin)) continue;
-    const result = spawnSync(bin, [...prefix, ...passthrough], {
+    const isUvx = bin === "uvx";
+    const doRefresh = isUvx && shouldRefresh();
+    const args = doRefresh ? ["--refresh", ...prefix] : prefix;
+    const result = spawnSync(bin, [...args, ...passthrough], {
       stdio: "inherit",
     });
     if (result.error) continue; // try the next runner on spawn failure
+    if (doRefresh) markRefreshed();
     process.exit(result.status === null ? 1 : result.status);
   }
 

--- a/npm-wrapper/bin/tj.js
+++ b/npm-wrapper/bin/tj.js
@@ -92,13 +92,15 @@ function shouldRefresh() {
   }
 }
 
-// Called only AFTER `uvx --refresh` has actually returned (not before we
-// spawn it). If the refresh's download is interrupted partway through
-// (network drop, Ctrl-C, OOM kill), spawnSync never returns normally, this
-// never runs, and the *next* invocation still sees a stale/missing
-// timestamp and retries `--refresh`. Writing the timestamp up front instead
-// would mark the cache "fresh" the moment we decided to refresh even if
-// that refresh never completed, silently pinning a broken/partial
+// Called only AFTER `uvx --refresh` has actually returned with a zero exit
+// status (not before we spawn it, and not on failure). If the refresh's
+// download is interrupted partway through (network drop, Ctrl-C, OOM kill),
+// spawnSync never returns normally, this never runs. If it returns but uv
+// exits non-zero (PyPI unreachable, partial download), the caller also
+// skips this call. Either way the *next* invocation still sees a
+// stale/missing timestamp and retries `--refresh`. Writing the timestamp up
+// front, or unconditionally on return, would mark the cache "fresh" even
+// though that refresh never completed, silently pinning a broken/partial
 // environment for a full 24h. Best-effort/fail-open: swallow fs errors.
 function markRefreshed() {
   try {
@@ -127,7 +129,7 @@ function main() {
       stdio: "inherit",
     });
     if (result.error) continue; // try the next runner on spawn failure
-    if (doRefresh) markRefreshed();
+    if (doRefresh && result.status === 0) markRefreshed();
     process.exit(result.status === null ? 1 : result.status);
   }
 


### PR DESCRIPTION
## Summary
- `npm-wrapper/bin/tj.js`'s `uvx --from tokenjam tj …` runner reused uv's cached tool environment forever, so returning users silently stayed pinned to whichever version they first resolved even after newer releases hit PyPI (observed live 2026-07-08 during 0.5.4 release verification).
- The `uvx` branch now passes `--refresh` at most once per 24h, tracked via a timestamp file at `~/.cache/tokenjam-npx/last-refresh` (honors `XDG_CACHE_HOME`).
- `pipx run` and the installed-`tj` branch are untouched: pipx's own cache already expires (~14 days) on its own, and the installed branch has no cache to go stale.
- Fail-open: any fs error in the freshness check/write (unwritable dir, weird perms, ...) silently falls back to today's no-refresh behavior — never breaks the headline command.
- Timestamp is written **after** `uvx` returns, not before spawning it. If the refresh is interrupted mid-download (network drop, Ctrl-C, OOM kill), `spawnSync` never returns normally, the timestamp is never marked fresh, and the next invocation retries `--refresh`. Writing before spawn would instead mark the cache "fresh" the instant we decided to refresh, potentially pinning a broken/partial environment for a full 24h.
- Did not bump `npm-wrapper/package.json` version — the publish workflow derives it from the release tag.

This fixes the stale-wrapper-version problem

## Test plan
- [x] `node -c npm-wrapper/bin/tj.js` — syntax check (same check CI's `publish-npm.yml` runs)
- [x] Manual verification with a fake `HOME` and a fake `uvx` binary that logs its argv:
  - Run 1 (no timestamp yet): spawned with `--refresh --from tokenjam tj --version`
  - Run 2 (immediately after, within 24h): spawned with `--from tokenjam tj --version` (no `--refresh`)
  - Run 3 (timestamp artificially aged >24h): spawned with `--refresh --from tokenjam tj --version` again
- [x] Manual verification of fail-open: made `~/.cache` unwritable (`chmod 000`) and confirmed the wrapper still exits 0 without crashing

🤖 Generated with [Claude Code](https://claude.com/claude-code)
