### PR TITLE
Fix tj ping: omit empty Bearer header so the test span is delivered

### DIFF
--- a/tests/unit/test_http_exporter_auth.py
+++ b/tests/unit/test_http_exporter_auth.py
@@ -1,0 +1,43 @@
+"""`TjHttpExporter` Authorization-header construction.
+
+Regression guard for the `tj ping` footgun where an empty ingest secret
+produced ``Authorization: Bearer `` — an illegal HTTP header value (leading/
+trailing whitespace is forbidden by RFC 9110). httpx/h11 raise
+``LocalProtocolError: Illegal header value b'Bearer '`` at send time, so the
+OTLP span export failed outright and `tj ping` reported "emitted … but not
+confirmed received".
+
+Contract enforced here:
+- non-empty secret  -> ``Authorization: Bearer <secret>`` (Critical Rule 4)
+- empty / missing   -> no ``Authorization`` header at all (never ``Bearer ``)
+"""
+from __future__ import annotations
+
+import pytest
+
+from tokenjam.sdk.http_exporter import TjHttpExporter
+
+ENDPOINT = "http://127.0.0.1:7391/api/v1/spans"
+
+
+def test_header_is_well_formed_bearer_when_secret_present() -> None:
+    secret = "0af032cb1234567890abcdef"
+    exporter = TjHttpExporter(ENDPOINT, secret)
+
+    assert exporter._headers["Authorization"] == f"Bearer {secret}"
+    # Well-formed: exactly one space, no trailing/leading whitespace in value.
+    value = exporter._headers["Authorization"]
+    assert value == value.strip()
+    assert value.startswith("Bearer ")
+    assert value[len("Bearer "):] == secret
+
+
+@pytest.mark.parametrize("empty_secret", ["", None])
+def test_no_authorization_header_when_secret_missing(empty_secret) -> None:
+    # ``None`` can slip through if a caller passes an unset config field.
+    exporter = TjHttpExporter(ENDPOINT, empty_secret)  # type: ignore[arg-type]
+
+    # Never emit an empty Bearer — omit the header entirely.
+    assert "Authorization" not in exporter._headers
+    assert all(v != "Bearer " for v in exporter._headers.values())
+    assert exporter._headers.get("Content-Type") == "application/json"

--- a/tokenjam/sdk/http_exporter.py
+++ b/tokenjam/sdk/http_exporter.py
@@ -19,11 +19,19 @@ class TjHttpExporter(SpanExporter):
 
     def __init__(self, endpoint: str, ingest_secret: str) -> None:
         self._endpoint = endpoint
-        self._ingest_secret = ingest_secret
+        self._ingest_secret = ingest_secret or ""
         self._headers = {
             "Content-Type": "application/json",
-            "Authorization": f"Bearer {ingest_secret}",
         }
+        # Only attach the Bearer header when a secret is actually configured.
+        # Sending "Authorization: Bearer " (empty secret) is an illegal HTTP
+        # header value — httpx raises LocalProtocolError before the request
+        # is even sent, so the span export fails outright (#: `tj ping`
+        # reported "emitted … but not confirmed received"). Omitting the
+        # header lets the request go out; if tj serve requires auth it 401s,
+        # which is handled gracefully in export() below.
+        if self._ingest_secret:
+            self._headers["Authorization"] = f"Bearer {self._ingest_secret}"
         # Cumulative count of spans dropped on auth failure. Exposed so
         # `tj doctor` can surface this in a future enhancement (#68 §2).
         self.dropped_auth_failures = 0


### PR DESCRIPTION
`tj ping` threw `httpx.LocalProtocolError: Illegal header value b'Bearer '` and never delivered its test span whenever the resolved config had no `security.ingest_secret`. This makes the command's proof-of-life useless in exactly the situation where a user is debugging their wiring.

## Summary
- Build the `Authorization` header conditionally in `TjHttpExporter`: send `Bearer <secret>` when a secret exists, omit the header entirely when there is none.
- Add a unit test asserting the header is well-formed (`Bearer <secret>`, no stray whitespace) when a secret is set, and absent — never an empty `Bearer ` — when it isn't.

## Root cause
`TjHttpExporter.__init__` (in `tokenjam/sdk/http_exporter.py`) unconditionally built:

```python
"Authorization": f"Bearer {ingest_secret}"
```

When `config.security.ingest_secret` is empty, that produces the literal header value `Bearer ` (trailing whitespace). Per RFC 9110, header values may not have leading/trailing whitespace, so h11/httpcore raise `LocalProtocolError: Illegal header value b'Bearer '` **at send time** — deep inside `BatchSpanProcessor`. The OTLP span export never completes, the span never reaches `tj serve`, and `tj ping` falls through to the "Span emitted … but not confirmed received" branch. The narrow `except (httpx.ConnectError, httpx.TimeoutException)` in `export()` doesn't cover this error, so it surfaces as an uncaught export traceback.

## Fix
Only attach `Authorization` when a secret is configured. If there genuinely is no secret, the request goes out without the header; `tj serve` returns 401 if it requires auth, which the existing `export()` 401 branch already handles gracefully (Critical Rule 4 preserved — a configured secret still sends `Bearer <secret>`).

## Tests / Verification
- New `tests/unit/test_http_exporter_auth.py`: header is `Bearer <secret>` (stripped, single space) with a secret; no `Authorization` header (and never `Bearer `) with `""`/`None`.
- Full unit suite green: `1596 passed, 2 skipped`. `ruff check tokenjam/` and `mypy tokenjam/sdk/http_exporter.py` clean.
- End-to-end against v0.5.4 with a live `tj serve`:
  - **Empty secret, pre-fix:** `tj ping` prints the `LocalProtocolError: Illegal header value b'Bearer '` traceback; span dropped.
  - **Empty secret, fixed:** `✓ Delivered to tj serve … (confirmed received)`.
  - **Matching secret, fixed:** `tj ping --json` → `{"confirmed": true, ...}`, exit 0.

## What's NOT in this PR
- The separate "config secret didn't load into the exporter" resolution question. Both `tj ping`'s CLI config and `bootstrap.ensure_initialised()` already call `load_config()`, so a configured secret does reach the exporter; the observed failure is purely the empty-Bearer header. Left the config-discovery path untouched to keep scope to the header bug.
- No change to the `export()` exception handling / retry semantics beyond preventing the illegal header from being constructed in the first place.

🤖 Generated with [Claude Code](https://claude.com/claude-code)