### PR TITLE
feat(quickstart): add statusline live preview section

### DIFF
--- a/tests/unit/test_quickstart.py
+++ b/tests/unit/test_quickstart.py
@@ -378,6 +378,46 @@ def test_quickstart_preview_shows_most_recent_substantial_crossing_session(
     assert expected_line in result.output
 
 
+def test_quickstart_preview_stops_walking_after_first_substantial_candidate(
+    tmp_path, monkeypatch,
+):
+    """Sessions are walked most-recent-first; once the most-recent SUBSTANTIAL
+    crossing candidate is found, selection must stop rather than re-reading
+    every remaining session's transcript — a large `~/.claude` history would
+    otherwise blow past quickstart's fast-first-run budget."""
+    from tokenjam.cli import cmd_quickstart as q
+
+    monkeypatch.setattr(q, "PREVIEW_MIN_TURNS", 3)
+    root = tmp_path / "projects"
+    # Most-recent session is ALREADY substantial + crossing -> must win
+    # without inspecting any of the five older sessions below it.
+    _session_with_crossing(
+        root, "sess-newest", "/Users/me/projZ", "2026-06-28",
+        n_turns=5, crossing_turn=2,
+    )
+    for i in range(5):
+        _session_with_crossing(
+            root, f"sess-old-{i}", f"/Users/me/proj{i}", f"2026-06-{10 + i:02d}",
+            n_turns=5, crossing_turn=2,
+        )
+
+    calls: list[str] = []
+    original_walk = q._walk_for_preview
+
+    def _counting_walk(path):
+        calls.append(path)
+        return original_walk(path)
+
+    monkeypatch.setattr(q, "_walk_for_preview", _counting_walk)
+
+    result = _invoke_quickstart(["--root", str(root), "--since", "90d"])
+    assert result.exit_code == 0, result.output
+    assert "session sess-newest" in _flat(result.output)
+    # Only the winning (most-recent, already-substantial) candidate's
+    # transcript was walked -- the 5 older sessions were never opened.
+    assert len(calls) == 1
+
+
 def test_quickstart_preview_falls_back_to_largest_when_none_substantial(
     tmp_path, monkeypatch,
 ):

--- a/tests/unit/test_quickstart.py
+++ b/tests/unit/test_quickstart.py
@@ -303,3 +303,121 @@ def test_quickstart_json_reports_cap_metadata(tmp_path, monkeypatch):
     assert payload["backfill"]["sessions_ingested"] == 6
     assert payload["backfill"]["limit_reached"] is True
     assert payload["backfill"]["max_sessions"] == 6
+
+
+# ── Statusline live preview ("what you'd see live") ──────────────────────────
+#
+# `_display_model_name` reconstructs "Sonnet 4.5" from the raw transcript
+# `claude-sonnet-4-5-20250929` id every fixture session below uses.
+
+def _flat(output: str) -> str:
+    """Collapse Rich's line-wrapping so long-sentence substring checks aren't
+    sensitive to where the terminal happened to wrap a word."""
+    return " ".join(output.split())
+
+
+def _session_with_crossing(root: Path, session_id: str, cwd: str, base_date: str,
+                            *, n_turns: int, crossing_turn: int) -> Path:
+    """A synthetic session whose cumulative re-read %% stays low through
+    `crossing_turn - 1`, then jumps hard enough that it crosses REREAD_WARN
+    (70%%) starting exactly at `crossing_turn` (1-indexed) and stays crossed.
+    """
+    records = []
+    for i in range(1, n_turns + 1):
+        ts = f"{base_date}T10:{i:02d}:00.000Z"
+        cache = 20 if i < crossing_turn else 100_000
+        records.append(_assistant(
+            f"{session_id}-{i}", session_id, cwd, ts,
+            input_tokens=100, output_tokens=50, cache_read=cache,
+        ))
+    return _make_session_file(root, session_id, cwd, records)
+
+
+def test_quickstart_preview_shows_most_recent_substantial_crossing_session(
+    tmp_path, monkeypatch,
+):
+    from tokenjam.cli import cmd_quickstart as q
+    from tokenjam.cli.cmd_statusline import format_status_line
+
+    monkeypatch.setattr(q, "PREVIEW_MIN_TURNS", 3)
+    root = tmp_path / "projects"
+    # Older, more turns, but NOT more recent -> must lose to the recent one.
+    _session_with_crossing(
+        root, "sess-old", "/Users/me/projA", "2026-06-10",
+        n_turns=10, crossing_turn=2,
+    )
+    # Recent AND substantial (5 >= PREVIEW_MIN_TURNS=3) -> wins on recency.
+    recent_path = _session_with_crossing(
+        root, "sess-recent", "/Users/me/projB", "2026-06-25",
+        n_turns=5, crossing_turn=3,
+    )
+
+    result = _invoke_quickstart(["--root", str(root), "--since", "90d"])
+    assert result.exit_code == 0, result.output
+    flat = _flat(result.output)
+    assert "With the statusline installed" in flat
+    assert "session sess-recent would have shown this at turn 3" in flat
+    assert "tj onboard" in flat.split("With the statusline installed")[1]
+
+    # Formatter reuse: the rendered line is byte-identical to what
+    # format_status_line produces for the FIRST turn whose cumulative re-read
+    # crosses the nudge threshold — never a hand-rolled duplicate of the live
+    # statusline's text.
+    from tokenjam.cli.cmd_statusline import REREAD_WARN
+    from tokenjam.core.usage import iter_cumulative_usage
+    with open(recent_path, encoding="utf-8") as fh:
+        crossing = next(
+            (turn_index, usage) for turn_index, _model, usage in iter_cumulative_usage(fh)
+            if usage.total and 100.0 * usage.cache_read_tokens / usage.total >= REREAD_WARN
+        )
+    turn_index, usage = crossing
+    assert turn_index == 3
+    total = usage.total
+    reread_pct = 100.0 * usage.cache_read_tokens / total
+    expected_line = format_status_line("Sonnet 4.5", total, reread_pct)
+    assert expected_line in result.output
+
+
+def test_quickstart_preview_falls_back_to_largest_when_none_substantial(
+    tmp_path, monkeypatch,
+):
+    from tokenjam.cli import cmd_quickstart as q
+
+    monkeypatch.setattr(q, "PREVIEW_MIN_TURNS", 50)  # neither session qualifies
+    root = tmp_path / "projects"
+    _session_with_crossing(
+        root, "sess-recent", "/Users/me/projB", "2026-06-25",
+        n_turns=5, crossing_turn=3,
+    )
+    _session_with_crossing(
+        root, "sess-old", "/Users/me/projA", "2026-06-10",
+        n_turns=8, crossing_turn=5,
+    )
+
+    result = _invoke_quickstart(["--root", str(root), "--since", "90d"])
+    assert result.exit_code == 0, result.output
+    # Neither is "substantial" -> falls back to the largest (by turns), not
+    # simply the most recent.
+    flat = _flat(result.output)
+    assert "session sess-old would have shown this at turn 5" in flat
+
+
+def test_quickstart_preview_omitted_when_no_session_crosses_threshold(tmp_path):
+    root = tmp_path / "projects"
+    # Healthy sessions: tiny cache reads relative to input/output, never near
+    # the 70% nudge threshold.
+    _make_session_file(root, "sess-a", "/Users/me/projA", [
+        _assistant("a1", "sess-a", "/Users/me/projA", "2026-06-20T10:00:00.000Z",
+                   input_tokens=1000, output_tokens=200, cache_read=10),
+    ])
+
+    result = _invoke_quickstart(["--root", str(root), "--since", "90d"])
+    assert result.exit_code == 0, result.output
+    assert "With the statusline installed" not in result.output
+
+
+def test_quickstart_preview_omitted_when_no_sessions(tmp_path):
+    missing = tmp_path / "does-not-exist"
+    result = _invoke_quickstart(["--root", str(missing)])
+    assert result.exit_code == 0, result.output
+    assert "With the statusline installed" not in result.output

--- a/tests/unit/test_statusline.py
+++ b/tests/unit/test_statusline.py
@@ -19,6 +19,7 @@ from tokenjam.cli.cmd_statusline import (
     REREAD_CRIT,
     REREAD_WARN,
     cmd_statusline,
+    format_status_line,
     render_line,
     session_shares,
 )
@@ -169,6 +170,30 @@ def test_million_boundary_switches_to_megabytes(tmp_path):
     # Just below a million stays in k; exactly a million flips to M.
     assert "999.0k tok" in _line_for_total(tmp_path, 999_000)
     assert "1.0M tok" in _line_for_total(tmp_path, 1_000_000)
+
+
+# --- format_status_line (shared with `tj quickstart`'s live preview) --------
+
+
+def test_format_status_line_model_only_when_no_figures():
+    assert format_status_line("Opus 4.8", None, None) == "◆ Opus 4.8"
+
+
+def test_format_status_line_matches_render_line_for_same_inputs(tmp_path):
+    # The preview (cmd_quickstart) calls format_status_line directly with a
+    # point-in-time (total, reread_pct); it must render BYTE-IDENTICAL text to
+    # what render_line would produce for a transcript with those same final
+    # figures, since that's the whole point of sharing the formatter.
+    path = write_claude_transcript(tmp_path / "s.jsonl", [
+        make_claude_transcript_assistant_line(
+            message_id="m1", input_tokens=200, output_tokens=100,
+            cache_read_input_tokens=9500, cache_creation_input_tokens=200,
+        ),
+    ])
+    via_render_line = render_line({"model": "Opus 4.8", "transcript_path": path})
+    total, reread_pct = session_shares(path)
+    via_formatter = format_status_line("Opus 4.8", total, reread_pct)
+    assert via_formatter == via_render_line
 
 
 # --- transcript discovery ---------------------------------------------------

--- a/tests/unit/test_usage.py
+++ b/tests/unit/test_usage.py
@@ -12,7 +12,9 @@ import json
 from tokenjam.core.usage import (
     AssistantUsage,
     assistant_message_key,
+    iter_assistant_turns,
     iter_assistant_usage,
+    iter_cumulative_usage,
     parse_usage,
     session_usage,
 )
@@ -97,3 +99,70 @@ def test_session_usage_no_id_records_counted_separately():
         _line(uuid="b", input_tokens=100),
     ]
     assert session_usage(lines).total == 200
+
+
+# --- iter_assistant_turns (model + usage per record) ------------------------
+
+
+def _line_with_model(model: str, **kwargs) -> str:
+    line = json.loads(_line(**kwargs))
+    line["message"]["model"] = model
+    return json.dumps(line)
+
+
+def test_iter_assistant_turns_surfaces_model_alongside_usage():
+    lines = [
+        _line_with_model("claude-opus-4-8", message_id="m1", input_tokens=100),
+        _line_with_model("claude-sonnet-4-5", message_id="m2", input_tokens=200),
+    ]
+    got = [(key, model) for key, model, _usage in iter_assistant_turns(lines)]
+    assert got == [("m1", "claude-opus-4-8"), ("m2", "claude-sonnet-4-5")]
+
+
+def test_iter_assistant_turns_same_filter_as_iter_assistant_usage():
+    lines = [
+        json.dumps({"type": "user", "message": {"content": "hi"}}),
+        "not json",
+        _line(message_id="m0", input_tokens=0, output_tokens=0),  # empty usage
+        _line_with_model("claude-opus-4-8", message_id="m1", input_tokens=500),
+    ]
+    got = list(iter_assistant_turns(lines))
+    assert got == [("m1", "claude-opus-4-8", AssistantUsage(500, 0, 0, 0))]
+
+
+# --- iter_cumulative_usage (point-in-time preview walk) ----------------------
+
+
+def test_iter_cumulative_usage_accumulates_across_distinct_turns():
+    lines = [
+        _line_with_model("claude-opus-4-8", message_id="m1", input_tokens=100),
+        _line_with_model("claude-opus-4-8", message_id="m2", cache_read_input_tokens=300),
+    ]
+    got = list(iter_cumulative_usage(lines))
+    assert got == [
+        (1, "claude-opus-4-8", AssistantUsage(100, 0, 0, 0)),
+        (2, "claude-opus-4-8", AssistantUsage(100, 0, 300, 0)),
+    ]
+
+
+def test_iter_cumulative_usage_growing_snapshot_does_not_advance_turn():
+    # A mid-stream growing snapshot under the SAME message id updates the
+    # running total in place — it is not a new turn.
+    lines = [
+        _line_with_model("claude-opus-4-8", message_id="m1", input_tokens=100, output_tokens=10),
+        _line_with_model("claude-opus-4-8", message_id="m1", input_tokens=100, output_tokens=400),
+    ]
+    got = list(iter_cumulative_usage(lines))
+    assert [turn for turn, _model, _usage in got] == [1, 1]
+    assert got[-1][2] == AssistantUsage(100, 400, 0, 0)
+
+
+def test_iter_cumulative_usage_final_total_matches_session_usage():
+    lines = [
+        _line_with_model("claude-opus-4-8", message_id="m1", input_tokens=100, output_tokens=10),
+        _line_with_model("claude-opus-4-8", message_id="m1", input_tokens=100, output_tokens=400),
+        _line_with_model("claude-sonnet-4-5", message_id="m2", cache_read_input_tokens=5000),
+    ]
+    *_rest, last = iter_cumulative_usage(lines)
+    _turn, _model, final = last
+    assert final == session_usage(lines)

--- a/tokenjam/cli/cmd_quickstart.py
+++ b/tokenjam/cli/cmd_quickstart.py
@@ -30,10 +30,14 @@ share re-derived from the JSONL, never a projected saving.
 """
 from __future__ import annotations
 
+import glob as _glob
 import json as _json
+import re as _re
+from pathlib import Path
 
 import click
 
+from tokenjam.cli.cmd_statusline import REREAD_WARN, format_status_line
 from tokenjam.core.backfill import (
     CLAUDE_CODE_PROJECTS_ROOT,
     ingest_claude_code,
@@ -41,9 +45,12 @@ from tokenjam.core.backfill import (
 from tokenjam.core.context_diagnostic import compute_context_diagnostic
 from tokenjam.core.db import InMemoryBackend
 from tokenjam.core.session_timeline import (
+    SessionTimeline,
+    TimelineSession,
     compute_session_timeline,
     timeline_to_dict,
 )
+from tokenjam.core.usage import AssistantUsage, iter_cumulative_usage
 from tokenjam.utils.formatting import console, format_cost, format_tokens
 from tokenjam.utils.time_parse import parse_since, utcnow
 
@@ -53,6 +60,12 @@ from tokenjam.utils.time_parse import parse_since, utcnow
 # of sessions) and disclose the cap; `--full` lifts it for the complete picture.
 # ~300 sessions keeps the slowest plausible session shapes comfortably in budget.
 DEFAULT_MAX_SESSIONS = 300
+
+# "Substantial" floor for the statusline live-preview (#120-adjacent): the
+# most-recent session is only worth previewing the nudge on if it actually ran
+# long enough to feel like a real session, not a two-turn smoke test. Below
+# this we fall back to the largest recent session that crossed the threshold.
+PREVIEW_MIN_TURNS = 20
 
 
 @click.command("quickstart")
@@ -120,7 +133,8 @@ def cmd_quickstart(ctx: click.Context, since: str, root_path: str | None,
         return
 
     _render(diag, timeline, since=since,
-            limit_reached=result.limit_reached, max_sessions=max_sessions)
+            limit_reached=result.limit_reached, max_sessions=max_sessions,
+            root=root)
 
 
 # ───────────────────────────── rendering ──────────────────────────────────
@@ -152,7 +166,8 @@ def _render_no_sessions(result, since: str, output_json: bool) -> None:
 
 
 def _render(diag, timeline, *, since: str,
-            limit_reached: bool = False, max_sessions: int | None = None) -> None:
+            limit_reached: bool = False, max_sessions: int | None = None,
+            root: Path | None = None) -> None:
     from rich.console import Group
     from rich.panel import Panel
     from rich.table import Table
@@ -243,6 +258,10 @@ def _render(diag, timeline, *, since: str,
         padding=(1, 2),
     ))
 
+    # ── Statusline live preview (self-contained; omits silently if no
+    # candidate session ever crosses the nudge threshold). ──
+    _render_statusline_preview(timeline, root)
+
     # ── Session timeline. ──
     table = Table(box=box.SIMPLE, show_header=True, header_style="bold dim",
                   title="Session timeline (most recent)", title_justify="left",
@@ -296,3 +315,149 @@ def _bar(value: int, maximum: int, width: int = 16) -> str:
         return ""
     filled = max(1, round(width * value / maximum)) if value > 0 else 0
     return "[cyan]" + ("█" * filled) + "[/cyan]" + ("─" * (width - filled))
+
+
+# ─────────────────────── statusline live preview ───────────────────────────
+#
+# `tj quickstart` is a read-only, one-shot report; `tj statusline` is the live
+# product it upsells (a zero-token Claude Code statusline, updated every turn).
+# This section renders — using the SAME `format_status_line` formatter the
+# live statusline calls — the line the user's own most-recent substantial
+# session would have shown at the exact turn its re-read share crossed the
+# nudge threshold. Forward-looking framing only: it previews the LIVE
+# experience, it is not advice about the (already-ended) session shown.
+
+
+def _display_model_name(raw: str | None) -> str:
+    """Best-effort human display name for a raw transcript `model` id.
+
+    The live statusline gets a ready-made `display_name` from Claude Code's
+    hook payload (see `cmd_statusline._model_name`); this preview only has the
+    raw JSONL `message.model` string (e.g. `claude-opus-4-8-20260115`), so it
+    reconstructs the same "Family X.Y" shape. Falls back to the raw string for
+    shapes it doesn't recognize (e.g. `<synthetic>`).
+    """
+    if not raw:
+        return "?"
+    stripped = _re.sub(r"-\d{8}$", "", raw)  # trailing -YYYYMMDD build stamp
+    m = _re.match(r"^claude-([a-z]+)-([\d-]+)$", stripped)
+    if m:
+        family, version = m.groups()
+        return f"{family.capitalize()} {version.replace('-', '.')}"
+    m = _re.match(r"^claude-([a-z]+)$", stripped)
+    if m:
+        return m.group(1).capitalize()
+    if _re.match(r"^[a-z]+$", stripped):
+        return stripped.capitalize()
+    return raw
+
+
+def _transcript_path_for(session_id: str, root: Path) -> str | None:
+    """Resolve a session id to its on-disk transcript path under `root`.
+
+    Same glob shape as the live statusline's `find_transcript` fallback, but
+    honors quickstart's own `--root` override instead of hardcoding
+    `~/.claude/projects` — quickstart already ingested from `root`, so the
+    preview must look in the same place.
+    """
+    pattern = str(root / "**" / f"{session_id}.jsonl")
+    hits = _glob.glob(pattern, recursive=True)
+    return hits[0] if hits else None
+
+
+class _PreviewCandidate:
+    """One timeline session's preview-selection scoring (see `_select_preview_session`)."""
+
+    __slots__ = ("session", "turns", "crossing")
+
+    def __init__(self, session: TimelineSession, turns: int,
+                 crossing: tuple[int, str | None, AssistantUsage] | None) -> None:
+        self.session = session
+        self.turns = turns
+        self.crossing = crossing
+
+
+def _walk_for_preview(path: str) -> tuple[int, tuple[int, str | None, AssistantUsage] | None]:
+    """Walk one transcript once: return `(total_turns, first_threshold_crossing)`.
+
+    `first_threshold_crossing` is `(turn_index, model, cumulative_usage)` for
+    the first turn whose cumulative re-read %% reaches the live statusline's
+    nudge threshold (`REREAD_WARN`), or None if the session never crosses it.
+    Reuses `core.usage.iter_cumulative_usage` — the exact cumulative walk the
+    live statusline's own numbers are built from — so this can't show a figure
+    the real statusline wouldn't have shown at that point. Never raises: an
+    unreadable transcript degrades to "no candidate" (0, None).
+    """
+    turns = 0
+    crossing: tuple[int, str | None, AssistantUsage] | None = None
+    try:
+        with open(path, encoding="utf-8", errors="replace") as fh:
+            for turn_index, model, usage in iter_cumulative_usage(fh):
+                turns = turn_index
+                if crossing is None:
+                    total = usage.total
+                    reread_pct = (100.0 * usage.cache_read_tokens / total) if total else 0.0
+                    if reread_pct >= REREAD_WARN:
+                        crossing = (turn_index, model, usage)
+    except Exception:
+        return 0, None
+    return turns, crossing
+
+
+def _select_preview_session(
+    timeline: SessionTimeline, root: Path,
+) -> _PreviewCandidate | None:
+    """Pick the session to preview: the most-recent substantial session that
+    crossed the nudge threshold; if none is substantial enough, the largest
+    (by turns) that still crossed it; if none ever crossed it, None.
+    """
+    candidates: list[_PreviewCandidate] = []
+    for session in timeline.sessions:  # already most-recent-first
+        path = _transcript_path_for(session.session_id, root)
+        if not path:
+            continue
+        turns, crossing = _walk_for_preview(path)
+        if crossing is not None:
+            candidates.append(_PreviewCandidate(session, turns, crossing))
+
+    if not candidates:
+        return None
+    substantial = [c for c in candidates if c.turns >= PREVIEW_MIN_TURNS]
+    if substantial:
+        return substantial[0]  # most-recent among the substantial ones
+    return max(candidates, key=lambda c: c.turns)
+
+
+def _render_statusline_preview(timeline: SessionTimeline, root: Path | None) -> None:
+    """"What you'd see live" preview section — self-contained; prints nothing
+    when there is no session to preview (no history, no readable transcript,
+    or no session ever crossed the nudge threshold)."""
+    if root is None or not timeline.sessions:
+        return
+
+    from rich.text import Text
+
+    picked = _select_preview_session(timeline, root)
+    if picked is None:
+        return
+
+    turn_index, model_raw, usage = picked.crossing
+    total = usage.total
+    reread_pct = (100.0 * usage.cache_read_tokens / total) if total else 0.0
+    line = format_status_line(_display_model_name(model_raw), total, reread_pct)
+
+    console.print()
+    intro = Text()
+    intro.append("With the statusline installed, ", style="dim")
+    intro.append(f"session {picked.session.session_id[:12]}", style="bold")
+    intro.append(f" would have shown this at turn {turn_index}:", style="dim")
+    console.print(intro)
+    console.print()
+    console.print(Text(f"  {line}", style="bold"))
+    console.print()
+    outro = Text()
+    outro.append("That's live, every turn, for zero model tokens — ", style="dim")
+    outro.append("tj onboard", style="bold cyan")
+    outro.append(" sets it up.", style="dim")
+    console.print(outro)
+    console.print()

--- a/tokenjam/cli/cmd_quickstart.py
+++ b/tokenjam/cli/cmd_quickstart.py
@@ -417,14 +417,20 @@ def _select_preview_session(
         if not path:
             continue
         turns, crossing = _walk_for_preview(path)
-        if crossing is not None:
-            candidates.append(_PreviewCandidate(session, turns, crossing))
+        if crossing is None:
+            continue
+        candidate = _PreviewCandidate(session, turns, crossing)
+        if turns >= PREVIEW_MIN_TURNS:
+            # Sessions are walked most-recent-first, so the first substantial
+            # crossing candidate IS the winner — stop here rather than
+            # re-reading the rest of a possibly-large (up to `--full`) history.
+            # The largest-by-turns fallback below only matters when NO
+            # candidate is substantial, a case this early return never hides.
+            return candidate
+        candidates.append(candidate)
 
     if not candidates:
         return None
-    substantial = [c for c in candidates if c.turns >= PREVIEW_MIN_TURNS]
-    if substantial:
-        return substantial[0]  # most-recent among the substantial ones
     return max(candidates, key=lambda c: c.turns)
 
 
@@ -440,6 +446,7 @@ def _render_statusline_preview(timeline: SessionTimeline, root: Path | None) -> 
     picked = _select_preview_session(timeline, root)
     if picked is None:
         return
+    assert picked.crossing is not None  # invariant: only crossing candidates are ever selected
 
     turn_index, model_raw, usage = picked.crossing
     total = usage.total

--- a/tokenjam/cli/cmd_statusline.py
+++ b/tokenjam/cli/cmd_statusline.py
@@ -94,6 +94,28 @@ def _badge_and_nudge(reread_pct: float) -> tuple[str, str | None]:
     return _BADGE_OK, None
 
 
+def format_status_line(
+    model_name: str, total: int | None, reread_pct: float | None
+) -> str:
+    """Build the statusline string from already-resolved figures.
+
+    Shared by the live line (``render_line``, fed the hook's per-turn payload)
+    and ``tj quickstart``'s "what you'd see live" preview section (fed a
+    point-in-time figure from a past transcript) — so the two surfaces render
+    IDENTICAL text for identical inputs and the preview can never drift from
+    the real product. ``total``/``reread_pct`` of ``None`` degrades to the
+    model-only segment (mirrors "no transcript" / "unreadable transcript").
+    """
+    parts = [f"◆ {model_name}"]  # ◆ model
+    if total is not None and reread_pct is not None:
+        parts.append(f"{format_tokens(total)} tok")
+        badge, nudge = _badge_and_nudge(reread_pct)
+        parts.append(f"{badge} re-read {reread_pct:.0f}%")
+        if nudge:
+            parts.append(nudge)
+    return "  ".join(parts)
+
+
 def render_line(data: dict) -> str:
     """Build the one-line statusline string from a parsed payload.
 
@@ -101,19 +123,15 @@ def render_line(data: dict) -> str:
     badge, and the compaction nudge only when a transcript is found and readable.
     Never raises — a transcript read failure degrades to the model-only line.
     """
-    parts = [f"◆ {_model_name(data)}"]  # ◆ model
+    model_name = _model_name(data)
     path = find_transcript(data)
-    if path:
-        try:
-            total, reread_pct = session_shares(path)
-        except Exception:
-            return "  ".join(parts)
-        parts.append(f"{format_tokens(total)} tok")
-        badge, nudge = _badge_and_nudge(reread_pct)
-        parts.append(f"{badge} re-read {reread_pct:.0f}%")
-        if nudge:
-            parts.append(nudge)
-    return "  ".join(parts)
+    if not path:
+        return format_status_line(model_name, None, None)
+    try:
+        total, reread_pct = session_shares(path)
+    except Exception:
+        return format_status_line(model_name, None, None)
+    return format_status_line(model_name, total, reread_pct)
 
 
 @click.command("statusline")

--- a/tokenjam/core/usage.py
+++ b/tokenjam/core/usage.py
@@ -65,12 +65,16 @@ def assistant_message_key(record: dict, msg: dict, line_no: int) -> str:
     return msg.get("id") or record.get("uuid") or str(line_no)
 
 
-def iter_assistant_usage(lines: Iterable[str]) -> Iterator[tuple[str, AssistantUsage]]:
-    """Yield ``(message_key, usage)`` for each assistant record carrying usage.
+def _iter_assistant_records(
+    lines: Iterable[str],
+) -> Iterator[tuple[dict, dict, int, AssistantUsage]]:
+    """Yield ``(record, msg, line_no, usage)`` for each billable assistant record.
 
-    Skips non-JSON lines, non-assistant records, and empty-usage records (no
-    cost contribution) — mirroring the filters ``core/backfill`` applies so both
-    paths see the same set of billable turns.
+    Skips non-JSON lines, non-assistant records, and empty/zero-usage records
+    (no cost contribution) — mirroring the filters ``core/backfill`` applies so
+    all readers see the same set of billable turns. Shared by
+    ``iter_assistant_usage`` and ``iter_assistant_turns`` so the two can never
+    disagree on which records count as a turn.
     """
     for line_no, line in enumerate(lines, start=1):
         try:
@@ -87,7 +91,67 @@ def iter_assistant_usage(lines: Iterable[str]) -> Iterator[tuple[str, AssistantU
         usage = parse_usage(msg.get("usage"))
         if usage.total == 0:
             continue
+        yield record, msg, line_no, usage
+
+
+def iter_assistant_usage(lines: Iterable[str]) -> Iterator[tuple[str, AssistantUsage]]:
+    """Yield ``(message_key, usage)`` for each assistant record carrying usage."""
+    for record, msg, line_no, usage in _iter_assistant_records(lines):
         yield assistant_message_key(record, msg, line_no), usage
+
+
+def iter_assistant_turns(
+    lines: Iterable[str],
+) -> Iterator[tuple[str, str | None, AssistantUsage]]:
+    """Yield ``(message_key, model, usage)`` for each assistant record carrying usage.
+
+    Same record + key as ``iter_assistant_usage`` but also surfaces the raw
+    ``model`` id Claude Code stamped on that record. Needed by point-in-time
+    previews (e.g. ``tj quickstart``'s "what you'd see live" section) that show
+    the model in effect at a specific turn, not just the session aggregate.
+    """
+    for record, msg, line_no, usage in _iter_assistant_records(lines):
+        yield assistant_message_key(record, msg, line_no), msg.get("model"), usage
+
+
+def iter_cumulative_usage(
+    lines: Iterable[str],
+) -> Iterator[tuple[int, str | None, AssistantUsage]]:
+    """Yield ``(turn_index, model, cumulative_usage)`` after each assistant turn.
+
+    ``turn_index`` is the 1-based count of distinct assistant turns seen so far
+    (after last-wins dedup); ``model`` is the raw model id on the record that
+    produced this yield; ``cumulative_usage`` is the running last-wins-deduped
+    total through that turn. The final yielded ``cumulative_usage`` always
+    equals ``session_usage`` over the same lines — same dedup key + last-wins
+    policy, just surfaced incrementally.
+
+    Powers point-in-time previews (``tj quickstart``'s "what you'd have seen
+    live" section) that need the statusline's numbers as they stood mid-session,
+    not only the final total.
+    """
+    latest: dict[str, AssistantUsage] = {}
+    running = AssistantUsage()
+    turn_index = 0
+    for key, model, usage in iter_assistant_turns(lines):
+        prev = latest.get(key)
+        if prev is None:
+            turn_index += 1
+            running = AssistantUsage(
+                running.input_tokens + usage.input_tokens,
+                running.output_tokens + usage.output_tokens,
+                running.cache_read_tokens + usage.cache_read_tokens,
+                running.cache_write_tokens + usage.cache_write_tokens,
+            )
+        else:
+            running = AssistantUsage(
+                running.input_tokens - prev.input_tokens + usage.input_tokens,
+                running.output_tokens - prev.output_tokens + usage.output_tokens,
+                running.cache_read_tokens - prev.cache_read_tokens + usage.cache_read_tokens,
+                running.cache_write_tokens - prev.cache_write_tokens + usage.cache_write_tokens,
+            )
+        latest[key] = usage
+        yield turn_index, model, running
 
 
 def session_usage(lines: Iterable[str]) -> AssistantUsage:


### PR DESCRIPTION
## Summary

Adds a "what you'd see live" statusline preview section to `tj quickstart` — the zero-install first touch that reads `~/.claude/projects/*.jsonl`. For the user's own most-recent *substantial* session, it renders the exact `tj statusline` line that would have appeared at the turn cumulative re-read share first crossed the nudge threshold, then ties it to `tj onboard`.

- Reuses the real statusline rendering code, not a re-derivation: `cmd_statusline.render_line` is refactored into a shared `format_status_line(model_name, total, reread_pct)`, so the preview and the live statusline can never render different text for the same figures.
- Added `core/usage.iter_assistant_turns` (usage + raw model per record) and `core/usage.iter_cumulative_usage` (running last-wins cumulative totals per turn), both built on a new shared `_iter_assistant_records` filter. `iter_assistant_usage`'s existing 2-tuple contract and its tests are untouched.
- Session selection: most-recent session with `>= PREVIEW_MIN_TURNS` (20) turns that crosses the re-read nudge threshold; if none is "substantial" enough, falls back to the largest (by turns) session that still crosses it; if no session ever crosses, the section is omitted silently.
- Forward-looking framing only — this previews the *live* product; it does not imply the (ended) session shown is actionable now.
- Zero new dependencies; matches the existing Rich-rendering style in `cmd_quickstart.py`.

### Rendered output (real run against my own `~/.claude/projects`)

```
╭─ Where your quota goes ──────────────────────────────────────────────────────╮
│                                                                              │
│  Quota composition  ·  61 sessions, 8880 turns (most-recent 300)             │
│  ...                                                                        │
╰──────────────────────────────────────────────────────────────────────────────╯

With the statusline installed, session 4794cf75-4bd would have shown this at 
turn 5:

  ◆ Fable 5  906.9k tok  ⚠ re-read 70%  → consider /compact

That's live, every turn, for zero model tokens — tj onboard sets it up.

Session timeline (most recent)
...
```

### Merge order

Another concurrent branch is concurrently editing the SAME `_render` function in `cmd_quickstart.py` — fixing the quota-composition headline math and deleting the "Biggest reclaim opportunities" section. This PR does not touch that code (composition box / compact-candidates section); the new preview is a self-contained addition placed between the composition panel and the session timeline. **that branch's PR is expected to merge first** — this branch will need a rebase afterward.

## Test plan

- [x] `make test` (full suite: unit + synthetic + agents + integration) — 2175 passed, 1 skipped, 0 failed
- [x] `ruff check tokenjam/` — clean
- [x] `mypy tokenjam/cli/cmd_quickstart.py tokenjam/cli/cmd_statusline.py tokenjam/core/usage.py` — clean
- [x] New unit tests:
  - `tests/unit/test_usage.py`: `iter_assistant_turns` (model surfaced, same filter as `iter_assistant_usage`), `iter_cumulative_usage` (accumulates across turns, growing snapshot doesn't advance turn count, final cumulative total matches `session_usage`)
  - `tests/unit/test_statusline.py`: `format_status_line` degrades to model-only with no figures; byte-identical output to `render_line` for the same inputs (formatter-reuse guarantee)
  - `tests/unit/test_quickstart.py`: preview picks the most-recent *substantial* crossing session over an older-but-bigger one; falls back to the largest crossing session when none is substantial; omits the section when no session ever crosses the threshold; omits when there are no sessions at all; asserts the rendered line is byte-identical to `format_status_line`'s own output for the crossing turn's figures
- [x] Eyeballed real output via `CliRunner` against my own `~/.claude/projects` (pasted above)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

