### PR TITLE
Fix: clarify uninstall/reinstall two-step + optional package removal

### DIFF
--- a/tests/integration/test_cli_uninstall.py
+++ b/tests/integration/test_cli_uninstall.py
@@ -1,0 +1,118 @@
+"""CLI tests for `tj uninstall` messaging + optional package removal.
+
+These focus on the closing UX (issue: uninstall/reinstall confusion) — the
+two-step "package remains; reinstall FRESH with upgrade/--force" messaging and
+the optional package-removal prompt. Filesystem side effects are neutered by
+pointing HOME at a tmp dir and mocking subprocess/shutil so nothing real is
+touched.
+"""
+from __future__ import annotations
+
+import subprocess
+from unittest.mock import MagicMock, patch
+
+import pytest
+from click.testing import CliRunner
+
+from tokenjam.cli import cmd_uninstall as uninstall_mod
+from tokenjam.cli.cmd_uninstall import cmd_uninstall
+
+
+@pytest.fixture
+def runner():
+    return CliRunner()
+
+
+@pytest.fixture(autouse=True)
+def _isolate(tmp_path, monkeypatch):
+    """Keep uninstall off real machine state: fake HOME/cwd, no real subprocess,
+    no `claude` on PATH so the MCP-deregister branch is skipped."""
+    home = tmp_path / "home"
+    home.mkdir()
+    # Wide console so Rich doesn't wrap commands mid-token in assertions.
+    monkeypatch.setenv("COLUMNS", "200")
+    monkeypatch.setattr("pathlib.Path.home", lambda: home)
+    monkeypatch.chdir(tmp_path)
+    # cmd_stop is invoked first; stub it out so it doesn't poke the real daemon.
+    monkeypatch.setattr("tokenjam.cli.cmd_stop.cmd_stop", MagicMock())
+    with patch.object(uninstall_mod.shutil, "which", return_value=None):
+        yield
+
+
+def _run(runner, *args, **kwargs):
+    return runner.invoke(cmd_uninstall, ["--yes", *args], **kwargs)
+
+
+def test_messaging_states_package_remains(runner):
+    """Default (no --remove-package, --yes): package left in place, two-step
+    guidance printed, and the FRESH-reinstall command is upgrade/--force."""
+    with patch.object(uninstall_mod, "_installed_via_pipx", return_value=True):
+        result = _run(runner)
+    assert result.exit_code == 0, result.output
+    out = result.output
+    assert "package itself is still installed" in out
+    assert "pipx uninstall tokenjam" in out
+    # FRESH reinstall must NOT be a bare `pipx install` (that no-ops).
+    assert "pipx upgrade tokenjam" in out
+    assert "pipx install --force tokenjam" in out
+    assert "no-ops when tokenjam is already present" in out
+
+
+def test_reinstall_hint_for_pip_install(runner):
+    """Non-pipx install: hint is pip uninstall + pip install --upgrade."""
+    with patch.object(uninstall_mod, "_installed_via_pipx", return_value=False):
+        result = _run(runner)
+    assert result.exit_code == 0, result.output
+    assert "pip uninstall tokenjam" in result.output
+    assert "pip install --upgrade tokenjam" in result.output
+
+
+def test_remove_package_flag_runs_pipx(runner):
+    """--remove-package on a pipx install runs `pipx uninstall tokenjam`."""
+    fake = MagicMock(returncode=0, stdout="", stderr="")
+    with patch.object(uninstall_mod, "_installed_via_pipx", return_value=True), \
+         patch.object(uninstall_mod.shutil, "which", side_effect=lambda c: "/usr/bin/pipx" if c == "pipx" else None), \
+         patch.object(uninstall_mod.subprocess, "run", return_value=fake) as run:
+        result = _run(runner, "--remove-package")
+    assert result.exit_code == 0, result.output
+    run.assert_called_once_with(
+        ["pipx", "uninstall", "tokenjam"], capture_output=True, text=True
+    )
+    assert "tokenjam package removed" in result.output
+
+
+def test_remove_package_flag_non_pipx_prints_command(runner):
+    """--remove-package on a non-pipx install must NOT guess/run — it prints
+    the right command instead."""
+    with patch.object(uninstall_mod, "_installed_via_pipx", return_value=False), \
+         patch.object(uninstall_mod.subprocess, "run") as run:
+        result = _run(runner, "--remove-package")
+    assert result.exit_code == 0, result.output
+    # Only cmd_stop (mocked) — no pipx/pip uninstall subprocess fired.
+    run.assert_not_called()
+    assert "not a pipx-managed venv" in result.output
+    assert "pip uninstall tokenjam" in result.output
+
+
+def test_prompt_offered_when_interactive(runner):
+    """Without --yes, the user is asked whether to also remove the package;
+    answering No leaves it and prints the two-step guidance."""
+    with patch.object(uninstall_mod, "_installed_via_pipx", return_value=True):
+        # First prompt: confirm delete-all (y). Second: also remove package (n).
+        result = runner.invoke(cmd_uninstall, [], input="y\nn\n")
+    assert result.exit_code == 0, result.output
+    assert "Also remove the tokenjam package now?" in result.output
+    assert "package itself is still installed" in result.output
+
+
+def test_pipx_uninstall_failure_falls_back_to_manual(runner):
+    """If pipx uninstall fails, we surface the error and the manual command
+    rather than claiming success."""
+    fake = MagicMock(returncode=1, stdout="", stderr="boom")
+    with patch.object(uninstall_mod, "_installed_via_pipx", return_value=True), \
+         patch.object(uninstall_mod.shutil, "which", side_effect=lambda c: "/usr/bin/pipx" if c == "pipx" else None), \
+         patch.object(uninstall_mod.subprocess, "run", return_value=fake):
+        result = _run(runner, "--remove-package")
+    assert result.exit_code == 0, result.output
+    assert "Could not remove the package automatically" in result.output
+    assert "pipx uninstall tokenjam" in result.output

--- a/tokenjam/cli/cmd_uninstall.py
+++ b/tokenjam/cli/cmd_uninstall.py
@@ -12,23 +12,47 @@ import click
 from tokenjam.utils.formatting import console
 
 
+def _installed_via_pipx() -> bool:
+    """True when this tj lives in a pipx-managed venv.
+
+    A pipx install lives at ~/.local/share/pipx/venvs/tokenjam/... — detecting
+    that is how we tell pipx installs apart from a plain pip / venv install.
+    """
+    return "pipx/venvs/" in sys.executable.replace("\\", "/")
+
+
 def _package_uninstall_hint() -> str:
     """Return the right uninstall command for how the user installed.
 
-    pipx is the canonical install path (per README and docs/installation.md).
-    A pipx install lives at ~/.local/share/pipx/venvs/tokenjam/... — detect
-    that and recommend `pipx uninstall`, otherwise fall back to `pip uninstall`
-    for venv / pip installs.
+    pipx is the canonical install path (per README and docs/installation.md);
+    otherwise fall back to `pip uninstall` for venv / pip installs.
     """
-    if "pipx/venvs/" in sys.executable.replace("\\", "/"):
-        return "pipx uninstall tokenjam"
-    return "pip uninstall tokenjam"
+    return "pipx uninstall tokenjam" if _installed_via_pipx() else "pip uninstall tokenjam"
+
+
+def _package_reinstall_hint() -> str:
+    """Return the command that actually reinstalls FRESH.
+
+    A plain `pipx install tokenjam` / `pip install tokenjam` no-ops when the
+    package is already present — the source of the confusing "fresh install"
+    that silently does nothing. Point pipx users at `pipx upgrade` (or
+    `pipx install --force`) and pip users at `pip install --upgrade`.
+    """
+    if _installed_via_pipx():
+        return "pipx upgrade tokenjam  (or: pipx install --force tokenjam)"
+    return "pip install --upgrade tokenjam"
 
 
 @click.command("uninstall")
 @click.option("--yes", is_flag=True, help="Skip confirmation prompt")
+@click.option(
+    "--remove-package",
+    is_flag=True,
+    help="Also remove the tokenjam package (runs pipx/pip uninstall). "
+    "With --yes, removes it without a second prompt.",
+)
 @click.pass_context
-def cmd_uninstall(ctx: click.Context, yes: bool) -> None:
+def cmd_uninstall(ctx: click.Context, yes: bool, remove_package: bool) -> None:
     """Remove all TokenJam data, config, and daemon."""
     if not yes:
         confirmed = click.confirm(
@@ -177,5 +201,66 @@ def cmd_uninstall(ctx: click.Context, yes: bool) -> None:
             console.print(f"  [yellow]Could not clean {zshrc}: {exc}[/yellow]")
 
     console.print()
-    console.print("[green]TokenJam data and config removed.[/green]")
-    console.print(f"To remove the package itself, run: [bold]{_package_uninstall_hint()}[/bold]")
+    console.print("[green]TokenJam data, config, and wiring removed.[/green]")
+    console.print("[dim]The tokenjam package itself is still installed.[/dim]")
+
+    # 12. Optionally remove the package too (safe, opt-in, default No).
+    uninstall_cmd = _package_uninstall_hint()
+    do_remove = remove_package
+    if not do_remove and not yes:
+        do_remove = click.confirm(
+            f"Also remove the tokenjam package now? (runs {uninstall_cmd})",
+            default=False,
+        )
+
+    if do_remove:
+        _remove_package(uninstall_cmd)
+        return
+
+    # Package left in place: spell out the two-step so a later reinstall isn't
+    # a silent no-op (a plain `pipx/pip install` no-ops when already present).
+    console.print()
+    console.print("Next steps:")
+    console.print(f"  Fully remove the package:  [bold]{uninstall_cmd}[/bold]")
+    console.print(f"  Reinstall FRESH:           [bold]{_package_reinstall_hint()}[/bold]")
+    console.print(
+        "  [dim]A plain `install` no-ops when tokenjam is already present — "
+        "use the upgrade/--force form above to reinstall.[/dim]"
+    )
+
+
+def _remove_package(uninstall_cmd: str) -> None:
+    """Run the package uninstall when we can, else print the exact command.
+
+    Only pipx is auto-run: it's the canonical install path and safe to invoke
+    non-interactively. For pip / venv installs we print the command instead of
+    guessing (a wrong `pip uninstall` in the wrong environment is worse than a
+    copy-paste)."""
+    if _installed_via_pipx() and shutil.which("pipx"):
+        console.print()
+        console.print(f"Running: [bold]{uninstall_cmd}[/bold]")
+        result = subprocess.run(
+            ["pipx", "uninstall", "tokenjam"],
+            capture_output=True,
+            text=True,
+        )
+        if result.returncode == 0:
+            console.print("[green]tokenjam package removed.[/green]")
+            console.print(
+                f"  [dim]To reinstall FRESH: {_package_reinstall_hint()}[/dim]"
+            )
+        else:
+            console.print(
+                f"  [yellow]Could not remove the package automatically: "
+                f"{result.stderr.strip() or result.stdout.strip()}[/yellow]"
+            )
+            console.print(f"  Run manually: [bold]{uninstall_cmd}[/bold]")
+        return
+
+    # Not a pipx install (or pipx missing) — print the right command, don't guess.
+    console.print()
+    console.print(
+        "  [yellow]Can't safely auto-remove this install "
+        "(not a pipx-managed venv).[/yellow]"
+    )
+    console.print(f"  Remove the package with: [bold]{uninstall_cmd}[/bold]")


### PR DESCRIPTION
`tj uninstall` removes data, config, daemon, MCP registration, and editor wiring, but leaves the pip/pipx package in place. The old closing line only said `pipx uninstall tokenjam` and never explained that a later plain `pipx install tokenjam` no-ops when the package is still present — so a "fresh install" silently does nothing (the exact pain Anil hit).

## Summary
- Make the uninstall two-step crystal clear at the end of `tj uninstall`.
- Optionally offer to remove the package too — a safe, default-No prompt (plus a `--remove-package` flag for non-interactive `--yes` runs).

## Messaging change
The closing output now:
- States plainly that **data/config/wiring are removed but the package remains**.
- Gives the **full removal** command (`pipx uninstall tokenjam` / `pip uninstall tokenjam`, picked by install method).
- Gives the command that actually **reinstalls FRESH** — `pipx upgrade tokenjam` (or `pipx install --force tokenjam`), or `pip install --upgrade tokenjam` — with an explicit note that a plain `install` no-ops when tokenjam is already present.

## Optional package-removal prompt
- Interactive (no `--yes`): after cleanup, prompts `Also remove the tokenjam package now? (runs pipx uninstall tokenjam)` — default **No**.
- Non-interactive: `--remove-package` triggers the same removal without a second prompt.
- **Safety:** only a **pipx-managed** install is auto-run (`pipx uninstall tokenjam`). For pip/venv installs (or a missing `pipx`), it prints the exact command rather than guessing at the wrong environment. If `pipx uninstall` fails, it surfaces the error and the manual command instead of claiming success.

## Tests / Verification
- New `tests/integration/test_cli_uninstall.py` (CliRunner, 6 tests): package-remains messaging + FRESH-reinstall command form; pip-vs-pipx hint selection; `--remove-package` runs pipx; non-pipx prints the command and does **not** run a subprocess; interactive prompt is offered; pipx-failure falls back to the manual command.
- `ruff check tokenjam/` clean; `pytest tests/unit/` (1593 passed, 2 skipped) and the CLI integration tests green locally.

## What's NOT in this PR
- No change to what gets deleted (data/config/daemon/MCP/wiring behavior is untouched) — this is purely closing UX + the opt-in package-removal path.
- No auto-run for pip/venv installs — deliberately printed, not executed, to avoid touching the wrong environment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)