### PR TITLE
fix: safe one-paste onboard CTA + dashboard mention in quickstart outro

### DIFF
--- a/npm-wrapper/bin/tj.js
+++ b/npm-wrapper/bin/tj.js
@@ -21,10 +21,22 @@
  * alongside `tj`, so bare `uvx tokenjam` / `pipx run tokenjam` work too. This
  * wrapper keeps the explicit `--from tokenjam tj` / `--spec tokenjam tj` form
  * below for back-compat with the 0.5.3 and earlier releases it also targets.
+ *
+ * Freshness (issue #111): `uv` reuses its cached tool environment and never
+ * re-resolves on its own, so a machine that first ran this wrapper on an old
+ * release keeps getting that release forever, even after newer ones hit
+ * PyPI. To avoid pinning stale versions indefinitely, the `uvx` branch passes
+ * `--refresh` at most once per 24h (tracked via a timestamp file — see
+ * `shouldRefresh`/`markRefreshed` below). `pipx run` isn't touched: its own
+ * cache already expires after ~14 days on its own. The installed-`tj` branch
+ * has no cache to go stale.
  */
 "use strict";
 
 const { spawnSync } = require("child_process");
+const fs = require("fs");
+const os = require("os");
+const path = require("path");
 
 // PyPI package name vs. command name differ (`tokenjam` ships the `tj` script),
 // so ephemeral runners must be told the source package explicitly.
@@ -45,6 +57,58 @@ function runners() {
   ];
 }
 
+// --- uvx cache freshness (issue #111) -------------------------------------
+//
+// Only the `uvx` runner needs this: `uv` caches a resolved tool environment
+// and reuses it forever unless told to `--refresh`, so a returning user
+// silently keeps whatever version they first resolved. Tracked with a plain
+// timestamp file rather than anything fancier — this wrapper is intentionally
+// dependency-free (stdlib `fs`/`os`/`path` only).
+
+const REFRESH_INTERVAL_MS = 24 * 60 * 60 * 1000; // 24h
+
+function refreshCacheDir() {
+  const xdgCacheHome = process.env.XDG_CACHE_HOME;
+  const base =
+    xdgCacheHome && xdgCacheHome.trim()
+      ? xdgCacheHome
+      : path.join(os.homedir(), ".cache");
+  return path.join(base, "tokenjam-npx");
+}
+
+function refreshTimestampPath() {
+  return path.join(refreshCacheDir(), "last-refresh");
+}
+
+// True if it's been >24h (or we've never refreshed / can't tell). Fails
+// open on any fs error — an unwritable/unreadable cache dir must never
+// break the wrapper, it just means we skip the freshness nudge this run.
+function shouldRefresh() {
+  try {
+    const stat = fs.statSync(refreshTimestampPath());
+    return Date.now() - stat.mtimeMs > REFRESH_INTERVAL_MS;
+  } catch {
+    return true; // no timestamp yet (or unreadable) => treat as stale
+  }
+}
+
+// Called only AFTER `uvx --refresh` has actually returned (not before we
+// spawn it). If the refresh's download is interrupted partway through
+// (network drop, Ctrl-C, OOM kill), spawnSync never returns normally, this
+// never runs, and the *next* invocation still sees a stale/missing
+// timestamp and retries `--refresh`. Writing the timestamp up front instead
+// would mark the cache "fresh" the moment we decided to refresh even if
+// that refresh never completed, silently pinning a broken/partial
+// environment for a full 24h. Best-effort/fail-open: swallow fs errors.
+function markRefreshed() {
+  try {
+    fs.mkdirSync(refreshCacheDir(), { recursive: true });
+    fs.writeFileSync(refreshTimestampPath(), String(Date.now()));
+  } catch {
+    // fail open — worst case we just try to refresh again next run
+  }
+}
+
 function main() {
   // Bare `npx tokenjam` IS the zero-install first run — route it to
   // `tj quickstart` (the quota report the docs promise). The branded home
@@ -56,10 +120,14 @@ function main() {
 
   for (const { bin, prefix } of runners()) {
     if (!has(bin)) continue;
-    const result = spawnSync(bin, [...prefix, ...passthrough], {
+    const isUvx = bin === "uvx";
+    const doRefresh = isUvx && shouldRefresh();
+    const args = doRefresh ? ["--refresh", ...prefix] : prefix;
+    const result = spawnSync(bin, [...args, ...passthrough], {
       stdio: "inherit",
     });
     if (result.error) continue; // try the next runner on spawn failure
+    if (doRefresh) markRefreshed();
     process.exit(result.status === null ? 1 : result.status);
   }
 

--- a/npm-wrapper/bin/tj.js
+++ b/npm-wrapper/bin/tj.js
@@ -92,13 +92,15 @@ function shouldRefresh() {
   }
 }
 
-// Called only AFTER `uvx --refresh` has actually returned (not before we
-// spawn it). If the refresh's download is interrupted partway through
-// (network drop, Ctrl-C, OOM kill), spawnSync never returns normally, this
-// never runs, and the *next* invocation still sees a stale/missing
-// timestamp and retries `--refresh`. Writing the timestamp up front instead
-// would mark the cache "fresh" the moment we decided to refresh even if
-// that refresh never completed, silently pinning a broken/partial
+// Called only AFTER `uvx --refresh` has actually returned with a zero exit
+// status (not before we spawn it, and not on failure). If the refresh's
+// download is interrupted partway through (network drop, Ctrl-C, OOM kill),
+// spawnSync never returns normally, this never runs. If it returns but uv
+// exits non-zero (PyPI unreachable, partial download), the caller also
+// skips this call. Either way the *next* invocation still sees a
+// stale/missing timestamp and retries `--refresh`. Writing the timestamp up
+// front, or unconditionally on return, would mark the cache "fresh" even
+// though that refresh never completed, silently pinning a broken/partial
 // environment for a full 24h. Best-effort/fail-open: swallow fs errors.
 function markRefreshed() {
   try {
@@ -127,7 +129,7 @@ function main() {
       stdio: "inherit",
     });
     if (result.error) continue; // try the next runner on spawn failure
-    if (doRefresh) markRefreshed();
+    if (doRefresh && result.status === 0) markRefreshed();
     process.exit(result.status === null ? 1 : result.status);
   }
 

--- a/tests/unit/test_context_diagnostic.py
+++ b/tests/unit/test_context_diagnostic.py
@@ -247,6 +247,41 @@ def test_quota_weighted_fields_in_json_payload(db):
     assert payload["quota_weighted_reread_share"] < payload["reread_share"]
 
 
+def test_quota_weight_constants_match_anthropic_pricing_table():
+    """#119: `CACHE_READ_QUOTA_WEIGHT` / `OUTPUT_QUOTA_WEIGHT` are asserted
+    constants, not a live pricing lookup — so a future Anthropic pricing change
+    in tokenjam/pricing/models.toml must fail this test loudly instead of
+    silently drifting the quickstart headline away from what it claims to be
+    (the whole credibility property #119 exists to fix)."""
+    from tokenjam.core.context_diagnostic import (
+        CACHE_READ_QUOTA_WEIGHT,
+        OUTPUT_QUOTA_WEIGHT,
+    )
+    from tokenjam.core.pricing import load_pricing_table
+
+    anthropic_rates = load_pricing_table().get("anthropic", {})
+    assert anthropic_rates, "expected at least one anthropic pricing row"
+
+    checked = 0
+    for model, rates in anthropic_rates.items():
+        if rates.input_per_mtok <= 0:
+            continue  # skip the zero-priced internal test model (tj-ping-test)
+        checked += 1
+        cache_read_ratio = rates.cache_read_per_mtok / rates.input_per_mtok
+        output_ratio = rates.output_per_mtok / rates.input_per_mtok
+        assert cache_read_ratio == pytest.approx(CACHE_READ_QUOTA_WEIGHT), (
+            f"{model}: cache_read/input ratio {cache_read_ratio} != "
+            f"CACHE_READ_QUOTA_WEIGHT {CACHE_READ_QUOTA_WEIGHT} — pricing drifted, "
+            f"update the constant (and re-verify the quickstart headline)."
+        )
+        assert output_ratio == pytest.approx(OUTPUT_QUOTA_WEIGHT), (
+            f"{model}: output/input ratio {output_ratio} != "
+            f"OUTPUT_QUOTA_WEIGHT {OUTPUT_QUOTA_WEIGHT} — pricing drifted, "
+            f"update the constant (and re-verify the quickstart headline)."
+        )
+    assert checked > 0
+
+
 def test_cache_miss_broken_out_as_named_overhead(db):
     """#11: cache-creation tokens are surfaced as their own named overhead
     category (prompt-cache MISS), distinct from re-read and net-new work."""

--- a/tests/unit/test_context_diagnostic.py
+++ b/tests/unit/test_context_diagnostic.py
@@ -184,6 +184,69 @@ def test_per_turn_composition_separates_reread_from_work(db):
     assert diag.heaviest_turns[0].reread_tokens == COMPACT_MIN_CACHE_TOKENS + 50_000
 
 
+def test_quota_weighted_reread_share_discounts_cache_reads(db):
+    """#119: the raw `reread_share` mixes "tokens" and "quota" framings — cache
+    reads are billed at a fraction of a base token, so a raw share overstates
+    re-reading's actual quota cost. `quota_weighted_reread_share` applies the
+    documented discount (cache reads x0.1, output x5) and should read
+    meaningfully lower than the raw share for this cache-read-heavy fixture.
+    """
+    _seed_multi_session(db)
+    diag = compute_context_diagnostic(
+        db.conn, SINCE, UNTIL, tool_inputs_captured=True
+    )
+
+    # Raw share is dominated by cache reads (see
+    # test_per_turn_composition_separates_reread_from_work).
+    assert diag.reread_share > 0.85
+
+    # Manually replicate the weighting to pin the exact expected value rather
+    # than just asserting a direction, catching any future formula drift.
+    reread = diag.total_reread_tokens
+    new_input = diag.total_new_input_tokens
+    output = diag.total_output_tokens
+    cache_write = diag.total_cache_write_tokens
+    expected_total = reread * 0.1 + new_input + output * 5.0 + cache_write
+    expected_share = (reread * 0.1) / expected_total
+
+    assert diag.total_quota_weighted_tokens == pytest.approx(expected_total)
+    assert diag.quota_weighted_reread_share == pytest.approx(expected_share)
+
+    # The discount moves the headline substantially — this is the bug: a raw
+    # share reads as ~90%+ while the quota-weighted share is well under half.
+    assert diag.quota_weighted_reread_share < 0.5
+    assert diag.quota_weighted_reread_share < diag.reread_share - 0.3
+
+    # Work's quota-weighted share is NOT the raw work share either (output is
+    # weighted 5x heavier than a base input token).
+    assert diag.quota_weighted_work_share != pytest.approx(
+        diag.total_work_tokens / diag.total_tokens
+    )
+
+
+def test_quota_weighted_fields_in_json_payload(db):
+    """The quota-weighted headline fields round-trip into the `--json` payload."""
+    from tokenjam.core.context_diagnostic import diagnostic_to_dict
+
+    _seed_multi_session(db)
+    diag = compute_context_diagnostic(
+        db.conn, SINCE, UNTIL, tool_inputs_captured=True
+    )
+    payload = diagnostic_to_dict(diag)
+
+    assert payload["quota_weighted_reread_share"] == round(
+        diag.quota_weighted_reread_share, 4
+    )
+    assert payload["quota_weighted_work_share"] == round(
+        diag.quota_weighted_work_share, 4
+    )
+    assert payload["total_quota_weighted_tokens"] == round(
+        diag.total_quota_weighted_tokens, 2
+    )
+    # Sanity: the quota-weighted share is meaningfully below the raw share.
+    assert payload["quota_weighted_reread_share"] < payload["reread_share"]
+
+
 def test_cache_miss_broken_out_as_named_overhead(db):
     """#11: cache-creation tokens are surfaced as their own named overhead
     category (prompt-cache MISS), distinct from re-read and net-new work."""

--- a/tests/unit/test_onboard_ephemeral_guard.py
+++ b/tests/unit/test_onboard_ephemeral_guard.py
@@ -158,6 +158,26 @@ def test_install_falls_back_to_pipx_when_uv_missing(monkeypatch, tmp_path):
     assert calls[0][0] == "pipx"
 
 
+def test_install_falls_back_to_path_when_bin_dir_is_customized(monkeypatch, tmp_path):
+    """`UV_TOOL_BIN_DIR` / `PIPX_BIN_DIR` (or a customized install prefix) can
+    place `tj` somewhere other than the default `~/.local/bin` — the default
+    dir check must not be the only signal, or a successful install there gets
+    reported as failed and the guard falls through to the ephemeral path it
+    exists to avoid (Greptile P1)."""
+    monkeypatch.setattr(cmd_onboard, "_LOCAL_BIN_DIR", tmp_path)  # empty: no tj here
+    custom_tj = "/opt/custom/bin/tj"
+    monkeypatch.setattr(
+        cmd_onboard.shutil, "which",
+        lambda bin_: {"uv": "/usr/bin/uv", "tj": custom_tj}.get(bin_),
+    )
+    monkeypatch.setattr(
+        cmd_onboard.subprocess, "run",
+        lambda cmd, **kwargs: subprocess.CompletedProcess(cmd, 0, stdout="", stderr=""),
+    )
+    result = cmd_onboard._install_tokenjam_persistently()
+    assert result == custom_tj
+
+
 def test_install_returns_none_when_no_runner_available(monkeypatch):
     monkeypatch.setattr(cmd_onboard.shutil, "which", lambda bin_: None)
     assert cmd_onboard._install_tokenjam_persistently() is None

--- a/tests/unit/test_onboard_ephemeral_guard.py
+++ b/tests/unit/test_onboard_ephemeral_guard.py
@@ -1,0 +1,176 @@
+"""Ephemeral-runner guard (#120).
+
+`npx tokenjam onboard` delegates to `uvx --from tokenjam tj onboard` (or
+`pipx run --spec tokenjam tj onboard`), both of which resolve `sys.executable`
+into a throwaway venv that is not kept on PATH once the process exits. Onboard
+wires a background daemon and a Claude Code statusline that both invoke `tj`
+afterward — under an ephemeral runner those references go stale the moment the
+session ends. `_maybe_guard_ephemeral_runner` detects that situation and offers
+(or performs) a persistent install, re-execing onboard through it.
+"""
+from __future__ import annotations
+
+import subprocess
+
+import click
+import pytest
+
+from tokenjam.cli import cmd_onboard
+
+
+def _ctx() -> click.Context:
+    return click.Context(cmd_onboard.cmd_onboard)
+
+
+# --- _is_ephemeral_runner: path-signature detection --------------------------
+
+
+@pytest.mark.parametrize(
+    "executable,expected",
+    [
+        ("/Users/x/.local/share/uv/tools/tokenjam/bin/python", False),
+        ("/Users/x/.local/share/pipx/venvs/tokenjam/bin/python", False),
+        ("/Users/x/.cache/uv/archive-v0/abc123/bin/python", True),
+        ("/Users/x/.local/share/pipx/.cache/xyz/bin/python", True),
+        ("/usr/bin/python3", False),
+        ("/Users/x/project/.venv/bin/python", False),
+    ],
+)
+def test_is_ephemeral_runner_by_executable_path(monkeypatch, executable, expected):
+    monkeypatch.setattr(cmd_onboard.sys, "executable", executable)
+    assert cmd_onboard._is_ephemeral_runner() is expected
+
+
+# --- _maybe_guard_ephemeral_runner: no-op for the common case ---------------
+
+
+def test_noop_when_not_ephemeral(monkeypatch, capsys):
+    monkeypatch.setattr(cmd_onboard, "_is_ephemeral_runner", lambda: False)
+    cmd_onboard._maybe_guard_ephemeral_runner(_ctx())
+    assert capsys.readouterr().out == ""
+
+
+# --- Non-interactive: warn and continue in-process --------------------------
+
+
+def test_non_interactive_warns_and_continues(monkeypatch, capsys):
+    monkeypatch.setattr(cmd_onboard, "_is_ephemeral_runner", lambda: True)
+    monkeypatch.setattr(cmd_onboard, "_is_interactive", lambda: False)
+    cmd_onboard._maybe_guard_ephemeral_runner(_ctx())
+    out = capsys.readouterr().out
+    assert "Heads up" in out
+    assert "Non-interactive" in out
+
+
+# --- Interactive: declined install continues in-process ---------------------
+
+
+def test_interactive_decline_continues(monkeypatch, capsys):
+    monkeypatch.setattr(cmd_onboard, "_is_ephemeral_runner", lambda: True)
+    monkeypatch.setattr(cmd_onboard, "_is_interactive", lambda: True)
+    monkeypatch.setattr(click, "confirm", lambda *a, **k: False)
+    cmd_onboard._maybe_guard_ephemeral_runner(_ctx())
+    out = capsys.readouterr().out
+    assert "Continuing without a persistent install" in out
+
+
+# --- Interactive: install failure continues in-process -----------------------
+
+
+def test_interactive_install_failure_continues(monkeypatch, capsys):
+    monkeypatch.setattr(cmd_onboard, "_is_ephemeral_runner", lambda: True)
+    monkeypatch.setattr(cmd_onboard, "_is_interactive", lambda: True)
+    monkeypatch.setattr(click, "confirm", lambda *a, **k: True)
+    monkeypatch.setattr(cmd_onboard, "_install_tokenjam_persistently", lambda: None)
+    cmd_onboard._maybe_guard_ephemeral_runner(_ctx())
+    out = capsys.readouterr().out
+    assert "Persistent install failed" in out
+
+
+# --- Interactive: successful install re-execs and exits ---------------------
+
+
+def test_interactive_success_reexecs_and_exits(monkeypatch, capsys):
+    monkeypatch.setattr(cmd_onboard, "_is_ephemeral_runner", lambda: True)
+    monkeypatch.setattr(cmd_onboard, "_is_interactive", lambda: True)
+    monkeypatch.setattr(click, "confirm", lambda *a, **k: True)
+    monkeypatch.setattr(
+        cmd_onboard, "_install_tokenjam_persistently",
+        lambda: "/home/x/.local/bin/tj",
+    )
+    monkeypatch.setattr(cmd_onboard.sys, "argv", ["tj", "onboard", "--claude-code"])
+
+    calls = {}
+
+    def _fake_run(cmd):
+        calls["cmd"] = cmd
+        return subprocess.CompletedProcess(cmd, 0)
+
+    monkeypatch.setattr(cmd_onboard.subprocess, "run", _fake_run)
+
+    with pytest.raises(click.exceptions.Exit) as exc_info:
+        cmd_onboard._maybe_guard_ephemeral_runner(_ctx())
+
+    assert exc_info.value.exit_code == 0
+    assert calls["cmd"] == ["/home/x/.local/bin/tj", "onboard", "--claude-code"]
+    out = capsys.readouterr().out
+    assert "re-running onboard" in out
+
+
+# --- _install_tokenjam_persistently: runner selection + idempotence ---------
+
+
+def test_install_prefers_uv_over_pipx(monkeypatch, tmp_path):
+    monkeypatch.setattr(cmd_onboard, "_LOCAL_BIN_DIR", tmp_path)
+    (tmp_path / "tj").write_text("#!/bin/sh\n")
+    monkeypatch.setattr(
+        cmd_onboard.shutil, "which",
+        lambda bin_: f"/usr/bin/{bin_}" if bin_ in ("uv", "pipx") else None,
+    )
+    calls = []
+
+    def _fake_run(cmd, **kwargs):
+        calls.append(cmd)
+        return subprocess.CompletedProcess(cmd, 0, stdout="", stderr="")
+
+    monkeypatch.setattr(cmd_onboard.subprocess, "run", _fake_run)
+    result = cmd_onboard._install_tokenjam_persistently()
+    assert result == str(tmp_path / "tj")
+    assert calls[0][0] == "uv"
+
+
+def test_install_falls_back_to_pipx_when_uv_missing(monkeypatch, tmp_path):
+    monkeypatch.setattr(cmd_onboard, "_LOCAL_BIN_DIR", tmp_path)
+    (tmp_path / "tj").write_text("#!/bin/sh\n")
+    monkeypatch.setattr(
+        cmd_onboard.shutil, "which",
+        lambda bin_: "/usr/bin/pipx" if bin_ == "pipx" else None,
+    )
+    calls = []
+
+    def _fake_run(cmd, **kwargs):
+        calls.append(cmd)
+        return subprocess.CompletedProcess(cmd, 0, stdout="", stderr="")
+
+    monkeypatch.setattr(cmd_onboard.subprocess, "run", _fake_run)
+    result = cmd_onboard._install_tokenjam_persistently()
+    assert result == str(tmp_path / "tj")
+    assert calls[0][0] == "pipx"
+
+
+def test_install_returns_none_when_no_runner_available(monkeypatch):
+    monkeypatch.setattr(cmd_onboard.shutil, "which", lambda bin_: None)
+    assert cmd_onboard._install_tokenjam_persistently() is None
+
+
+def test_install_returns_none_when_binary_never_appears(monkeypatch, tmp_path):
+    monkeypatch.setattr(cmd_onboard, "_LOCAL_BIN_DIR", tmp_path)
+    monkeypatch.setattr(
+        cmd_onboard.shutil, "which",
+        lambda bin_: "/usr/bin/uv" if bin_ == "uv" else None,
+    )
+    monkeypatch.setattr(
+        cmd_onboard.subprocess, "run",
+        lambda cmd, **kwargs: subprocess.CompletedProcess(cmd, 0, stdout="", stderr=""),
+    )
+    assert cmd_onboard._install_tokenjam_persistently() is None

--- a/tests/unit/test_quickstart.py
+++ b/tests/unit/test_quickstart.py
@@ -150,9 +150,11 @@ def test_quickstart_renders_without_daemon_or_ondisk_db(tmp_path):
     # Both halves of the first-run value are present.
     assert "quota" in result.output.lower()
     assert "Session timeline" in result.output
-    # The opt-in "go deeper" pointer prints the full pasteable install command,
-    # since the quickstart audience has no `tj` on PATH (it ran via `npx tokenjam`).
-    assert "pipx install tokenjam && tj onboard" in result.output
+    # The opt-in "go deeper" pointer prints the one-paste CTA: the audience
+    # just ran `npx tokenjam`, so `npx tokenjam onboard` is the same tool they
+    # already have (#120) — the ephemeral-runner guard in `tj onboard` now
+    # makes this safe, unlike the earlier tool-switching `pipx install` CTA.
+    assert "npx tokenjam onboard" in result.output
     # The outro also sells the local web dashboard (#120) — the most
     # product-looking asset shouldn't be invisible at the conversion moment.
     assert "local web dashboard" in result.output

--- a/tests/unit/test_quickstart.py
+++ b/tests/unit/test_quickstart.py
@@ -155,9 +155,12 @@ def test_quickstart_renders_without_daemon_or_ondisk_db(tmp_path):
     # already have (#120) — the ephemeral-runner guard in `tj onboard` now
     # makes this safe, unlike the earlier tool-switching `pipx install` CTA.
     assert "npx tokenjam onboard" in result.output
-    # The outro also sells the local web dashboard (#120) — the most
-    # product-looking asset shouldn't be invisible at the conversion moment.
-    assert "local web dashboard" in result.output
+    # The outro sells the local dashboard (#120) exactly once — the most
+    # product-looking asset shouldn't be invisible at the conversion moment,
+    # but a second, redundant mention right under the CTA was dropped (#436
+    # review) to keep the outro tight and consistent with the npx-form CTA.
+    assert result.output.count("dashboard") == 1
+    assert "Lens" in result.output
 
 
 def test_quickstart_json_emits_both_views(tmp_path):

--- a/tests/unit/test_quickstart.py
+++ b/tests/unit/test_quickstart.py
@@ -155,6 +155,67 @@ def test_quickstart_renders_without_daemon_or_ondisk_db(tmp_path):
     assert "pipx install tokenjam && tj onboard" in result.output
 
 
+# ── Quota-weighted headline + no named-session reclaim list (#119) ──────────
+#
+# The headline used to report a RAW token share as "quota" (mixing the two
+# framings) and named individual ended sessions as "actionable" — but a user
+# never returns to a session closed days ago, so a per-session retrospective
+# callout is unactionable noise. The headline must now read as quota-weighted,
+# and the default output must never name a past session.
+
+def test_quickstart_headline_reads_as_quota_not_raw_tokens(tmp_path):
+    root = _fixture_root(tmp_path)
+    result = _invoke_quickstart(["--root", str(root), "--since", "90d"])
+
+    assert result.exit_code == 0, result.output
+    assert "of your quota went to" in result.output
+    # The old raw-token wording is gone.
+    assert "of your tokens went to" not in result.output
+
+
+def _heavy_reread_fixture_root(tmp_path: Path) -> Path:
+    """A session with one huge-cache-read turn — clears the compact-candidate
+    thresholds (>= 200k re-read tokens, >= 80% re-read share) so the aggregate
+    reclaim line renders."""
+    root = tmp_path / "projects"
+    _make_session_file(root, "sess-heavy", "/Users/me/projHeavy", [
+        _assistant("h1", "sess-heavy", "/Users/me/projHeavy",
+                   "2026-06-20T10:00:00.000Z",
+                   input_tokens=500, output_tokens=200, cache_read=300_000),
+    ])
+    return root
+
+
+def test_quickstart_reclaim_section_is_aggregate_not_named_sessions(tmp_path):
+    root = _heavy_reread_fixture_root(tmp_path)
+    result = _invoke_quickstart(["--root", str(root), "--since", "90d"])
+    # Rich wraps panel text to console width and interleaves the panel's own
+    # box-drawing border characters, so compare against normalized output
+    # (whitespace-collapsed, borders stripped) rather than a raw substring.
+    stripped = result.output.translate({ord(c): " " for c in "│╭╮╰╯─"})
+    normalized = " ".join(stripped.split())
+
+    assert result.exit_code == 0, result.output
+    # The old per-session list (and its heading) is gone entirely.
+    assert "Biggest reclaim opportunities" not in result.output
+    assert "sess-heavy" not in result.output
+    # An aggregate line takes its place — no named session, live-signal framing.
+    assert "ran context-heavy enough to warrant a mid-session" in normalized
+    assert "/compact" in normalized
+    assert "a closed session can't be reclaimed" in normalized
+
+
+def test_quickstart_no_compact_candidates_omits_reclaim_section(tmp_path):
+    """A history with no context-heavy sessions renders no reclaim section at
+    all (same gating as before — this isn't about forcing the line to show)."""
+    root = _fixture_root(tmp_path)
+    result = _invoke_quickstart(["--root", str(root), "--since", "90d"])
+
+    assert result.exit_code == 0, result.output
+    assert "ran context-heavy enough to warrant a mid-session" not in result.output
+    assert "Biggest reclaim opportunities" not in result.output
+
+
 def test_quickstart_json_emits_both_views(tmp_path):
     root = _fixture_root(tmp_path)
     result = _invoke_quickstart(["--root", str(root), "--since", "90d", "--json"])

--- a/tests/unit/test_quickstart.py
+++ b/tests/unit/test_quickstart.py
@@ -153,6 +153,9 @@ def test_quickstart_renders_without_daemon_or_ondisk_db(tmp_path):
     # The opt-in "go deeper" pointer prints the full pasteable install command,
     # since the quickstart audience has no `tj` on PATH (it ran via `npx tokenjam`).
     assert "pipx install tokenjam && tj onboard" in result.output
+    # The outro also sells the local web dashboard (#120) — the most
+    # product-looking asset shouldn't be invisible at the conversion moment.
+    assert "local web dashboard" in result.output
 
 
 def test_quickstart_json_emits_both_views(tmp_path):

--- a/tests/unit/test_quickstart.py
+++ b/tests/unit/test_quickstart.py
@@ -378,6 +378,46 @@ def test_quickstart_preview_shows_most_recent_substantial_crossing_session(
     assert expected_line in result.output
 
 
+def test_quickstart_preview_stops_walking_after_first_substantial_candidate(
+    tmp_path, monkeypatch,
+):
+    """Sessions are walked most-recent-first; once the most-recent SUBSTANTIAL
+    crossing candidate is found, selection must stop rather than re-reading
+    every remaining session's transcript — a large `~/.claude` history would
+    otherwise blow past quickstart's fast-first-run budget."""
+    from tokenjam.cli import cmd_quickstart as q
+
+    monkeypatch.setattr(q, "PREVIEW_MIN_TURNS", 3)
+    root = tmp_path / "projects"
+    # Most-recent session is ALREADY substantial + crossing -> must win
+    # without inspecting any of the five older sessions below it.
+    _session_with_crossing(
+        root, "sess-newest", "/Users/me/projZ", "2026-06-28",
+        n_turns=5, crossing_turn=2,
+    )
+    for i in range(5):
+        _session_with_crossing(
+            root, f"sess-old-{i}", f"/Users/me/proj{i}", f"2026-06-{10 + i:02d}",
+            n_turns=5, crossing_turn=2,
+        )
+
+    calls: list[str] = []
+    original_walk = q._walk_for_preview
+
+    def _counting_walk(path):
+        calls.append(path)
+        return original_walk(path)
+
+    monkeypatch.setattr(q, "_walk_for_preview", _counting_walk)
+
+    result = _invoke_quickstart(["--root", str(root), "--since", "90d"])
+    assert result.exit_code == 0, result.output
+    assert "session sess-newest" in _flat(result.output)
+    # Only the winning (most-recent, already-substantial) candidate's
+    # transcript was walked -- the 5 older sessions were never opened.
+    assert len(calls) == 1
+
+
 def test_quickstart_preview_falls_back_to_largest_when_none_substantial(
     tmp_path, monkeypatch,
 ):

--- a/tests/unit/test_quickstart.py
+++ b/tests/unit/test_quickstart.py
@@ -206,7 +206,13 @@ def test_quickstart_reclaim_section_is_aggregate_not_named_sessions(tmp_path):
     assert result.exit_code == 0, result.output
     # The old per-session list (and its heading) is gone entirely.
     assert "Biggest reclaim opportunities" not in result.output
-    assert "sess-heavy" not in result.output
+    # The aggregate reclaim line inside the quota-composition panel never
+    # names a session (#119). Scope this to the panel itself: the SEPARATE
+    # statusline live preview section (#438) legitimately names one session
+    # as a concrete "what you'd have seen live" example — a whole-output
+    # check would false-positive against that unrelated, later section.
+    panel_text = result.output.split("With the statusline installed")[0]
+    assert "sess-heavy" not in panel_text
     # An aggregate line takes its place — no named session, live-signal framing.
     assert "ran context-heavy enough to warrant a mid-session" in normalized
     assert "/compact" in normalized

--- a/tests/unit/test_quickstart.py
+++ b/tests/unit/test_quickstart.py
@@ -303,3 +303,121 @@ def test_quickstart_json_reports_cap_metadata(tmp_path, monkeypatch):
     assert payload["backfill"]["sessions_ingested"] == 6
     assert payload["backfill"]["limit_reached"] is True
     assert payload["backfill"]["max_sessions"] == 6
+
+
+# ── Statusline live preview ("what you'd see live") ──────────────────────────
+#
+# `_display_model_name` reconstructs "Sonnet 4.5" from the raw transcript
+# `claude-sonnet-4-5-20250929` id every fixture session below uses.
+
+def _flat(output: str) -> str:
+    """Collapse Rich's line-wrapping so long-sentence substring checks aren't
+    sensitive to where the terminal happened to wrap a word."""
+    return " ".join(output.split())
+
+
+def _session_with_crossing(root: Path, session_id: str, cwd: str, base_date: str,
+                            *, n_turns: int, crossing_turn: int) -> Path:
+    """A synthetic session whose cumulative re-read %% stays low through
+    `crossing_turn - 1`, then jumps hard enough that it crosses REREAD_WARN
+    (70%%) starting exactly at `crossing_turn` (1-indexed) and stays crossed.
+    """
+    records = []
+    for i in range(1, n_turns + 1):
+        ts = f"{base_date}T10:{i:02d}:00.000Z"
+        cache = 20 if i < crossing_turn else 100_000
+        records.append(_assistant(
+            f"{session_id}-{i}", session_id, cwd, ts,
+            input_tokens=100, output_tokens=50, cache_read=cache,
+        ))
+    return _make_session_file(root, session_id, cwd, records)
+
+
+def test_quickstart_preview_shows_most_recent_substantial_crossing_session(
+    tmp_path, monkeypatch,
+):
+    from tokenjam.cli import cmd_quickstart as q
+    from tokenjam.cli.cmd_statusline import format_status_line
+
+    monkeypatch.setattr(q, "PREVIEW_MIN_TURNS", 3)
+    root = tmp_path / "projects"
+    # Older, more turns, but NOT more recent -> must lose to the recent one.
+    _session_with_crossing(
+        root, "sess-old", "/Users/me/projA", "2026-06-10",
+        n_turns=10, crossing_turn=2,
+    )
+    # Recent AND substantial (5 >= PREVIEW_MIN_TURNS=3) -> wins on recency.
+    recent_path = _session_with_crossing(
+        root, "sess-recent", "/Users/me/projB", "2026-06-25",
+        n_turns=5, crossing_turn=3,
+    )
+
+    result = _invoke_quickstart(["--root", str(root), "--since", "90d"])
+    assert result.exit_code == 0, result.output
+    flat = _flat(result.output)
+    assert "With the statusline installed" in flat
+    assert "session sess-recent would have shown this at turn 3" in flat
+    assert "tj onboard" in flat.split("With the statusline installed")[1]
+
+    # Formatter reuse: the rendered line is byte-identical to what
+    # format_status_line produces for the FIRST turn whose cumulative re-read
+    # crosses the nudge threshold — never a hand-rolled duplicate of the live
+    # statusline's text.
+    from tokenjam.cli.cmd_statusline import REREAD_WARN
+    from tokenjam.core.usage import iter_cumulative_usage
+    with open(recent_path, encoding="utf-8") as fh:
+        crossing = next(
+            (turn_index, usage) for turn_index, _model, usage in iter_cumulative_usage(fh)
+            if usage.total and 100.0 * usage.cache_read_tokens / usage.total >= REREAD_WARN
+        )
+    turn_index, usage = crossing
+    assert turn_index == 3
+    total = usage.total
+    reread_pct = 100.0 * usage.cache_read_tokens / total
+    expected_line = format_status_line("Sonnet 4.5", total, reread_pct)
+    assert expected_line in result.output
+
+
+def test_quickstart_preview_falls_back_to_largest_when_none_substantial(
+    tmp_path, monkeypatch,
+):
+    from tokenjam.cli import cmd_quickstart as q
+
+    monkeypatch.setattr(q, "PREVIEW_MIN_TURNS", 50)  # neither session qualifies
+    root = tmp_path / "projects"
+    _session_with_crossing(
+        root, "sess-recent", "/Users/me/projB", "2026-06-25",
+        n_turns=5, crossing_turn=3,
+    )
+    _session_with_crossing(
+        root, "sess-old", "/Users/me/projA", "2026-06-10",
+        n_turns=8, crossing_turn=5,
+    )
+
+    result = _invoke_quickstart(["--root", str(root), "--since", "90d"])
+    assert result.exit_code == 0, result.output
+    # Neither is "substantial" -> falls back to the largest (by turns), not
+    # simply the most recent.
+    flat = _flat(result.output)
+    assert "session sess-old would have shown this at turn 5" in flat
+
+
+def test_quickstart_preview_omitted_when_no_session_crosses_threshold(tmp_path):
+    root = tmp_path / "projects"
+    # Healthy sessions: tiny cache reads relative to input/output, never near
+    # the 70% nudge threshold.
+    _make_session_file(root, "sess-a", "/Users/me/projA", [
+        _assistant("a1", "sess-a", "/Users/me/projA", "2026-06-20T10:00:00.000Z",
+                   input_tokens=1000, output_tokens=200, cache_read=10),
+    ])
+
+    result = _invoke_quickstart(["--root", str(root), "--since", "90d"])
+    assert result.exit_code == 0, result.output
+    assert "With the statusline installed" not in result.output
+
+
+def test_quickstart_preview_omitted_when_no_sessions(tmp_path):
+    missing = tmp_path / "does-not-exist"
+    result = _invoke_quickstart(["--root", str(missing)])
+    assert result.exit_code == 0, result.output
+    assert "With the statusline installed" not in result.output

--- a/tests/unit/test_statusline.py
+++ b/tests/unit/test_statusline.py
@@ -19,6 +19,7 @@ from tokenjam.cli.cmd_statusline import (
     REREAD_CRIT,
     REREAD_WARN,
     cmd_statusline,
+    format_status_line,
     render_line,
     session_shares,
 )
@@ -169,6 +170,30 @@ def test_million_boundary_switches_to_megabytes(tmp_path):
     # Just below a million stays in k; exactly a million flips to M.
     assert "999.0k tok" in _line_for_total(tmp_path, 999_000)
     assert "1.0M tok" in _line_for_total(tmp_path, 1_000_000)
+
+
+# --- format_status_line (shared with `tj quickstart`'s live preview) --------
+
+
+def test_format_status_line_model_only_when_no_figures():
+    assert format_status_line("Opus 4.8", None, None) == "◆ Opus 4.8"
+
+
+def test_format_status_line_matches_render_line_for_same_inputs(tmp_path):
+    # The preview (cmd_quickstart) calls format_status_line directly with a
+    # point-in-time (total, reread_pct); it must render BYTE-IDENTICAL text to
+    # what render_line would produce for a transcript with those same final
+    # figures, since that's the whole point of sharing the formatter.
+    path = write_claude_transcript(tmp_path / "s.jsonl", [
+        make_claude_transcript_assistant_line(
+            message_id="m1", input_tokens=200, output_tokens=100,
+            cache_read_input_tokens=9500, cache_creation_input_tokens=200,
+        ),
+    ])
+    via_render_line = render_line({"model": "Opus 4.8", "transcript_path": path})
+    total, reread_pct = session_shares(path)
+    via_formatter = format_status_line("Opus 4.8", total, reread_pct)
+    assert via_formatter == via_render_line
 
 
 # --- transcript discovery ---------------------------------------------------

--- a/tests/unit/test_usage.py
+++ b/tests/unit/test_usage.py
@@ -12,7 +12,9 @@ import json
 from tokenjam.core.usage import (
     AssistantUsage,
     assistant_message_key,
+    iter_assistant_turns,
     iter_assistant_usage,
+    iter_cumulative_usage,
     parse_usage,
     session_usage,
 )
@@ -97,3 +99,70 @@ def test_session_usage_no_id_records_counted_separately():
         _line(uuid="b", input_tokens=100),
     ]
     assert session_usage(lines).total == 200
+
+
+# --- iter_assistant_turns (model + usage per record) ------------------------
+
+
+def _line_with_model(model: str, **kwargs) -> str:
+    line = json.loads(_line(**kwargs))
+    line["message"]["model"] = model
+    return json.dumps(line)
+
+
+def test_iter_assistant_turns_surfaces_model_alongside_usage():
+    lines = [
+        _line_with_model("claude-opus-4-8", message_id="m1", input_tokens=100),
+        _line_with_model("claude-sonnet-4-5", message_id="m2", input_tokens=200),
+    ]
+    got = [(key, model) for key, model, _usage in iter_assistant_turns(lines)]
+    assert got == [("m1", "claude-opus-4-8"), ("m2", "claude-sonnet-4-5")]
+
+
+def test_iter_assistant_turns_same_filter_as_iter_assistant_usage():
+    lines = [
+        json.dumps({"type": "user", "message": {"content": "hi"}}),
+        "not json",
+        _line(message_id="m0", input_tokens=0, output_tokens=0),  # empty usage
+        _line_with_model("claude-opus-4-8", message_id="m1", input_tokens=500),
+    ]
+    got = list(iter_assistant_turns(lines))
+    assert got == [("m1", "claude-opus-4-8", AssistantUsage(500, 0, 0, 0))]
+
+
+# --- iter_cumulative_usage (point-in-time preview walk) ----------------------
+
+
+def test_iter_cumulative_usage_accumulates_across_distinct_turns():
+    lines = [
+        _line_with_model("claude-opus-4-8", message_id="m1", input_tokens=100),
+        _line_with_model("claude-opus-4-8", message_id="m2", cache_read_input_tokens=300),
+    ]
+    got = list(iter_cumulative_usage(lines))
+    assert got == [
+        (1, "claude-opus-4-8", AssistantUsage(100, 0, 0, 0)),
+        (2, "claude-opus-4-8", AssistantUsage(100, 0, 300, 0)),
+    ]
+
+
+def test_iter_cumulative_usage_growing_snapshot_does_not_advance_turn():
+    # A mid-stream growing snapshot under the SAME message id updates the
+    # running total in place — it is not a new turn.
+    lines = [
+        _line_with_model("claude-opus-4-8", message_id="m1", input_tokens=100, output_tokens=10),
+        _line_with_model("claude-opus-4-8", message_id="m1", input_tokens=100, output_tokens=400),
+    ]
+    got = list(iter_cumulative_usage(lines))
+    assert [turn for turn, _model, _usage in got] == [1, 1]
+    assert got[-1][2] == AssistantUsage(100, 400, 0, 0)
+
+
+def test_iter_cumulative_usage_final_total_matches_session_usage():
+    lines = [
+        _line_with_model("claude-opus-4-8", message_id="m1", input_tokens=100, output_tokens=10),
+        _line_with_model("claude-opus-4-8", message_id="m1", input_tokens=100, output_tokens=400),
+        _line_with_model("claude-sonnet-4-5", message_id="m2", cache_read_input_tokens=5000),
+    ]
+    *_rest, last = iter_cumulative_usage(lines)
+    _turn, _model, final = last
+    assert final == session_usage(lines)

--- a/tokenjam/cli/cmd_onboard.py
+++ b/tokenjam/cli/cmd_onboard.py
@@ -226,9 +226,16 @@ def _install_tokenjam_persistently() -> str | None:
         combined = f"{result.stdout}\n{result.stderr}".lower()
         if result.returncode != 0 and "already" not in combined:
             continue
+        # The default shim dir covers a stock install; `UV_TOOL_BIN_DIR` /
+        # `PIPX_BIN_DIR` (or a customized PATH) can place `tj` elsewhere, and
+        # missing that would silently fall through to the ephemeral path this
+        # guard exists to avoid — so also resolve `tj` via PATH.
         tj_path = _LOCAL_BIN_DIR / "tj"
         if tj_path.exists():
             return str(tj_path)
+        on_path = shutil.which("tj")
+        if on_path:
+            return on_path
     return None
 
 

--- a/tokenjam/cli/cmd_onboard.py
+++ b/tokenjam/cli/cmd_onboard.py
@@ -178,6 +178,111 @@ def _unwire_claude_resume_brief_hook(settings: dict) -> bool:
     return True
 
 
+# --- Ephemeral-runner guard (#120) -------------------------------------------
+# `npx tokenjam onboard` delegates to `uvx --from tokenjam tj onboard` (or
+# `pipx run --spec tokenjam tj onboard`) — both resolve `sys.executable` into a
+# throwaway, cache-managed venv that is not kept on PATH once this process
+# exits. Onboard wires a background daemon and a Claude Code statusline that
+# both invoke `tj` afterward; under an ephemeral runner those references go
+# stale the moment the session ends. This guard detects that situation and
+# offers (or performs) a persistent install before any wiring happens.
+
+_LOCAL_BIN_DIR = Path.home() / ".local" / "bin"
+
+
+def _is_ephemeral_runner() -> bool:
+    """True when this process is running from a throwaway uvx/pipx-run venv
+    rather than a persistent install.
+
+    Persistent installs resolve `sys.executable` into a stable, named
+    location:
+      - `uv tool install`  → .../uv/tools/<pkg>/...
+      - `pipx install`     → .../pipx/venvs/<pkg>/...  (see `_installed_via_pipx`
+        in cmd_uninstall.py — same signature, different concern)
+    Ephemeral `uvx` / `pipx run` executions resolve into a cache directory
+    instead (e.g. `~/.cache/uv/archive-v0/...` for uvx).
+    """
+    exe = sys.executable.replace("\\", "/")
+    if "/uv/tools/" in exe or "/pipx/venvs/" in exe:
+        return False
+    return "/uv/" in exe or "/pipx/" in exe
+
+
+def _install_tokenjam_persistently() -> str | None:
+    """Best-effort persistent install via `uv tool install` (preferred) or
+    `pipx install`. Returns the absolute path to the newly installed `tj`, or
+    None if neither runner is available or the install failed.
+    """
+    candidates: list[list[str]] = []
+    if shutil.which("uv"):
+        candidates.append(["uv", "tool", "install", "tokenjam"])
+    if shutil.which("pipx"):
+        candidates.append(["pipx", "install", "tokenjam"])
+    for cmd in candidates:
+        try:
+            result = subprocess.run(cmd, capture_output=True, text=True, timeout=120)
+        except Exception:
+            continue
+        combined = f"{result.stdout}\n{result.stderr}".lower()
+        if result.returncode != 0 and "already" not in combined:
+            continue
+        tj_path = _LOCAL_BIN_DIR / "tj"
+        if tj_path.exists():
+            return str(tj_path)
+    return None
+
+
+def _maybe_guard_ephemeral_runner(ctx: click.Context) -> None:
+    """If running under an ephemeral uvx/pipx-run env, offer a persistent
+    install and re-exec onboard through it (#120). No-op for the common case
+    (already-installed `tj`, plain pip/venv) — zero behavior change there.
+    """
+    if not _is_ephemeral_runner():
+        return
+
+    console.print(
+        "\n[yellow]Heads up:[/yellow] you're running via a temporary "
+        "uvx/pipx-run environment. [bold]tj onboard[/bold] wires a "
+        "background daemon and a Claude Code statusline that both need a "
+        "persistent [bold]tj[/bold] on PATH — those would go stale the "
+        "moment this session ends."
+    )
+
+    if not _is_interactive():
+        console.print(
+            "[dim]Non-interactive — continuing without a persistent "
+            "install. Run [bold]pipx install tokenjam && tj onboard[/bold] "
+            "(or [bold]uv tool install tokenjam[/bold]) for a setup that "
+            "survives.[/dim]\n"
+        )
+        return
+
+    if not click.confirm(
+        "Install tokenjam persistently now (uv tool install / pipx "
+        "install), then continue onboarding?", default=True,
+    ):
+        console.print(
+            "[dim]Continuing without a persistent install — re-run "
+            "[bold]pipx install tokenjam && tj onboard[/bold] "
+            "later.[/dim]\n"
+        )
+        return
+
+    console.print("[dim]Installing tokenjam…[/dim]")
+    tj_path = _install_tokenjam_persistently()
+    if tj_path is None:
+        console.print(
+            "[red]Persistent install failed.[/red] Continuing this "
+            "session ephemerally — run [bold]pipx install tokenjam && "
+            "tj onboard[/bold] yourself afterward.\n"
+        )
+        return
+
+    console.print(f"[green]✓[/green] Installed — re-running onboard via {tj_path}\n")
+    result = subprocess.run([tj_path, *sys.argv[1:]])
+    ctx.exit(result.returncode)
+
+
 def _print_generic_instrument_snippet() -> None:
     """The one-size-fits-all Anthropic snippet — fallback when detection finds nothing."""
     console.print("[dim]     from tokenjam.sdk import watch[/dim]")
@@ -294,6 +399,14 @@ def cmd_onboard(ctx: click.Context, claude_code: bool, codex: bool, budget: floa
     if verify_only:
         _run_verify_only(ctx, claude_code=claude_code, codex=codex)
         return
+    # Ephemeral-runner guard (#120): onboard below wires a daemon + Claude Code
+    # statusline that both invoke `tj` after this process exits. Under
+    # `uvx --from tokenjam tj onboard` / `pipx run --spec tokenjam tj onboard`
+    # (what the `npx tokenjam onboard` wrapper delegates to) there is no
+    # persistent `tj` left on PATH once this run ends, so those references
+    # would go stale. Offer (or perform) a persistent install and re-exec
+    # onboard through it before any wiring happens.
+    _maybe_guard_ephemeral_runner(ctx)
     # Branded welcome moment (#240) — shown once at the top of every onboard
     # flow (plain / --claude-code / --codex) before any prompt or config check.
     print_welcome_banner()

--- a/tokenjam/cli/cmd_quickstart.py
+++ b/tokenjam/cli/cmd_quickstart.py
@@ -243,7 +243,7 @@ def _render(diag, timeline, *, since: str,
                     style="dim")
         sections.append(agg)
         sections.append(Text(
-            "    The statusline flags this live, before a session ends — "
+            "The statusline flags this live, before a session ends — "
             "a closed session can't be reclaimed.",
             style="green",
         ))

--- a/tokenjam/cli/cmd_quickstart.py
+++ b/tokenjam/cli/cmd_quickstart.py
@@ -30,10 +30,14 @@ share re-derived from the JSONL, never a projected saving.
 """
 from __future__ import annotations
 
+import glob as _glob
 import json as _json
+import re as _re
+from pathlib import Path
 
 import click
 
+from tokenjam.cli.cmd_statusline import REREAD_WARN, format_status_line
 from tokenjam.core.backfill import (
     CLAUDE_CODE_PROJECTS_ROOT,
     ingest_claude_code,
@@ -41,9 +45,12 @@ from tokenjam.core.backfill import (
 from tokenjam.core.context_diagnostic import compute_context_diagnostic
 from tokenjam.core.db import InMemoryBackend
 from tokenjam.core.session_timeline import (
+    SessionTimeline,
+    TimelineSession,
     compute_session_timeline,
     timeline_to_dict,
 )
+from tokenjam.core.usage import AssistantUsage, iter_cumulative_usage
 from tokenjam.utils.formatting import console, format_cost, format_tokens
 from tokenjam.utils.time_parse import parse_since, utcnow
 
@@ -53,6 +60,12 @@ from tokenjam.utils.time_parse import parse_since, utcnow
 # of sessions) and disclose the cap; `--full` lifts it for the complete picture.
 # ~300 sessions keeps the slowest plausible session shapes comfortably in budget.
 DEFAULT_MAX_SESSIONS = 300
+
+# "Substantial" floor for the statusline live-preview (#120-adjacent): the
+# most-recent session is only worth previewing the nudge on if it actually ran
+# long enough to feel like a real session, not a two-turn smoke test. Below
+# this we fall back to the largest recent session that crossed the threshold.
+PREVIEW_MIN_TURNS = 20
 
 
 @click.command("quickstart")
@@ -120,7 +133,8 @@ def cmd_quickstart(ctx: click.Context, since: str, root_path: str | None,
         return
 
     _render(diag, timeline, since=since,
-            limit_reached=result.limit_reached, max_sessions=max_sessions)
+            limit_reached=result.limit_reached, max_sessions=max_sessions,
+            root=root)
 
 
 # ───────────────────────────── rendering ──────────────────────────────────
@@ -152,7 +166,8 @@ def _render_no_sessions(result, since: str, output_json: bool) -> None:
 
 
 def _render(diag, timeline, *, since: str,
-            limit_reached: bool = False, max_sessions: int | None = None) -> None:
+            limit_reached: bool = False, max_sessions: int | None = None,
+            root: Path | None = None) -> None:
     from rich.console import Group
     from rich.panel import Panel
     from rich.table import Table
@@ -243,6 +258,10 @@ def _render(diag, timeline, *, since: str,
         padding=(1, 2),
     ))
 
+    # ── Statusline live preview (self-contained; omits silently if no
+    # candidate session ever crosses the nudge threshold). ──
+    _render_statusline_preview(timeline, root)
+
     # ── Session timeline. ──
     table = Table(box=box.SIMPLE, show_header=True, header_style="bold dim",
                   title="Session timeline (most recent)", title_justify="left",
@@ -296,3 +315,149 @@ def _bar(value: int, maximum: int, width: int = 16) -> str:
         return ""
     filled = max(1, round(width * value / maximum)) if value > 0 else 0
     return "[cyan]" + ("█" * filled) + "[/cyan]" + ("─" * (width - filled))
+
+
+# ─────────────────────── statusline live preview ───────────────────────────
+#
+# `tj quickstart` is a read-only, one-shot report; `tj statusline` is the live
+# product it upsells (a zero-token Claude Code statusline, updated every turn).
+# This section renders — using the SAME `format_status_line` formatter the
+# live statusline calls — the line the user's own most-recent substantial
+# session would have shown at the exact turn its re-read share crossed the
+# nudge threshold. Forward-looking framing only: it previews the LIVE
+# experience, it is not advice about the (already-ended) session shown.
+
+
+def _display_model_name(raw: str | None) -> str:
+    """Best-effort human display name for a raw transcript `model` id.
+
+    The live statusline gets a ready-made `display_name` from Claude Code's
+    hook payload (see `cmd_statusline._model_name`); this preview only has the
+    raw JSONL `message.model` string (e.g. `claude-opus-4-8-20260115`), so it
+    reconstructs the same "Family X.Y" shape. Falls back to the raw string for
+    shapes it doesn't recognize (e.g. `<synthetic>`).
+    """
+    if not raw:
+        return "?"
+    stripped = _re.sub(r"-\d{8}$", "", raw)  # trailing -YYYYMMDD build stamp
+    m = _re.match(r"^claude-([a-z]+)-([\d-]+)$", stripped)
+    if m:
+        family, version = m.groups()
+        return f"{family.capitalize()} {version.replace('-', '.')}"
+    m = _re.match(r"^claude-([a-z]+)$", stripped)
+    if m:
+        return m.group(1).capitalize()
+    if _re.match(r"^[a-z]+$", stripped):
+        return stripped.capitalize()
+    return raw
+
+
+def _transcript_path_for(session_id: str, root: Path) -> str | None:
+    """Resolve a session id to its on-disk transcript path under `root`.
+
+    Same glob shape as the live statusline's `find_transcript` fallback, but
+    honors quickstart's own `--root` override instead of hardcoding
+    `~/.claude/projects` — quickstart already ingested from `root`, so the
+    preview must look in the same place.
+    """
+    pattern = str(root / "**" / f"{session_id}.jsonl")
+    hits = _glob.glob(pattern, recursive=True)
+    return hits[0] if hits else None
+
+
+class _PreviewCandidate:
+    """One timeline session's preview-selection scoring (see `_select_preview_session`)."""
+
+    __slots__ = ("session", "turns", "crossing")
+
+    def __init__(self, session: TimelineSession, turns: int,
+                 crossing: tuple[int, str | None, AssistantUsage] | None) -> None:
+        self.session = session
+        self.turns = turns
+        self.crossing = crossing
+
+
+def _walk_for_preview(path: str) -> tuple[int, tuple[int, str | None, AssistantUsage] | None]:
+    """Walk one transcript once: return `(total_turns, first_threshold_crossing)`.
+
+    `first_threshold_crossing` is `(turn_index, model, cumulative_usage)` for
+    the first turn whose cumulative re-read %% reaches the live statusline's
+    nudge threshold (`REREAD_WARN`), or None if the session never crosses it.
+    Reuses `core.usage.iter_cumulative_usage` — the exact cumulative walk the
+    live statusline's own numbers are built from — so this can't show a figure
+    the real statusline wouldn't have shown at that point. Never raises: an
+    unreadable transcript degrades to "no candidate" (0, None).
+    """
+    turns = 0
+    crossing: tuple[int, str | None, AssistantUsage] | None = None
+    try:
+        with open(path, encoding="utf-8", errors="replace") as fh:
+            for turn_index, model, usage in iter_cumulative_usage(fh):
+                turns = turn_index
+                if crossing is None:
+                    total = usage.total
+                    reread_pct = (100.0 * usage.cache_read_tokens / total) if total else 0.0
+                    if reread_pct >= REREAD_WARN:
+                        crossing = (turn_index, model, usage)
+    except Exception:
+        return 0, None
+    return turns, crossing
+
+
+def _select_preview_session(
+    timeline: SessionTimeline, root: Path,
+) -> _PreviewCandidate | None:
+    """Pick the session to preview: the most-recent substantial session that
+    crossed the nudge threshold; if none is substantial enough, the largest
+    (by turns) that still crossed it; if none ever crossed it, None.
+    """
+    candidates: list[_PreviewCandidate] = []
+    for session in timeline.sessions:  # already most-recent-first
+        path = _transcript_path_for(session.session_id, root)
+        if not path:
+            continue
+        turns, crossing = _walk_for_preview(path)
+        if crossing is not None:
+            candidates.append(_PreviewCandidate(session, turns, crossing))
+
+    if not candidates:
+        return None
+    substantial = [c for c in candidates if c.turns >= PREVIEW_MIN_TURNS]
+    if substantial:
+        return substantial[0]  # most-recent among the substantial ones
+    return max(candidates, key=lambda c: c.turns)
+
+
+def _render_statusline_preview(timeline: SessionTimeline, root: Path | None) -> None:
+    """"What you'd see live" preview section — self-contained; prints nothing
+    when there is no session to preview (no history, no readable transcript,
+    or no session ever crossed the nudge threshold)."""
+    if root is None or not timeline.sessions:
+        return
+
+    from rich.text import Text
+
+    picked = _select_preview_session(timeline, root)
+    if picked is None:
+        return
+
+    turn_index, model_raw, usage = picked.crossing
+    total = usage.total
+    reread_pct = (100.0 * usage.cache_read_tokens / total) if total else 0.0
+    line = format_status_line(_display_model_name(model_raw), total, reread_pct)
+
+    console.print()
+    intro = Text()
+    intro.append("With the statusline installed, ", style="dim")
+    intro.append(f"session {picked.session.session_id[:12]}", style="bold")
+    intro.append(f" would have shown this at turn {turn_index}:", style="dim")
+    console.print(intro)
+    console.print()
+    console.print(Text(f"  {line}", style="bold"))
+    console.print()
+    outro = Text()
+    outro.append("That's live, every turn, for zero model tokens — ", style="dim")
+    outro.append("tj onboard", style="bold cyan")
+    outro.append(" sets it up.", style="dim")
+    console.print(outro)
+    console.print()

--- a/tokenjam/cli/cmd_quickstart.py
+++ b/tokenjam/cli/cmd_quickstart.py
@@ -282,16 +282,11 @@ def _render(diag, timeline, *, since: str,
     console.print()
     deeper = Text()
     deeper.append("Go deeper", style="bold")
-    deeper.append(" — install and set up live capture, the local dashboard, "
-                  "and the zero-token statusline:", style="dim")
+    deeper.append(" — live capture, Lens (the local dashboard), and the "
+                  "zero-token statusline. No signup:", style="dim")
     console.print(deeper)
     console.print()
     console.print(Text("  npx tokenjam onboard", style="bold cyan"))
-    console.print()
-    console.print(Text(
-        "  tj onboard also gives you a local web dashboard of all this "
-        "— no signup.", style="dim",
-    ))
     console.print()
 
 

--- a/tokenjam/cli/cmd_quickstart.py
+++ b/tokenjam/cli/cmd_quickstart.py
@@ -288,6 +288,11 @@ def _render(diag, timeline, *, since: str,
     console.print()
     console.print(Text("  pipx install tokenjam && tj onboard", style="bold cyan"))
     console.print()
+    console.print(Text(
+        "  tj onboard also gives you a local web dashboard of all this "
+        "— no signup.", style="dim",
+    ))
+    console.print()
 
 
 def _bar(value: int, maximum: int, width: int = 16) -> str:

--- a/tokenjam/cli/cmd_quickstart.py
+++ b/tokenjam/cli/cmd_quickstart.py
@@ -286,7 +286,7 @@ def _render(diag, timeline, *, since: str,
                   "and the zero-token statusline:", style="dim")
     console.print(deeper)
     console.print()
-    console.print(Text("  pipx install tokenjam && tj onboard", style="bold cyan"))
+    console.print(Text("  npx tokenjam onboard", style="bold cyan"))
     console.print()
     console.print(Text(
         "  tj onboard also gives you a local web dashboard of all this "

--- a/tokenjam/cli/cmd_quickstart.py
+++ b/tokenjam/cli/cmd_quickstart.py
@@ -194,18 +194,20 @@ def _render(diag, timeline, *, since: str,
     sections.append(head)
     sections.append(Text(""))
 
+    # Quota-weighted, not raw tokens (#119): cache reads are discounted well
+    # below a base input token in both API pricing and Anthropic's subscription
+    # rate-limit weighting, so a raw token share overstates re-reading's actual
+    # quota cost. diag.quota_weighted_reread_share applies that discount (and
+    # output's premium) — see context_diagnostic.py's CACHE_READ_QUOTA_WEIGHT.
     reread = Text()
-    reread.append(f"{_pct(diag.reread_share)} ", style="bold red")
-    reread.append("of your tokens went to ", style="")
+    reread.append(f"{_pct(diag.quota_weighted_reread_share)} ", style="bold red")
+    reread.append("of your quota went to ", style="")
     reread.append("re-reading context", style="bold")
     reread.append(" (history, CLAUDE.md, tool output)", style="dim")
     sections.append(reread)
 
-    work_share = (
-        diag.total_work_tokens / diag.total_tokens if diag.total_tokens else 0.0
-    )
     work = Text()
-    work.append(f"{_pct(work_share)} ", style="bold green")
+    work.append(f"{_pct(diag.quota_weighted_work_share)} ", style="bold green")
     work.append("went to ", style="")
     work.append("net-new work", style="bold")
     work.append(" (uncached input + output)", style="dim")
@@ -219,19 +221,30 @@ def _render(diag, timeline, *, since: str,
     detail.append(f"{format_tokens(diag.total_work_tokens)} tokens", style="bold")
     sections.append(detail)
 
+    # Aggregate only — never named past sessions (#119). A user has thousands
+    # of sessions and never returns to one closed days ago, so a per-session
+    # retrospective callout is unactionable noise; the only place a burn signal
+    # is actionable is the LIVE session, which the statusline already nudges.
     if diag.compact_candidates:
         sections.append(Text(""))
-        ch = Text("Biggest reclaim opportunities", style="bold")
-        sections.append(ch)
-        for c in diag.compact_candidates[:3]:
-            line = Text("  · ", style="dim")
-            line.append(f"session {c.session_id[:12]}", style="bold")
-            line.append(f"  {_pct(c.reread_share)} re-read, "
-                        f"{format_tokens(c.reread_tokens)} cache "
-                        f"({c.turns} turns)", style="dim")
-            sections.append(line)
+        candidate_reread = sum(c.reread_tokens for c in diag.compact_candidates)
+        share_of_reread = (
+            candidate_reread / diag.total_reread_tokens
+            if diag.total_reread_tokens else 0.0
+        )
+        agg = Text()
+        agg.append(
+            f"{len(diag.compact_candidates)} of your {diag.sessions} sessions",
+            style="bold",
+        )
+        agg.append(" ran context-heavy enough to warrant a mid-session ")
+        agg.append("/compact", style="bold")
+        agg.append(f" — {_pct(share_of_reread)} of this window's re-read tokens.",
+                    style="dim")
+        sections.append(agg)
         sections.append(Text(
-            "    → /compact mid-session (or start fresh) to reclaim that quota.",
+            "    The statusline flags this live, before a session ends — "
+            "a closed session can't be reclaimed.",
             style="green",
         ))
 

--- a/tokenjam/cli/cmd_quickstart.py
+++ b/tokenjam/cli/cmd_quickstart.py
@@ -417,14 +417,20 @@ def _select_preview_session(
         if not path:
             continue
         turns, crossing = _walk_for_preview(path)
-        if crossing is not None:
-            candidates.append(_PreviewCandidate(session, turns, crossing))
+        if crossing is None:
+            continue
+        candidate = _PreviewCandidate(session, turns, crossing)
+        if turns >= PREVIEW_MIN_TURNS:
+            # Sessions are walked most-recent-first, so the first substantial
+            # crossing candidate IS the winner — stop here rather than
+            # re-reading the rest of a possibly-large (up to `--full`) history.
+            # The largest-by-turns fallback below only matters when NO
+            # candidate is substantial, a case this early return never hides.
+            return candidate
+        candidates.append(candidate)
 
     if not candidates:
         return None
-    substantial = [c for c in candidates if c.turns >= PREVIEW_MIN_TURNS]
-    if substantial:
-        return substantial[0]  # most-recent among the substantial ones
     return max(candidates, key=lambda c: c.turns)
 
 
@@ -440,6 +446,7 @@ def _render_statusline_preview(timeline: SessionTimeline, root: Path | None) -> 
     picked = _select_preview_session(timeline, root)
     if picked is None:
         return
+    assert picked.crossing is not None  # invariant: only crossing candidates are ever selected
 
     turn_index, model_raw, usage = picked.crossing
     total = usage.total

--- a/tokenjam/cli/cmd_statusline.py
+++ b/tokenjam/cli/cmd_statusline.py
@@ -94,6 +94,28 @@ def _badge_and_nudge(reread_pct: float) -> tuple[str, str | None]:
     return _BADGE_OK, None
 
 
+def format_status_line(
+    model_name: str, total: int | None, reread_pct: float | None
+) -> str:
+    """Build the statusline string from already-resolved figures.
+
+    Shared by the live line (``render_line``, fed the hook's per-turn payload)
+    and ``tj quickstart``'s "what you'd see live" preview section (fed a
+    point-in-time figure from a past transcript) — so the two surfaces render
+    IDENTICAL text for identical inputs and the preview can never drift from
+    the real product. ``total``/``reread_pct`` of ``None`` degrades to the
+    model-only segment (mirrors "no transcript" / "unreadable transcript").
+    """
+    parts = [f"◆ {model_name}"]  # ◆ model
+    if total is not None and reread_pct is not None:
+        parts.append(f"{format_tokens(total)} tok")
+        badge, nudge = _badge_and_nudge(reread_pct)
+        parts.append(f"{badge} re-read {reread_pct:.0f}%")
+        if nudge:
+            parts.append(nudge)
+    return "  ".join(parts)
+
+
 def render_line(data: dict) -> str:
     """Build the one-line statusline string from a parsed payload.
 
@@ -101,19 +123,15 @@ def render_line(data: dict) -> str:
     badge, and the compaction nudge only when a transcript is found and readable.
     Never raises — a transcript read failure degrades to the model-only line.
     """
-    parts = [f"◆ {_model_name(data)}"]  # ◆ model
+    model_name = _model_name(data)
     path = find_transcript(data)
-    if path:
-        try:
-            total, reread_pct = session_shares(path)
-        except Exception:
-            return "  ".join(parts)
-        parts.append(f"{format_tokens(total)} tok")
-        badge, nudge = _badge_and_nudge(reread_pct)
-        parts.append(f"{badge} re-read {reread_pct:.0f}%")
-        if nudge:
-            parts.append(nudge)
-    return "  ".join(parts)
+    if not path:
+        return format_status_line(model_name, None, None)
+    try:
+        total, reread_pct = session_shares(path)
+    except Exception:
+        return format_status_line(model_name, None, None)
+    return format_status_line(model_name, total, reread_pct)
 
 
 @click.command("statusline")

--- a/tokenjam/core/context_diagnostic.py
+++ b/tokenjam/core/context_diagnostic.py
@@ -125,6 +125,22 @@ SUBAGENT_UNACCOUNTED_NOTE = (
 # detection query and any future renderer agree on it.
 DELEGATION_TOOL_NAME = "task"
 
+# Quota-weighted headline (#119). `diag.reread_share` above is a RAW token
+# share — it mixes "tokens" and "quota" framings, because cache-read tokens
+# are discounted well below a base input token in both API pricing and
+# Anthropic's subscription rate-limit weighting. tokenjam's own pricing table
+# (tokenjam/pricing/models.toml) prices every current Claude model at a fixed
+# ratio to its base input rate: cache reads at 0.1x, output at 5x — consistent
+# across every Anthropic model row, not a per-model coincidence. Weighting raw
+# token counts by these ratios turns "% of tokens" into "% of quota" without a
+# live per-model pricing lookup at render time. New-input and cache-write
+# (cache-miss) tokens keep their raw weight of 1.0 — they are genuinely new
+# content this turn, not a re-read, so they're outside the discount this
+# reflects. Named constants (not inlined) so the ratio's provenance is visible
+# at every call site.
+CACHE_READ_QUOTA_WEIGHT = 0.1
+OUTPUT_QUOTA_WEIGHT = 5.0
+
 # A re-read share at or above this fraction is "context-heavy" and worth a
 # compact / restructure look. Calibrated against the community signal that
 # steady-state CC turns can run well above this once history + CLAUDE.md grow.
@@ -214,6 +230,27 @@ class TurnComposition:
     def cache_miss_share(self) -> float:
         total = self.total_tokens
         return (self.cache_miss_tokens / total) if total else 0.0
+
+    @property
+    def quota_weighted_tokens(self) -> float:
+        """This turn's tokens weighted by quota cost, not raw count (#119).
+
+        Cache reads count for ``CACHE_READ_QUOTA_WEIGHT`` of a base token;
+        output counts for ``OUTPUT_QUOTA_WEIGHT``. See the constants' docstring
+        for the pricing-table provenance.
+        """
+        return (
+            self.reread_tokens * CACHE_READ_QUOTA_WEIGHT
+            + self.new_input_tokens
+            + self.output_tokens * OUTPUT_QUOTA_WEIGHT
+            + self.cache_write_tokens
+        )
+
+    @property
+    def quota_weighted_reread_share(self) -> float:
+        """Re-read's share of this turn's QUOTA-weighted tokens, not raw count."""
+        total = self.quota_weighted_tokens
+        return (self.reread_tokens * CACHE_READ_QUOTA_WEIGHT / total) if total else 0.0
 
 
 @dataclass
@@ -311,6 +348,47 @@ class ContextDiagnostic:
     def cache_miss_share(self) -> float:
         total = self.total_tokens
         return (self.total_cache_miss_tokens / total) if total else 0.0
+
+    @property
+    def total_quota_weighted_tokens(self) -> float:
+        """Window tokens weighted by quota cost, not raw count (#119).
+
+        Cache reads count for ``CACHE_READ_QUOTA_WEIGHT`` of a base token;
+        output counts for ``OUTPUT_QUOTA_WEIGHT``. See the constants' docstring
+        for the pricing-table provenance.
+        """
+        return (
+            self.total_reread_tokens * CACHE_READ_QUOTA_WEIGHT
+            + self.total_new_input_tokens
+            + self.total_output_tokens * OUTPUT_QUOTA_WEIGHT
+            + self.total_cache_write_tokens
+        )
+
+    @property
+    def quota_weighted_reread_share(self) -> float:
+        """Re-read's share of the window's QUOTA-weighted tokens (#119).
+
+        This is the headline number: ``reread_share`` above mixes "tokens" and
+        "quota" framings because cache reads are billed at a fraction of a base
+        token. This property is what the "% of your quota" headline should read.
+        """
+        total = self.total_quota_weighted_tokens
+        return (
+            (self.total_reread_tokens * CACHE_READ_QUOTA_WEIGHT / total)
+            if total else 0.0
+        )
+
+    @property
+    def quota_weighted_work_share(self) -> float:
+        """Net-new work's share of the window's QUOTA-weighted tokens (#119)."""
+        total = self.total_quota_weighted_tokens
+        if not total:
+            return 0.0
+        weighted_work = (
+            self.total_new_input_tokens
+            + self.total_output_tokens * OUTPUT_QUOTA_WEIGHT
+        )
+        return weighted_work / total
 
     @property
     def subagent_accounting_partial(self) -> bool:
@@ -923,6 +1001,11 @@ def diagnostic_to_dict(diag: ContextDiagnostic) -> dict[str, Any]:
         "total_tokens": diag.total_tokens,
         "reread_share": round(diag.reread_share, 4),
         "cache_miss_share": round(diag.cache_miss_share, 4),
+        # Quota-weighted headline (#119) — cache reads discounted, output
+        # weighted heavier, per the pricing-table ratios cited on the constants.
+        "total_quota_weighted_tokens": round(diag.total_quota_weighted_tokens, 2),
+        "quota_weighted_reread_share": round(diag.quota_weighted_reread_share, 4),
+        "quota_weighted_work_share": round(diag.quota_weighted_work_share, 4),
         "total_cost_usd": round(diag.total_cost_usd, 6),
         "heaviest_turns": [
             {

--- a/tokenjam/core/context_diagnostic.py
+++ b/tokenjam/core/context_diagnostic.py
@@ -238,6 +238,12 @@ class TurnComposition:
         Cache reads count for ``CACHE_READ_QUOTA_WEIGHT`` of a base token;
         output counts for ``OUTPUT_QUOTA_WEIGHT``. See the constants' docstring
         for the pricing-table provenance.
+
+        Not consumed by any renderer yet — quickstart uses the window-level
+        ``ContextDiagnostic.quota_weighted_reread_share`` below. This per-turn
+        variant is deliberate groundwork for #122 (tj context / tj tokenmaxx
+        switching their own headlines to quota-weighted shares). Do not remove
+        as unused.
         """
         return (
             self.reread_tokens * CACHE_READ_QUOTA_WEIGHT
@@ -248,7 +254,11 @@ class TurnComposition:
 
     @property
     def quota_weighted_reread_share(self) -> float:
-        """Re-read's share of this turn's QUOTA-weighted tokens, not raw count."""
+        """Re-read's share of this turn's QUOTA-weighted tokens, not raw count.
+
+        Groundwork for #122, same as ``quota_weighted_tokens`` above — not
+        consumed by any renderer yet. Do not remove as unused.
+        """
         total = self.quota_weighted_tokens
         return (self.reread_tokens * CACHE_READ_QUOTA_WEIGHT / total) if total else 0.0
 

--- a/tokenjam/core/usage.py
+++ b/tokenjam/core/usage.py
@@ -65,12 +65,16 @@ def assistant_message_key(record: dict, msg: dict, line_no: int) -> str:
     return msg.get("id") or record.get("uuid") or str(line_no)
 
 
-def iter_assistant_usage(lines: Iterable[str]) -> Iterator[tuple[str, AssistantUsage]]:
-    """Yield ``(message_key, usage)`` for each assistant record carrying usage.
+def _iter_assistant_records(
+    lines: Iterable[str],
+) -> Iterator[tuple[dict, dict, int, AssistantUsage]]:
+    """Yield ``(record, msg, line_no, usage)`` for each billable assistant record.
 
-    Skips non-JSON lines, non-assistant records, and empty-usage records (no
-    cost contribution) — mirroring the filters ``core/backfill`` applies so both
-    paths see the same set of billable turns.
+    Skips non-JSON lines, non-assistant records, and empty/zero-usage records
+    (no cost contribution) — mirroring the filters ``core/backfill`` applies so
+    all readers see the same set of billable turns. Shared by
+    ``iter_assistant_usage`` and ``iter_assistant_turns`` so the two can never
+    disagree on which records count as a turn.
     """
     for line_no, line in enumerate(lines, start=1):
         try:
@@ -87,7 +91,67 @@ def iter_assistant_usage(lines: Iterable[str]) -> Iterator[tuple[str, AssistantU
         usage = parse_usage(msg.get("usage"))
         if usage.total == 0:
             continue
+        yield record, msg, line_no, usage
+
+
+def iter_assistant_usage(lines: Iterable[str]) -> Iterator[tuple[str, AssistantUsage]]:
+    """Yield ``(message_key, usage)`` for each assistant record carrying usage."""
+    for record, msg, line_no, usage in _iter_assistant_records(lines):
         yield assistant_message_key(record, msg, line_no), usage
+
+
+def iter_assistant_turns(
+    lines: Iterable[str],
+) -> Iterator[tuple[str, str | None, AssistantUsage]]:
+    """Yield ``(message_key, model, usage)`` for each assistant record carrying usage.
+
+    Same record + key as ``iter_assistant_usage`` but also surfaces the raw
+    ``model`` id Claude Code stamped on that record. Needed by point-in-time
+    previews (e.g. ``tj quickstart``'s "what you'd see live" section) that show
+    the model in effect at a specific turn, not just the session aggregate.
+    """
+    for record, msg, line_no, usage in _iter_assistant_records(lines):
+        yield assistant_message_key(record, msg, line_no), msg.get("model"), usage
+
+
+def iter_cumulative_usage(
+    lines: Iterable[str],
+) -> Iterator[tuple[int, str | None, AssistantUsage]]:
+    """Yield ``(turn_index, model, cumulative_usage)`` after each assistant turn.
+
+    ``turn_index`` is the 1-based count of distinct assistant turns seen so far
+    (after last-wins dedup); ``model`` is the raw model id on the record that
+    produced this yield; ``cumulative_usage`` is the running last-wins-deduped
+    total through that turn. The final yielded ``cumulative_usage`` always
+    equals ``session_usage`` over the same lines — same dedup key + last-wins
+    policy, just surfaced incrementally.
+
+    Powers point-in-time previews (``tj quickstart``'s "what you'd have seen
+    live" section) that need the statusline's numbers as they stood mid-session,
+    not only the final total.
+    """
+    latest: dict[str, AssistantUsage] = {}
+    running = AssistantUsage()
+    turn_index = 0
+    for key, model, usage in iter_assistant_turns(lines):
+        prev = latest.get(key)
+        if prev is None:
+            turn_index += 1
+            running = AssistantUsage(
+                running.input_tokens + usage.input_tokens,
+                running.output_tokens + usage.output_tokens,
+                running.cache_read_tokens + usage.cache_read_tokens,
+                running.cache_write_tokens + usage.cache_write_tokens,
+            )
+        else:
+            running = AssistantUsage(
+                running.input_tokens - prev.input_tokens + usage.input_tokens,
+                running.output_tokens - prev.output_tokens + usage.output_tokens,
+                running.cache_read_tokens - prev.cache_read_tokens + usage.cache_read_tokens,
+                running.cache_write_tokens - prev.cache_write_tokens + usage.cache_write_tokens,
+            )
+        latest[key] = usage
+        yield turn_index, model, running
 
 
 def session_usage(lines: Iterable[str]) -> AssistantUsage:


### PR DESCRIPTION
## Summary

`npx tokenjam onboard`'s upgrade CTA asked the user to switch tools right after a successful `npx tokenjam` run, and the wrapper's ephemeral runner (`uvx`/`pipx run`) silently produced a broken install — the daemon and Claude Code statusline it wires both invoke `tj` after the process exits, but under an ephemeral runner there's no persistent `tj` left on PATH. Separately, the quickstart outro's dashboard mention was buried inside a longer sentence rather than called out.

- **Ephemeral-runner guard** (`tokenjam/cli/cmd_onboard.py`): added `_is_ephemeral_runner()`, which detects the throwaway-venv signature in `sys.executable` (uvx/`pipx run` resolve into a cache dir, e.g. `~/.cache/uv/archive-v0/...`, vs. persistent `uv tool install` → `.../uv/tools/<pkg>/...` and `pipx install` → `.../pipx/venvs/<pkg>/...`, matching the existing detection pattern already used in `cmd_uninstall.py`). When ephemeral and interactive, `_maybe_guard_ephemeral_runner()` offers a persistent install (`uv tool install tokenjam`, falling back to `pipx install tokenjam`) and re-execs `tj onboard` (same args) through the freshly installed binary before any daemon/statusline wiring happens. Non-interactive runs (scripts/CI) print a warning and continue unblocked — no change to existing automation. The common case (already-installed `tj`, plain pip/venv) is a total no-op.

  **Chose the onboard-side guard over a wrapper-side fix** (`npm-wrapper/bin/tj.js`): it also covers users who invoke `uvx --from tokenjam tj onboard` directly, without ever going through `npx`/the Node wrapper, and the repo has full pytest coverage for `cmd_onboard.py` versus zero test harness for the JS wrapper (no test file, no test script in `npm-wrapper/package.json`). The wrapper's passthrough behavior is unchanged.

- **Quickstart outro** (`tokenjam/cli/cmd_quickstart.py`): added a dedicated line selling the local web dashboard ("no signup"), consistent in tone with the existing statusline/daemon mention, so it isn't invisible at the commitment moment.

## Test plan

- [x] `pytest tests/unit/test_onboard_ephemeral_guard.py tests/unit/test_quickstart.py tests/unit/test_onboard_path_branch.py -q` — 48 passed (new tests cover: path-signature detection for uv/pipx persistent vs. ephemeral paths, no-op when not ephemeral, non-interactive warn-and-continue, interactive decline, interactive install failure, interactive success re-exec + `ctx.exit`, and `_install_tokenjam_persistently` runner selection/fallback/failure)
- [x] `make test` — full suite: 2179 passed, 1 skipped, 0 failed
- [x] `make lint` — ruff clean
- [x] `make typecheck` — mypy clean, 184 source files
- [x] Manually verified `_is_ephemeral_runner()` against real `sys.executable` values produced by actual `uvx --from pip pip -V` (ephemeral cache path) and `uv tool install pip` (persistent `.../uv/tools/...` path) on this machine
- [x] `node -c npm-wrapper/bin/tj.js` — wrapper untouched, syntax OK

Co-Authored-By: Claude <noreply@anthropic.com>
