### PR TITLE
feat(uninstall): consented --purge package removal + runner-aware hint (#121)

### DIFF
--- a/docs/claude-code-integration.md
+++ b/docs/claude-code-integration.md
@@ -111,15 +111,15 @@ investigation.
 
 ## Uninstalling
 
-```bash
-# Remove all TokenJam data, config, daemon, MCP registration, and env vars from every onboarded project:
-tj uninstall --yes
+Set up and remove are a symmetric one-command pair:
 
-# Then remove the package itself (tj uninstall intentionally skips this):
-pip uninstall tokenjam -y
+```bash
+npx tokenjam onboard --claude-code   # one paste to set up
+npx tokenjam uninstall [--purge]     # one paste to remove
 ```
 
-`tj uninstall` cleans up everything set by `tj onboard --claude-code`:
+`npx tokenjam uninstall` (equivalently `tj uninstall` if you have a persistent install on PATH) cleans
+up everything set by `tj onboard --claude-code`:
 - Stops and removes the background daemon (launchd/systemd)
 - Deregisters the MCP server from Claude Code
 - Deletes `~/.tj/` (telemetry database)
@@ -127,3 +127,19 @@ pip uninstall tokenjam -y
 - Removes OTLP env vars from `~/.claude/settings.json`
 - Removes `OTEL_RESOURCE_ATTRIBUTES` from `.claude/settings.json` in every onboarded project
 - Removes the harness env block from `~/.zshrc`
+
+That cleans up onboarding's side effects, but leaves the `tokenjam` package itself installed — pass
+`--purge` to remove it too (or answer "y" to the prompt `tj uninstall` shows when run interactively
+without `--yes`):
+
+```bash
+npx tokenjam uninstall --purge --yes
+```
+
+`--purge` detects how you installed and runs the matching removal command — `pipx uninstall tokenjam`
+or `uv tool uninstall tokenjam` are run automatically (both are isolated, canonical install paths); a
+plain `pip`/venv install instead prints the exact `pip uninstall tokenjam` command to run yourself
+(guessing the wrong environment is worse than a copy-paste). If you're running via an **ephemeral**
+runner — `npx tokenjam`'s default `uvx`/`pipx run` fallback, or `uvx tokenjam uninstall` directly —
+there's no persistent package to remove in the first place, so `--purge` is a safe no-op that says so;
+the onboarding side-effects above are still fully cleaned either way.

--- a/tests/integration/test_cli_uninstall.py
+++ b/tests/integration/test_cli_uninstall.py
@@ -95,7 +95,7 @@ def test_remove_package_flag_non_pipx_prints_command(runner):
     assert result.exit_code == 0, result.output
     # Only cmd_stop (mocked) — no pipx/pip uninstall subprocess fired.
     run.assert_not_called()
-    assert "not a pipx-managed venv" in result.output
+    assert "not a pipx- or uv-tool-managed venv" in result.output
     assert "pip uninstall tokenjam" in result.output
 
 
@@ -120,6 +120,60 @@ def test_prompt_wording_matches_install_type(runner):
     with patch.object(uninstall_mod, "_installed_via_pipx", return_value=False):
         res_pip = runner.invoke(cmd_uninstall, [], input="y\nn\n")
     assert "prints pip uninstall tokenjam" in res_pip.output
+
+
+def test_remove_package_flag_runs_uv_tool(runner):
+    """--purge (alias for --remove-package) on a uv-tool install runs
+    `uv tool uninstall tokenjam` (#121)."""
+    fake = MagicMock(returncode=0, stdout="", stderr="")
+    with patch.object(uninstall_mod, "_installed_via_pipx", return_value=False), \
+         patch.object(uninstall_mod, "_installed_via_uv_tool", return_value=True), \
+         patch.object(uninstall_mod.shutil, "which", side_effect=lambda c: "/usr/bin/uv" if c == "uv" else None), \
+         patch.object(uninstall_mod.subprocess, "run", return_value=fake) as run:
+        result = _run(runner, "--purge")
+    assert result.exit_code == 0, result.output
+    run.assert_called_once_with(
+        ["uv", "tool", "uninstall", "tokenjam"], capture_output=True, text=True
+    )
+    assert "tokenjam package removed" in result.output
+    assert "uv tool install tokenjam" in result.output
+    assert "uv tool upgrade" not in result.output
+
+
+def test_uv_tool_reinstall_hint(runner):
+    """Non-pipx, uv-tool install: hint is `uv tool uninstall` + `uv tool
+    upgrade` (#121)."""
+    with patch.object(uninstall_mod, "_installed_via_pipx", return_value=False), \
+         patch.object(uninstall_mod, "_installed_via_uv_tool", return_value=True):
+        result = _run(runner)
+    assert result.exit_code == 0, result.output
+    assert "uv tool uninstall tokenjam" in result.output
+    assert "uv tool upgrade tokenjam" in result.output
+
+
+def test_purge_is_noop_on_ephemeral_runner(runner):
+    """`--purge` on an ephemeral runner (uvx/pipx run — no persistent
+    install) must not attempt any removal; it explains why and exits clean
+    (#121)."""
+    with patch.object(uninstall_mod, "_is_ephemeral_runner", return_value=True), \
+         patch.object(uninstall_mod.subprocess, "run") as run:
+        result = _run(runner, "--purge")
+    assert result.exit_code == 0, result.output
+    run.assert_not_called()
+    assert "no persistent" in result.output.lower() or "nothing persistent" in result.output.lower()
+    assert "--purge is a no-op here" in result.output
+    # The (inapplicable) "package still installed" two-step must not print.
+    assert "package itself is still installed" not in result.output
+
+
+def test_no_purge_prompt_on_ephemeral_runner(runner):
+    """Without --purge/--yes, an ephemeral runner must not ask to remove a
+    package that was never persistently installed (#121)."""
+    with patch.object(uninstall_mod, "_is_ephemeral_runner", return_value=True):
+        result = runner.invoke(cmd_uninstall, [], input="y\n")
+    assert result.exit_code == 0, result.output
+    assert "Also remove the tokenjam package now?" not in result.output
+    assert "nothing persistent to remove" in result.output.lower()
 
 
 def test_pipx_uninstall_failure_falls_back_to_manual(runner):

--- a/tests/unit/test_uninstall_runner_detect.py
+++ b/tests/unit/test_uninstall_runner_detect.py
@@ -1,0 +1,87 @@
+"""Runner detection -> package-removal command mapping for `tj uninstall`
+(#121): pipx vs `uv tool` vs plain pip vs an ephemeral runner (uvx/pipx run)
+with nothing persistent to remove.
+
+Paths below were verified empirically against real `uv`/`pipx` installs:
+  - `uv tool install <pkg>` venv:  .../uv/tools/<pkg>/bin/python
+  - `uvx --from <pkg> ...` venv:   .../uv/archive-v0/<hash>/bin/python
+  - `pipx install <pkg>` venv:     .../pipx/venvs/<pkg>/bin/python
+  - `pipx run --spec <pkg> ...`:   delegates to uv when present (same as
+    uvx above), else falls back to .../pipx/.cache/<hash>/bin/python
+"""
+from __future__ import annotations
+
+from unittest.mock import patch
+
+from tokenjam.cli import cmd_uninstall as uninstall_mod
+
+
+def _exe(path: str):
+    return patch.object(uninstall_mod.sys, "executable", path)
+
+
+# --- persistent installs: detected, NOT ephemeral ---------------------------
+
+
+def test_pipx_venv_detected_as_pipx_not_ephemeral():
+    with _exe("/Users/x/.local/share/pipx/venvs/tokenjam/bin/python"):
+        assert uninstall_mod._installed_via_pipx() is True
+        assert uninstall_mod._installed_via_uv_tool() is False
+        assert uninstall_mod._is_ephemeral_runner() is False
+
+
+def test_uv_tool_venv_detected_as_uv_tool_not_ephemeral():
+    with _exe("/Users/x/.local/share/uv/tools/tokenjam/bin/python"):
+        assert uninstall_mod._installed_via_uv_tool() is True
+        assert uninstall_mod._installed_via_pipx() is False
+        assert uninstall_mod._is_ephemeral_runner() is False
+
+
+def test_plain_pip_venv_is_neither_pipx_uv_tool_nor_ephemeral():
+    with _exe("/usr/local/bin/python3"):
+        assert uninstall_mod._installed_via_pipx() is False
+        assert uninstall_mod._installed_via_uv_tool() is False
+        assert uninstall_mod._is_ephemeral_runner() is False
+
+
+# --- ephemeral runners: ephemeral, NOT a persistent install ------------------
+
+
+def test_uvx_cache_venv_detected_as_ephemeral():
+    with _exe("/Users/x/.cache/uv/archive-v0/abc123/bin/python"):
+        assert uninstall_mod._is_ephemeral_runner() is True
+        assert uninstall_mod._installed_via_pipx() is False
+        assert uninstall_mod._installed_via_uv_tool() is False
+
+
+def test_pipx_run_cache_venv_detected_as_ephemeral():
+    with _exe("/Users/x/.local/pipx/.cache/abc123/bin/python"):
+        assert uninstall_mod._is_ephemeral_runner() is True
+        assert uninstall_mod._installed_via_pipx() is False
+
+
+# --- command mapping: uninstall / reinstall / fresh-install hints -----------
+
+
+def test_command_hints_for_pipx():
+    with patch.object(uninstall_mod, "_installed_via_pipx", return_value=True), \
+         patch.object(uninstall_mod, "_installed_via_uv_tool", return_value=False):
+        assert uninstall_mod._package_uninstall_hint() == "pipx uninstall tokenjam"
+        assert "pipx upgrade tokenjam" in uninstall_mod._package_reinstall_hint()
+        assert uninstall_mod._package_fresh_install_hint() == "pipx install tokenjam"
+
+
+def test_command_hints_for_uv_tool():
+    with patch.object(uninstall_mod, "_installed_via_pipx", return_value=False), \
+         patch.object(uninstall_mod, "_installed_via_uv_tool", return_value=True):
+        assert uninstall_mod._package_uninstall_hint() == "uv tool uninstall tokenjam"
+        assert "uv tool upgrade tokenjam" in uninstall_mod._package_reinstall_hint()
+        assert uninstall_mod._package_fresh_install_hint() == "uv tool install tokenjam"
+
+
+def test_command_hints_for_plain_pip():
+    with patch.object(uninstall_mod, "_installed_via_pipx", return_value=False), \
+         patch.object(uninstall_mod, "_installed_via_uv_tool", return_value=False):
+        assert uninstall_mod._package_uninstall_hint() == "pip uninstall tokenjam"
+        assert uninstall_mod._package_reinstall_hint() == "pip install --upgrade tokenjam"
+        assert uninstall_mod._package_fresh_install_hint() == "pip install tokenjam"

--- a/tokenjam/cli/cmd_uninstall.py
+++ b/tokenjam/cli/cmd_uninstall.py
@@ -21,51 +21,93 @@ def _installed_via_pipx() -> bool:
     return "pipx/venvs/" in sys.executable.replace("\\", "/")
 
 
+def _installed_via_uv_tool() -> bool:
+    """True when this tj lives in a `uv tool install`-managed venv.
+
+    A persistent uv tool install lives at .../uv/tools/tokenjam/... (verified:
+    `uv tool install cowsay` puts its venv at ~/.local/share/uv/tools/cowsay/).
+    That's distinct from the ephemeral venvs `uvx`/`uv tool run` spin up, which
+    live under uv's *cache* dir instead — see `_is_ephemeral_runner()`.
+    """
+    return "/uv/tools/" in sys.executable.replace("\\", "/")
+
+
+def _is_ephemeral_runner() -> bool:
+    """True when this process is a throwaway venv from `uvx`/`uv tool run` or
+    `pipx run` — there is no persistent tokenjam install to purge.
+
+    Verified empirically: `uvx --from tokenjam tj ...` materializes its venv
+    under uv's cache dir (.../uv/archive-v0/<hash>/...), never under
+    .../uv/tools/. `pipx run` lands in the same place when pipx delegates to
+    uv (its default backend whenever uv is on PATH); pipx's own non-uv
+    fallback instead uses its run-cache at .../pipx/.cache/<hash>/.
+    """
+    if _installed_via_pipx() or _installed_via_uv_tool():
+        return False
+    exe = sys.executable.replace("\\", "/")
+    return "/uv/" in exe or "/pipx/.cache/" in exe
+
+
 def _package_uninstall_hint() -> str:
     """Return the right uninstall command for how the user installed.
 
-    pipx is the canonical install path (per README and docs/installation.md);
-    otherwise fall back to `pip uninstall` for venv / pip installs.
+    pipx and `uv tool` are both isolated, canonical install paths (per
+    README and docs/installation.md); otherwise fall back to `pip uninstall`
+    for venv / pip installs.
     """
-    return "pipx uninstall tokenjam" if _installed_via_pipx() else "pip uninstall tokenjam"
+    if _installed_via_pipx():
+        return "pipx uninstall tokenjam"
+    if _installed_via_uv_tool():
+        return "uv tool uninstall tokenjam"
+    return "pip uninstall tokenjam"
 
 
 def _package_reinstall_hint() -> str:
     """Return the command that actually reinstalls FRESH.
 
-    A plain `pipx install tokenjam` / `pip install tokenjam` no-ops when the
-    package is already present — the source of the confusing "fresh install"
-    that silently does nothing. Point pipx users at `pipx upgrade` (or
-    `pipx install --force`) and pip users at `pip install --upgrade`.
+    A plain `pipx install tokenjam` / `uv tool install tokenjam` /
+    `pip install tokenjam` no-ops when the package is already present — the
+    source of the confusing "fresh install" that silently does nothing. Point
+    pipx users at `pipx upgrade` (or `pipx install --force`), uv tool users at
+    `uv tool upgrade` (or `uv tool install --force`), and pip users at
+    `pip install --upgrade`.
     """
     if _installed_via_pipx():
         return "pipx upgrade tokenjam  (or: pipx install --force tokenjam)"
+    if _installed_via_uv_tool():
+        return "uv tool upgrade tokenjam  (or: uv tool install --force tokenjam)"
     return "pip install --upgrade tokenjam"
 
 
 def _package_fresh_install_hint() -> str:
     """Return the command that reinstalls after the package was fully removed.
 
-    Once the venv is gone, `pipx upgrade tokenjam` fails ("not installed") — the
-    right command is the plain `pipx install tokenjam` (a fresh install, no venv
-    to upgrade). This is distinct from `_package_reinstall_hint()`, which is only
-    correct while the package REMAINS in place (a plain install would no-op then,
-    so it points at upgrade/--force).
+    Once the venv is gone, `pipx upgrade` / `uv tool upgrade` fail ("not
+    installed") — the right command is the plain install form (a fresh
+    install, no venv to upgrade). This is distinct from
+    `_package_reinstall_hint()`, which is only correct while the package
+    REMAINS in place (a plain install would no-op then, so it points at
+    upgrade/--force).
     """
-    return (
-        "pipx install tokenjam" if _installed_via_pipx()
-        else "pip install tokenjam"
-    )
+    if _installed_via_pipx():
+        return "pipx install tokenjam"
+    if _installed_via_uv_tool():
+        return "uv tool install tokenjam"
+    return "pip install tokenjam"
 
 
 @click.command("uninstall")
 @click.option("--yes", is_flag=True, help="Skip confirmation prompt")
 @click.option(
+    "--purge",
     "--remove-package",
+    "remove_package",
     is_flag=True,
     help="Also remove the tokenjam package: runs the uninstall for "
-    "pipx-managed installs, or prints the command to run for pip/venv "
-    "installs. With --yes, proceeds without a second prompt.",
+    "pipx- or uv-tool-managed installs, or prints the command to run for "
+    "pip/venv installs. A no-op (with an explanation) when running from an "
+    "ephemeral runner (uvx/pipx run) — there's nothing persistent to "
+    "remove. With --yes, proceeds without a second prompt.",
 )
 @click.pass_context
 def cmd_uninstall(ctx: click.Context, yes: bool, remove_package: bool) -> None:
@@ -218,17 +260,34 @@ def cmd_uninstall(ctx: click.Context, yes: bool, remove_package: bool) -> None:
 
     console.print()
     console.print("[green]TokenJam data, config, and wiring removed.[/green]")
+
+    # 12. Package removal (#121). `npx tokenjam uninstall` is meant to be the
+    # single symmetric counterpart to `npx tokenjam onboard` — but an
+    # ephemeral runner (uvx/pipx run, incl. via the npx wrapper) has no
+    # persistent package to remove in the first place. Detect that first so
+    # --purge / the prompt never offer to remove something that isn't there.
+    if _is_ephemeral_runner():
+        console.print(
+            "[dim]Running via an ephemeral runner (uvx/pipx run) — "
+            "nothing persistent to remove; onboarding side-effects above are "
+            "already cleaned.[/dim]"
+        )
+        if remove_package:
+            console.print("[dim]--purge is a no-op here.[/dim]")
+        return
+
     console.print("[dim]The tokenjam package itself is still installed.[/dim]")
 
-    # 12. Optionally remove the package too (safe, opt-in, default No).
     uninstall_cmd = _package_uninstall_hint()
     do_remove = remove_package
     if not do_remove and not yes:
-        # pipx installs are auto-run; pip/venv installs only get the command
-        # printed (a wrong `pip uninstall` in the wrong env is worse), so word
-        # the prompt to match what will actually happen (#430).
+        # pipx/uv-tool installs are auto-run; pip/venv installs only get the
+        # command printed (a wrong `pip uninstall` in the wrong env is
+        # worse), so word the prompt to match what will actually happen
+        # (#430).
         prompt_action = (
-            f"runs {uninstall_cmd}" if _installed_via_pipx()
+            f"runs {uninstall_cmd}"
+            if _installed_via_pipx() or _installed_via_uv_tool()
             else f"prints {uninstall_cmd} for you to run"
         )
         do_remove = click.confirm(
@@ -252,40 +311,49 @@ def cmd_uninstall(ctx: click.Context, yes: bool, remove_package: bool) -> None:
     )
 
 
+def _run_auto_uninstall(argv: list[str], uninstall_cmd: str) -> None:
+    """Shared runner for the pipx/uv-tool auto-remove branches: run `argv`,
+    then report success (with the fresh-install hint) or fall back to the
+    manual command on failure."""
+    console.print()
+    console.print(f"Running: [bold]{uninstall_cmd}[/bold]")
+    result = subprocess.run(argv, capture_output=True, text=True)
+    if result.returncode == 0:
+        console.print("[green]tokenjam package removed.[/green]")
+        # The venv is gone now, so upgrade would fail ("not installed") —
+        # point at the plain fresh install, not the upgrade/--force reinstall
+        # hint (#430).
+        console.print(
+            f"  [dim]To reinstall FRESH: {_package_fresh_install_hint()}[/dim]"
+        )
+    else:
+        console.print(
+            f"  [yellow]Could not remove the package automatically: "
+            f"{result.stderr.strip() or result.stdout.strip()}[/yellow]"
+        )
+        console.print(f"  Run manually: [bold]{uninstall_cmd}[/bold]")
+
+
 def _remove_package(uninstall_cmd: str) -> None:
     """Run the package uninstall when we can, else print the exact command.
 
-    Only pipx is auto-run: it's the canonical install path and safe to invoke
-    non-interactively. For pip / venv installs we print the command instead of
-    guessing (a wrong `pip uninstall` in the wrong environment is worse than a
-    copy-paste)."""
+    Only pipx and `uv tool` are auto-run: both are isolated, canonical install
+    paths safe to invoke non-interactively. For pip / venv installs we print
+    the command instead of guessing (a wrong `pip uninstall` in the wrong
+    environment is worse than a copy-paste)."""
     if _installed_via_pipx() and shutil.which("pipx"):
-        console.print()
-        console.print(f"Running: [bold]{uninstall_cmd}[/bold]")
-        result = subprocess.run(
-            ["pipx", "uninstall", "tokenjam"],
-            capture_output=True,
-            text=True,
-        )
-        if result.returncode == 0:
-            console.print("[green]tokenjam package removed.[/green]")
-            # The venv is gone now, so `pipx upgrade` would fail — point at the
-            # plain fresh install, not the upgrade/--force reinstall hint (#430).
-            console.print(
-                f"  [dim]To reinstall FRESH: {_package_fresh_install_hint()}[/dim]"
-            )
-        else:
-            console.print(
-                f"  [yellow]Could not remove the package automatically: "
-                f"{result.stderr.strip() or result.stdout.strip()}[/yellow]"
-            )
-            console.print(f"  Run manually: [bold]{uninstall_cmd}[/bold]")
+        _run_auto_uninstall(["pipx", "uninstall", "tokenjam"], uninstall_cmd)
         return
 
-    # Not a pipx install (or pipx missing) — print the right command, don't guess.
+    if _installed_via_uv_tool() and shutil.which("uv"):
+        _run_auto_uninstall(["uv", "tool", "uninstall", "tokenjam"], uninstall_cmd)
+        return
+
+    # Not a pipx/uv-tool install (or the tool binary is missing) — print the
+    # right command, don't guess.
     console.print()
     console.print(
         "  [yellow]Can't safely auto-remove this install "
-        "(not a pipx-managed venv).[/yellow]"
+        "(not a pipx- or uv-tool-managed venv).[/yellow]"
     )
     console.print(f"  Remove the package with: [bold]{uninstall_cmd}[/bold]")


### PR DESCRIPTION
## Summary
- Extends `tj uninstall`'s existing opt-in package removal (`--remove-package`, #430) with a `--purge` alias and full runner detection, making `npx tokenjam uninstall [--purge]` the complete, symmetric counterpart to `npx tokenjam onboard`.
- Adds `uv tool install` detection alongside the existing pipx detection — `--purge` now auto-runs `uv tool uninstall tokenjam` for uv-tool installs, and the default (non-purge) closing hint prints the exact matching command (`pipx uninstall` / `uv tool uninstall` / `pip uninstall`) instead of only ever guessing pipx-or-pip.
- Adds `_is_ephemeral_runner()` detection (verified empirically against real `uv`/`pipx` installs — see code comments for the exact paths) so an ephemeral invocation (`uvx`/`pipx run`, including via the `npx tokenjam` wrapper's runner fallback) makes `--purge` a safe no-op with an explanation, rather than guessing at a removal command for a package that was never persistently installed.
- Documents install/remove as a symmetric pair in `docs/claude-code-integration.md`.

Resolves #121.

## Test plan
- [x] `python -m pytest tests/unit/ -k "uninstall or purge or runner" -q` → 20 passed
- [x] `python -m pytest tests/unit/ tests/integration/ -q` (full suite) → 2048 passed, 1 skipped (pre-existing)
- [x] `ruff check` clean on all touched/new files
- [x] Manually exercised the CLI output for the ephemeral + `--purge` no-op path

**Merge order:** CC install/remove cluster — merge #117 → #118 → #121; this is #121, MERGE LAST (depends on #117 + #118 for a fully-clean uninstall).

🤖 Generated with [Claude Code](https://claude.com/claude-code)