### PR TITLE
fix: bound and surface progress for onboard's Claude Code backfill

### DIFF
--- a/tests/unit/test_backfill.py
+++ b/tests/unit/test_backfill.py
@@ -10,6 +10,7 @@ from click.testing import CliRunner
 from tokenjam.cli import cmd_backfill as cmd_backfill_module
 from tokenjam.core.backfill import (
     BackfillResult,
+    count_claude_code_sessions_in_scope,
     ingest_claude_code,
     iter_claude_code_sessions,
     parse_claude_code_session,
@@ -514,6 +515,78 @@ def test_claude_code_backfill_rejects_two_since_flags(tmp_path, monkeypatch):
 
     assert result.exit_code != 0
     assert "Use either --since or --since-days" in result.output
+
+
+# --- #443: cheap in-scope session count (progress bar total + heads-up) -----
+
+
+def test_count_sessions_in_scope_no_root_returns_zero(tmp_path):
+    assert count_claude_code_sessions_in_scope(root=tmp_path / "no-such-dir") == 0
+
+
+def test_count_sessions_in_scope_counts_all_files_with_no_since(tmp_path):
+    for i in range(5):
+        _make_session_file(tmp_path, f"sess-{i}", "/Users/me/proj", [
+            _assistant_record(f"u{i}", "claude-sonnet-4-5-20250929", 10, 5,
+                              "2026-06-20T10:00:00.000Z", f"sess-{i}", "/Users/me/proj"),
+        ])
+    assert count_claude_code_sessions_in_scope(root=tmp_path) == 5
+
+
+def test_count_sessions_in_scope_honors_since_mtime_filter(tmp_path):
+    old = _make_session_file(tmp_path, "sess-old", "/Users/me/proj", [
+        _assistant_record("u1", "claude-sonnet-4-5-20250929", 10, 5,
+                          "2020-01-01T10:00:00.000Z", "sess-old", "/Users/me/proj"),
+    ])
+    _make_session_file(tmp_path, "sess-new", "/Users/me/proj", [
+        _assistant_record("u2", "claude-sonnet-4-5-20250929", 10, 5,
+                          "2026-06-20T10:00:00.000Z", "sess-new", "/Users/me/proj"),
+    ])
+    import os
+    import time
+    old_time = time.time() - 3600 * 24 * 400  # 400 days ago
+    os.utime(old, (old_time, old_time))
+
+    cutoff = datetime(2026, 1, 1, tzinfo=timezone.utc)
+    assert count_claude_code_sessions_in_scope(root=tmp_path, since=cutoff) == 1
+
+
+def test_count_sessions_in_scope_caps_at_max_sessions(tmp_path):
+    for i in range(10):
+        _make_session_file(tmp_path, f"sess-{i}", "/Users/me/proj", [
+            _assistant_record(f"u{i}", "claude-sonnet-4-5-20250929", 10, 5,
+                              "2026-06-20T10:00:00.000Z", f"sess-{i}", "/Users/me/proj"),
+        ])
+    assert count_claude_code_sessions_in_scope(root=tmp_path, max_sessions=4) == 4
+    assert count_claude_code_sessions_in_scope(root=tmp_path, max_sessions=100) == 10
+
+
+def test_ingest_since_and_max_sessions_together_caps_and_keeps_most_recent(tmp_path):
+    """The onboard "fast" path (#443) passes `since` AND `max_sessions`
+    together — `since` alone doesn't reliably bound the work on a machine
+    where most session files share recent mtimes, so `max_sessions` is the
+    real guarantee. Confirms both apply: `limit_reached` fires, and the cap
+    keeps the most-recent (by mtime) sessions, not an arbitrary subset."""
+    import os
+
+    for i in range(10):
+        sid = f"sess-{i:02d}"
+        path = _make_session_file(tmp_path, sid, _CWD, [
+            _assistant_record(f"u{i}", "claude-sonnet-4-5-20250929", 10, 5,
+                              "2026-06-20T10:00:00.000Z", sid, _CWD),
+        ])
+        # Newer index => newer mtime; all comfortably within `since`.
+        os.utime(path, (1_900_000_000 + i, 1_900_000_000 + i))
+
+    db = InMemoryBackend()
+    since = datetime(2020, 1, 1, tzinfo=timezone.utc)  # wide enough to include all 10
+    result = ingest_claude_code(db, root=tmp_path, since=since, max_sessions=4)
+
+    assert result.limit_reached is True
+    assert result.sessions_ingested == 4
+    session_ids = {r[0] for r in db.conn.execute("SELECT session_id FROM sessions").fetchall()}
+    # The 4 highest-indexed (newest-mtime) sessions were kept, not the oldest.
+    assert session_ids == {"sess-06", "sess-07", "sess-08", "sess-09"}
 
 
 # --- #294: dedup resumed/branched sessions (over-counted tokens) -------------- #

--- a/tests/unit/test_backfill_progress.py
+++ b/tests/unit/test_backfill_progress.py
@@ -1,0 +1,76 @@
+"""Unit tests for the shared Claude Code backfill progress UI (#443).
+
+`tj backfill claude-code` and `tj onboard --claude-code` both drive
+`ingest_claude_code`'s `progress=` hook through `backfill_progress` — this
+covers the TTY-aware branch (Rich `Progress` vs. periodic plain prints) and
+the running counters (session count, "of total", accumulated tokens).
+"""
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+from tokenjam.cli.backfill_progress import backfill_progress
+from tokenjam.core.backfill import BackfillResult, ParsedSession
+
+
+def _parsed(session_id: str, input_tokens: int = 100, output_tokens: int = 50,
+           cache_tokens: int = 0) -> ParsedSession:
+    now = datetime(2026, 6, 20, tzinfo=timezone.utc)
+    return ParsedSession(
+        session_id=session_id,
+        agent_id="claude-code-proj",
+        started_at=now,
+        ended_at=now,
+        cwd="/Users/me/proj",
+        spans=[],
+        total_input_tokens=input_tokens,
+        total_output_tokens=output_tokens,
+        total_cache_tokens=cache_tokens,
+        total_cost_usd=0.01,
+        tool_call_count=0,
+    )
+
+
+def _result(sessions_seen: int) -> BackfillResult:
+    r = BackfillResult()
+    r.sessions_seen = sessions_seen
+    return r
+
+
+def test_quiet_yields_noop_callback(capsys):
+    with backfill_progress(10, quiet=True) as cb:
+        cb(_parsed("s1"), _result(1))
+    # No output at all — matches `tj backfill claude-code --quiet`.
+    assert capsys.readouterr().out == ""
+
+
+def test_non_tty_prints_periodically_not_every_session(capsys):
+    # capsys-captured stdout is never a tty, so this exercises the plain-print
+    # degrade path without needing to fake a terminal.
+    with backfill_progress(250, quiet=False) as cb:
+        for i in range(150):
+            cb(_parsed(f"s{i}"), _result(i + 1))
+    out = capsys.readouterr().out
+    # Cadence is every 100th session — one line at #100, not at every session.
+    assert out.count("Backfilling") == 1
+    assert "100/250" in out
+
+
+def test_non_tty_line_includes_running_token_total(capsys):
+    with backfill_progress(None, quiet=False) as cb:
+        for i in range(100):
+            cb(_parsed(f"s{i}", input_tokens=100, output_tokens=50), _result(i + 1))
+    out = capsys.readouterr().out
+    # 100 sessions * 150 tokens = 15,000 -> humanized as "15.0k" by format_tokens.
+    assert "15.0k tokens read" in out
+    # No total was given, so no "/total" suffix — just the running count.
+    assert "100 sessions" in out
+    assert "/" not in out.split("sessions")[0]
+
+
+def test_no_total_shows_bare_running_count(capsys):
+    with backfill_progress(None, quiet=False) as cb:
+        for i in range(100):
+            cb(_parsed(f"s{i}"), _result(i + 1))
+    out = capsys.readouterr().out
+    assert "100 sessions" in out

--- a/tests/unit/test_onboard_backfill_scope.py
+++ b/tests/unit/test_onboard_backfill_scope.py
@@ -1,0 +1,205 @@
+"""`tj onboard --claude-code` backfill-scope UX (#443).
+
+Founder-reported issue: onboard used to backfill the ENTIRE on-disk Claude
+Code history with no cap and no progress output. On a large `~/.claude`
+history that's many silent, 100%-CPU minutes right after "tj config written
+to...", indistinguishable from a hang at the exact moment a new user's trust
+is most fragile. This covers the fix: a backfill-scope prompt (interactive)
+or default (non-interactive) before ingest starts, explicit `--backfill-days`
+/ `--backfill-all` flags for scripting, and the "complete it later" pointer at
+the real `tj backfill claude-code` command.
+"""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+from click.testing import CliRunner
+
+import tokenjam.core.backfill as backfill_mod
+from tokenjam.cli.cmd_onboard import DEFAULT_BACKFILL_DAYS, cmd_onboard
+
+
+def _make_session_file(root: Path, session_id: str, cwd: str, ts: str) -> Path:
+    project_dir = root / cwd.replace("/", "-")
+    project_dir.mkdir(parents=True, exist_ok=True)
+    path = project_dir / f"{session_id}.jsonl"
+    record = {
+        "type": "assistant",
+        "uuid": f"u-{session_id}",
+        "timestamp": ts,
+        "sessionId": session_id,
+        "cwd": cwd,
+        "message": {
+            "model": "claude-sonnet-4-5-20250929",
+            "content": [{"type": "text", "text": "ok"}],
+            "usage": {
+                "input_tokens": 100, "output_tokens": 50,
+                "cache_read_input_tokens": 0, "cache_creation_input_tokens": 0,
+            },
+        },
+    }
+    path.write_text(json.dumps(record))
+    return path
+
+
+@pytest.fixture
+def _isolated_claude_code_with_history(monkeypatch, tmp_path):
+    """Same isolation as `_isolated_claude_code` in test_onboard_first_run.py,
+    but points CLAUDE_CODE_PROJECTS_ROOT at a real directory with session
+    files, so the backfill path actually runs (has_data == True) instead of
+    being skipped."""
+    monkeypatch.setattr("pathlib.Path.home", lambda: tmp_path)
+    projects_root = tmp_path / ".claude" / "projects"
+    monkeypatch.setattr(backfill_mod, "CLAUDE_CODE_PROJECTS_ROOT", projects_root)
+    monkeypatch.setattr("tokenjam.cli.cmd_onboard.shutil.which", lambda _x: None)
+    monkeypatch.setattr(
+        "tokenjam.cli.cmd_onboard._stop_serve_for_db_write", lambda: False,
+    )
+    monkeypatch.setattr(
+        "tokenjam.cli.cmd_onboard._finish_onboard_serve", lambda *a, **k: None,
+    )
+    monkeypatch.setattr(
+        "tokenjam.cli.cmd_onboard._try_apply_declared_plans", lambda *a, **k: None,
+    )
+    _make_session_file(projects_root, "sess-recent", "/Users/me/proj",
+                      "2026-06-25T10:00:00.000Z")
+    _make_session_file(projects_root, "sess-old", "/Users/me/proj",
+                      "2020-01-01T10:00:00.000Z")
+    return projects_root
+
+
+def _flat(output: str) -> str:
+    """Collapse Rich's terminal-width word-wrapping so assertions can match a
+    phrase regardless of where the console happened to break the line."""
+    return " ".join(output.split())
+
+
+def _run_claude_code(tmp_path, *extra_args, input_str="3\n0\n"):
+    runner = CliRunner()
+    with runner.isolated_filesystem(temp_dir=tmp_path):
+        return runner.invoke(
+            cmd_onboard,
+            ["--claude-code", "--no-daemon", "--project", "testproj", *extra_args],
+            input=input_str, obj={},
+        )
+
+
+# --- Non-interactive default (no TTY, no explicit flag) ----------------------
+
+
+def test_non_interactive_takes_default_window_and_notes_it(
+    _isolated_claude_code_with_history, tmp_path,
+):
+    # CliRunner's stdin is never a tty, and `_is_interactive()` isn't patched
+    # here — so this exercises the real non-interactive path.
+    res = _run_claude_code(tmp_path)
+    assert res.exit_code == 0, res.output
+    flat = _flat(res.output)
+    assert (
+        f"Non-interactive: backfilling the last {DEFAULT_BACKFILL_DAYS} days" in flat
+    )
+    assert "by default" in flat
+    assert "tj backfill claude-code" in flat
+    # The old session (2020) is outside the 30-day default window, only the
+    # recent one should have been counted as "in scope".
+    assert "1 new" in res.output or "1 total session" in res.output
+
+
+# --- Interactive prompt (menu) ------------------------------------------------
+
+
+def test_interactive_prompt_shown_and_recent_choice_notes_complete_later(
+    _isolated_claude_code_with_history, tmp_path, monkeypatch,
+):
+    monkeypatch.setattr("tokenjam.cli.cmd_onboard._is_interactive", lambda: True)
+    # Plan choice "3", budget "0", THEN backfill-scope choice "1" (recent).
+    res = _run_claude_code(tmp_path, input_str="3\n0\n1\n")
+    assert res.exit_code == 0, res.output
+    flat = _flat(res.output)
+    assert "Backfill your Claude Code history:" in flat
+    assert f"Last {DEFAULT_BACKFILL_DAYS} days" in flat
+    assert "Everything" in flat
+    assert "Run `tj backfill claude-code` afterwards for your full history" in flat
+
+
+def test_interactive_prompt_everything_choice_skips_complete_later_note(
+    _isolated_claude_code_with_history, tmp_path, monkeypatch,
+):
+    monkeypatch.setattr("tokenjam.cli.cmd_onboard._is_interactive", lambda: True)
+    res = _run_claude_code(tmp_path, input_str="3\n0\n2\n")
+    assert res.exit_code == 0, res.output
+    flat = _flat(res.output)
+    assert "afterwards for your full history" not in flat
+    # Both sessions (recent + old) should be backfilled with no window.
+    assert "2 total session" in flat
+
+
+# --- Explicit scripting flags -------------------------------------------------
+
+
+def test_backfill_days_flag_skips_prompt(_isolated_claude_code_with_history, tmp_path):
+    res = _run_claude_code(tmp_path, "--backfill-days", "7")
+    assert res.exit_code == 0, res.output
+    flat = _flat(res.output)
+    assert "Backfill your Claude Code history:" not in flat
+    assert "Backfilling the last 7 days" in flat
+
+
+def test_backfill_all_flag_skips_prompt_and_note(
+    _isolated_claude_code_with_history, tmp_path,
+):
+    res = _run_claude_code(tmp_path, "--backfill-all")
+    assert res.exit_code == 0, res.output
+    flat = _flat(res.output)
+    assert "Backfill your Claude Code history:" not in flat
+    assert "afterwards for your full history" not in flat
+    assert "2 total session" in flat
+
+
+def test_backfill_days_and_backfill_all_are_mutually_exclusive(
+    _isolated_claude_code_with_history, tmp_path,
+):
+    res = _run_claude_code(tmp_path, "--backfill-days", "7", "--backfill-all")
+    assert res.exit_code != 0
+    assert "Use either --backfill-days or --backfill-all" in _flat(res.output)
+
+
+def test_backfill_days_must_be_positive(_isolated_claude_code_with_history, tmp_path):
+    res = _run_claude_code(tmp_path, "--backfill-days", "0")
+    assert res.exit_code != 0
+    assert "--backfill-days must be > 0" in _flat(res.output)
+
+
+# --- Big-scope heads-up --------------------------------------------------------
+
+
+def test_headsup_printed_when_scope_exceeds_threshold(
+    _isolated_claude_code_with_history, tmp_path, monkeypatch,
+):
+    monkeypatch.setattr("tokenjam.cli.cmd_onboard._BACKFILL_HEADSUP_THRESHOLD", 1)
+    res = _run_claude_code(tmp_path, "--backfill-all")
+    assert res.exit_code == 0, res.output
+    flat = _flat(res.output)
+    assert "sessions in scope" in flat
+    assert "this may take a few minutes" in flat
+
+
+def test_no_headsup_below_threshold(_isolated_claude_code_with_history, tmp_path):
+    res = _run_claude_code(tmp_path, "--backfill-all")
+    assert res.exit_code == 0, res.output
+    assert "sessions in scope" not in _flat(res.output)
+
+
+# --- since actually reaches ingest_claude_code --------------------------------
+
+
+def test_default_window_actually_filters_old_session(
+    _isolated_claude_code_with_history, tmp_path,
+):
+    res = _run_claude_code(tmp_path)
+    assert res.exit_code == 0, res.output
+    # Only the recent (2026-06-25) session is within a 30-day-from-now window;
+    # the 2020 session must be excluded from the backfilled total.
+    assert "1 total session" in res.output

--- a/tokenjam/cli/backfill_progress.py
+++ b/tokenjam/cli/backfill_progress.py
@@ -1,0 +1,85 @@
+"""Shared streaming-progress UI for Claude Code backfill (#443).
+
+`tj backfill claude-code` and `tj onboard --claude-code` both ingest through
+`ingest_claude_code`'s `progress=` hook (called once per parsed session) — this
+module gives both callers the same live counter instead of each rolling its
+own. On a real terminal it renders one line that updates in place (Rich
+`Progress`); on a non-terminal (piped output, CI, redirected logs — anywhere
+Rich's live redraw can't work) it degrades to periodic plain `console.print`
+lines so a long backfill still shows signs of life without spamming a line per
+session.
+"""
+from __future__ import annotations
+
+from contextlib import contextmanager
+from typing import Callable, Iterator
+
+from rich.progress import Progress, SpinnerColumn, TextColumn
+
+from tokenjam.core.backfill import BackfillResult, ParsedSession
+from tokenjam.utils.formatting import console
+from tokenjam.utils.humanize import format_tokens
+
+ProgressCallback = Callable[[ParsedSession, BackfillResult], None]
+
+# Non-TTY print cadence: one line every Nth session, so a redirected/CI run
+# shows progress without a line per session on a large history.
+_PLAIN_PRINT_EVERY = 100
+
+
+def _noop(_parsed: ParsedSession, _result: BackfillResult) -> None:
+    pass
+
+
+@contextmanager
+def backfill_progress(total: int | None, *, quiet: bool = False) -> Iterator[ProgressCallback]:
+    """Yield a `progress(parsed, result)` callback for `ingest_claude_code`.
+
+    `total` is the cheap pre-count of in-scope sessions
+    (`count_claude_code_sessions_in_scope`), or `None` when unknown — the
+    counter then shows a running count with no "/total". `quiet=True` yields a
+    no-op callback (mirrors `tj backfill claude-code --quiet`).
+    """
+    if quiet:
+        yield _noop
+        return
+
+    tokens_seen = 0
+
+    def _line(result: BackfillResult) -> str:
+        count = f"{result.sessions_seen:,}/{total:,}" if total else f"{result.sessions_seen:,}"
+        return f"Backfilling {count} sessions · {format_tokens(tokens_seen)} tokens read"
+
+    def _accumulate(parsed: ParsedSession) -> None:
+        nonlocal tokens_seen
+        tokens_seen += (
+            parsed.total_input_tokens
+            + parsed.total_output_tokens
+            + parsed.total_cache_tokens
+        )
+
+    if console.is_terminal:
+        with Progress(
+            SpinnerColumn(style="cyan"),
+            TextColumn("[bold]◆[/bold] {task.description}"),
+            console=console,
+            transient=True,
+        ) as progress:
+            task_id = progress.add_task("Backfilling…", total=None)
+
+            def _tick(parsed: ParsedSession, result: BackfillResult) -> None:
+                _accumulate(parsed)
+                progress.update(task_id, description=_line(result))
+
+            yield _tick
+        return
+
+    def _tick_plain(parsed: ParsedSession, result: BackfillResult) -> None:
+        _accumulate(parsed)
+        if result.sessions_seen % _PLAIN_PRINT_EVERY == 0:
+            console.print(f"  [dim]{_line(result)}[/dim]")
+
+    yield _tick_plain
+
+
+__all__ = ["backfill_progress", "ProgressCallback"]

--- a/tokenjam/cli/backfill_progress.py
+++ b/tokenjam/cli/backfill_progress.py
@@ -47,7 +47,10 @@ def backfill_progress(total: int | None, *, quiet: bool = False) -> Iterator[Pro
     tokens_seen = 0
 
     def _line(result: BackfillResult) -> str:
-        count = f"{result.sessions_seen:,}/{total:,}" if total else f"{result.sessions_seen:,}"
+        count = (
+            f"{result.sessions_seen:,}/{total:,}" if total is not None
+            else f"{result.sessions_seen:,}"
+        )
         return f"Backfilling {count} sessions · {format_tokens(tokens_seen)} tokens read"
 
     def _accumulate(parsed: ParsedSession) -> None:

--- a/tokenjam/cli/cmd_backfill.py
+++ b/tokenjam/cli/cmd_backfill.py
@@ -6,9 +6,10 @@ from pathlib import Path
 
 import click
 
+from tokenjam.cli.backfill_progress import backfill_progress
 from tokenjam.core.backfill import (
     CLAUDE_CODE_PROJECTS_ROOT,
-    BackfillResult,
+    count_claude_code_sessions_in_scope,
     ingest_claude_code,
 )
 from tokenjam.core.ingest_adapters.codex import (
@@ -71,30 +72,17 @@ def claude_code(ctx: click.Context, root_path: str | None, since_value: str | No
             raise click.BadParameter("amount must be > 0", param_hint="'--since-days'")
         since = utcnow() - timedelta(days=since_days)
 
-    state = {"last_print": 0}
-
-    def progress(parsed, result: BackfillResult) -> None:
-        if quiet:
-            return
-        if result.sessions_seen - state["last_print"] >= 1:
-            console.print(
-                f"  [dim]({result.conversations_seen} conversations, "
-                f"{result.spans_ingested} new spans, "
-                f"{format_cost(result.total_cost_usd)} total)[/dim]",
-                end="\r",
-            )
-            state["last_print"] = result.sessions_seen
+    # Cheap pre-count (stat() only, no parsing) so the shared progress counter
+    # can show "N/total" rather than a bare running count (#443).
+    total_in_scope = count_claude_code_sessions_in_scope(root=root, since=since)
 
     console.print(f"Backfilling Claude Code sessions from {root} …")
     # Pass config so backfilled sessions carry the declared plan tier (#176).
-    result = ingest_claude_code(
-        db, root=root, since=since, progress=progress,
-        config=ctx.obj.get("config"), reingest=reingest,
-    )
-
-    if not quiet:
-        # Clear the carriage-return line
-        console.print(" " * 80, end="\r")
+    with backfill_progress(total_in_scope, quiet=quiet) as progress:
+        result = ingest_claude_code(
+            db, root=root, since=since, progress=progress,
+            config=ctx.obj.get("config"), reingest=reingest,
+        )
 
     if result.sessions_seen == 0:
         console.print(

--- a/tokenjam/cli/cmd_onboard.py
+++ b/tokenjam/cli/cmd_onboard.py
@@ -16,6 +16,22 @@ from tokenjam.cli.onboard_detect import SdkMatch, detect_stack, install_hint
 from tokenjam.core.config import find_config_file
 from tokenjam.utils.formatting import console, display_path
 
+# --- Claude Code backfill scope (#443) ---------------------------------------
+# `tj onboard --claude-code` used to backfill the ENTIRE on-disk history with
+# no cap and no progress output — on a large `~/.claude/projects` (thousands of
+# JSONL files) that's 10-30+ minutes of silent, 100%-CPU work right after "tj
+# config written to...", indistinguishable from a hang at the exact moment a
+# new user's trust is most fragile. Mirrors `tj quickstart`'s DEFAULT_MAX_SESSIONS
+# cap (#13) but scopes by *time* (`since`) instead of a session count, since
+# onboard's backfill is meant to be completable in full later via
+# `tj backfill claude-code` — the prompt below always says so.
+DEFAULT_BACKFILL_DAYS = 30
+
+# Above this many in-scope sessions, print a one-line heads-up before the
+# (still potentially slow) ingest starts, so a big "everything" choice or a
+# very active last-30-days window doesn't look like a hang either.
+_BACKFILL_HEADSUP_THRESHOLD = 300
+
 # --- output-trim (`tj hook cap-output`) PostToolUse hook wiring --------------
 # Installed into ~/.claude/settings.json out-of-band (zero in-loop token cost).
 # Idempotent + non-destructive: a tj-managed entry is detected by the
@@ -383,6 +399,13 @@ def _print_instrument_agent_snippet() -> None:
               help="Project name to group this repo under in the dashboard "
                    "(OTel service.namespace — e.g. all Aquanodeio/* repos under "
                    "'aquanode'). Defaults to the git org. Used with --claude-code.")
+@click.option("--backfill-days", "backfill_days", type=int, default=None,
+              help=f"Backfill only the last N days of Claude Code history "
+                   f"(default {DEFAULT_BACKFILL_DAYS} when neither this nor "
+                   f"--backfill-all is set). Skips the interactive scope prompt.")
+@click.option("--backfill-all", "backfill_all", is_flag=True, default=False,
+              help="Backfill the entire Claude Code history instead of the "
+                   "default recent window. Skips the interactive scope prompt.")
 @click.option("--verify", is_flag=True, default=False,
               help="After setup, poll for the first span from the newly "
                    "configured source and report whether telemetry is flowing "
@@ -397,6 +420,7 @@ def _print_instrument_agent_snippet() -> None:
 def cmd_onboard(ctx: click.Context, claude_code: bool, codex: bool, budget: float | None,
                 install_daemon: bool, no_daemon: bool, force: bool,
                 reconfigure: bool, plan: str | None, project_override: str | None,
+                backfill_days: int | None, backfill_all: bool,
                 verify: bool, verify_only: bool) -> None:
     """Interactive setup wizard for tj."""
     # --verify-only is the documented post-restart re-check: config already
@@ -405,6 +429,16 @@ def cmd_onboard(ctx: click.Context, claude_code: bool, codex: bool, budget: floa
     # noise (#102). Skip straight to the poll, before the banner and any setup.
     if verify_only:
         _run_verify_only(ctx, claude_code=claude_code, codex=codex)
+        return
+    if backfill_days is not None and backfill_all:
+        console.print(
+            "[red]Use either --backfill-days or --backfill-all, not both.[/red]"
+        )
+        ctx.exit(1)
+        return
+    if backfill_days is not None and backfill_days <= 0:
+        console.print("[red]--backfill-days must be > 0.[/red]")
+        ctx.exit(1)
         return
     # Ephemeral-runner guard (#120): onboard below wires a daemon + Claude Code
     # statusline that both invoke `tj` after this process exits. Under
@@ -419,7 +453,8 @@ def cmd_onboard(ctx: click.Context, claude_code: bool, codex: bool, budget: floa
     print_welcome_banner()
     if claude_code:
         _onboard_claude_code(ctx, budget, no_daemon, force, reconfigure, plan,
-                             project_override, verify=verify)
+                             project_override, verify=verify,
+                             backfill_days=backfill_days, backfill_all=backfill_all)
         return
     if codex:
         _onboard_codex(ctx, budget, no_daemon, force, reconfigure, plan, verify=verify)
@@ -438,7 +473,8 @@ def cmd_onboard(ctx: click.Context, claude_code: bool, codex: bool, budget: floa
         choice = _prompt_usage_path()
         if choice == "claude_code":
             _onboard_claude_code(ctx, budget, no_daemon, force, reconfigure, plan,
-                                 project_override, verify=verify)
+                                 project_override, verify=verify,
+                                 backfill_days=backfill_days, backfill_all=backfill_all)
             return
         if choice == "codex":
             _onboard_codex(ctx, budget, no_daemon, force, reconfigure, plan,
@@ -446,7 +482,8 @@ def cmd_onboard(ctx: click.Context, claude_code: bool, codex: bool, budget: floa
             return
         if choice == "combination":
             _onboard_combination(ctx, budget, no_daemon, force, plan,
-                                  project_override, verify=verify)
+                                  project_override, verify=verify,
+                                  backfill_days=backfill_days, backfill_all=backfill_all)
             return
         # choice == "sdk" → fall through to the generic SDK/API path below.
 
@@ -945,6 +982,87 @@ def _prompt_daily_budget(budget: float | None) -> float:
     )
 
 
+def _resolve_backfill_scope(
+    backfill_days: int | None, backfill_all: bool,
+):
+    """Resolve the Claude Code backfill window (#443).
+
+    Returns ``(since, is_full, max_sessions)``:
+      - ``is_full=True`` (``since``/``max_sessions`` both ``None``) means
+        "everything" — the full `tj backfill claude-code` path, unbounded.
+      - Otherwise ``since`` is the cutoff for `ingest_claude_code`, and
+        ``max_sessions`` is an additional cap (or ``None`` for none).
+
+    The "fast" default (interactive choice 1, and the non-interactive
+    fallback) pairs `since` with `max_sessions`. `since` alone measured as
+    NOT reliably bounding the work on an actively-used machine — the mtime
+    pre-filter it relies on barely excludes anything when most session files
+    have recent mtimes regardless of the conversation's actual age, so a
+    "last 30 days" on an old, huge history would still parse nearly
+    everything before the (correct but late) `ended_at` filter drops it.
+    `max_sessions` (mirroring `tj quickstart`'s `DEFAULT_MAX_SESSIONS` cap,
+    #13 — kept as the SAME constant so the two don't drift) guarantees
+    bounded work regardless of mtime patterns.
+
+    `--backfill-days N` is a scripting flag and means exactly what it says —
+    days only, no implicit cap — so automation gets what it asked for.
+    `--backfill-all` means everything, uncapped.
+
+    Precedence, matching the ``--plan``/``--budget`` non-interactive contract:
+    an explicit flag always skips the prompt. Otherwise an interactive
+    terminal gets a two-choice menu (default: fast/recent). A non-interactive
+    terminal (no TTY — CI, piped output, a non-interactive `uvx`/`npx`
+    install) can never answer a prompt, so it silently takes the same fast
+    default and prints one line explaining why, instead of hanging.
+    """
+    from datetime import timedelta
+
+    from tokenjam.cli.cmd_quickstart import DEFAULT_MAX_SESSIONS
+    from tokenjam.utils.time_parse import utcnow
+
+    def _print_complete_later_tip(days: int) -> None:
+        console.print(
+            f"[dim]  Backfilling the last {days} days. Run "
+            f"`tj backfill claude-code` afterwards for your full history.[/dim]"
+        )
+
+    if backfill_all:
+        return None, True, None
+    if backfill_days is not None:
+        _print_complete_later_tip(backfill_days)
+        return utcnow() - timedelta(days=backfill_days), False, None
+
+    if _is_interactive():
+        console.print()
+        console.print("[bold]Backfill your Claude Code history:[/bold]")
+        console.print(
+            f"  1) Last {DEFAULT_BACKFILL_DAYS} days "
+            f"[dim](most recent {DEFAULT_MAX_SESSIONS} sessions — fast, "
+            f"recommended)[/dim]"
+        )
+        console.print("  2) Everything")
+        choice = click.prompt(
+            "Choose", type=click.IntRange(1, 2), default=1, show_default=True,
+        )
+        if choice == 2:
+            return None, True, None
+        _print_complete_later_tip(DEFAULT_BACKFILL_DAYS)
+        return (
+            utcnow() - timedelta(days=DEFAULT_BACKFILL_DAYS), False,
+            DEFAULT_MAX_SESSIONS,
+        )
+
+    console.print(
+        f"[dim]Non-interactive: backfilling the last {DEFAULT_BACKFILL_DAYS} "
+        f"days (most recent {DEFAULT_MAX_SESSIONS} sessions) by default. Run "
+        f"`tj backfill claude-code` afterwards for your full history, or pass "
+        f"--backfill-all next time.[/dim]"
+    )
+    return (
+        utcnow() - timedelta(days=DEFAULT_BACKFILL_DAYS), False, DEFAULT_MAX_SESSIONS,
+    )
+
+
 def _print_next_steps_nudge(*, has_data: bool, days: int | None = None) -> None:
     """Curated post-onboard nudge (#240).
 
@@ -1107,6 +1225,8 @@ def _onboard_claude_code(
     project_override: str | None = None,
     verify: bool = False,
     standalone: bool = True,
+    backfill_days: int | None = None,
+    backfill_all: bool = False,
 ) -> None:
     """Configure Claude Code to send telemetry to tj.
 
@@ -1243,17 +1363,43 @@ def _onboard_claude_code(
     # DuckDB write lock (#71). Idempotent — safe to re-run.
     backfill_msg: str | None = None
     backfill_has_data = False
-    backfill_days: int | None = None
+    backfill_span_days: int | None = None
     backfill_sessions_total = 0
     try:
+        from tokenjam.cli.backfill_progress import backfill_progress
         from tokenjam.core.backfill import (
-            CLAUDE_CODE_PROJECTS_ROOT, ingest_claude_code,
+            CLAUDE_CODE_PROJECTS_ROOT,
+            count_claude_code_sessions_in_scope,
+            ingest_claude_code,
         )
         if CLAUDE_CODE_PROJECTS_ROOT.exists():
             from tokenjam.core.db import open_db
             try:
+                since, _backfill_is_full, max_sessions = _resolve_backfill_scope(
+                    backfill_days, backfill_all,
+                )
+                total_in_scope = count_claude_code_sessions_in_scope(
+                    since=since, max_sessions=max_sessions,
+                )
+                if total_in_scope > _BACKFILL_HEADSUP_THRESHOLD:
+                    console.print(
+                        f"[dim]  ~{total_in_scope:,} sessions in scope — this "
+                        f"may take a few minutes.[/dim]"
+                    )
                 db = open_db(config.storage)
-                result = ingest_claude_code(db, config=config)
+                with backfill_progress(total_in_scope) as backfill_progress_cb:
+                    result = ingest_claude_code(
+                        db, config=config, since=since,
+                        max_sessions=max_sessions,
+                        progress=backfill_progress_cb,
+                    )
+                if result.limit_reached and max_sessions is not None:
+                    console.print(
+                        f"[yellow]  Showing your most-recent {max_sessions} "
+                        f"sessions for a fast first run[/yellow] — run "
+                        f"[bold]tj backfill claude-code[/bold] for your full "
+                        f"history."
+                    )
                 post_apply = _try_apply_declared_plans(
                     config, reconcile=reconfigure and plan_changed,
                 )
@@ -1265,7 +1411,7 @@ def _onboard_claude_code(
                     days = None
                     if result.earliest and result.latest:
                         days = (result.latest - result.earliest).days
-                    backfill_days = days
+                    backfill_span_days = days
                     # Report new / already-present / total so a re-run reads as
                     # "13 total" rather than "1 session" (#238).
                     total = result.sessions_total
@@ -1527,7 +1673,7 @@ def _onboard_claude_code(
     )
     console.print()
     # Lead with the wins that need no restart, THEN the restart note (#240).
-    _print_next_steps_nudge(has_data=backfill_has_data, days=backfill_days)
+    _print_next_steps_nudge(has_data=backfill_has_data, days=backfill_span_days)
     if not want_daemon:
         _warn_manual_serve_restart(stopped_for_db=stopped_for_db, no_daemon=True)
         console.print("[dim]Start the server:[/dim]  tj serve")
@@ -1550,7 +1696,7 @@ def _onboard_claude_code(
         _print_setup_complete_home(
             sessions_backfilled=backfill_sessions_total,
             has_data=backfill_has_data,
-            days=backfill_days,
+            days=backfill_span_days,
         )
 
 
@@ -1881,6 +2027,8 @@ def _onboard_combination(
     plan_override: str | None = None,
     project_override: str | None = None,
     verify: bool = False,
+    backfill_days: int | None = None,
+    backfill_all: bool = False,
 ) -> None:
     """The "combination" path (#448): the user runs more than one kind of agent.
 
@@ -1919,6 +2067,7 @@ def _onboard_combination(
             ctx, budget, no_daemon, force, reconfigure=False,
             plan_override=plan_override, project_override=project_override,
             verify=False, standalone=False,
+            backfill_days=backfill_days, backfill_all=backfill_all,
         )
         done.append("Claude Code")
 

--- a/tokenjam/cli/cmd_onboard.py
+++ b/tokenjam/cli/cmd_onboard.py
@@ -431,15 +431,9 @@ def cmd_onboard(ctx: click.Context, claude_code: bool, codex: bool, budget: floa
         _run_verify_only(ctx, claude_code=claude_code, codex=codex)
         return
     if backfill_days is not None and backfill_all:
-        console.print(
-            "[red]Use either --backfill-days or --backfill-all, not both.[/red]"
-        )
-        ctx.exit(1)
-        return
+        raise click.UsageError("Use either --backfill-days or --backfill-all, not both.")
     if backfill_days is not None and backfill_days <= 0:
-        console.print("[red]--backfill-days must be > 0.[/red]")
-        ctx.exit(1)
-        return
+        raise click.UsageError("--backfill-days must be > 0.")
     # Ephemeral-runner guard (#120): onboard below wires a daemon + Claude Code
     # statusline that both invoke `tj` after this process exits. Under
     # `uvx --from tokenjam tj onboard` / `pipx run --spec tokenjam tj onboard`

--- a/tokenjam/core/backfill.py
+++ b/tokenjam/core/backfill.py
@@ -542,6 +542,40 @@ def iter_claude_code_sessions(
         yielded += 1
 
 
+def count_claude_code_sessions_in_scope(
+    root: Path | None = None,
+    since: datetime | None = None,
+    max_sessions: int | None = None,
+) -> int:
+    """Cheaply count how many Claude Code session files `ingest_claude_code`
+    would walk for the given `root`/`since`/`max_sessions` — `stat()` calls
+    only, no file is opened or parsed.
+
+    Mirrors `iter_claude_code_sessions`'s file selection (the `since` mtime
+    pre-filter, the `max_sessions` cap) closely enough to size a progress bar
+    or print a heads-up before a potentially slow ingest starts (#443); it is
+    NOT exact (it counts conversation *files*, matching `sessions_seen`, not
+    the post-parse distinct-session count a full ingest reports), but it's
+    the same cheap estimate `tj quickstart`'s first-run cap already accepts.
+    """
+    base = root or CLAUDE_CODE_PROJECTS_ROOT
+    if not base.exists() or not base.is_dir():
+        return 0
+    paths = list(base.rglob("*.jsonl"))
+    if since is not None:
+        kept = []
+        for p in paths:
+            try:
+                mtime = datetime.fromtimestamp(p.stat().st_mtime, tz=timezone.utc)
+            except OSError:
+                continue
+            if mtime >= since:
+                kept.append(p)
+        paths = kept
+    total = len(paths)
+    return min(total, max_sessions) if max_sessions is not None else total
+
+
 def session_record_from_parsed(
     parsed: ParsedSession, plan_tier: str = "unknown",
 ) -> SessionRecord:
@@ -870,4 +904,5 @@ __all__ = [
     "iter_claude_code_sessions",
     "ingest_claude_code",
     "session_record_from_parsed",
+    "count_claude_code_sessions_in_scope",
 ]


### PR DESCRIPTION
## Summary

`tj onboard --claude-code` backfills the **entire** on-disk `~/.claude/projects` history with no cap and no progress output. On a large history (the founder hit this live: 5.6 GB / 7,461 JSONL transcripts) that's 10-30+ minutes of silent, 100%-CPU work right after `tj config written to...` — indistinguishable from a hang at the exact moment a new user's trust is most fragile. `tj quickstart` already solved this with a 300-session cap (#13); `onboard` had neither a cap nor progress.

- **Backfill-scope prompt** before ingest starts (interactive): `1) last 30 days (most recent 300 sessions — fast, recommended)` / `2) everything`, default 30 days. Non-interactive runs (no TTY) silently take the default and print one line explaining it plus how to get the rest.
- **`--backfill-days N` / `--backfill-all`** flags for scripting (mutually exclusive, validated). `--backfill-days` means exactly what it says — days only, no implicit cap, so automation gets what it asked for.
- **The 300-session cap is load-bearing, not cosmetic.** `since` alone doesn't reliably bound the work: measured against the real 7,463-file history, the mtime pre-filter only excluded 32 files — nearly everything still gets parsed before the correct-but-late `ended_at` filter drops old sessions, because an actively-used machine's file mtimes cluster recent regardless of the conversation's actual age. So the "fast" choice pairs `since=30d` with `max_sessions=300` (the SAME constant `tj quickstart` uses — imported, not duplicated, so they can't drift). When the cap actually truncates the result, an honest "showing your most-recent 300 sessions" disclosure prints (mirroring quickstart's own disclosure), never claiming the full window landed when it didn't.
- **Streaming progress counter**, shared between `tj onboard --claude-code` and `tj backfill claude-code` via `ingest_claude_code`'s existing `progress=` hook (new `tokenjam/cli/backfill_progress.py`): a single in-place-updating line on a TTY (Rich `Progress` + spinner), periodic plain prints every 100 sessions when not a TTY.
- **Cheap pre-scan heads-up**: a new stat()-only `count_claude_code_sessions_in_scope` (core/backfill.py) sizes the progress bar's "of N" and prints a one-line heads-up ("~N sessions in scope — this may take a few minutes") when scope exceeds 300, before the (still potentially large) "everything" choice starts.

### Before / after (measured against a real 7,463-session / 5.6 GB history, scratch HOME)

| | Before | After (fast/default path) |
|---|---|---|
| Output during backfill | none (silent) | live counter: `Backfilling 100/300 sessions · 154.9M tokens read` → ... → `300/300` |
| Wall time | 6m 38s | 40s |
| Disclosure | none | `Showing your most-recent 300 sessions for a fast first run — run tj backfill claude-code for your full history.` |

## Test plan

- [x] `make test` (unit + synthetic + agents + integration): 2255 passed, 1 pre-existing skip
- [x] `ruff check tokenjam/`: clean
- [x] `mypy tokenjam/`: clean (186 source files)
- [x] New unit tests: `count_claude_code_sessions_in_scope` (cheap pre-scan), the shared `backfill_progress` TTY/non-TTY degrade + token accumulation, `ingest_claude_code(since=..., max_sessions=...)` combined (`limit_reached` + most-recent-first ordering), and the full onboard scope UX (prompt, flags, non-interactive default, heads-up, disclosure, "complete it later" tip)
- [x] Manual verification against the real `~/.claude/projects` (7,463 sessions / 5.6 GB) via a scratch HOME (read-only symlink) — confirmed the counter renders and the fast path completes in 40s instead of hanging

One observation for the record (not investigated further, doesn't block this fix): on the founder's machine, file mtimes across `~/.claude/projects` are almost entirely recent (only 32/7,463 files fell outside a 30-day mtime window) despite conversations spanning much further back — likely something touches/rewrites transcripts during active use. The `max_sessions` cap covers performance regardless of this; the `ended_at` filter still keeps correctness for what actually lands in the DB.

🤖 Generated with [Claude Code](https://claude.com/claude-code)