### PR TITLE
Fix Greptile review findings from onboarding batch (#430–#433)

### DIFF
--- a/tests/integration/test_cli_uninstall.py
+++ b/tests/integration/test_cli_uninstall.py
@@ -79,6 +79,11 @@ def test_remove_package_flag_runs_pipx(runner):
         ["pipx", "uninstall", "tokenjam"], capture_output=True, text=True
     )
     assert "tokenjam package removed" in result.output
+    # After a SUCCESSFUL removal the venv is gone, so `pipx upgrade` would fail
+    # ("not installed"). The reinstall hint must be a fresh `pipx install`, not
+    # upgrade/--force (#430).
+    assert "pipx install tokenjam" in result.output
+    assert "pipx upgrade" not in result.output
 
 
 def test_remove_package_flag_non_pipx_prints_command(runner):
@@ -103,6 +108,18 @@ def test_prompt_offered_when_interactive(runner):
     assert result.exit_code == 0, result.output
     assert "Also remove the tokenjam package now?" in result.output
     assert "package itself is still installed" in result.output
+
+
+def test_prompt_wording_matches_install_type(runner):
+    """The confirm prompt must describe what actually happens: pipx installs are
+    auto-run, pip/venv installs only get the command printed (#430)."""
+    with patch.object(uninstall_mod, "_installed_via_pipx", return_value=True):
+        res_pipx = runner.invoke(cmd_uninstall, [], input="y\nn\n")
+    assert "runs pipx uninstall tokenjam" in res_pipx.output
+
+    with patch.object(uninstall_mod, "_installed_via_pipx", return_value=False):
+        res_pip = runner.invoke(cmd_uninstall, [], input="y\nn\n")
+    assert "prints pip uninstall tokenjam" in res_pip.output
 
 
 def test_pipx_uninstall_failure_falls_back_to_manual(runner):

--- a/tests/unit/test_backfill_codex.py
+++ b/tests/unit/test_backfill_codex.py
@@ -254,6 +254,32 @@ def test_ingest_is_idempotent(tmp_path):
         db.close()
 
 
+def test_ingest_is_idempotent_on_duckdb_bulk_path(tmp_path):
+    """The DuckDB path exercises the bulk `_existing_span_ids` idempotency check
+    (#433) — one `WHERE span_id IN (...)` per session instead of a SELECT per
+    span. A re-run must still skip every already-present span."""
+    from tokenjam.core.config import StorageConfig
+    from tokenjam.core.db import DuckDBBackend
+
+    _write_rollout(tmp_path, "sess-idem-db", [
+        _session_meta_line("sess-idem-db"),
+        _turn_context_line("gpt-5.5"),
+        _function_call_line("shell", "call_a"),
+        _token_count_line(500, 0, 100),
+        _token_count_line(300, 0, 50),
+    ])
+    db = DuckDBBackend(StorageConfig(path=str(tmp_path / "t.duckdb")))
+    try:
+        r1 = ingest_codex(db, root=tmp_path)
+        assert r1["spans_written"] == 3  # 1 tool + 2 llm turns
+        assert r1["spans_skipped"] == 0
+        r2 = ingest_codex(db, root=tmp_path)
+        assert r2["spans_written"] == 0
+        assert r2["spans_skipped"] == 3
+    finally:
+        db.close()
+
+
 def test_ingest_propagates_config_plan_tier(tmp_path):
     # Config declares an OpenAI plan -> sessions get that plan_tier, not
     # "unknown". Mirrors the Claude Code backfill #176 behavior.

--- a/tests/unit/test_http_exporter_auth.py
+++ b/tests/unit/test_http_exporter_auth.py
@@ -32,12 +32,14 @@ def test_header_is_well_formed_bearer_when_secret_present() -> None:
     assert value[len("Bearer "):] == secret
 
 
-@pytest.mark.parametrize("empty_secret", ["", None])
+@pytest.mark.parametrize("empty_secret", ["", None, " ", "   ", "\t", "\n"])
 def test_no_authorization_header_when_secret_missing(empty_secret) -> None:
-    # ``None`` can slip through if a caller passes an unset config field.
+    # ``None`` can slip through if a caller passes an unset config field, and a
+    # whitespace-only secret is treated as absent (#431) — otherwise
+    # ``Bearer  `` (a stray space) is the same illegal header value.
     exporter = TjHttpExporter(ENDPOINT, empty_secret)  # type: ignore[arg-type]
 
-    # Never emit an empty Bearer — omit the header entirely.
+    # Never emit an empty / whitespace Bearer — omit the header entirely.
     assert "Authorization" not in exporter._headers
-    assert all(v != "Bearer " for v in exporter._headers.values())
+    assert all(not v.startswith("Bearer ") for v in exporter._headers.values())
     assert exporter._headers.get("Content-Type") == "application/json"

--- a/tests/unit/test_onboard_path_branch.py
+++ b/tests/unit/test_onboard_path_branch.py
@@ -14,6 +14,7 @@ from click.testing import CliRunner
 
 import tokenjam.core.backfill as backfill_mod
 from tokenjam.cli.cmd_onboard import (
+    _onboard_combination,
     _print_setup_complete_home,
     _prompt_usage_path,
     _try_backfill_codex,
@@ -244,3 +245,109 @@ class TestSetupCompleteHome:
         out = capsys.readouterr().out
         assert "You're set up." in out
         assert "backfilled" not in out.lower()
+
+
+# --- Combination path: backfill + banner run exactly once (#432) -------------
+
+
+class TestCombinationPathNoDoubleRun:
+    """The combination flow (#432) delegates to `_onboard_claude_code` and
+    `_onboard_codex` for wiring, then runs the Codex backfill once and prints the
+    closing home banner once at the very end. Before the fix, `_onboard_codex`
+    ran its own backfill AND printed the banner, `_onboard_claude_code` printed
+    the banner too, and combination did both again — the Codex backfill ran twice
+    and the banner printed up to three times.
+    """
+
+    def _stub(self, monkeypatch):
+        counters: dict[str, int] = {
+            "banner": 0, "codex_backfill": 0, "cc_standalone_true": 0,
+            "codex_standalone_true": 0,
+        }
+
+        def _cc(*a, **k):
+            if k.get("standalone", True):
+                counters["cc_standalone_true"] += 1
+
+        def _codex(*a, **k):
+            if k.get("standalone", True):
+                counters["codex_standalone_true"] += 1
+
+        def _backfill(_cfg):
+            counters["codex_backfill"] += 1
+            return ("1 new (0 already present) · 1 total session", True, 1)
+
+        def _banner(*a, **k):
+            counters["banner"] += 1
+
+        monkeypatch.setattr(
+            "tokenjam.cli.cmd_onboard._onboard_claude_code", _cc,
+        )
+        monkeypatch.setattr(
+            "tokenjam.cli.cmd_onboard._onboard_codex", _codex,
+        )
+        monkeypatch.setattr(
+            "tokenjam.cli.cmd_onboard._try_backfill_codex", _backfill,
+        )
+        monkeypatch.setattr(
+            "tokenjam.cli.cmd_onboard._print_setup_complete_home", _banner,
+        )
+        monkeypatch.setattr(
+            "tokenjam.cli.cmd_onboard._print_instrument_agent_snippet",
+            lambda *a, **k: None,
+        )
+        # The Codex backfill leg loads the global config; make it a no-op path so
+        # the stubbed `_try_backfill_codex` (not disk) is what runs.
+        monkeypatch.setattr(
+            "tokenjam.core.config.load_config", lambda *a, **k: object(),
+        )
+        return counters
+
+    def _run(self, monkeypatch, answers, tmp_path):
+        import click as _click
+
+        counters = self._stub(monkeypatch)
+        replies = iter(answers)
+        monkeypatch.setattr(
+            _click, "confirm", lambda *a, **k: next(replies),
+        )
+        # The Codex backfill leg only fires when the global config exists; point
+        # HOME at a tmp dir with the file present so it runs (stubbed) once.
+        home = tmp_path / "home"
+        (home / ".config" / "tj").mkdir(parents=True)
+        (home / ".config" / "tj" / "config.toml").write_text('version = "1"\n')
+        monkeypatch.setattr("pathlib.Path.home", lambda: home)
+
+        class _Ctx:
+            def exit(self, code=0):
+                raise SystemExit(code)
+
+        _onboard_combination(
+            _Ctx(), None, True, False,
+            plan_override=None, project_override=None, verify=False,
+        )
+        return counters
+
+    def test_banner_prints_exactly_once_all_surfaces(self, monkeypatch, tmp_path):
+        # Answer yes to Claude Code, Codex, and SDK.
+        counters = self._run(monkeypatch, [True, True, True], tmp_path)
+        assert counters["banner"] == 1
+
+    def test_codex_backfill_runs_exactly_once(self, monkeypatch, tmp_path):
+        counters = self._run(monkeypatch, [True, True, True], tmp_path)
+        assert counters["codex_backfill"] == 1
+
+    def test_sub_onboarders_invoked_non_standalone(self, monkeypatch, tmp_path):
+        """The per-path onboarders must be called with standalone=False so they
+        skip their own backfill + banner on the combination path."""
+        counters = self._run(monkeypatch, [True, True, False], tmp_path)
+        # Neither sub-onboarder was called with standalone=True (the default).
+        assert counters["cc_standalone_true"] == 0
+        assert counters["codex_standalone_true"] == 0
+
+    def test_banner_once_even_codex_only(self, monkeypatch, tmp_path):
+        # Claude Code no, Codex yes, SDK no — still exactly one banner, one
+        # backfill.
+        counters = self._run(monkeypatch, [False, True, False], tmp_path)
+        assert counters["banner"] == 1
+        assert counters["codex_backfill"] == 1

--- a/tokenjam/cli/cmd_onboard.py
+++ b/tokenjam/cli/cmd_onboard.py
@@ -920,8 +920,16 @@ def _onboard_claude_code(
     plan_override: str | None = None,
     project_override: str | None = None,
     verify: bool = False,
+    standalone: bool = True,
 ) -> None:
-    """Configure Claude Code to send telemetry to tj."""
+    """Configure Claude Code to send telemetry to tj.
+
+    ``standalone`` is True on the single-path flow (`tj onboard --claude-code`)
+    and False when this runs as one leg of the combination flow (#432). On the
+    combination path the closing home banner must print exactly once, at the end
+    of `_onboard_combination` — so we suppress it here when not standalone. The
+    inline Claude Code backfill still runs (it is only ever invoked from here).
+    """
     from tokenjam.core.config import (
         AgentConfig, BudgetConfig, ProviderBudget, TjConfig, SecurityConfig,
         load_config, write_config,
@@ -1361,12 +1369,14 @@ def _onboard_claude_code(
     # Shared closing banner (#448): every onboard path ends on the branded home
     # screen + tailored next-best-actions. For Claude Code the success signal is
     # the backfill ("N sessions backfilled"), NOT a live span — the log parse
-    # already ran above.
-    _print_setup_complete_home(
-        sessions_backfilled=backfill_sessions_total,
-        has_data=backfill_has_data,
-        days=backfill_days,
-    )
+    # already ran above. On the combination path this is deferred to
+    # `_onboard_combination` so the banner prints exactly once (#432).
+    if standalone:
+        _print_setup_complete_home(
+            sessions_backfilled=backfill_sessions_total,
+            has_data=backfill_has_data,
+            days=backfill_days,
+        )
 
 
 def _onboard_codex(
@@ -1377,8 +1387,18 @@ def _onboard_codex(
     reconfigure: bool = False,
     plan_override: str | None = None,
     verify: bool = False,
+    standalone: bool = True,
 ) -> None:
-    """Configure Codex CLI to send telemetry to tj."""
+    """Configure Codex CLI to send telemetry to tj.
+
+    ``standalone`` is True on the single-path flow (`tj onboard --codex`) and
+    False when this runs as one leg of the combination flow (#432). When not
+    standalone we skip BOTH the internal Codex backfill and the closing home
+    banner: `_onboard_combination` runs the Codex backfill exactly once itself
+    and prints the banner exactly once at the very end. Running the backfill
+    here too would double-run it, and printing the banner here would show it up
+    to three times.
+    """
     try:
         import tomllib  # type: ignore[import]
     except ImportError:
@@ -1550,9 +1570,13 @@ def _onboard_codex(
             )
         # Even on the "already configured" fast path, attempt a defensive Codex
         # backfill so re-onboarding picks up any newly-written on-disk logs (#448).
-        cx_msg, cx_has, cx_total = _try_backfill_codex(config)
-        if cx_msg:
-            console.print(f"  Backfilled:          {cx_msg}")
+        # On the combination path the backfill is run once by the caller, so skip
+        # it here to avoid double-running (#432).
+        cx_has, cx_total = False, 0
+        if standalone:
+            cx_msg, cx_has, cx_total = _try_backfill_codex(config)
+            if cx_msg:
+                console.print(f"  Backfilled:          {cx_msg}")
         _finish_onboard_serve(
             str(config_path.resolve()),
             want_daemon=not no_daemon,
@@ -1563,9 +1587,10 @@ def _onboard_codex(
             force=force,
         )
         _warn_manual_serve_restart(stopped_for_db=stopped_for_db, no_daemon=no_daemon)
-        _print_setup_complete_home(
-            sessions_backfilled=cx_total, has_data=cx_has,
-        )
+        if standalone:
+            _print_setup_complete_home(
+                sessions_backfilled=cx_total, has_data=cx_has,
+            )
         return
 
     otel_block = _codex_otel_toml_block(port, secret, agent_id)
@@ -1590,8 +1615,14 @@ def _onboard_codex(
     # defensively — if the adapter hasn't landed yet, we fall back to
     # forward-only framing rather than claiming a backfill that didn't happen
     # (honesty discipline, Rule 14). Run before daemon install so a freshly
-    # started serve doesn't hold the DuckDB write lock (#71).
-    codex_backfill_msg, codex_has_data, codex_sessions_total = _try_backfill_codex(config)
+    # started serve doesn't hold the DuckDB write lock (#71). On the combination
+    # path the caller runs this backfill exactly once, so skip it here (#432).
+    codex_backfill_msg: str | None = None
+    codex_has_data, codex_sessions_total = False, 0
+    if standalone:
+        codex_backfill_msg, codex_has_data, codex_sessions_total = (
+            _try_backfill_codex(config)
+        )
 
     # --- Install / restart serve after DB writes ---
     _finish_onboard_serve(
@@ -1658,11 +1689,13 @@ def _onboard_codex(
 
     _maybe_verify_onboarding(config, persona="codex", verify=verify)
 
-    # Shared closing banner (#448).
-    _print_setup_complete_home(
-        sessions_backfilled=codex_sessions_total,
-        has_data=codex_has_data,
-    )
+    # Shared closing banner (#448). On the combination path this is deferred to
+    # `_onboard_combination` so the banner prints exactly once (#432).
+    if standalone:
+        _print_setup_complete_home(
+            sessions_backfilled=codex_sessions_total,
+            has_data=codex_has_data,
+        )
 
 
 def _onboard_combination(
@@ -1710,7 +1743,7 @@ def _onboard_combination(
         _onboard_claude_code(
             ctx, budget, no_daemon, force, reconfigure=False,
             plan_override=plan_override, project_override=project_override,
-            verify=False,
+            verify=False, standalone=False,
         )
         done.append("Claude Code")
 
@@ -1720,10 +1753,11 @@ def _onboard_combination(
         console.print("[bold]Setting up Codex…[/bold]")
         _onboard_codex(
             ctx, budget, no_daemon, force, reconfigure=False,
-            plan_override=plan_override, verify=False,
+            plan_override=plan_override, verify=False, standalone=False,
         )
-        # The per-Codex onboarder is forward-only (no backfill of its own); try
-        # the on-disk Codex backfill defensively so combination reports it too.
+        # Run the on-disk Codex backfill exactly once here. Passing
+        # standalone=False above suppressed the per-path onboarder's own backfill
+        # so it doesn't double-run (#432).
         try:
             from tokenjam.core.config import load_config as _lc
             global_path = Path.home() / ".config" / "tj" / "config.toml"

--- a/tokenjam/cli/cmd_uninstall.py
+++ b/tokenjam/cli/cmd_uninstall.py
@@ -43,13 +43,29 @@ def _package_reinstall_hint() -> str:
     return "pip install --upgrade tokenjam"
 
 
+def _package_fresh_install_hint() -> str:
+    """Return the command that reinstalls after the package was fully removed.
+
+    Once the venv is gone, `pipx upgrade tokenjam` fails ("not installed") — the
+    right command is the plain `pipx install tokenjam` (a fresh install, no venv
+    to upgrade). This is distinct from `_package_reinstall_hint()`, which is only
+    correct while the package REMAINS in place (a plain install would no-op then,
+    so it points at upgrade/--force).
+    """
+    return (
+        "pipx install tokenjam" if _installed_via_pipx()
+        else "pip install tokenjam"
+    )
+
+
 @click.command("uninstall")
 @click.option("--yes", is_flag=True, help="Skip confirmation prompt")
 @click.option(
     "--remove-package",
     is_flag=True,
-    help="Also remove the tokenjam package (runs pipx/pip uninstall). "
-    "With --yes, removes it without a second prompt.",
+    help="Also remove the tokenjam package: runs the uninstall for "
+    "pipx-managed installs, or prints the command to run for pip/venv "
+    "installs. With --yes, proceeds without a second prompt.",
 )
 @click.pass_context
 def cmd_uninstall(ctx: click.Context, yes: bool, remove_package: bool) -> None:
@@ -208,8 +224,15 @@ def cmd_uninstall(ctx: click.Context, yes: bool, remove_package: bool) -> None:
     uninstall_cmd = _package_uninstall_hint()
     do_remove = remove_package
     if not do_remove and not yes:
+        # pipx installs are auto-run; pip/venv installs only get the command
+        # printed (a wrong `pip uninstall` in the wrong env is worse), so word
+        # the prompt to match what will actually happen (#430).
+        prompt_action = (
+            f"runs {uninstall_cmd}" if _installed_via_pipx()
+            else f"prints {uninstall_cmd} for you to run"
+        )
         do_remove = click.confirm(
-            f"Also remove the tokenjam package now? (runs {uninstall_cmd})",
+            f"Also remove the tokenjam package now? ({prompt_action})",
             default=False,
         )
 
@@ -246,8 +269,10 @@ def _remove_package(uninstall_cmd: str) -> None:
         )
         if result.returncode == 0:
             console.print("[green]tokenjam package removed.[/green]")
+            # The venv is gone now, so `pipx upgrade` would fail — point at the
+            # plain fresh install, not the upgrade/--force reinstall hint (#430).
             console.print(
-                f"  [dim]To reinstall FRESH: {_package_reinstall_hint()}[/dim]"
+                f"  [dim]To reinstall FRESH: {_package_fresh_install_hint()}[/dim]"
             )
         else:
             console.print(

--- a/tokenjam/core/ingest_adapters/codex.py
+++ b/tokenjam/core/ingest_adapters/codex.py
@@ -48,6 +48,7 @@ from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any, Iterator
 
+from tokenjam.core.backfill import _existing_span_ids
 from tokenjam.core.cost import calculate_cost
 from tokenjam.core.models import (
     NormalizedSpan,
@@ -431,14 +432,20 @@ def ingest_codex(
         seen_session_ids.add(parsed.session_id)
         try:
             inserted = 0
+            # Bulk idempotency (#433): partition the session's spans into
+            # new-vs-existing with ONE chunked `WHERE span_id IN (...)` query
+            # (via the shared `_existing_span_ids` helper the Claude Code path
+            # uses) instead of a SELECT per span. When the backend has no `conn`
+            # (e.g. InMemoryBackend), fall back to plain inserts and let the
+            # PRIMARY KEY conflict skip duplicates.
+            if conn is not None:
+                existing = _existing_span_ids(conn, [s.span_id for s in parsed.spans])
+            else:
+                existing = set()
             for span in parsed.spans:
-                if conn is not None:
-                    existing = conn.execute(
-                        "SELECT 1 FROM spans WHERE span_id = $1", [span.span_id]
-                    ).fetchone()
-                    if existing:
-                        spans_skipped += 1
-                        continue
+                if span.span_id in existing:
+                    spans_skipped += 1
+                    continue
                 try:
                     db.insert_span(span)
                     inserted += 1

--- a/tokenjam/sdk/http_exporter.py
+++ b/tokenjam/sdk/http_exporter.py
@@ -29,8 +29,10 @@ class TjHttpExporter(SpanExporter):
         # is even sent, so the span export fails outright (#: `tj ping`
         # reported "emitted … but not confirmed received"). Omitting the
         # header lets the request go out; if tj serve requires auth it 401s,
-        # which is handled gracefully in export() below.
-        if self._ingest_secret:
+        # which is handled gracefully in export() below. A blank / whitespace-only
+        # secret is treated as absent — otherwise "Bearer  " (a stray space) is
+        # the same illegal header value (#431).
+        if self._ingest_secret.strip():
             self._headers["Authorization"] = f"Bearer {self._ingest_secret}"
         # Cumulative count of spans dropped on auth failure. Exposed so
         # `tj doctor` can surface this in a future enhancement (#68 §2).


### PR DESCRIPTION
Addresses the five Greptile review findings raised on the just-merged onboarding batch (#430–#433). Grouped into one PR because they cluster around the same onboard/uninstall UX plus the SDK exporter/backfill idempotency touched in that batch.

## Summary
- Combination onboarding no longer double-runs the Codex backfill or prints the closing banner up to 3× (#432).
- After-removal reinstall hint is now a fresh `pipx install`, not `pipx upgrade` (#430).
- `--remove-package` help + prompt wording now matches what actually happens per install type (#430).
- Whitespace-only ingest secret now omits the `Authorization` header instead of sending `Bearer  ` (#431).
- `ingest_codex` uses the bulk idempotency check the Claude Code path uses, replacing the per-span SELECT (#433).

## [#432 P1] Combination path double-ran backfill + printed the banner up to 3×
`_onboard_codex` called `_try_backfill_codex` internally and printed `_print_setup_complete_home`; `_onboard_claude_code` also printed the banner; `_onboard_combination` then ran the Codex backfill AND printed the banner again. Net: Codex backfill ran twice, banner printed up to three times.

**Fix:** added `standalone: bool = True` to both `_onboard_claude_code` and `_onboard_codex`. The combination flow passes `standalone=False`, which suppresses each sub-onboarder's own Codex backfill and closing banner. The combination leg runs the Codex backfill exactly once and prints the banner exactly once at the end. Single-path flows (`--claude-code` / `--codex` alone) keep `standalone=True` and are unchanged — they still backfill + print once. Both Codex return points (the "already configured" fast path and the main path) honor the flag.

## [#430 P1] Wrong reinstall hint after successful package removal
After `pipx uninstall tokenjam` succeeds the venv is gone, so `pipx upgrade tokenjam` fails ("not installed"). Added `_package_fresh_install_hint()` (bare `pipx install` / `pip install`) used only on the successful-removal path. The existing `_package_reinstall_hint()` (upgrade / `--force`) stays where it's correct — when the package REMAINS in place (a plain install no-ops there).

## [#430 P2] `--remove-package` help + prompt wording
The help said "runs pipx/pip uninstall" but for non-pipx installs it only PRINTS the command. Reworded the option help and the interactive confirm prompt so they say "runs" for pipx-managed installs and "prints … for you to run" for pip/venv installs.

## [#431 P2] Whitespace-only ingest secret
`if self._ingest_secret:` was truthy for `" "`, producing `Bearer  ` — the same illegal header value the empty case already guards. Now guard on `.strip()` so a blank/whitespace-only secret omits the `Authorization` header.

## [#433 P2] Per-span SELECT idempotency in `ingest_codex`
`ingest_codex` issued one `SELECT 1 FROM spans WHERE span_id=$1` per span. Aligned it with the Claude Code path (`core.backfill._insert_session_idempotent`) by reusing that module's `_existing_span_ids` helper — one chunked `WHERE span_id IN (...)` per session partitions new-vs-existing spans, replacing the per-span existence SELECT. Backends without a `conn` (InMemoryBackend) fall back to plain inserts and let the PRIMARY KEY conflict skip duplicates. Straightforward reuse of the existing shared helper (no raw-SQL duplication; inserts still go through `db.insert_span`), so this was done here rather than deferred. No circular import (`backfill` does not import from `ingest_adapters.codex`).

## Tests / Verification
- `tests/unit/test_onboard_path_branch.py::TestCombinationPathNoDoubleRun` — the key one: combination path backfills Codex ONCE, prints the banner ONCE (incl. a Codex-only variant), and calls both sub-onboarders with `standalone=False`.
- `tests/integration/test_cli_uninstall.py` — after a successful removal the reinstall hint is `pipx install` (and NOT `pipx upgrade`); prompt wording matches install type.
- `tests/unit/test_http_exporter_auth.py` — whitespace-only secrets (`" "`, `"\t"`, `"\n"`, …) omit the `Authorization` header.
- `tests/unit/test_backfill_codex.py` — a DuckDB-backed idempotency test exercises the new bulk `_existing_span_ids` path (the existing idempotency test used InMemoryBackend, which hits the fallback branch).
- `ruff check tokenjam/` clean; `mypy` clean on the four touched source files. 184 tests pass in the onboard/backfill/codex/exporter/uninstall sweep.

## What's NOT in this PR
- Two pre-existing `F401` unused-import warnings in `tests/unit/test_onboard_path_branch.py` (`backfill_mod`) and `tests/integration/test_cli_uninstall.py` (`subprocess`) — present before this change, out of scope. `tokenjam/` itself is ruff-clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)