### PR TITLE
Fix #365: decompress gzip OTLP bodies on ingest

### DIFF
--- a/tests/integration/test_api.py
+++ b/tests/integration/test_api.py
@@ -2,6 +2,8 @@
 from __future__ import annotations
 
 import asyncio
+import gzip
+import json
 
 import pytest
 import httpx
@@ -192,6 +194,136 @@ async def test_post_spans_partial_rejection_returns_200(client, db, config):
     assert data["ingested"] == 1
     assert data["rejected"] == 1
     assert len(data["rejections"]) == 1
+
+
+# ── Gzip ingest (issue #365) ────────────────────────────────────────────────
+
+async def test_post_spans_gzip_with_content_encoding_header_succeeds(client):
+    """OTel Collector default: gzip body + Content-Encoding: gzip header → 200."""
+    raw = gzip.compress(json.dumps(_otlp_body()).encode())
+    resp = await client.post(
+        "/api/v1/spans",
+        content=raw,
+        headers={
+            "Authorization": f"Bearer {INGEST_SECRET}",
+            "Content-Type": "application/json",
+            "Content-Encoding": "gzip",
+        },
+    )
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["ingested"] == 1
+    assert data["rejected"] == 0
+
+
+async def test_post_spans_gzip_without_header_sniff_fallback_succeeds(client):
+    """Misconfigured exporter: gzip body but no Content-Encoding header → sniff and succeed."""
+    raw = gzip.compress(json.dumps(_otlp_body()).encode())
+    resp = await client.post(
+        "/api/v1/spans",
+        content=raw,
+        headers={
+            "Authorization": f"Bearer {INGEST_SECRET}",
+            "Content-Type": "application/json",
+            # Intentionally no Content-Encoding header
+        },
+    )
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["ingested"] == 1
+    assert data["rejected"] == 0
+
+
+async def test_post_spans_corrupt_gzip_with_header_returns_400_with_reason(client):
+    """Corrupt gzip + Content-Encoding: gzip header → 400 with descriptive error."""
+    resp = await client.post(
+        "/api/v1/spans",
+        content=b"\x1f\x8b\x00\x00corrupt garbage",
+        headers={
+            "Authorization": f"Bearer {INGEST_SECRET}",
+            "Content-Type": "application/json",
+            "Content-Encoding": "gzip",
+        },
+    )
+    assert resp.status_code == 400
+    data = resp.json()
+    assert "error" in data
+    assert "could not parse OTLP body" in data["error"]
+
+
+async def test_post_spans_invalid_json_error_message_contains_reason(client):
+    """Plain invalid (non-gzip) body → 400 with a reason in the error message."""
+    resp = await client.post(
+        "/api/v1/spans",
+        content=b"not json at all",
+        headers={
+            "Authorization": f"Bearer {INGEST_SECRET}",
+            "Content-Type": "application/json",
+        },
+    )
+    assert resp.status_code == 400
+    data = resp.json()
+    assert "error" in data
+    assert "could not parse OTLP body" in data["error"]
+
+
+async def test_post_spans_corrupt_gzip_sniff_path_returns_400(client):
+    """Corrupt body with gzip magic bytes but no header → sniff path → 400 with reason."""
+    resp = await client.post(
+        "/api/v1/spans",
+        content=b"\x1f\x8b\x00\x00corrupt garbage",
+        headers={
+            "Authorization": f"Bearer {INGEST_SECRET}",
+            "Content-Type": "application/json",
+            # No Content-Encoding: gzip header — hits the sniff branch
+        },
+    )
+    assert resp.status_code == 400
+    data = resp.json()
+    assert "error" in data
+    assert "could not parse OTLP body" in data["error"]
+
+
+async def test_otlp_traces_alias_gzip_with_header_succeeds(client):
+    """/v1/traces delegates to ingest_spans and inherits gzip support."""
+    raw = gzip.compress(json.dumps(_otlp_body()).encode())
+    resp = await client.post(
+        "/v1/traces",
+        content=raw,
+        headers={
+            "Authorization": f"Bearer {INGEST_SECRET}",
+            "Content-Type": "application/json",
+            "Content-Encoding": "gzip",
+        },
+    )
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["ingested"] == 1
+
+
+async def test_otlp_logs_gzip_with_header_succeeds(client):
+    """/v1/logs also decompresses gzip bodies (Content-Encoding: gzip)."""
+    log_body = {
+        "resourceLogs": [{
+            "resource": {
+                "attributes": [
+                    {"key": "gen_ai.agent.id", "value": {"stringValue": "test-agent"}},
+                ]
+            },
+            "scopeLogs": [],
+        }]
+    }
+    raw = gzip.compress(json.dumps(log_body).encode())
+    resp = await client.post(
+        "/v1/logs",
+        content=raw,
+        headers={
+            "Authorization": f"Bearer {INGEST_SECRET}",
+            "Content-Type": "application/json",
+            "Content-Encoding": "gzip",
+        },
+    )
+    assert resp.status_code == 200
 
 
 # ── GET endpoints ──────────────────────────────────────────────────────────

--- a/tokenjam/api/routes/_body.py
+++ b/tokenjam/api/routes/_body.py
@@ -1,0 +1,49 @@
+"""OTLP body parsing utilities."""
+from __future__ import annotations
+
+import gzip
+import io
+import json
+from typing import Any
+
+from fastapi import Request
+
+_MAX_DECOMPRESSED = 32 * 1024 * 1024  # 32 MB
+
+def _decompress_gzip(data: bytes) -> bytes:
+    with gzip.GzipFile(fileobj=io.BytesIO(data)) as f:
+        result = f.read(_MAX_DECOMPRESSED + 1)
+    if len(result) > _MAX_DECOMPRESSED:
+        raise ValueError("decompressed body exceeds size limit")
+    return result
+
+async def read_otlp_body(request: Request) -> Any:
+    """Return the parsed JSON body, decompressing gzip if needed.
+
+    Decompresses when Content-Encoding: gzip is set, or when the body starts
+    with the gzip magic bytes (\x1f\x8b) as a fallback for exporters that
+    compress without setting the header. Raises ValueError on any failure.
+    """
+    raw = await request.body()
+
+    # 1. Honour explicit Content-Encoding header
+    if request.headers.get("content-encoding", "").lower() == "gzip":
+        try:
+            raw = _decompress_gzip(raw)
+        except Exception as exc:
+            # gzip.decompress can raise OSError, EOFError, or zlib.error
+            raise ValueError(f"gzip decompression failed: {exc}") from exc
+    # 2. Sniff fallback — gzip magic bytes present but no Content-Encoding header
+    elif raw[:2] == b"\x1f\x8b":
+        try:
+            raw = _decompress_gzip(raw)
+        except Exception as exc:
+            # gzip.decompress can raise OSError, EOFError, or zlib.error
+            raise ValueError(
+                f"body appears gzip-compressed but decompression failed: {exc}"
+            ) from exc
+
+    try:
+        return json.loads(raw)
+    except Exception as exc:
+        raise ValueError(f"JSON decode failed: {exc}") from exc

--- a/tokenjam/api/routes/otlp.py
+++ b/tokenjam/api/routes/otlp.py
@@ -16,7 +16,8 @@ import logging
 from fastapi import APIRouter, Request
 from fastapi.responses import JSONResponse
 
-from tokenjam.api.routes.spans import _read_otlp_body, ingest_spans
+from tokenjam.api.routes.spans import ingest_spans
+from tokenjam.api.routes._body import read_otlp_body
 
 logger = logging.getLogger(__name__)
 
@@ -41,7 +42,7 @@ async def otlp_logs(request: Request) -> JSONResponse:
     from tokenjam.api.routes.logs import parse_log_records
 
     try:
-        body = await _read_otlp_body(request)
+        body = await read_otlp_body(request)
     except ValueError as exc:
         return JSONResponse(status_code=400, content={"error": f"could not parse OTLP body: {exc}"})
 

--- a/tokenjam/api/routes/otlp.py
+++ b/tokenjam/api/routes/otlp.py
@@ -16,7 +16,7 @@ import logging
 from fastapi import APIRouter, Request
 from fastapi.responses import JSONResponse
 
-from tokenjam.api.routes.spans import ingest_spans
+from tokenjam.api.routes.spans import _read_otlp_body, ingest_spans
 
 logger = logging.getLogger(__name__)
 
@@ -41,9 +41,9 @@ async def otlp_logs(request: Request) -> JSONResponse:
     from tokenjam.api.routes.logs import parse_log_records
 
     try:
-        body = await request.json()
-    except Exception:
-        return JSONResponse(status_code=400, content={"error": "Invalid JSON body"})
+        body = await _read_otlp_body(request)
+    except ValueError as exc:
+        return JSONResponse(status_code=400, content={"error": f"could not parse OTLP body: {exc}"})
 
     if not isinstance(body, dict) or "resourceLogs" not in body:
         # Non-log OTLP signals (resourceSpans, resourceMetrics) routed here

--- a/tokenjam/api/routes/spans.py
+++ b/tokenjam/api/routes/spans.py
@@ -1,7 +1,10 @@
 """POST /api/v1/spans — OTLP JSON span ingest endpoint."""
 from __future__ import annotations
 
+import gzip
+import json
 import logging
+from typing import Any
 
 from fastapi import APIRouter, Request
 from fastapi.responses import JSONResponse
@@ -21,19 +24,51 @@ logger = logging.getLogger(__name__)
 router = APIRouter()
 
 
+async def _read_otlp_body(request: Request) -> dict[str, Any]:
+    """Return the parsed JSON body, decompressing gzip if needed.
+
+    Decompresses when Content-Encoding: gzip is set, or when the body starts
+    with the gzip magic bytes (\\x1f\\x8b) as a fallback for exporters that
+    compress without setting the header. Raises ValueError on any failure.
+    """
+    raw = await request.body()
+
+    # 1. Honour explicit Content-Encoding header
+    if request.headers.get("content-encoding", "").lower() == "gzip":
+        try:
+            raw = gzip.decompress(raw)
+        except Exception as exc:
+            # gzip.decompress can raise OSError, EOFError, or zlib.error
+            raise ValueError(f"gzip decompression failed: {exc}") from exc
+    # 2. Sniff fallback — gzip magic bytes present but no Content-Encoding header
+    elif raw[:2] == b"\x1f\x8b":
+        try:
+            raw = gzip.decompress(raw)
+        except Exception as exc:
+            # gzip.decompress can raise OSError, EOFError, or zlib.error
+            raise ValueError(
+                f"body appears gzip-compressed but decompression failed: {exc}"
+            ) from exc
+
+    try:
+        return json.loads(raw)  # type: ignore[no-any-return]
+    except Exception as exc:
+        raise ValueError(f"JSON decode failed: {exc}") from exc
+
+
 @router.post("/spans")
 async def ingest_spans(request: Request) -> JSONResponse:
     """
     Accept a batch of spans in OTLP JSON format.
     Auth is enforced by IngestAuthMiddleware.
-    Returns 200 even on partial rejection; 400 only if body is entirely malformed.
+    Returns 200 even on partial rejection; 400 only if the body is entirely unparseable.
     """
     try:
-        body = await request.json()
-    except Exception:
+        body = await _read_otlp_body(request)
+    except ValueError as exc:
         return JSONResponse(
             status_code=400,
-            content={"error": "Invalid JSON body"},
+            content={"error": f"could not parse OTLP body: {exc}"},
         )
 
     if not isinstance(body, dict) or "resourceSpans" not in body:

--- a/tokenjam/api/routes/spans.py
+++ b/tokenjam/api/routes/spans.py
@@ -1,10 +1,7 @@
 """POST /api/v1/spans — OTLP JSON span ingest endpoint."""
 from __future__ import annotations
 
-import gzip
-import json
 import logging
-from typing import Any
 
 from fastapi import APIRouter, Request
 from fastapi.responses import JSONResponse
@@ -18,43 +15,11 @@ from tokenjam.otel.otlp_parsing import (
     safe_int as _safe_int,        # noqa: F401  (re-exported)
 )
 from tokenjam.utils.ids import new_span_id
+from tokenjam.api.routes._body import read_otlp_body
 
 logger = logging.getLogger(__name__)
 
 router = APIRouter()
-
-
-async def _read_otlp_body(request: Request) -> dict[str, Any]:
-    """Return the parsed JSON body, decompressing gzip if needed.
-
-    Decompresses when Content-Encoding: gzip is set, or when the body starts
-    with the gzip magic bytes (\\x1f\\x8b) as a fallback for exporters that
-    compress without setting the header. Raises ValueError on any failure.
-    """
-    raw = await request.body()
-
-    # 1. Honour explicit Content-Encoding header
-    if request.headers.get("content-encoding", "").lower() == "gzip":
-        try:
-            raw = gzip.decompress(raw)
-        except Exception as exc:
-            # gzip.decompress can raise OSError, EOFError, or zlib.error
-            raise ValueError(f"gzip decompression failed: {exc}") from exc
-    # 2. Sniff fallback — gzip magic bytes present but no Content-Encoding header
-    elif raw[:2] == b"\x1f\x8b":
-        try:
-            raw = gzip.decompress(raw)
-        except Exception as exc:
-            # gzip.decompress can raise OSError, EOFError, or zlib.error
-            raise ValueError(
-                f"body appears gzip-compressed but decompression failed: {exc}"
-            ) from exc
-
-    try:
-        return json.loads(raw)  # type: ignore[no-any-return]
-    except Exception as exc:
-        raise ValueError(f"JSON decode failed: {exc}") from exc
-
 
 @router.post("/spans")
 async def ingest_spans(request: Request) -> JSONResponse:
@@ -64,7 +29,7 @@ async def ingest_spans(request: Request) -> JSONResponse:
     Returns 200 even on partial rejection; 400 only if the body is entirely unparseable.
     """
     try:
-        body = await _read_otlp_body(request)
+        body = await read_otlp_body(request)
     except ValueError as exc:
         return JSONResponse(
             status_code=400,


### PR DESCRIPTION
OTLP/HTTP exporters (OTel Collector `otlphttp`, most SDK exporters) gzip request bodies by default. The ingest endpoint called `request.json()` directly which doesn't handle `Content-Encoding: gzip`, causing a 400 on every default-configured client connection — forcing users to set `compression: none` manually, which they won't know to do.

## Summary
- Add `_read_otlp_body()` helper that transparently decompresses gzip before JSON parsing
- Apply to `POST /api/v1/spans` and `POST /v1/logs`; `POST /v1/traces` inherits automatically
- Replace the bare `"Invalid JSON body"` 400 with `{"error": "could not parse OTLP body: <reason>"}` so the failure reason surfaces in collector logs
- 7 new integration tests; all 2024 existing tests still pass

## Gzip decompression — two paths

1. **`Content-Encoding: gzip` header present** — spec-compliant path, handles OTel Collector default
2. **Gzip magic bytes `\x1f\x8b` without the header** — sniff fallback for exporters that compress but omit the header (goes slightly beyond the issue, covers misconfigured clients)

## Tests / Verification
- 7 new integration tests in `tests/integration/test_api.py` (header path, sniff path, corrupt gzip × 2, plain JSON regression, `/v1/traces`, `/v1/logs`)
- Manually verified against a live `tj serve` — confirmed 400s on `main`, all pass on this branch

## What's NOT in this PR
- `x-gzip` alias support — not used by any known OTel exporter, deferred

## Related issue
Closes #365 

## Checklist

- [X] Tests pass (`pytest tests/unit/ tests/synthetic/ tests/agents/ tests/integration/`)
- [X] Lint clean (`ruff check tokenjam/`)
- [X] Type check clean (`mypy tokenjam/`)
- [X] CLAUDE.md updated (if architecture changed)
- [X] Test spans use `tests/factories.py` (not raw `NormalizedSpan`)
- [X] Requested `@anilmurty` as reviewer (or @-mentioned him above)

@anilmurty  please review

** Let me know if the Gzip magic bytes is a stretch and not needed here. will remove it