### PR TITLE
fix(summarize): guard file reads against non-UTF-8 + correct /check missing-file semantics

### DIFF
--- a/tests/integration/test_summarize_run_api.py
+++ b/tests/integration/test_summarize_run_api.py
@@ -189,14 +189,41 @@ async def test_run_refused_when_outbound_disabled(db, config):
     assert "allow_outbound_run" in r.json()["detail"]
 
 
-async def test_check_missing_file_returns_404(client, monkeypatch):
-    # File vanished between prep and check → 404, parity with /prep and /run.
-    def gone(config, path, summary, source_hash, **kw):
-        raise FileNotFoundError(path)
-    monkeypatch.setattr("tokenjam.core.summarize.session.check", gone)
+async def test_check_missing_file_returns_409_real(client, tmp_path):
+    # check() guards missing files with is_file → SummarizeRefused, so a REAL missing
+    # file is 409 (its documented "vanished since prep" contract) — not the 404 an
+    # earlier mocked test wrongly asserted. (Contrast /prep + /run below, which DO 404
+    # via prepare's FileNotFoundError — verified per-function, not assumed.)
     r = await client.post("/api/v1/summarize/check",
-                          json={"path": "./gone.md", "summary": "s", "source_hash": "abc"})
-    assert r.status_code == 404
+                          json={"path": str(tmp_path / "gone.md"), "summary": "s", "source_hash": "abc"})
+    assert r.status_code == 409
+
+
+async def test_check_non_utf8_returns_409_real(client, tmp_path):
+    # Non-UTF-8 file → check()'s read raises UnicodeDecodeError → SummarizeRefused → 409,
+    # not an uncaught 500. Real file, no mock.
+    p = tmp_path / "CLAUDE.md"
+    p.write_bytes(b"\xff\xfe not valid utf-8 \x80\x81")
+    r = await client.post("/api/v1/summarize/check",
+                          json={"path": str(p), "summary": "s", "source_hash": "abc"})
+    assert r.status_code == 409
+
+
+async def test_prep_non_utf8_returns_409_real(client, tmp_path):
+    # prepare → _read maps UnicodeDecodeError → SummarizeRefused → 409 (missing still 404).
+    p = tmp_path / "CLAUDE.md"
+    p.write_bytes(b"\xff\xfe not valid utf-8 \x80\x81")
+    r = await client.post("/api/v1/summarize/prep", json={"path": str(p)})
+    assert r.status_code == 409
+
+
+async def test_run_non_utf8_returns_409_real(client, tmp_path):
+    # Outbound run reads via prepare first, so a non-UTF-8 file is refused (409) BEFORE
+    # any model call — real file, flag-on fixture, no outbound reached.
+    p = tmp_path / "CLAUDE.md"
+    p.write_bytes(b"\xff\xfe not valid utf-8 \x80\x81")
+    r = await client.post("/api/v1/summarize/run", json={"path": str(p), "mode": "api"})
+    assert r.status_code == 409
 
 
 async def test_check_structure_fail_never_stages(client, config, tmp_path):

--- a/tests/unit/test_summarize_backup.py
+++ b/tests/unit/test_summarize_backup.py
@@ -69,3 +69,32 @@ def test_not_undoable_when_file_gone(cfg, tmp_path):
     p.unlink()
     (rec,) = backup.list_backups(cfg)
     assert rec["undoable"] is False and rec["reason"] == "file no longer exists"
+
+
+def test_non_utf8_file_is_not_undoable_and_does_not_crash(cfg, tmp_path):
+    # UnicodeDecodeError is a ValueError, not OSError — a non-UTF-8 applied file must
+    # come back undoable=False, not raise and 500 the whole /backups response (#424).
+    sp, p = _applied(cfg, tmp_path)
+    p.write_bytes(b"\xff\xfe not valid utf-8 \x80\x81\x82")
+    (rec,) = backup.list_backups(cfg)
+    assert rec["source_path"] == sp
+    assert rec["undoable"] is False and rec["reason"] == "cannot read the file"
+
+
+def test_load_original_refuses_corrupt_meta(cfg, tmp_path):
+    # A non-UTF-8 / truncated / key-missing meta sidecar must make undo refuse (→409),
+    # not raise UnicodeDecodeError/JSONDecodeError/KeyError out of undo() as a 500 (#429).
+    from tokenjam.core.summarize.session import SummarizeRefused
+    sp, _ = _applied(cfg, tmp_path)
+    backup._meta_path(cfg, sp).write_bytes(b"\xff\xfe not json, not utf-8 \x80")
+    with pytest.raises(SummarizeRefused):
+        backup.load_original(cfg, sp, current="whatever")
+
+
+def test_load_original_refuses_corrupt_blob(cfg, tmp_path):
+    # A corrupt gzip blob → SummarizeRefused, not a bare OSError/BadGzipFile 500.
+    from tokenjam.core.summarize.session import SummarizeRefused
+    sp, _ = _applied(cfg, tmp_path)
+    backup._orig_path(cfg, sp).write_bytes(b"this is not a gzip stream")
+    with pytest.raises(SummarizeRefused):
+        backup.load_original(cfg, sp, current=None)

--- a/tests/unit/test_summarize_session.py
+++ b/tests/unit/test_summarize_session.py
@@ -286,3 +286,16 @@ def test_undo_refuses_symlink(cfg, tmp_path):
     link.symlink_to(real)
     with pytest.raises(SummarizeRefused, match="symlink"):
         undo(cfg, str(link))
+
+
+def test_staged_reads_skip_corrupt_and_unreadable(cfg):
+    # Our staged records are always UTF-8 JSON, but a half-written / hand-edited /
+    # non-UTF-8 file must not crash the readers (Greptile #429 follow-up): list_staged
+    # skips it, read_staged returns None — instead of a UnicodeDecodeError 500.
+    from tokenjam.core.summarize import session
+    d = session.results_dir(cfg)
+    d.mkdir(parents=True, exist_ok=True)
+    path = "/tmp/whatever.md"
+    (d / f"{session.stage_key(path)}.json").write_bytes(b"\xff\xfe not valid utf-8 \x80\x81")
+    assert list_staged(cfg) == []            # skipped, not a crash
+    assert read_staged(cfg, path) is None    # unreadable → None, not a raise

--- a/tokenjam/api/routes/summarize_run.py
+++ b/tokenjam/api/routes/summarize_run.py
@@ -122,13 +122,11 @@ def post_summarize_prep(request: Request, body: PrepRequest) -> dict[str, Any]:
 @router.post("/summarize/check", dependencies=[Depends(require_api_key)])
 def post_summarize_check(request: Request, body: CheckRequest) -> dict[str, Any]:
     """Manual step 2 (no outbound): verify the pasted-back summary + stage it if structure
-    holds. 409 if the file changed since prep (the summary was built against another version)."""
+    holds. 409 if the file is missing/changed/non-UTF-8 since prep — `check()` guards all of
+    those as SummarizeRefused (it never raises FileNotFoundError), so 409 is the whole story."""
     from tokenjam.core.summarize.session import SummarizeRefused, check
 
     try:
         return check(_config(request), body.path, body.summary, body.source_hash).to_dict()
     except SummarizeRefused as exc:
         raise HTTPException(status_code=409, detail=str(exc)) from exc
-    except FileNotFoundError as exc:
-        # File vanished between prep and check → 404, parity with /prep and /run.
-        raise HTTPException(status_code=404, detail=f"cannot read {body.path}: {exc}") from exc

--- a/tokenjam/core/summarize/backup.py
+++ b/tokenjam/core/summarize/backup.py
@@ -60,7 +60,7 @@ def recorded_output(config: TjConfig, path: str) -> str | None:
         return None
     try:
         return json.loads(f.read_text(encoding="utf-8"))["output_sha256"]
-    except (OSError, json.JSONDecodeError, KeyError):
+    except (OSError, UnicodeDecodeError, json.JSONDecodeError, KeyError):
         return None
 
 
@@ -80,7 +80,7 @@ def list_backups(config: TjConfig) -> list[dict]:
     for meta_f in sorted(d.glob("*.meta.json")):
         try:
             meta = json.loads(meta_f.read_text(encoding="utf-8"))
-        except (OSError, json.JSONDecodeError):
+        except (OSError, UnicodeDecodeError, json.JSONDecodeError):
             continue
         sp = meta.get("source_path")
         if not sp:
@@ -104,7 +104,9 @@ def list_backups(config: TjConfig) -> list[dict]:
         else:
             try:
                 current = p.read_text(encoding="utf-8")
-            except OSError:
+            except (OSError, UnicodeDecodeError):
+                # UnicodeDecodeError is a ValueError, not an OSError — catch it too, or
+                # one non-UTF-8 applied file 500s the whole /backups response (#424).
                 undoable, reason = False, "cannot read the file"
             else:
                 if sha256(current) != meta.get("output_sha256"):
@@ -129,10 +131,17 @@ def load_original(config: TjConfig, path: str, current: str | None) -> str:
     orig_f, meta_f = _orig_path(config, path), _meta_path(config, path)
     if not (orig_f.exists() and meta_f.exists()):
         raise SummarizeRefused(f"no summarize backup for {path} — nothing to undo.")
-    if current is not None:
-        meta = json.loads(meta_f.read_text(encoding="utf-8"))
-        if sha256(current) != meta["output_sha256"]:
-            raise SummarizeRefused(
-                f"{path} has changed since `tj summarize apply` wrote it — "
-                "refusing to undo (newer edits would be lost).")
-    return gzip.decompress(orig_f.read_bytes()).decode("utf-8")
+    try:
+        if current is not None:
+            meta = json.loads(meta_f.read_text(encoding="utf-8"))
+            if sha256(current) != meta["output_sha256"]:
+                raise SummarizeRefused(
+                    f"{path} has changed since `tj summarize apply` wrote it — "
+                    "refusing to undo (newer edits would be lost).")
+        return gzip.decompress(orig_f.read_bytes()).decode("utf-8")
+    except (OSError, UnicodeDecodeError, json.JSONDecodeError, KeyError) as exc:
+        # Corrupt/unreadable sidecar or blob (non-UTF-8, truncated JSON, missing key,
+        # bad gzip) → refuse cleanly (undo() → 409), never a 500. (The drift
+        # SummarizeRefused above is a different type and propagates untouched.)
+        raise SummarizeRefused(
+            f"summarize backup for {path} is unreadable or corrupt — cannot undo.") from exc

--- a/tokenjam/core/summarize/session.py
+++ b/tokenjam/core/summarize/session.py
@@ -25,7 +25,9 @@ from tokenjam.core.summarize.estimate import DEFAULT_TARGET_RATIO
 
 
 class SummarizeRefused(Exception):
-    """File changed or vanished since prep — re-prep before check/apply (carries the house-voice text)."""
+    """Refusing to summarize/apply a file (carries the house-voice text): it changed or
+    vanished since prep, isn't valid UTF-8, is a symlink, or otherwise can't be processed.
+    Callers surface it as a 409 / re-prep prompt."""
 
 
 CHECK_NOTE = (
@@ -115,7 +117,13 @@ def sha256(text: str) -> str:
 
 
 def _read(path: str) -> str:
-    return Path(path).expanduser().read_text(encoding="utf-8")
+    try:
+        return Path(path).expanduser().read_text(encoding="utf-8")
+    except UnicodeDecodeError as exc:
+        # A non-UTF-8 prompt file can't be summarized — refuse cleanly (callers map
+        # SummarizeRefused → 409) instead of letting a ValueError (not an OSError)
+        # crash the read. Missing files still raise FileNotFoundError (→ 404).
+        raise SummarizeRefused(f"{path} isn't valid UTF-8 — cannot summarize it.") from exc
 
 
 def _refuse_symlink(path: str) -> None:
@@ -166,8 +174,8 @@ def list_staged(config: TjConfig) -> list[dict]:
     for f in sorted(d.glob("*.json")):
         try:
             out.append(json.loads(f.read_text(encoding="utf-8")))
-        except json.JSONDecodeError:
-            continue                                  # skip a half-written/corrupt entry
+        except (OSError, UnicodeDecodeError, json.JSONDecodeError):
+            continue                                  # skip a half-written/corrupt/unreadable entry
     return out
 
 
@@ -175,7 +183,10 @@ def read_staged(config: TjConfig, path: str) -> dict | None:
     f = results_dir(config) / f"{stage_key(path)}.json"
     if not f.exists():
         return None
-    parsed: dict = json.loads(f.read_text(encoding="utf-8"))
+    try:
+        parsed: dict = json.loads(f.read_text(encoding="utf-8"))
+    except (OSError, UnicodeDecodeError, json.JSONDecodeError):
+        return None                                   # corrupt/unreadable → treat as no record
     return parsed
 
 
@@ -244,7 +255,13 @@ def check(config: TjConfig, path: str, summary: str, source_hash: str,
         raise SummarizeRefused(
             f"{path} not found (moved or deleted since prep) — re-run `tj summarize prep`.")
     p = p.resolve()   # canonical absolute — `apply` must not reinterpret a relative path against its cwd
-    current = p.read_text(encoding="utf-8")
+    try:
+        current = p.read_text(encoding="utf-8")
+    except FileNotFoundError as exc:   # vanished between the is_file check above and here (TOCTOU)
+        raise SummarizeRefused(
+            f"{path} not found (moved or deleted since prep) — re-run `tj summarize prep`.") from exc
+    except UnicodeDecodeError as exc:
+        raise SummarizeRefused(f"{path} isn't valid UTF-8 — cannot summarize it.") from exc
     if sha256(current) != source_hash:
         raise SummarizeRefused(
             f"{path} changed since `tj summarize prep` — re-run prep, then check.")


### PR DESCRIPTION
Follow-up to the summarize stack (#423–#426). Greptile's post-merge review flagged two real exception-handling bugs on `main`, both the same class — a too-narrow / wrong-exception catch. This fixes the whole class across the module (every `read_text` / `read_bytes` / `json.loads` in `backup.py` + `session.py`).

**1. Non-UTF-8 / corrupt crashes `/summarize/backups` and `/undo` (from #424).** `list_backups`, `recorded_output`, and `load_original` (used by `undo`) read via `read_text(encoding="utf-8")` / `gzip.decompress().decode()` but caught too narrow — `UnicodeDecodeError` is a `ValueError` (not `OSError`), and `load_original` also had an unguarded `KeyError` on the meta — so one non-UTF-8 / truncated / corrupt applied file or backup 500s the response instead of a clean `undoable=false` / 409. Broadened every backup read to catch `(OSError, UnicodeDecodeError, json.JSONDecodeError, KeyError)`.

**2. `/summarize/check` `FileNotFoundError→404` was dead code (from #425).** `check()` guards missing files with `is_file → SummarizeRefused`, so a missing file is **409** (its documented "vanished since prep" contract), never `FileNotFoundError`. The route's 404 catch never fired, and its test *mocked* `check` to raise `FileNotFoundError` — green while asserting an impossible path. Removed the dead catch.

**3. Same non-UTF-8 gap in the check/prepare reads.** Hardened `session.check` and `_read` (used by `prepare`) so `UnicodeDecodeError → SummarizeRefused` (→ 409); `check` also maps its `FileNotFoundError` race (vanish between `is_file` and the read) → `SummarizeRefused`. `prepare` still raises `FileNotFoundError` for a genuinely missing file, so `/prep` and `/run` stay **404** for missing — only the encoding case is remapped.

**4. Staged-record readers hardened.** `session.list_staged` / `read_staged` now catch `(OSError, UnicodeDecodeError, json.JSONDecodeError)`, so a corrupt / unreadable / non-UTF-8 staged record is skipped (or returns `None`) instead of crashing `/summarize/staged`.

**Why 409 (not 404) for `/check` on a missing file:** `check` is the second phase (after `prep`); a file gone by then is a conflict with the prepped state, which `check` already models as `SummarizeRefused` (409). The real goal — no 500 — is met; literal 404-parity with `/prep`/`/run` doesn't fit, since those are first-read ops.

**Also:** updated the `SummarizeRefused` docstring, which previously undersold how broadly the exception is now used.

**Tests** are real-input (real missing file, real non-UTF-8 bytes, corrupt staged record, corrupt backup meta/blob), not mocked exceptions.
