### PR TITLE
fix(uninstall): remove claude() shell wrapper + unwire output_cap hook (#117)

### DIFF
--- a/tests/unit/test_uninstall_wrapper.py
+++ b/tests/unit/test_uninstall_wrapper.py
@@ -1,0 +1,140 @@
+"""Tests for #117: `tj uninstall` must remove the `claude()` shell wrapper
+that `tj onboard --claude-code` installs (and unwire the opt-in output-cap
+PostToolUse hook alongside it).
+
+Two layers:
+  - `_unwire_claude_wrapper()` in cmd_onboard.py — the counterpart to
+    `_install_claude_wrapper()` that `tj uninstall` was previously missing
+    entirely, leaving a `claude()` function that calls `tj` (and errors)
+    after the package is uninstalled.
+  - the `cmd_uninstall` CLI path end-to-end: seed a fixture ~/.zshrc with
+    both onboard-written blocks (harness observability + the wrapper), run
+    uninstall, and assert no `tj ` references or `claude()` function remain.
+"""
+from __future__ import annotations
+
+import json
+from unittest.mock import MagicMock, patch
+
+import pytest
+from click.testing import CliRunner
+
+from tokenjam.cli import cmd_onboard as onboard_mod
+from tokenjam.cli import cmd_uninstall as uninstall_mod
+from tokenjam.cli.cmd_onboard import (
+    _WRAPPER_END_MARKER,
+    _WRAPPER_MARKER,
+    _install_claude_wrapper,
+    _unwire_claude_wrapper,
+    _wire_claude_output_cap_hook,
+)
+from tokenjam.cli.cmd_uninstall import cmd_uninstall
+
+
+@pytest.fixture
+def fake_home(tmp_path, monkeypatch):
+    home = tmp_path / "home"
+    home.mkdir()
+    monkeypatch.setattr(onboard_mod.Path, "home", lambda: home)
+    return home
+
+
+def test_unwire_removes_block_written_by_install(fake_home):
+    _install_claude_wrapper()
+    zshrc = fake_home / ".zshrc"
+    assert _WRAPPER_MARKER in zshrc.read_text()
+
+    removed = _unwire_claude_wrapper()
+    assert str(zshrc) in removed
+
+    cleaned = zshrc.read_text()
+    assert _WRAPPER_MARKER not in cleaned
+    assert _WRAPPER_END_MARKER not in cleaned
+    assert "claude()" not in cleaned
+    assert "tj " not in cleaned
+
+
+def test_unwire_also_cleans_bashrc_when_present(fake_home):
+    (fake_home / ".bashrc").write_text("# pre-existing bashrc content\n")
+    _install_claude_wrapper()
+    assert _WRAPPER_MARKER in (fake_home / ".bashrc").read_text()
+
+    removed = _unwire_claude_wrapper()
+    assert str(fake_home / ".bashrc") in removed
+    cleaned = (fake_home / ".bashrc").read_text()
+    assert _WRAPPER_MARKER not in cleaned
+    assert "pre-existing bashrc content" in cleaned
+
+
+def test_unwire_is_idempotent_noop_when_absent(fake_home):
+    (fake_home / ".zshrc").write_text("echo hi\n")
+    assert _unwire_claude_wrapper() == []
+    assert (fake_home / ".zshrc").read_text() == "echo hi\n"
+
+
+def test_unwire_preserves_surrounding_content(fake_home):
+    zshrc = fake_home / ".zshrc"
+    zshrc.write_text("export FOO=bar\nalias ll='ls -la'\n")
+    _install_claude_wrapper()
+    with zshrc.open("a") as f:
+        f.write("\nexport AFTER=1\n")
+
+    _unwire_claude_wrapper()
+    cleaned = zshrc.read_text()
+    assert "export FOO=bar" in cleaned
+    assert "alias ll='ls -la'" in cleaned
+    assert "export AFTER=1" in cleaned
+    assert _WRAPPER_MARKER not in cleaned
+
+
+_OTEL_ZSHRC_BLOCK = (
+    "\n# tj harness observability\n"
+    "export CLAUDE_CODE_ENABLE_TELEMETRY=1\n"
+    "export OTEL_LOGS_EXPORTER=otlp\n"
+    "export OTEL_EXPORTER_OTLP_PROTOCOL=http/json\n"
+    "export OTEL_EXPORTER_OTLP_ENDPOINT=http://host.docker.internal:7391\n"
+    'export OTEL_EXPORTER_OTLP_HEADERS="Authorization=Bearer deadbeef"\n'
+)
+
+
+def test_uninstall_cli_removes_wrapper_and_cap_hook(tmp_path, monkeypatch):
+    home = tmp_path / "home"
+    home.mkdir()
+    monkeypatch.setenv("COLUMNS", "200")
+    monkeypatch.setattr("pathlib.Path.home", lambda: home)
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setattr("tokenjam.cli.cmd_stop.cmd_stop", MagicMock())
+
+    # Seed a fixture ~/.zshrc as `tj onboard --claude-code` would leave it:
+    # the OTEL harness-observability block, then the claude() wrapper.
+    (home / ".zshrc").write_text(_OTEL_ZSHRC_BLOCK)
+    _install_claude_wrapper()
+
+    # Simulate the opt-in output-cap PostToolUse hook also being wired.
+    claude_dir = home / ".claude"
+    claude_dir.mkdir(parents=True, exist_ok=True)
+    settings_path = claude_dir / "settings.json"
+    settings: dict = {}
+    _wire_claude_output_cap_hook(settings)
+    settings_path.write_text(json.dumps(settings, indent=2) + "\n")
+
+    zshrc_before = (home / ".zshrc").read_text()
+    assert "claude()" in zshrc_before
+    assert "tj " in zshrc_before
+
+    runner = CliRunner()
+    with patch.object(uninstall_mod.shutil, "which", return_value=None):
+        result = runner.invoke(cmd_uninstall, ["--yes"])
+    assert result.exit_code == 0, result.output
+
+    zshrc_after = (home / ".zshrc").read_text()
+    assert "claude()" not in zshrc_after
+    assert "tj " not in zshrc_after
+
+    settings_after = json.loads(settings_path.read_text())
+    post = settings_after.get("hooks", {}).get("PostToolUse", [])
+    assert not any(
+        "hook cap-output" in str(h)
+        for entry in post
+        for h in entry.get("hooks", [])
+    )

--- a/tokenjam/cli/cmd_onboard.py
+++ b/tokenjam/cli/cmd_onboard.py
@@ -2293,6 +2293,41 @@ def _install_claude_wrapper() -> list[str]:
     return written
 
 
+def _unwire_claude_wrapper() -> list[str]:
+    """Remove the ``claude`` shell-wrapper block from the user's shell rc files.
+
+    The counterpart to ``_install_claude_wrapper()`` — strips the exact
+    ``_WRAPPER_MARKER`` .. ``_WRAPPER_END_MARKER`` block (marker-delimited,
+    not a fragile regex on the body, so it can't accidentally eat unrelated
+    rc content) from ``~/.zshrc`` and ``~/.bashrc`` (whichever exist).
+    Idempotent — a no-op when the block is absent. Used by ``tj uninstall``
+    (#117: uninstall previously left this wrapper behind, breaking every
+    subsequent ``claude`` launch once the tj package was removed).
+
+    Returns the list of rc files that were actually modified.
+    """
+    import re as _re
+
+    removed: list[str] = []
+    for rc in (Path.home() / ".zshrc", Path.home() / ".bashrc"):
+        if not rc.exists():
+            continue
+        text = rc.read_text()
+        if _WRAPPER_MARKER not in text:
+            continue
+        updated = _re.sub(
+            _re.escape(_WRAPPER_MARKER) + r".*?" + _re.escape(_WRAPPER_END_MARKER) + r"\n",
+            "",
+            text,
+            flags=_re.DOTALL,
+        )
+        if updated != text:
+            rc.write_text(updated)
+            removed.append(str(rc))
+
+    return removed
+
+
 def _derive_project_name() -> str:
     """
     Derive a meaningful project name for the agent ID.

--- a/tokenjam/cli/cmd_uninstall.py
+++ b/tokenjam/cli/cmd_uninstall.py
@@ -164,16 +164,23 @@ def cmd_uninstall(ctx: click.Context, yes: bool, remove_package: bool) -> None:
                 del env[k]
             if removed:
                 gs["env"] = env
-            # Remove the tj-managed SessionStart resume-brief hook (idempotent,
-            # non-destructive — foreign SessionStart hooks are preserved).
-            from tokenjam.cli.cmd_onboard import _unwire_claude_resume_brief_hook
+            # Remove the tj-managed SessionStart resume-brief hook and the
+            # opt-in PostToolUse output-cap hook (both idempotent,
+            # non-destructive — foreign hooks of either kind are preserved).
+            from tokenjam.cli.cmd_onboard import (
+                _unwire_claude_output_cap_hook,
+                _unwire_claude_resume_brief_hook,
+            )
             hook_removed = _unwire_claude_resume_brief_hook(gs)
-            if removed or hook_removed:
+            cap_removed = _unwire_claude_output_cap_hook(gs)
+            if removed or hook_removed or cap_removed:
                 global_settings_path.write_text(json.dumps(gs, indent=2) + "\n")
             if removed:
                 console.print(f"  Cleaned {len(removed)} TokenJam env vars from {global_settings_path}")
             if hook_removed:
                 console.print(f"  Removed tj resume-brief SessionStart hook from {global_settings_path}")
+            if cap_removed:
+                console.print(f"  Removed tj output-cap PostToolUse hook from {global_settings_path}")
         except Exception as exc:
             console.print(f"  [yellow]Could not clean {global_settings_path}: {exc}[/yellow]")
 
@@ -215,6 +222,19 @@ def cmd_uninstall(ctx: click.Context, yes: bool, remove_package: bool) -> None:
                 console.print(f"  Removed TokenJam env block from {zshrc}")
         except Exception as exc:
             console.print(f"  [yellow]Could not clean {zshrc}: {exc}[/yellow]")
+
+    # Remove the `claude()` shell wrapper (`# tj per-terminal naming` ..
+    # `# end tj per-terminal naming`) from ~/.zshrc / ~/.bashrc. This is the
+    # counterpart to `_install_claude_wrapper()` in cmd_onboard.py — without
+    # it, a leftover `claude()` function calls `tj` on every launch, which
+    # errors once the package is removed (#117).
+    from tokenjam.cli.cmd_onboard import _unwire_claude_wrapper
+    try:
+        wrapper_removed = _unwire_claude_wrapper()
+        for rc_path in wrapper_removed:
+            console.print(f"  Removed claude() shell wrapper from {rc_path}")
+    except Exception as exc:
+        console.print(f"  [yellow]Could not clean claude() shell wrapper: {exc}[/yellow]")
 
     console.print()
     console.print("[green]TokenJam data, config, and wiring removed.[/green]")


### PR DESCRIPTION
## Summary

`tj onboard --claude-code` writes TWO things into `~/.zshrc`: (1) a `# tj harness observability` OTEL export block, and (2) a `# tj per-terminal naming` … `# end tj per-terminal naming` block defining a `claude()` shell function that calls `tj otel-resource-attrs` and `tj session-end`. `tj uninstall` removed block (1) but had NO code path removing block (2) — so after `tj uninstall` + `pip uninstall tokenjam`, the leftover `claude()` function errors (`tj: command not found`) on every `claude` launch.

- Added `_unwire_claude_wrapper()` in `cmd_onboard.py` — the counterpart to `_install_claude_wrapper()`. Removes the `# tj per-terminal naming` … `# end tj per-terminal naming` block from `~/.zshrc` / `~/.bashrc` via exact marker-delimited removal (not a fragile regex on the block body), idempotent, preserves everything else.
- Wired `_unwire_claude_wrapper()` into `cmd_uninstall.py`.
- Also wired in the existing-but-never-called `_unwire_claude_output_cap_hook()` so an opted-in PostToolUse cap hook is cleaned up on uninstall too.
- Left the OTEL-export block's marker-matching logic untouched (owned by #118).

## Test plan

- [x] New unit tests in `tests/unit/test_uninstall_wrapper.py`: `_unwire_claude_wrapper()` removes the block written by `_install_claude_wrapper()`, cleans `.bashrc` when present, is idempotent/no-op when absent, preserves surrounding rc content, and an end-to-end `cmd_uninstall` CLI test (fixture `~/.zshrc` with both onboard-written blocks + a wired cap-output hook) asserting no `tj ` references or `claude()` function remain after uninstall.
- [x] `python3 -m pytest tests/unit/ -k "uninstall or onboard or wrapper" -q` → `144 passed, 1498 deselected`
- [x] `python3 -m pytest tests/unit/ -q` → `1641 passed, 1 skipped`
- [x] `python3 -m pytest tests/integration/test_cli_uninstall.py tests/integration/test_cli.py -q` → `85 passed`
- [x] `ruff check` clean on changed files

**Merge order**: Part of the CC install/remove cluster — merge #117 → #118 → #121; this is #117 (foundation, merge first).

🤖 Generated with [Claude Code](https://claude.com/claude-code)