### PR TITLE
feat(uninstall): full removal by default + new 'tj reset' (drop --purge)

### DIFF
--- a/docs/claude-code-integration.md
+++ b/docs/claude-code-integration.md
@@ -109,37 +109,41 @@ See **[docs/agent-capability-matrix.md](agent-capability-matrix.md)** for the fu
 Codex vs. Python SDK vs. OTLP capability breakdown, including the backfill/statusline parity
 investigation.
 
-## Uninstalling
+## Uninstalling (and resetting)
 
 Set up and remove are a symmetric one-command pair:
 
 ```bash
 npx tokenjam onboard --claude-code   # one paste to set up
-npx tokenjam uninstall [--purge]     # one paste to remove
+npx tokenjam uninstall               # one paste to remove — config AND the package
 ```
 
-`npx tokenjam uninstall` (equivalently `tj uninstall` if you have a persistent install on PATH) cleans
-up everything set by `tj onboard --claude-code`:
+`npx tokenjam uninstall` (equivalently `tj uninstall` if you have a persistent install on PATH) does a
+**full removal**: everything set up by `tj onboard --claude-code`, plus the `tokenjam` package itself.
+It cleans up:
 - Stops and removes the background daemon (launchd/systemd)
 - Deregisters the MCP server from Claude Code
 - Deletes `~/.tj/` (telemetry database)
 - Deletes `~/.config/tj/` (global config and projects index)
 - Removes OTLP env vars from `~/.claude/settings.json`
 - Removes `OTEL_RESOURCE_ATTRIBUTES` from `.claude/settings.json` in every onboarded project
-- Removes the harness env block from `~/.zshrc`
+- Removes the harness env block from `~/.zshrc`, and the `claude()` shell wrapper
 
-That cleans up onboarding's side effects, but leaves the `tokenjam` package itself installed — pass
-`--purge` to remove it too (or answer "y" to the prompt `tj uninstall` shows when run interactively
-without `--yes`):
+...then removes the package: it detects how you installed and runs the matching removal command —
+`pipx uninstall tokenjam` or `uv tool uninstall tokenjam` are run automatically (both are isolated,
+canonical install paths); a plain `pip`/venv install instead prints the exact `pip uninstall tokenjam`
+command to run yourself (guessing the wrong environment is worse than a copy-paste). If you're running
+via an **ephemeral** runner — `npx tokenjam`'s default `uvx`/`pipx run` fallback, or
+`uvx tokenjam uninstall` directly — there's no persistent package to remove in the first place, so that
+step is a safe no-op that says so; the config/wiring cleanup above still runs either way.
+
+If you just want to **reconfigure or pause** TokenJam — wipe its config/daemon/wiring but keep the CLI
+installed so `tj onboard` works again without reinstalling — use `tj reset` instead:
 
 ```bash
-npx tokenjam uninstall --purge --yes
+npx tokenjam reset --yes
 ```
 
-`--purge` detects how you installed and runs the matching removal command — `pipx uninstall tokenjam`
-or `uv tool uninstall tokenjam` are run automatically (both are isolated, canonical install paths); a
-plain `pip`/venv install instead prints the exact `pip uninstall tokenjam` command to run yourself
-(guessing the wrong environment is worse than a copy-paste). If you're running via an **ephemeral**
-runner — `npx tokenjam`'s default `uvx`/`pipx run` fallback, or `uvx tokenjam uninstall` directly —
-there's no persistent package to remove in the first place, so `--purge` is a safe no-op that says so;
-the onboarding side-effects above are still fully cleaned either way.
+`tj reset` runs the exact same config/wiring teardown as `tj uninstall` above, minus the package-removal
+step. `npx tokenjam reset` and `npx tokenjam uninstall` both work through the wrapper's runner
+passthrough the same way `onboard` does.

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -443,9 +443,22 @@ tj stop
 
 ### `tj uninstall`
 
-Remove all TokenJam data, config, daemon, MCP registration, and env vars.
+Full removal: all TokenJam data, config, daemon, MCP registration, and env vars — AND the `tokenjam`
+package itself (pipx/uv-tool installs are removed automatically; a plain pip/venv install gets the
+exact `pip uninstall` command printed instead of a guess). The symmetric counterpart to `tj onboard`.
 
 ```bash
 tj uninstall          # interactive confirmation
 tj uninstall --yes    # skip confirmation
+```
+
+### `tj reset`
+
+Config-only teardown — the same wiring/config cleanup as `tj uninstall` above, but leaves the
+`tokenjam` package installed so `tj onboard` works again without reinstalling. Use this to reconfigure
+or pause TokenJam.
+
+```bash
+tj reset          # interactive confirmation
+tj reset --yes    # skip confirmation
 ```

--- a/tests/integration/test_cli.py
+++ b/tests/integration/test_cli.py
@@ -1842,6 +1842,10 @@ def test_uninstall_removes_legacy_and_current_zshrc_otel_blocks(runner, tmp_path
     # real `claude` CLI's MCP deregister — same isolation as test_cli_uninstall.py.
     monkeypatch.setattr("tokenjam.cli.cmd_stop.cmd_stop", MagicMock())
     monkeypatch.setattr("tokenjam.cli.cmd_uninstall.shutil.which", lambda _name: None)
+    # `_find_persistent_install()`'s dir-probe fallback reads these directly
+    # (not via $HOME) — unset so a real PIPX_HOME/XDG_DATA_HOME can't leak in.
+    monkeypatch.delenv("PIPX_HOME", raising=False)
+    monkeypatch.delenv("XDG_DATA_HOME", raising=False)
 
     result = runner.invoke(cli, ["uninstall", "--yes"])
 

--- a/tests/integration/test_cli_uninstall.py
+++ b/tests/integration/test_cli_uninstall.py
@@ -1,10 +1,10 @@
-"""CLI tests for `tj uninstall` messaging + optional package removal.
-
-These focus on the closing UX (issue: uninstall/reinstall confusion) — the
-two-step "package remains; reinstall FRESH with upgrade/--force" messaging and
-the optional package-removal prompt. Filesystem side effects are neutered by
-pointing HOME at a tmp dir and mocking subprocess/shutil so nothing real is
-touched.
+"""CLI tests for `tj uninstall` — full removal by default (#442): config,
+daemon, wiring, AND the tokenjam package itself, in one command. The
+installer-aware package-removal step is unchanged from #121 — pipx/uv-tool
+installs are auto-run, a plain pip/venv install only gets the exact command
+printed (never guessed), and an ephemeral runner (uvx/pipx run) is a no-op
+with an explanation. Filesystem side effects are neutered by pointing HOME at
+a tmp dir and mocking subprocess/shutil so nothing real is touched.
 """
 from __future__ import annotations
 
@@ -42,37 +42,15 @@ def _run(runner, *args, **kwargs):
     return runner.invoke(cmd_uninstall, ["--yes", *args], **kwargs)
 
 
-def test_messaging_states_package_remains(runner):
-    """Default (no --remove-package, --yes): package left in place, two-step
-    guidance printed, and the FRESH-reinstall command is upgrade/--force."""
-    with patch.object(uninstall_mod, "_installed_via_pipx", return_value=True):
-        result = _run(runner)
-    assert result.exit_code == 0, result.output
-    out = result.output
-    assert "package itself is still installed" in out
-    assert "pipx uninstall tokenjam" in out
-    # FRESH reinstall must NOT be a bare `pipx install` (that no-ops).
-    assert "pipx upgrade tokenjam" in out
-    assert "pipx install --force tokenjam" in out
-    assert "no-ops when tokenjam is already present" in out
-
-
-def test_reinstall_hint_for_pip_install(runner):
-    """Non-pipx install: hint is pip uninstall + pip install --upgrade."""
-    with patch.object(uninstall_mod, "_installed_via_pipx", return_value=False):
-        result = _run(runner)
-    assert result.exit_code == 0, result.output
-    assert "pip uninstall tokenjam" in result.output
-    assert "pip install --upgrade tokenjam" in result.output
-
-
-def test_remove_package_flag_runs_pipx(runner):
-    """--remove-package on a pipx install runs `pipx uninstall tokenjam`."""
+def test_default_removes_package_for_pipx_install(runner):
+    """Default `tj uninstall --yes` now ALSO removes the package (previously
+    gated behind --remove-package/--purge, which #442 dropped) — a pipx
+    install auto-runs `pipx uninstall tokenjam`."""
     fake = MagicMock(returncode=0, stdout="", stderr="")
     with patch.object(uninstall_mod, "_installed_via_pipx", return_value=True), \
          patch.object(uninstall_mod.shutil, "which", side_effect=lambda c: "/usr/bin/pipx" if c == "pipx" else None), \
          patch.object(uninstall_mod.subprocess, "run", return_value=fake) as run:
-        result = _run(runner, "--remove-package")
+        result = _run(runner)
     assert result.exit_code == 0, result.output
     run.assert_called_once_with(
         ["pipx", "uninstall", "tokenjam"], capture_output=True, text=True
@@ -85,58 +63,15 @@ def test_remove_package_flag_runs_pipx(runner):
     assert "pipx upgrade" not in result.output
 
 
-def test_remove_package_flag_non_pipx_prints_command(runner):
-    """--remove-package on a non-pipx install must NOT guess/run — it prints
-    the right command instead.
-
-    Mocks `_installed_via_uv_tool` and `_is_ephemeral_runner` too (not just
-    `_installed_via_pipx`) so this is hermetic — otherwise it silently
-    depends on whatever venv the CI runner's `sys.executable` happens to
-    live under (e.g. a uv-managed venv would flip the branch taken)."""
-    with patch.object(uninstall_mod, "_installed_via_pipx", return_value=False), \
-         patch.object(uninstall_mod, "_installed_via_uv_tool", return_value=False), \
-         patch.object(uninstall_mod, "_is_ephemeral_runner", return_value=False), \
-         patch.object(uninstall_mod.subprocess, "run") as run:
-        result = _run(runner, "--remove-package")
-    assert result.exit_code == 0, result.output
-    # Only cmd_stop (mocked) — no pipx/pip uninstall subprocess fired.
-    run.assert_not_called()
-    assert "not a pipx- or uv-tool-managed venv" in result.output
-    assert "pip uninstall tokenjam" in result.output
-
-
-def test_prompt_offered_when_interactive(runner):
-    """Without --yes, the user is asked whether to also remove the package;
-    answering No leaves it and prints the two-step guidance."""
-    with patch.object(uninstall_mod, "_installed_via_pipx", return_value=True):
-        # First prompt: confirm delete-all (y). Second: also remove package (n).
-        result = runner.invoke(cmd_uninstall, [], input="y\nn\n")
-    assert result.exit_code == 0, result.output
-    assert "Also remove the tokenjam package now?" in result.output
-    assert "package itself is still installed" in result.output
-
-
-def test_prompt_wording_matches_install_type(runner):
-    """The confirm prompt must describe what actually happens: pipx installs are
-    auto-run, pip/venv installs only get the command printed (#430)."""
-    with patch.object(uninstall_mod, "_installed_via_pipx", return_value=True):
-        res_pipx = runner.invoke(cmd_uninstall, [], input="y\nn\n")
-    assert "runs pipx uninstall tokenjam" in res_pipx.output
-
-    with patch.object(uninstall_mod, "_installed_via_pipx", return_value=False):
-        res_pip = runner.invoke(cmd_uninstall, [], input="y\nn\n")
-    assert "prints pip uninstall tokenjam" in res_pip.output
-
-
-def test_remove_package_flag_runs_uv_tool(runner):
-    """--purge (alias for --remove-package) on a uv-tool install runs
-    `uv tool uninstall tokenjam` (#121)."""
+def test_default_removes_package_for_uv_tool_install(runner):
+    """Default `tj uninstall --yes` on a uv-tool install auto-runs
+    `uv tool uninstall tokenjam` (#121, now unconditional)."""
     fake = MagicMock(returncode=0, stdout="", stderr="")
     with patch.object(uninstall_mod, "_installed_via_pipx", return_value=False), \
          patch.object(uninstall_mod, "_installed_via_uv_tool", return_value=True), \
          patch.object(uninstall_mod.shutil, "which", side_effect=lambda c: "/usr/bin/uv" if c == "uv" else None), \
          patch.object(uninstall_mod.subprocess, "run", return_value=fake) as run:
-        result = _run(runner, "--purge")
+        result = _run(runner)
     assert result.exit_code == 0, result.output
     run.assert_called_once_with(
         ["uv", "tool", "uninstall", "tokenjam"], capture_output=True, text=True
@@ -146,39 +81,58 @@ def test_remove_package_flag_runs_uv_tool(runner):
     assert "uv tool upgrade" not in result.output
 
 
-def test_uv_tool_reinstall_hint(runner):
-    """Non-pipx, uv-tool install: hint is `uv tool uninstall` + `uv tool
-    upgrade` (#121)."""
+def test_default_prints_command_for_pip_install(runner):
+    """Default `tj uninstall --yes` on a non-pipx/non-uv-tool install must NOT
+    guess/run the package removal — it prints the right command instead.
+
+    Mocks `_installed_via_uv_tool` and `_is_ephemeral_runner` too (not just
+    `_installed_via_pipx`) so this is hermetic — otherwise it silently
+    depends on whatever venv the CI runner's `sys.executable` happens to
+    live under (e.g. a uv-managed venv would flip the branch taken)."""
     with patch.object(uninstall_mod, "_installed_via_pipx", return_value=False), \
-         patch.object(uninstall_mod, "_installed_via_uv_tool", return_value=True):
+         patch.object(uninstall_mod, "_installed_via_uv_tool", return_value=False), \
+         patch.object(uninstall_mod, "_is_ephemeral_runner", return_value=False), \
+         patch.object(uninstall_mod.subprocess, "run") as run:
         result = _run(runner)
     assert result.exit_code == 0, result.output
-    assert "uv tool uninstall tokenjam" in result.output
-    assert "uv tool upgrade tokenjam" in result.output
-
-
-def test_purge_is_noop_on_ephemeral_runner(runner):
-    """`--purge` on an ephemeral runner (uvx/pipx run — no persistent
-    install) must not attempt any removal; it explains why and exits clean
-    (#121)."""
-    with patch.object(uninstall_mod, "_is_ephemeral_runner", return_value=True), \
-         patch.object(uninstall_mod.subprocess, "run") as run:
-        result = _run(runner, "--purge")
-    assert result.exit_code == 0, result.output
+    # Only cmd_stop (mocked) — no pipx/pip uninstall subprocess fired.
     run.assert_not_called()
-    assert "no persistent" in result.output.lower() or "nothing persistent" in result.output.lower()
-    assert "--purge is a no-op here" in result.output
-    # The (inapplicable) "package still installed" two-step must not print.
-    assert "package itself is still installed" not in result.output
+    assert "not a pipx- or uv-tool-managed venv" in result.output
+    assert "pip uninstall tokenjam" in result.output
 
 
-def test_no_purge_prompt_on_ephemeral_runner(runner):
-    """Without --purge/--yes, an ephemeral runner must not ask to remove a
-    package that was never persistently installed (#121)."""
-    with patch.object(uninstall_mod, "_is_ephemeral_runner", return_value=True):
+def test_confirm_prompt_mentions_config_and_package(runner):
+    """Without --yes, the single confirmation prompt must make clear it
+    removes BOTH config/wiring AND the package — there is no longer a second
+    "also remove the package?" prompt (#442)."""
+    fake = MagicMock(returncode=0, stdout="", stderr="")
+    with patch.object(uninstall_mod, "_installed_via_pipx", return_value=True), \
+         patch.object(uninstall_mod.shutil, "which", side_effect=lambda c: "/usr/bin/pipx" if c == "pipx" else None), \
+         patch.object(uninstall_mod.subprocess, "run", return_value=fake):
         result = runner.invoke(cmd_uninstall, [], input="y\n")
     assert result.exit_code == 0, result.output
-    assert "Also remove the tokenjam package now?" not in result.output
+    assert "AND remove the tokenjam package itself" in result.output
+    assert "tokenjam package removed" in result.output
+
+
+def test_declining_confirm_cancels_everything(runner):
+    """Declining the single prompt cancels the whole operation — no teardown,
+    no package removal attempted."""
+    with patch.object(uninstall_mod.subprocess, "run") as run:
+        result = runner.invoke(cmd_uninstall, [], input="n\n")
+    assert result.exit_code == 0, result.output
+    assert "Cancelled" in result.output
+    run.assert_not_called()
+
+
+def test_ephemeral_runner_is_noop_for_package_removal(runner):
+    """An ephemeral runner (uvx/pipx run — no persistent install) must not
+    attempt any package removal; it explains why and exits clean (#121)."""
+    with patch.object(uninstall_mod, "_is_ephemeral_runner", return_value=True), \
+         patch.object(uninstall_mod.subprocess, "run") as run:
+        result = _run(runner)
+    assert result.exit_code == 0, result.output
+    run.assert_not_called()
     assert "nothing persistent to remove" in result.output.lower()
 
 
@@ -189,7 +143,7 @@ def test_pipx_uninstall_failure_falls_back_to_manual(runner):
     with patch.object(uninstall_mod, "_installed_via_pipx", return_value=True), \
          patch.object(uninstall_mod.shutil, "which", side_effect=lambda c: "/usr/bin/pipx" if c == "pipx" else None), \
          patch.object(uninstall_mod.subprocess, "run", return_value=fake):
-        result = _run(runner, "--remove-package")
+        result = _run(runner)
     assert result.exit_code == 0, result.output
     assert "Could not remove the package automatically" in result.output
     assert "pipx uninstall tokenjam" in result.output

--- a/tests/integration/test_cli_uninstall.py
+++ b/tests/integration/test_cli_uninstall.py
@@ -1,10 +1,17 @@
-"""CLI tests for `tj uninstall` — full removal by default (#442): config,
-daemon, wiring, AND the tokenjam package itself, in one command. The
-installer-aware package-removal step is unchanged from #121 — pipx/uv-tool
-installs are auto-run, a plain pip/venv install only gets the exact command
-printed (never guessed), and an ephemeral runner (uvx/pipx run) is a no-op
-with an explanation. Filesystem side effects are neutered by pointing HOME at
-a tmp dir and mocking subprocess/shutil so nothing real is touched.
+"""CLI tests for `tj uninstall` — full removal by default (#442), with
+package detection now ENVIRONMENT-WIDE via `_find_persistent_install()`
+rather than the current process's `sys.executable` (Greptile P1 on #443):
+`npx tokenjam uninstall` always runs `tj` via an ephemeral `uvx`/`pipx run`
+venv, so the old `sys.executable`-based detection always reported "nothing
+to remove" even when a persistent pipx/uv-tool install existed elsewhere on
+the machine — and the confirm prompt lied about what would actually happen.
+
+These tests patch `_find_persistent_install()` directly to drive
+`cmd_uninstall`'s prompt wording and execution; the detection function's own
+probing logic (subprocess + dir-probe fallback) is unit-tested in
+tests/unit/test_uninstall_persistent_install.py. Filesystem side effects are
+neutered by pointing HOME at a tmp dir and mocking subprocess/shutil so
+nothing real is touched.
 """
 from __future__ import annotations
 
@@ -14,7 +21,7 @@ import pytest
 from click.testing import CliRunner
 
 from tokenjam.cli import cmd_uninstall as uninstall_mod
-from tokenjam.cli.cmd_uninstall import cmd_uninstall
+from tokenjam.cli.cmd_uninstall import PersistentInstall, cmd_uninstall
 
 
 @pytest.fixture
@@ -34,6 +41,12 @@ def _isolate(tmp_path, monkeypatch):
     monkeypatch.chdir(tmp_path)
     # cmd_stop is invoked first; stub it out so it doesn't poke the real daemon.
     monkeypatch.setattr("tokenjam.cli.cmd_stop.cmd_stop", MagicMock())
+    # `_find_persistent_install()`'s dir-probe fallback reads these directly
+    # (not via Path.home()) — unset so a developer's/CI runner's real
+    # PIPX_HOME/XDG_DATA_HOME can never leak a real tokenjam install into a
+    # test that doesn't explicitly mock `_find_persistent_install()`.
+    monkeypatch.delenv("PIPX_HOME", raising=False)
+    monkeypatch.delenv("XDG_DATA_HOME", raising=False)
     with patch.object(uninstall_mod.shutil, "which", return_value=None):
         yield
 
@@ -42,13 +55,24 @@ def _run(runner, *args, **kwargs):
     return runner.invoke(cmd_uninstall, ["--yes", *args], **kwargs)
 
 
+_PIPX_INSTALL = PersistentInstall(
+    manager="pipx", auto=True,
+    argv=["pipx", "uninstall", "tokenjam"], display="pipx uninstall tokenjam",
+)
+_UV_TOOL_INSTALL = PersistentInstall(
+    manager="uv-tool", auto=True,
+    argv=["uv", "tool", "uninstall", "tokenjam"],
+    display="uv tool uninstall tokenjam",
+)
+_PIP_INSTALL = PersistentInstall(
+    manager="pip", auto=False, argv=None, display="pip uninstall tokenjam",
+)
+
+
 def test_default_removes_package_for_pipx_install(runner):
-    """Default `tj uninstall --yes` now ALSO removes the package (previously
-    gated behind --remove-package/--purge, which #442 dropped) — a pipx
-    install auto-runs `pipx uninstall tokenjam`."""
+    """A detected persistent pipx install is auto-removed by default."""
     fake = MagicMock(returncode=0, stdout="", stderr="")
-    with patch.object(uninstall_mod, "_installed_via_pipx", return_value=True), \
-         patch.object(uninstall_mod.shutil, "which", side_effect=lambda c: "/usr/bin/pipx" if c == "pipx" else None), \
+    with patch.object(uninstall_mod, "_find_persistent_install", return_value=[_PIPX_INSTALL]), \
          patch.object(uninstall_mod.subprocess, "run", return_value=fake) as run:
         result = _run(runner)
     assert result.exit_code == 0, result.output
@@ -58,18 +82,16 @@ def test_default_removes_package_for_pipx_install(runner):
     assert "tokenjam package removed" in result.output
     # After a SUCCESSFUL removal the venv is gone, so `pipx upgrade` would fail
     # ("not installed"). The reinstall hint must be a fresh `pipx install`, not
-    # upgrade/--force (#430).
+    # upgrade/--force (#430) — and must reflect the MANAGER that was actually
+    # removed (pipx), not the current (often ephemeral) process's guess.
     assert "pipx install tokenjam" in result.output
     assert "pipx upgrade" not in result.output
 
 
 def test_default_removes_package_for_uv_tool_install(runner):
-    """Default `tj uninstall --yes` on a uv-tool install auto-runs
-    `uv tool uninstall tokenjam` (#121, now unconditional)."""
+    """A detected persistent uv-tool install is auto-removed by default."""
     fake = MagicMock(returncode=0, stdout="", stderr="")
-    with patch.object(uninstall_mod, "_installed_via_pipx", return_value=False), \
-         patch.object(uninstall_mod, "_installed_via_uv_tool", return_value=True), \
-         patch.object(uninstall_mod.shutil, "which", side_effect=lambda c: "/usr/bin/uv" if c == "uv" else None), \
+    with patch.object(uninstall_mod, "_find_persistent_install", return_value=[_UV_TOOL_INSTALL]), \
          patch.object(uninstall_mod.subprocess, "run", return_value=fake) as run:
         result = _run(runner)
     assert result.exit_code == 0, result.output
@@ -82,66 +104,114 @@ def test_default_removes_package_for_uv_tool_install(runner):
 
 
 def test_default_prints_command_for_pip_install(runner):
-    """Default `tj uninstall --yes` on a non-pipx/non-uv-tool install must NOT
-    guess/run the package removal — it prints the right command instead.
-
-    Mocks `_installed_via_uv_tool` and `_is_ephemeral_runner` too (not just
-    `_installed_via_pipx`) so this is hermetic — otherwise it silently
-    depends on whatever venv the CI runner's `sys.executable` happens to
-    live under (e.g. a uv-managed venv would flip the branch taken)."""
-    with patch.object(uninstall_mod, "_installed_via_pipx", return_value=False), \
-         patch.object(uninstall_mod, "_installed_via_uv_tool", return_value=False), \
-         patch.object(uninstall_mod, "_is_ephemeral_runner", return_value=False), \
+    """A detected pip/editable install is never auto-run — only printed
+    (guessing the wrong environment, or nuking a shared/live/editable-dev
+    venv, is worse than a copy-paste)."""
+    with patch.object(uninstall_mod, "_find_persistent_install", return_value=[_PIP_INSTALL]), \
          patch.object(uninstall_mod.subprocess, "run") as run:
         result = _run(runner)
     assert result.exit_code == 0, result.output
-    # Only cmd_stop (mocked) — no pipx/pip uninstall subprocess fired.
     run.assert_not_called()
     assert "not a pipx- or uv-tool-managed venv" in result.output
     assert "pip uninstall tokenjam" in result.output
 
 
-def test_confirm_prompt_mentions_config_and_package(runner):
-    """Without --yes, the single confirmation prompt must make clear it
-    removes BOTH config/wiring AND the package — there is no longer a second
-    "also remove the package?" prompt (#442)."""
+def test_default_noop_when_nothing_persistent_found(runner):
+    """No persistent install anywhere → no package-removal attempt, clean exit."""
+    with patch.object(uninstall_mod, "_find_persistent_install", return_value=[]), \
+         patch.object(uninstall_mod.subprocess, "run") as run:
+        result = _run(runner)
+    assert result.exit_code == 0, result.output
+    run.assert_not_called()
+    assert "no persistent tokenjam install found" in result.output.lower()
+
+
+def test_both_pipx_and_uv_tool_present_removes_both(runner):
+    """If BOTH a pipx and a uv-tool install exist on the machine, `tj
+    uninstall` removes each auto-removable one, not just the first."""
     fake = MagicMock(returncode=0, stdout="", stderr="")
-    with patch.object(uninstall_mod, "_installed_via_pipx", return_value=True), \
-         patch.object(uninstall_mod.shutil, "which", side_effect=lambda c: "/usr/bin/pipx" if c == "pipx" else None), \
-         patch.object(uninstall_mod.subprocess, "run", return_value=fake):
+    with patch.object(
+        uninstall_mod, "_find_persistent_install",
+        return_value=[_PIPX_INSTALL, _UV_TOOL_INSTALL],
+    ), patch.object(uninstall_mod.subprocess, "run", return_value=fake) as run:
+        result = _run(runner)
+    assert result.exit_code == 0, result.output
+    assert run.call_count == 2
+    run.assert_any_call(
+        ["pipx", "uninstall", "tokenjam"], capture_output=True, text=True
+    )
+    run.assert_any_call(
+        ["uv", "tool", "uninstall", "tokenjam"], capture_output=True, text=True
+    )
+
+
+# -- Honest confirm prompt (Greptile P1 on #443) -----------------------------
+#
+# Detection now runs BEFORE the prompt is built, and is environment-wide
+# (`_find_persistent_install()`), not based on the current process. Before
+# this fix, `npx tokenjam uninstall` — which always runs `tj` via an
+# ephemeral uvx/pipx-run venv — would introspect ITS OWN `sys.executable`,
+# always conclude "ephemeral, nothing to remove", and both the prompt and
+# the outcome would silently leave a persistent pipx/uv-tool install behind.
+
+
+def test_prompt_promises_removal_when_persistent_pipx_present(runner):
+    """Without --yes: even when the CURRENT process is an ephemeral
+    uvx/pipx-run runner, if `_find_persistent_install()` detects a
+    persistent pipx install elsewhere on the machine, the prompt promises
+    package removal — and answering yes actually removes it."""
+    fake = MagicMock(returncode=0, stdout="", stderr="")
+    with patch.object(uninstall_mod, "_is_ephemeral_runner", return_value=True), \
+         patch.object(uninstall_mod, "_find_persistent_install", return_value=[_PIPX_INSTALL]), \
+         patch.object(uninstall_mod.subprocess, "run", return_value=fake) as run:
         result = runner.invoke(cmd_uninstall, [], input="y\n")
     assert result.exit_code == 0, result.output
-    assert "AND remove the tokenjam package itself" in result.output
+    assert "uninstall the tokenjam package (via pipx)" in result.output
+    run.assert_called_once()
     assert "tokenjam package removed" in result.output
+
+
+def test_prompt_does_not_mention_package_when_nothing_persistent(runner):
+    """Without --yes: if nothing persistent is found anywhere, the prompt
+    must NOT claim it will remove a package — only config/daemon/wiring."""
+    with patch.object(uninstall_mod, "_find_persistent_install", return_value=[]), \
+         patch.object(uninstall_mod.subprocess, "run") as run:
+        result = runner.invoke(cmd_uninstall, [], input="y\n")
+    assert result.exit_code == 0, result.output
+    assert "uninstall the tokenjam package" not in result.output
+    assert "config, telemetry history" in result.output
+    run.assert_not_called()
+
+
+def test_prompt_wording_for_pip_install_defers_to_shown_command(runner):
+    """Without --yes: a pip/editable install's prompt says the command will
+    be shown after (never auto-run), instead of claiming an automatic
+    removal."""
+    with patch.object(uninstall_mod, "_find_persistent_install", return_value=[_PIP_INSTALL]), \
+         patch.object(uninstall_mod.subprocess, "run") as run:
+        result = runner.invoke(cmd_uninstall, [], input="y\n")
+    assert result.exit_code == 0, result.output
+    assert "will need `pip uninstall tokenjam` (shown after)" in result.output
+    run.assert_not_called()
+    assert "pip uninstall tokenjam" in result.output
 
 
 def test_declining_confirm_cancels_everything(runner):
     """Declining the single prompt cancels the whole operation — no teardown,
     no package removal attempted."""
-    with patch.object(uninstall_mod.subprocess, "run") as run:
+    with patch.object(uninstall_mod, "_find_persistent_install", return_value=[_PIPX_INSTALL]), \
+         patch.object(uninstall_mod.subprocess, "run") as run:
         result = runner.invoke(cmd_uninstall, [], input="n\n")
     assert result.exit_code == 0, result.output
     assert "Cancelled" in result.output
     run.assert_not_called()
 
 
-def test_ephemeral_runner_is_noop_for_package_removal(runner):
-    """An ephemeral runner (uvx/pipx run — no persistent install) must not
-    attempt any package removal; it explains why and exits clean (#121)."""
-    with patch.object(uninstall_mod, "_is_ephemeral_runner", return_value=True), \
-         patch.object(uninstall_mod.subprocess, "run") as run:
-        result = _run(runner)
-    assert result.exit_code == 0, result.output
-    run.assert_not_called()
-    assert "nothing persistent to remove" in result.output.lower()
-
-
 def test_pipx_uninstall_failure_falls_back_to_manual(runner):
     """If pipx uninstall fails, we surface the error and the manual command
     rather than claiming success."""
     fake = MagicMock(returncode=1, stdout="", stderr="boom")
-    with patch.object(uninstall_mod, "_installed_via_pipx", return_value=True), \
-         patch.object(uninstall_mod.shutil, "which", side_effect=lambda c: "/usr/bin/pipx" if c == "pipx" else None), \
+    with patch.object(uninstall_mod, "_find_persistent_install", return_value=[_PIPX_INSTALL]), \
          patch.object(uninstall_mod.subprocess, "run", return_value=fake):
         result = _run(runner)
     assert result.exit_code == 0, result.output

--- a/tests/unit/test_reset.py
+++ b/tests/unit/test_reset.py
@@ -1,0 +1,70 @@
+"""Tests for `tj reset` (#442): the config-only counterpart to `tj uninstall`.
+
+`tj uninstall` was redesigned to do a full removal by default — config/
+daemon/wiring AND the tokenjam package itself, dropping the old `--purge`/
+`--remove-package` flags. `tj reset` is the new command that runs ONLY the
+shared `_teardown_side_effects()` helper (config/daemon/wiring cleanup) and
+never touches the package, leaving the CLI ready for `tj onboard` again.
+"""
+from __future__ import annotations
+
+from unittest.mock import patch
+
+import pytest
+from click.testing import CliRunner
+
+from tokenjam.cli import cmd_uninstall as uninstall_mod
+from tokenjam.cli.cmd_reset import cmd_reset
+
+
+@pytest.fixture
+def runner():
+    return CliRunner()
+
+
+def test_reset_calls_shared_teardown(runner):
+    """`tj reset --yes` invokes the same `_teardown_side_effects()` helper
+    that `tj uninstall` uses for its config/wiring cleanup."""
+    with patch.object(uninstall_mod, "_teardown_side_effects") as teardown:
+        result = runner.invoke(cmd_reset, ["--yes"])
+    assert result.exit_code == 0, result.output
+    teardown.assert_called_once()
+
+
+def test_reset_never_touches_package_removal(runner):
+    """`tj reset` must not invoke any package-removal path — no subprocess
+    call, regardless of how tokenjam was installed."""
+    with patch.object(uninstall_mod, "_teardown_side_effects"), \
+         patch.object(uninstall_mod, "_remove_package") as remove_package, \
+         patch.object(uninstall_mod.subprocess, "run") as run:
+        result = runner.invoke(cmd_reset, ["--yes"])
+    assert result.exit_code == 0, result.output
+    remove_package.assert_not_called()
+    run.assert_not_called()
+
+
+def test_reset_prints_onboard_hint(runner):
+    """After a successful reset, tell the user how to set back up."""
+    with patch.object(uninstall_mod, "_teardown_side_effects"):
+        result = runner.invoke(cmd_reset, ["--yes"])
+    assert result.exit_code == 0, result.output
+    assert "tj onboard" in result.output
+
+
+def test_reset_prompt_confirms_before_wiping(runner):
+    """Without --yes, `tj reset` asks first — declining is a no-op that never
+    reaches the teardown helper."""
+    with patch.object(uninstall_mod, "_teardown_side_effects") as teardown:
+        result = runner.invoke(cmd_reset, [], input="n\n")
+    assert result.exit_code == 0, result.output
+    assert "Cancelled" in result.output
+    teardown.assert_not_called()
+
+
+def test_reset_prompt_wording_keeps_package_installed(runner):
+    """The confirm prompt must make clear the package stays installed — the
+    distinguishing behavior from `tj uninstall`'s full-removal prompt."""
+    with patch.object(uninstall_mod, "_teardown_side_effects"):
+        result = runner.invoke(cmd_reset, [], input="y\n")
+    assert result.exit_code == 0, result.output
+    assert "tokenjam package itself stays installed" in result.output

--- a/tests/unit/test_reset.py
+++ b/tests/unit/test_reset.py
@@ -8,7 +8,7 @@ never touches the package, leaving the CLI ready for `tj onboard` again.
 """
 from __future__ import annotations
 
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 import pytest
 from click.testing import CliRunner
@@ -20,6 +20,25 @@ from tokenjam.cli.cmd_reset import cmd_reset
 @pytest.fixture
 def runner():
     return CliRunner()
+
+
+@pytest.fixture(autouse=True)
+def _isolate(tmp_path, monkeypatch):
+    """Keep reset off real machine state: fake HOME/cwd, no real subprocess,
+    no `claude` on PATH. Most tests below mock `_teardown_side_effects()`
+    entirely, but this guards any future test that exercises it for real —
+    mirrors the `_isolate` fixture in tests/integration/test_cli_uninstall.py
+    (Greptile #443)."""
+    home = tmp_path / "home"
+    home.mkdir()
+    monkeypatch.setenv("COLUMNS", "200")
+    monkeypatch.setattr("pathlib.Path.home", lambda: home)
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setattr("tokenjam.cli.cmd_stop.cmd_stop", MagicMock())
+    monkeypatch.delenv("PIPX_HOME", raising=False)
+    monkeypatch.delenv("XDG_DATA_HOME", raising=False)
+    with patch.object(uninstall_mod.shutil, "which", return_value=None):
+        yield
 
 
 def test_reset_calls_shared_teardown(runner):
@@ -35,11 +54,13 @@ def test_reset_never_touches_package_removal(runner):
     """`tj reset` must not invoke any package-removal path — no subprocess
     call, regardless of how tokenjam was installed."""
     with patch.object(uninstall_mod, "_teardown_side_effects"), \
-         patch.object(uninstall_mod, "_remove_package") as remove_package, \
+         patch.object(uninstall_mod, "_remove_persistent_install") as remove_install, \
+         patch.object(uninstall_mod, "_find_persistent_install") as find_installs, \
          patch.object(uninstall_mod.subprocess, "run") as run:
         result = runner.invoke(cmd_reset, ["--yes"])
     assert result.exit_code == 0, result.output
-    remove_package.assert_not_called()
+    remove_install.assert_not_called()
+    find_installs.assert_not_called()
     run.assert_not_called()
 
 

--- a/tests/unit/test_uninstall_persistent_install.py
+++ b/tests/unit/test_uninstall_persistent_install.py
@@ -1,0 +1,233 @@
+"""Tests for `_find_persistent_install()` (#443, Greptile P1): `tj uninstall`
+detects a persistent tokenjam install by probing the ENVIRONMENT, not the
+current process's `sys.executable`.
+
+Why this matters: `npx tokenjam uninstall` always runs `tj` via an ephemeral
+`uvx`/`pipx run` venv (see npm-wrapper/bin/tj.js's runner preference). The
+OLD `sys.executable`-based detection (`_installed_via_pipx()` etc.) always
+reported "this process is ephemeral, nothing to remove" on that path — even
+when the user had separately `pipx install`ed (or `uv tool install`ed)
+tokenjam, leaving that install behind while `tj uninstall` claimed success.
+
+These tests mock subprocess (`pipx list --json` / `uv tool list`) and the
+filesystem dir-probe fallback directly — never touch a real pipx/uv install.
+CLI-level behavior (prompt wording, execution) is covered in
+tests/integration/test_cli_uninstall.py, which patches
+`_find_persistent_install()` wholesale.
+"""
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from tokenjam.cli import cmd_uninstall as uninstall_mod
+
+
+@pytest.fixture(autouse=True)
+def _isolate(tmp_path, monkeypatch):
+    """Fake HOME so the dir-probe fallback never touches the real machine,
+    and unset PIPX_HOME/XDG_DATA_HOME so a developer's/CI runner's real
+    values can't leak into these tests."""
+    home = tmp_path / "home"
+    home.mkdir()
+    monkeypatch.setattr("pathlib.Path.home", lambda: home)
+    monkeypatch.delenv("PIPX_HOME", raising=False)
+    monkeypatch.delenv("XDG_DATA_HOME", raising=False)
+    return home
+
+
+# -- _pipx_has_tokenjam(): authoritative `pipx list --json`, dir-probe fallback
+
+
+def test_pipx_has_tokenjam_true_via_json_list():
+    fake = MagicMock(
+        returncode=0,
+        stdout='{"venvs": {"tokenjam": {"metadata": {}}}}',
+        stderr="",
+    )
+    with patch.object(uninstall_mod.shutil, "which", return_value="/usr/bin/pipx"), \
+         patch.object(uninstall_mod.subprocess, "run", return_value=fake) as run:
+        assert uninstall_mod._pipx_has_tokenjam() is True
+    run.assert_called_once_with(
+        ["/usr/bin/pipx", "list", "--json"],
+        capture_output=True, text=True, timeout=10,
+    )
+
+
+def test_pipx_has_tokenjam_false_via_json_list_when_absent():
+    """`pipx list --json` succeeds but tokenjam isn't in it — trust that,
+    don't fall back to the dir probe."""
+    fake = MagicMock(returncode=0, stdout='{"venvs": {"other": {}}}', stderr="")
+    with patch.object(uninstall_mod.shutil, "which", return_value="/usr/bin/pipx"), \
+         patch.object(uninstall_mod.subprocess, "run", return_value=fake):
+        assert uninstall_mod._pipx_has_tokenjam() is False
+
+
+def test_pipx_has_tokenjam_falls_back_to_dir_probe_when_pipx_missing(tmp_path, _isolate):
+    """No `pipx` binary on PATH (e.g. running via an ephemeral uvx venv that
+    has no pipx of its own) — fall back to the dir probe."""
+    venv_dir = _isolate / ".local" / "pipx" / "venvs" / "tokenjam"
+    venv_dir.mkdir(parents=True)
+    with patch.object(uninstall_mod.shutil, "which", return_value=None), \
+         patch.object(uninstall_mod.subprocess, "run") as run:
+        assert uninstall_mod._pipx_has_tokenjam() is True
+    run.assert_not_called()
+
+
+def test_pipx_has_tokenjam_dir_probe_respects_pipx_home_override(tmp_path, monkeypatch, _isolate):
+    custom = tmp_path / "custom-pipx"
+    (custom / "venvs" / "tokenjam").mkdir(parents=True)
+    monkeypatch.setenv("PIPX_HOME", str(custom))
+    with patch.object(uninstall_mod.shutil, "which", return_value=None):
+        assert uninstall_mod._pipx_has_tokenjam() is True
+
+
+def test_pipx_has_tokenjam_falls_back_when_command_errors():
+    """`pipx` is on PATH but the command exits non-zero — treat as "missing",
+    fall back to the dir probe (which reports False since nothing was seeded)."""
+    fake = MagicMock(returncode=1, stdout="", stderr="boom")
+    with patch.object(uninstall_mod.shutil, "which", return_value="/usr/bin/pipx"), \
+         patch.object(uninstall_mod.subprocess, "run", return_value=fake):
+        assert uninstall_mod._pipx_has_tokenjam() is False
+
+
+# -- _uv_tool_has_tokenjam(): authoritative `uv tool list`, dir-probe fallback
+
+
+def test_uv_tool_has_tokenjam_true_via_list():
+    fake = MagicMock(
+        returncode=0,
+        stdout="tokenjam v0.5.4\n- tj\n- tokenjam\nother v1.0.0\n- other\n",
+        stderr="",
+    )
+    with patch.object(uninstall_mod.shutil, "which", return_value="/usr/bin/uv"), \
+         patch.object(uninstall_mod.subprocess, "run", return_value=fake) as run:
+        assert uninstall_mod._uv_tool_has_tokenjam() is True
+    run.assert_called_once_with(
+        ["/usr/bin/uv", "tool", "list"],
+        capture_output=True, text=True, timeout=10,
+    )
+
+
+def test_uv_tool_has_tokenjam_ignores_entrypoint_lines():
+    """A tool literally named "tokenjam" as an ENTRYPOINT of some other
+    package (indented `- tokenjam` line) must not false-positive."""
+    fake = MagicMock(
+        returncode=0,
+        stdout="other-pkg v1.0.0\n- tokenjam\n- other-pkg\n",
+        stderr="",
+    )
+    with patch.object(uninstall_mod.shutil, "which", return_value="/usr/bin/uv"), \
+         patch.object(uninstall_mod.subprocess, "run", return_value=fake):
+        assert uninstall_mod._uv_tool_has_tokenjam() is False
+
+
+def test_uv_tool_has_tokenjam_falls_back_to_dir_probe_when_uv_missing(_isolate):
+    tool_dir = _isolate / ".local" / "share" / "uv" / "tools" / "tokenjam"
+    tool_dir.mkdir(parents=True)
+    with patch.object(uninstall_mod.shutil, "which", return_value=None), \
+         patch.object(uninstall_mod.subprocess, "run") as run:
+        assert uninstall_mod._uv_tool_has_tokenjam() is True
+    run.assert_not_called()
+
+
+def test_uv_tool_has_tokenjam_dir_probe_respects_xdg_data_home_override(tmp_path, monkeypatch, _isolate):
+    custom = tmp_path / "custom-xdg"
+    (custom / "uv" / "tools" / "tokenjam").mkdir(parents=True)
+    monkeypatch.setenv("XDG_DATA_HOME", str(custom))
+    with patch.object(uninstall_mod.shutil, "which", return_value=None):
+        assert uninstall_mod._uv_tool_has_tokenjam() is True
+
+
+# -- _pip_tj_on_path(): plain pip / editable-dev install on PATH
+
+
+def test_pip_tj_on_path_returns_plain_install():
+    with patch.object(uninstall_mod.shutil, "which", return_value="/usr/local/bin/tj"):
+        assert uninstall_mod._pip_tj_on_path() == "/usr/local/bin/tj"
+
+
+def test_pip_tj_on_path_none_when_missing():
+    with patch.object(uninstall_mod.shutil, "which", return_value=None):
+        assert uninstall_mod._pip_tj_on_path() is None
+
+
+@pytest.mark.parametrize("path", [
+    "/Users/x/.local/share/pipx/venvs/tokenjam/bin/tj",
+    "/Users/x/.local/share/uv/tools/tokenjam/bin/tj",
+    "/Users/x/.cache/uv/archive-v0/abc123/bin/tj",
+    "/Users/x/.local/pipx/.cache/abc123/bin/tj",
+])
+def test_pip_tj_on_path_excludes_other_managers_and_ephemeral_shims(path):
+    """Already covered by the pipx/uv-tool probes, or genuinely ephemeral —
+    must not double-count or falsely report a "plain pip" install."""
+    with patch.object(uninstall_mod.shutil, "which", return_value=path):
+        assert uninstall_mod._pip_tj_on_path() is None
+
+
+# -- _find_persistent_install(): the combined detection matrix
+
+
+def test_find_persistent_install_pipx_only():
+    with patch.object(uninstall_mod, "_pipx_has_tokenjam", return_value=True), \
+         patch.object(uninstall_mod, "_uv_tool_has_tokenjam", return_value=False), \
+         patch.object(uninstall_mod, "_pip_tj_on_path", return_value=None):
+        installs = uninstall_mod._find_persistent_install()
+    assert len(installs) == 1
+    assert installs[0].manager == "pipx"
+    assert installs[0].auto is True
+    assert installs[0].argv == ["pipx", "uninstall", "tokenjam"]
+
+
+def test_find_persistent_install_uv_tool_only():
+    with patch.object(uninstall_mod, "_pipx_has_tokenjam", return_value=False), \
+         patch.object(uninstall_mod, "_uv_tool_has_tokenjam", return_value=True), \
+         patch.object(uninstall_mod, "_pip_tj_on_path", return_value=None):
+        installs = uninstall_mod._find_persistent_install()
+    assert len(installs) == 1
+    assert installs[0].manager == "uv-tool"
+    assert installs[0].auto is True
+    assert installs[0].argv == ["uv", "tool", "uninstall", "tokenjam"]
+
+
+def test_find_persistent_install_pip_editable_only():
+    with patch.object(uninstall_mod, "_pipx_has_tokenjam", return_value=False), \
+         patch.object(uninstall_mod, "_uv_tool_has_tokenjam", return_value=False), \
+         patch.object(uninstall_mod, "_pip_tj_on_path", return_value="/usr/local/bin/tj"):
+        installs = uninstall_mod._find_persistent_install()
+    assert len(installs) == 1
+    assert installs[0].manager == "pip"
+    assert installs[0].auto is False
+    assert installs[0].argv is None
+
+
+def test_find_persistent_install_none_found():
+    with patch.object(uninstall_mod, "_pipx_has_tokenjam", return_value=False), \
+         patch.object(uninstall_mod, "_uv_tool_has_tokenjam", return_value=False), \
+         patch.object(uninstall_mod, "_pip_tj_on_path", return_value=None):
+        assert uninstall_mod._find_persistent_install() == []
+
+
+def test_find_persistent_install_both_pipx_and_uv_tool():
+    """Both a pipx AND a uv-tool install exist on the machine — both are
+    returned, so `tj uninstall` removes each auto-removable one."""
+    with patch.object(uninstall_mod, "_pipx_has_tokenjam", return_value=True), \
+         patch.object(uninstall_mod, "_uv_tool_has_tokenjam", return_value=True), \
+         patch.object(uninstall_mod, "_pip_tj_on_path", return_value=None):
+        installs = uninstall_mod._find_persistent_install()
+    assert {i.manager for i in installs} == {"pipx", "uv-tool"}
+    assert all(i.auto for i in installs)
+
+
+def test_find_persistent_install_ephemeral_current_process_still_detects_pipx():
+    """The scenario this whole fix targets: the CURRENT process is an
+    ephemeral uvx/pipx-run runner (as `npx tokenjam uninstall` always is),
+    but a persistent pipx install exists elsewhere — it's still detected."""
+    with patch.object(uninstall_mod, "_is_ephemeral_runner", return_value=True), \
+         patch.object(uninstall_mod, "_pipx_has_tokenjam", return_value=True), \
+         patch.object(uninstall_mod, "_uv_tool_has_tokenjam", return_value=False), \
+         patch.object(uninstall_mod, "_pip_tj_on_path", return_value=None):
+        installs = uninstall_mod._find_persistent_install()
+    assert len(installs) == 1
+    assert installs[0].manager == "pipx"

--- a/tests/unit/test_uninstall_runner_detect.py
+++ b/tests/unit/test_uninstall_runner_detect.py
@@ -46,9 +46,10 @@ def test_plain_pip_venv_is_neither_pipx_uv_tool_nor_ephemeral():
 
 def test_uv_managed_python_runtime_is_not_ephemeral():
     """A `pip install`-into-a-uv-managed-Python setup must NOT be classified
-    as ephemeral — that previously caused `tj uninstall --purge` to silently
-    no-op for these users (the `/uv/` substring check also matched uv's
-    managed *Python runtime* paths, not just its throwaway cache venvs).
+    as ephemeral — that previously caused `tj uninstall`'s package-removal
+    step to silently no-op for these users (the `/uv/` substring check also
+    matched uv's managed *Python runtime* paths, not just its throwaway
+    cache venvs).
     """
     with _exe(
         "/Users/x/.local/share/uv/python/cpython-3.12.4-macos-aarch64-none/"

--- a/tests/unit/test_uninstall_wrapper.py
+++ b/tests/unit/test_uninstall_wrapper.py
@@ -126,6 +126,11 @@ def test_uninstall_cli_removes_wrapper_and_cap_hook(tmp_path, monkeypatch):
     monkeypatch.setattr("pathlib.Path.home", lambda: home)
     monkeypatch.chdir(tmp_path)
     monkeypatch.setattr("tokenjam.cli.cmd_stop.cmd_stop", MagicMock())
+    # `_find_persistent_install()`'s dir-probe fallback reads these directly
+    # (not via Path.home()) — unset so a real PIPX_HOME/XDG_DATA_HOME on the
+    # dev/CI machine can't leak into this test's package-removal step.
+    monkeypatch.delenv("PIPX_HOME", raising=False)
+    monkeypatch.delenv("XDG_DATA_HOME", raising=False)
 
     # Seed a fixture ~/.zshrc as `tj onboard --claude-code` would leave it:
     # the OTEL harness-observability block, then the claude() wrapper.

--- a/tokenjam/cli/cmd_reset.py
+++ b/tokenjam/cli/cmd_reset.py
@@ -1,0 +1,33 @@
+from __future__ import annotations
+
+import click
+
+from tokenjam.utils.formatting import console
+
+
+@click.command("reset")
+@click.option("--yes", is_flag=True, help="Skip confirmation prompt")
+@click.pass_context
+def cmd_reset(ctx: click.Context, yes: bool) -> None:
+    """Wipe TokenJam's config/daemon/wiring — keeps the tokenjam package installed.
+
+    The config-only counterpart to `tj uninstall` (which also removes the
+    package itself): use `tj reset` to reconfigure or pause TokenJam without
+    reinstalling the CLI afterward. Run `tj onboard` again to set back up.
+    """
+    if not yes:
+        confirmed = click.confirm(
+            "This will delete all TokenJam config, telemetry history, daemon, "
+            "and shell wiring — the tokenjam package itself stays installed. "
+            "Continue?",
+            default=False,
+        )
+        if not confirmed:
+            console.print("[dim]Cancelled.[/dim]")
+            return
+
+    from tokenjam.cli.cmd_uninstall import _teardown_side_effects
+    _teardown_side_effects(ctx)
+
+    console.print()
+    console.print("[dim]Run[/dim]  tj onboard  [dim]to set up again.[/dim]")

--- a/tokenjam/cli/cmd_uninstall.py
+++ b/tokenjam/cli/cmd_uninstall.py
@@ -1,9 +1,11 @@
 from __future__ import annotations
 
 import json
+import os
 import shutil
 import subprocess
 import sys
+from dataclasses import dataclass
 from pathlib import Path
 
 import click
@@ -90,7 +92,7 @@ def _package_reinstall_hint() -> str:
     return "pip install --upgrade tokenjam"
 
 
-def _package_fresh_install_hint() -> str:
+def _package_fresh_install_hint(manager: str | None = None) -> str:
     """Return the command that reinstalls after the package was fully removed.
 
     Once the venv is gone, `pipx upgrade` / `uv tool upgrade` fail ("not
@@ -99,12 +101,191 @@ def _package_fresh_install_hint() -> str:
     `_package_reinstall_hint()`, which is only correct while the package
     REMAINS in place (a plain install would no-op then, so it points at
     upgrade/--force).
+
+    `manager` overrides the current-process auto-detection (one of
+    `PersistentInstall.manager`'s values: "pipx" / "uv-tool" / "pip") — pass
+    the manager of the install that was just removed via
+    `_find_persistent_install()`. This matters because `tj uninstall` almost
+    always runs from an ephemeral `uvx`/`pipx run` process (the npx wrapper's
+    default), whose OWN `sys.executable` never matches the persistent
+    pipx/uv-tool install it just removed on the user's behalf.
     """
-    if _installed_via_pipx():
+    if manager is None:
+        if _installed_via_pipx():
+            manager = "pipx"
+        elif _installed_via_uv_tool():
+            manager = "uv-tool"
+        else:
+            manager = "pip"
+    if manager == "pipx":
         return "pipx install tokenjam"
-    if _installed_via_uv_tool():
+    if manager == "uv-tool":
         return "uv tool install tokenjam"
     return "pip install tokenjam"
+
+
+@dataclass(frozen=True)
+class PersistentInstall:
+    """One persistent tokenjam install found somewhere on the machine —
+    independent of how the CURRENT `tj` process happens to be running (see
+    `_find_persistent_install()`)."""
+
+    manager: str              # "pipx" | "uv-tool" | "pip"
+    auto: bool                # True: safe to auto-run `argv` non-interactively
+    argv: list[str] | None    # subprocess argv when auto=True, else None
+    display: str              # human-readable command, for prompts + printing
+
+
+_MANAGER_LABEL = {"pipx": "pipx", "uv-tool": "uv tool", "pip": "pip"}
+
+
+def _pipx_home() -> Path:
+    """pipx's data dir — `PIPX_HOME` overrides the default `~/.local/pipx`."""
+    override = os.environ.get("PIPX_HOME")
+    return Path(override) if override else Path.home() / ".local" / "pipx"
+
+
+def _uv_data_home() -> Path:
+    """uv's data dir — `XDG_DATA_HOME` overrides the default `~/.local/share`."""
+    override = os.environ.get("XDG_DATA_HOME")
+    base = Path(override) if override else Path.home() / ".local" / "share"
+    return base / "uv"
+
+
+def _pipx_has_tokenjam() -> bool:
+    """Authoritative: `pipx list --json` reports a `tokenjam` venv. Falls
+    back to a dir probe (`${PIPX_HOME:-~/.local/pipx}/venvs/tokenjam`) only
+    when the `pipx` binary is missing or the command errors — e.g. probing
+    from an ephemeral `uvx`/`pipx run` process that has no `pipx` on its own
+    PATH, even though a persistent pipx install exists elsewhere on the
+    machine."""
+    pipx_bin = shutil.which("pipx")
+    if pipx_bin:
+        try:
+            result = subprocess.run(
+                [pipx_bin, "list", "--json"],
+                capture_output=True, text=True, timeout=10,
+            )
+            if result.returncode == 0:
+                data = json.loads(result.stdout)
+                return "tokenjam" in data.get("venvs", {})
+        except Exception:
+            pass
+    return (_pipx_home() / "venvs" / "tokenjam").exists()
+
+
+def _uv_tool_has_tokenjam() -> bool:
+    """Authoritative: `uv tool list` reports a `tokenjam` tool. Falls back to
+    a dir probe (`${XDG_DATA_HOME:-~/.local/share}/uv/tools/tokenjam`) only
+    when `uv` is missing or the command errors. `uv tool list` has no --json
+    output today, so text-parse it — only unindented lines that don't start
+    with `-` are package names (indented `- <entrypoint>` lines list each
+    tool's installed scripts, not other packages)."""
+    uv_bin = shutil.which("uv")
+    if uv_bin:
+        try:
+            result = subprocess.run(
+                [uv_bin, "tool", "list"],
+                capture_output=True, text=True, timeout=10,
+            )
+            if result.returncode == 0:
+                for line in result.stdout.splitlines():
+                    if not line or line[0].isspace() or line.lstrip().startswith("-"):
+                        continue
+                    if line.split()[0] == "tokenjam":
+                        return True
+                return False
+        except Exception:
+            pass
+    return (_uv_data_home() / "tools" / "tokenjam").exists()
+
+
+def _pip_tj_on_path() -> str | None:
+    """Return a persistent `tj` on PATH that is a plain pip / editable-dev
+    install — i.e. neither pipx- nor uv-tool-managed (those are already
+    covered by `_pipx_has_tokenjam()`/`_uv_tool_has_tokenjam()`) nor an
+    ephemeral cache shim (`uvx`/`pipx run` — nothing to remove there).
+    None if `tj` isn't found on PATH, or it resolves to one of those other
+    categories."""
+    tj_path = shutil.which("tj")
+    if not tj_path:
+        return None
+    norm = tj_path.replace("\\", "/")
+    if "pipx/venvs/" in norm or "/uv/tools/" in norm:
+        return None
+    if (
+        "/uv/archive-" in norm or "/uv/builds-" in norm
+        or ".cache/uv/" in norm or "/pipx/.cache/" in norm
+    ):
+        return None
+    return tj_path
+
+
+def _find_persistent_install() -> list[PersistentInstall]:
+    """Probe the ENVIRONMENT — not the current process — for every
+    persistent tokenjam install on the machine.
+
+    `npx tokenjam uninstall` always runs `tj` via an ephemeral `uvx`/
+    `pipx run` venv (see npm-wrapper/bin/tj.js's runner preference), so the
+    `sys.executable`-based helpers above (`_installed_via_pipx()`,
+    `_is_ephemeral_runner()`, etc.) always report "this process is
+    ephemeral" on that path — the WRONG signal for what `tj uninstall`
+    should remove. A user who separately `pipx install`ed tokenjam still has
+    that install sitting on disk; only probing the environment (not
+    `sys.executable`) finds it, so it can actually be removed from within an
+    ephemeral `npx tokenjam uninstall` run instead of silently leaving it
+    behind while claiming success.
+
+    Checks, in order: `pipx list --json` (dir-probe fallback), `uv tool
+    list` (dir-probe fallback), then a plain `tj` on PATH that is neither of
+    those managers nor an ephemeral cache shim (a plain pip install or an
+    editable dev checkout). Returns EVERY match, not just the first — pipx
+    and uv-tool installs can coexist on one machine, and `tj uninstall`
+    removes every auto-removable one it finds.
+    """
+    installs: list[PersistentInstall] = []
+    if _pipx_has_tokenjam():
+        installs.append(PersistentInstall(
+            manager="pipx", auto=True,
+            argv=["pipx", "uninstall", "tokenjam"],
+            display="pipx uninstall tokenjam",
+        ))
+    if _uv_tool_has_tokenjam():
+        installs.append(PersistentInstall(
+            manager="uv-tool", auto=True,
+            argv=["uv", "tool", "uninstall", "tokenjam"],
+            display="uv tool uninstall tokenjam",
+        ))
+    if _pip_tj_on_path():
+        installs.append(PersistentInstall(
+            manager="pip", auto=False, argv=None,
+            display="pip uninstall tokenjam",
+        ))
+    return installs
+
+
+def _uninstall_confirm_prompt(installs: list[PersistentInstall]) -> str:
+    """Build the `tj uninstall` confirm prompt so it states EXACTLY what will
+    happen. Detection (`_find_persistent_install()`) runs BEFORE this is
+    called (see `cmd_uninstall`) — the prompt must never promise a package
+    removal that won't actually happen, or fail to mention one that will
+    (Greptile P1 on #443)."""
+    base = (
+        "This will delete all TokenJam data (config, telemetry history, "
+        "daemon, shell wiring)"
+    )
+    auto = [i for i in installs if i.auto]
+    manual = [i for i in installs if not i.auto]
+    clauses = []
+    if auto:
+        labels = " and ".join(_MANAGER_LABEL[i.manager] for i in auto)
+        clauses.append(f"and uninstall the tokenjam package (via {labels})")
+    if manual:
+        cmds = " / ".join(i.display for i in manual)
+        clauses.append(f"your package install will need `{cmds}` (shown after)")
+    if clauses:
+        base += ", " + "; ".join(clauses)
+    return base + ". Continue?"
 
 
 @click.command("uninstall")
@@ -116,34 +297,38 @@ def cmd_uninstall(ctx: click.Context, yes: bool) -> None:
     The full symmetric counterpart to `tj onboard`. For a config-only reset
     that leaves the tokenjam CLI installed (e.g. to reconfigure or pause),
     use `tj reset` instead.
+
+    Package detection is environment-wide (`_find_persistent_install()`),
+    not based on the current process — `tj uninstall` almost always runs via
+    an ephemeral `uvx`/`pipx run` venv (the npx wrapper's default), and that
+    process's own `sys.executable` says nothing about a persistent pipx/
+    uv-tool install sitting elsewhere on the machine.
     """
+    # Detect FIRST so the confirmation prompt states exactly what will
+    # happen — never promising a package removal that won't occur, or vice
+    # versa.
+    installs = _find_persistent_install()
+
     if not yes:
-        confirmed = click.confirm(
-            "This will delete all TokenJam data (config, telemetry history, "
-            "daemon, shell wiring) AND remove the tokenjam package itself. "
-            "Continue?",
-            default=False,
-        )
+        confirmed = click.confirm(_uninstall_confirm_prompt(installs), default=False)
         if not confirmed:
             console.print("[dim]Cancelled.[/dim]")
             return
 
     _teardown_side_effects(ctx)
 
-    # Package removal (#121, now the default — see #442). `tj uninstall` is
-    # meant to be the single symmetric counterpart to `tj onboard` — but an
-    # ephemeral runner (uvx/pipx run, incl. via the npx wrapper) has no
-    # persistent package to remove in the first place.
-    if _is_ephemeral_runner():
+    if not installs:
         console.print(
-            "[dim]Running via an ephemeral runner (uvx/pipx run) — "
-            "nothing persistent to remove; onboarding side-effects above are "
-            "already cleaned.[/dim]"
+            "[dim]No persistent tokenjam install found on this machine — "
+            "nothing to remove; the config/wiring cleanup above is already "
+            "done.[/dim]"
         )
         return
 
+    console.print()
     console.print("[dim]Removing the tokenjam package...[/dim]")
-    _remove_package(_package_uninstall_hint())
+    for install in installs:
+        _remove_persistent_install(install)
 
 
 def _teardown_side_effects(ctx: click.Context) -> None:
@@ -316,10 +501,10 @@ def _teardown_side_effects(ctx: click.Context) -> None:
     console.print("[green]TokenJam data, config, and wiring removed.[/green]")
 
 
-def _run_auto_uninstall(argv: list[str], uninstall_cmd: str) -> None:
+def _run_auto_uninstall(argv: list[str], uninstall_cmd: str, manager: str) -> None:
     """Shared runner for the pipx/uv-tool auto-remove branches: run `argv`,
-    then report success (with the fresh-install hint) or fall back to the
-    manual command on failure."""
+    then report success (with the fresh-install hint for `manager`) or fall
+    back to the manual command on failure."""
     console.print()
     console.print(f"Running: [bold]{uninstall_cmd}[/bold]")
     result = subprocess.run(argv, capture_output=True, text=True)
@@ -327,9 +512,11 @@ def _run_auto_uninstall(argv: list[str], uninstall_cmd: str) -> None:
         console.print("[green]tokenjam package removed.[/green]")
         # The venv is gone now, so upgrade would fail ("not installed") —
         # point at the plain fresh install, not the upgrade/--force reinstall
-        # hint (#430).
+        # hint (#430). `manager` is the install that was JUST removed, not
+        # necessarily what the current (often ephemeral) process would guess.
         console.print(
-            f"  [dim]To reinstall FRESH: {_package_fresh_install_hint()}[/dim]"
+            f"  [dim]To reinstall FRESH: "
+            f"{_package_fresh_install_hint(manager)}[/dim]"
         )
     else:
         console.print(
@@ -339,26 +526,22 @@ def _run_auto_uninstall(argv: list[str], uninstall_cmd: str) -> None:
         console.print(f"  Run manually: [bold]{uninstall_cmd}[/bold]")
 
 
-def _remove_package(uninstall_cmd: str) -> None:
-    """Run the package uninstall when we can, else print the exact command.
+def _remove_persistent_install(install: PersistentInstall) -> None:
+    """Execute (pipx/uv-tool) or print (pip/editable) removal for one
+    detected persistent install (`_find_persistent_install()`).
 
-    Only pipx and `uv tool` are auto-run: both are isolated, canonical install
-    paths safe to invoke non-interactively. For pip / venv installs we print
-    the command instead of guessing (a wrong `pip uninstall` in the wrong
-    environment is worse than a copy-paste)."""
-    if _installed_via_pipx() and shutil.which("pipx"):
-        _run_auto_uninstall(["pipx", "uninstall", "tokenjam"], uninstall_cmd)
+    Only pipx and `uv tool` are auto-run: both are isolated, canonical
+    install paths safe to invoke non-interactively. For pip / editable-dev
+    installs we print the command instead of guessing — a wrong
+    `pip uninstall` in the wrong (possibly shared/live) environment is worse
+    than a copy-paste."""
+    if install.auto and install.argv:
+        _run_auto_uninstall(install.argv, install.display, install.manager)
         return
 
-    if _installed_via_uv_tool() and shutil.which("uv"):
-        _run_auto_uninstall(["uv", "tool", "uninstall", "tokenjam"], uninstall_cmd)
-        return
-
-    # Not a pipx/uv-tool install (or the tool binary is missing) — print the
-    # right command, don't guess.
     console.print()
     console.print(
         "  [yellow]Can't safely auto-remove this install "
         "(not a pipx- or uv-tool-managed venv).[/yellow]"
     )
-    console.print(f"  Remove the package with: [bold]{uninstall_cmd}[/bold]")
+    console.print(f"  Remove the package with: [bold]{install.display}[/bold]")

--- a/tokenjam/cli/cmd_uninstall.py
+++ b/tokenjam/cli/cmd_uninstall.py
@@ -33,7 +33,7 @@ def _installed_via_uv_tool() -> bool:
 
 def _is_ephemeral_runner() -> bool:
     """True when this process is a throwaway venv from `uvx`/`uv tool run` or
-    `pipx run` — there is no persistent tokenjam install to purge.
+    `pipx run` — there is no persistent tokenjam install to remove.
 
     Verified empirically: `uvx --from tokenjam tj ...` materializes its venv
     under uv's cache dir (.../uv/archive-<rev>/<hash>/...), never under
@@ -44,10 +44,11 @@ def _is_ephemeral_runner() -> bool:
     Deliberately narrow: matching on a bare "/uv/" substring also caught
     uv-managed Python *runtimes* (.../uv/python/cpython-.../bin/python3) and
     uv-tool installs (.../uv/tools/...) — both persistent installs, not
-    ephemeral ones — which silently no-opped `tj uninstall --purge` for
-    those users. Only uv's cache dirs (archive/builds, or the generic
-    .cache/uv/ prefix) count as ephemeral; uv doesn't pin the "archive-v0"
-    suffix forever, so match the prefix rather than the exact revision.
+    ephemeral ones — which silently no-opped `tj uninstall`'s package-removal
+    step for those users. Only uv's cache dirs (archive/builds, or the
+    generic .cache/uv/ prefix) count as ephemeral; uv doesn't pin the
+    "archive-v0" suffix forever, so match the prefix rather than the exact
+    revision.
     """
     if _installed_via_pipx() or _installed_via_uv_tool():
         return False
@@ -108,29 +109,53 @@ def _package_fresh_install_hint() -> str:
 
 @click.command("uninstall")
 @click.option("--yes", is_flag=True, help="Skip confirmation prompt")
-@click.option(
-    "--purge",
-    "--remove-package",
-    "remove_package",
-    is_flag=True,
-    help="Also remove the tokenjam package: runs the uninstall for "
-    "pipx- or uv-tool-managed installs, or prints the command to run for "
-    "pip/venv installs. A no-op (with an explanation) when running from an "
-    "ephemeral runner (uvx/pipx run) — there's nothing persistent to "
-    "remove. With --yes, proceeds without a second prompt.",
-)
 @click.pass_context
-def cmd_uninstall(ctx: click.Context, yes: bool, remove_package: bool) -> None:
-    """Remove all TokenJam data, config, and daemon."""
+def cmd_uninstall(ctx: click.Context, yes: bool) -> None:
+    """Remove TokenJam entirely: config/daemon/wiring AND the tokenjam package.
+
+    The full symmetric counterpart to `tj onboard`. For a config-only reset
+    that leaves the tokenjam CLI installed (e.g. to reconfigure or pause),
+    use `tj reset` instead.
+    """
     if not yes:
         confirmed = click.confirm(
-            "This will delete all TokenJam data including telemetry history. Continue?",
+            "This will delete all TokenJam data (config, telemetry history, "
+            "daemon, shell wiring) AND remove the tokenjam package itself. "
+            "Continue?",
             default=False,
         )
         if not confirmed:
             console.print("[dim]Cancelled.[/dim]")
             return
 
+    _teardown_side_effects(ctx)
+
+    # Package removal (#121, now the default — see #442). `tj uninstall` is
+    # meant to be the single symmetric counterpart to `tj onboard` — but an
+    # ephemeral runner (uvx/pipx run, incl. via the npx wrapper) has no
+    # persistent package to remove in the first place.
+    if _is_ephemeral_runner():
+        console.print(
+            "[dim]Running via an ephemeral runner (uvx/pipx run) — "
+            "nothing persistent to remove; onboarding side-effects above are "
+            "already cleaned.[/dim]"
+        )
+        return
+
+    console.print("[dim]Removing the tokenjam package...[/dim]")
+    _remove_package(_package_uninstall_hint())
+
+
+def _teardown_side_effects(ctx: click.Context) -> None:
+    """Reverse everything `tj onboard` wires up — stop/unregister the daemon,
+    deregister the Claude Code MCP server, delete TokenJam's config/DB/temp
+    files, and strip the tj-managed `~/.zshrc` OTEL block + `claude()`
+    wrapper + per-project `settings.json` env vars. Does NOT touch the
+    tokenjam package itself.
+
+    Shared by `tj uninstall` (this, plus removing the package) and `tj reset`
+    (this only — package stays installed, ready for `tj onboard` again).
+    """
     # 1. Stop tj serve if running
     from tokenjam.cli.cmd_stop import cmd_stop
     ctx.invoke(cmd_stop)
@@ -289,55 +314,6 @@ def cmd_uninstall(ctx: click.Context, yes: bool, remove_package: bool) -> None:
 
     console.print()
     console.print("[green]TokenJam data, config, and wiring removed.[/green]")
-
-    # 12. Package removal (#121). `npx tokenjam uninstall` is meant to be the
-    # single symmetric counterpart to `npx tokenjam onboard` — but an
-    # ephemeral runner (uvx/pipx run, incl. via the npx wrapper) has no
-    # persistent package to remove in the first place. Detect that first so
-    # --purge / the prompt never offer to remove something that isn't there.
-    if _is_ephemeral_runner():
-        console.print(
-            "[dim]Running via an ephemeral runner (uvx/pipx run) — "
-            "nothing persistent to remove; onboarding side-effects above are "
-            "already cleaned.[/dim]"
-        )
-        if remove_package:
-            console.print("[dim]--purge is a no-op here.[/dim]")
-        return
-
-    console.print("[dim]The tokenjam package itself is still installed.[/dim]")
-
-    uninstall_cmd = _package_uninstall_hint()
-    do_remove = remove_package
-    if not do_remove and not yes:
-        # pipx/uv-tool installs are auto-run; pip/venv installs only get the
-        # command printed (a wrong `pip uninstall` in the wrong env is
-        # worse), so word the prompt to match what will actually happen
-        # (#430).
-        prompt_action = (
-            f"runs {uninstall_cmd}"
-            if _installed_via_pipx() or _installed_via_uv_tool()
-            else f"prints {uninstall_cmd} for you to run"
-        )
-        do_remove = click.confirm(
-            f"Also remove the tokenjam package now? ({prompt_action})",
-            default=False,
-        )
-
-    if do_remove:
-        _remove_package(uninstall_cmd)
-        return
-
-    # Package left in place: spell out the two-step so a later reinstall isn't
-    # a silent no-op (a plain `pipx/pip install` no-ops when already present).
-    console.print()
-    console.print("Next steps:")
-    console.print(f"  Fully remove the package:  [bold]{uninstall_cmd}[/bold]")
-    console.print(f"  Reinstall FRESH:           [bold]{_package_reinstall_hint()}[/bold]")
-    console.print(
-        "  [dim]A plain `install` no-ops when tokenjam is already present — "
-        "use the upgrade/--force form above to reinstall.[/dim]"
-    )
 
 
 def _run_auto_uninstall(argv: list[str], uninstall_cmd: str) -> None:

--- a/tokenjam/cli/main.py
+++ b/tokenjam/cli/main.py
@@ -110,6 +110,7 @@ from tokenjam.cli.cmd_export import cmd_export  # noqa: E402
 from tokenjam.cli.cmd_serve import cmd_serve  # noqa: E402
 from tokenjam.cli.cmd_stop import cmd_stop  # noqa: E402
 from tokenjam.cli.cmd_uninstall import cmd_uninstall  # noqa: E402
+from tokenjam.cli.cmd_reset import cmd_reset  # noqa: E402
 from tokenjam.cli.cmd_doctor import cmd_doctor  # noqa: E402
 from tokenjam.cli.cmd_budget import cmd_budget  # noqa: E402
 from tokenjam.cli.cmd_optimize import cmd_optimize  # noqa: E402
@@ -141,6 +142,7 @@ cli.add_command(cmd_export, name="export")
 cli.add_command(cmd_serve, name="serve")
 cli.add_command(cmd_stop, name="stop")
 cli.add_command(cmd_uninstall, name="uninstall")
+cli.add_command(cmd_reset, name="reset")
 cli.add_command(cmd_doctor, name="doctor")
 cli.add_command(cmd_budget, name="budget")
 cli.add_command(cmd_optimize, name="optimize")


### PR DESCRIPTION
## Summary

Follow-up to #442 (already merged): redesigns the uninstall UX per product decision, replacing the `--purge`/`--remove-package` flag with two clearly-named commands — then fixes a P1 Greptile finding in the package-detection logic itself.

### Two commands, no flag

- **`tj uninstall`** → full removal **by default**: the existing Layer-2 config/daemon/wiring teardown **plus** Layer-1 package removal (what `--purge` used to gate). Single symmetric counterpart to `tj onboard`.
- **`tj reset`** (new, `tokenjam/cli/cmd_reset.py`) → Layer-2 teardown **only** — package stays installed, ready for `tj onboard` again. Registered in `cli/main.py` next to onboard/uninstall.
- Extracted the shared Layer-2 teardown into `_teardown_side_effects()` in `cmd_uninstall.py` (pure refactor, no behavior change) so both commands share one code path.
- `--purge`, `--remove-package`, and the old second "also remove the package?" prompt are gone.
- `npx tokenjam uninstall` / `npx tokenjam reset` both work through the existing generic npm-wrapper passthrough — no wrapper changes needed.
- Updated `docs/claude-code-integration.md` and `docs/cli-reference.md` to the new model.

### Outward, environment-wide package detection (Greptile P1)

`npx tokenjam uninstall` **always** runs `tj` via an ephemeral `uvx`/`pipx run` venv (the npm wrapper's runner preference). The initial package-removal logic introspected the CURRENT process's `sys.executable`, so it always concluded "this process is ephemeral, nothing to remove" — even when the user had separately `pipx install`ed (or `uv tool install`ed) tokenjam. That silently left the package behind (making `tj uninstall` behave like `tj reset`) while the confirm prompt still claimed it would remove the package.

Fixed with a proper outward probe:
- **`_find_persistent_install()`**: checks `pipx list --json` (dir-probe fallback at `${PIPX_HOME:-~/.local/pipx}/venvs/tokenjam`), `uv tool list` (dir-probe fallback at `${XDG_DATA_HOME:-~/.local/share}/uv/tools/tokenjam`), then a plain `tj` on PATH that isn't either of those or an ephemeral cache shim (pip / editable-dev install). Returns **every** match — pipx and uv-tool installs can coexist, and `tj uninstall` removes each auto-removable one it finds.
- **Honest confirm prompt**: detection now runs *before* the prompt is built. Wording varies by what was actually found:
  - pipx/uv-tool present → "...and uninstall the tokenjam package (via pipx / uv tool)"
  - pip/editable only → "...your package install will need `pip uninstall tokenjam` (shown after)" (never auto-run — could be a shared/live env or an editable dev checkout)
  - nothing found → no package claim at all, only config/daemon/wiring
- `_package_fresh_install_hint()` now takes the removed install's manager explicitly instead of re-guessing from the (often ephemeral) current process.
- Test isolation hardened: the uninstall/reset `_isolate` fixtures now unset `PIPX_HOME`/`XDG_DATA_HOME` so a developer's/CI runner's real environment can't leak into a test that doesn't explicitly mock `_find_persistent_install()`.

### Greptile findings resolved

1. **[P1]** Package detection is environment-wide, not process-local — `npx tokenjam uninstall` now genuinely removes a persistent pipx/uv install even though the running process is ephemeral. *(fixed via `_find_persistent_install()` above)*
2. **[P2]** `tests/unit/test_reset.py` now has an `autouse` filesystem-isolation fixture mirroring `tests/integration/test_cli_uninstall.py`'s (fake `Path.home()`, stubbed `cmd_stop`, unset `PIPX_HOME`/`XDG_DATA_HOME`) so future tests can't hit real machine state.
3. **[P2]** New tests assert the confirm prompt matches reality per detected case, including invoking uninstall *without* `--yes` on an ephemeral-current-process-but-persistent-pipx-present scenario — the exact bug this PR fixes.

New unit coverage in `tests/unit/test_uninstall_persistent_install.py`: pipx-only, uv-tool-only, pip/editable-only, none, both-pipx-and-uv-tool, dir-probe fallback + env-var overrides, and the ephemeral-current-process-still-detects-a-persistent-install scenario.

Supersedes #439, #441, #440 — those are the per-ticket branches now folded into this single PR.

## Test plan

- [x] `python -m pytest tests/unit/ tests/integration/ -q` → **2126 passed, 1 skipped, 2 warnings in 42.26s**
- [x] `ruff check` clean on all touched files
- [x] `grep -rn 'purge|remove-package|remove_package|keep-package' tokenjam/ tests/ docs/` → zero real hits (only unrelated `_codex_purge_legacy_ocw`/data-purging comments, and one intentional historical mention in this PR's own test docstring)
- [x] Manually verified `tj uninstall --help` / `tj reset --help` and exercised `_uninstall_confirm_prompt()` for all three detection outcomes (pipx / none / pip) — wording matches spec exactly
- [x] Verified zero leftover `<<<<<<<`/`>>>>>>>`/`=======` conflict markers across both `main`-sync merges into this branch

🤖 Generated with [Claude Code](https://claude.com/claude-code)
