### PR TITLE
fix: gate onboard daily-budget prompt on subscription plan tier

### DIFF
--- a/tests/integration/test_cli.py
+++ b/tests/integration/test_cli.py
@@ -848,7 +848,10 @@ def test_onboard_claude_code_creates_tj_config(runner, tmp_path):
 
 
 def test_onboard_claude_code_prompts_for_budget(runner, tmp_path):
-    """Budget prompt is shown when --budget is not passed."""
+    """Budget prompt is shown when --budget is not passed, for the `api` plan
+    tier — the only tier with a per-token marginal cost. Subscription tiers
+    (e.g. max_20x) skip this prompt entirely (#128); see
+    test_onboard_claude_code_skips_budget_prompt_for_subscription_plan below."""
     fake_home = tmp_path / "home"
     fake_home.mkdir()
 
@@ -856,13 +859,37 @@ def test_onboard_claude_code_prompts_for_budget(runner, tmp_path):
          patch("tokenjam.cli.cmd_onboard.Path.home", return_value=fake_home), \
          patch("tokenjam.cli.cmd_onboard.click.confirm", return_value=False), \
          patch("tokenjam.core.config.write_config") as mock_write:
-        result = runner.invoke(cli, ["onboard", "--claude-code", "--no-daemon", "--plan", "max_20x", "--project", "aquanode"], input="7.0\n")
+        # --plan api skips both the plan-tier prompt and the API-spend-ceiling
+        # prompt (that one only fires without --plan); "7.0\n" answers the
+        # daily-budget prompt.
+        result = runner.invoke(cli, ["onboard", "--claude-code", "--no-daemon", "--plan", "api", "--project", "aquanode"], input="7.0\n")
 
     assert result.exit_code == 0
     assert mock_write.called
     saved_config = mock_write.call_args[0][0]
     agent_id = next(k for k in saved_config.agents if k.startswith("claude-code-"))
     assert saved_config.agents[agent_id].budget.daily_usd == 7.0
+
+
+def test_onboard_claude_code_skips_budget_prompt_for_subscription_plan(runner, tmp_path):
+    """Regression for #128: a subscription plan tier (max_20x) has $0/day
+    marginal cost, so onboard must not ask for a USD daily budget at all —
+    no prompt, no [agents.<id>.budget] daily_usd written."""
+    fake_home = tmp_path / "home"
+    fake_home.mkdir()
+
+    with patch("tokenjam.cli.cmd_onboard.find_config_file", return_value=None), \
+         patch("tokenjam.cli.cmd_onboard.Path.home", return_value=fake_home), \
+         patch("tokenjam.cli.cmd_onboard.click.confirm", return_value=False), \
+         patch("tokenjam.core.config.write_config") as mock_write:
+        result = runner.invoke(cli, ["onboard", "--claude-code", "--no-daemon", "--plan", "max_20x", "--project", "aquanode"])
+
+    assert result.exit_code == 0, result.output
+    assert "Daily budget in USD" not in result.output
+    assert mock_write.called
+    saved_config = mock_write.call_args[0][0]
+    agent_id = next(k for k in saved_config.agents if k.startswith("claude-code-"))
+    assert saved_config.agents[agent_id].budget.daily_usd is None
 
 
 def test_onboard_claude_code_project_flag_sets_config_project(runner, tmp_path):

--- a/tests/unit/test_onboard_budget_gate.py
+++ b/tests/unit/test_onboard_budget_gate.py
@@ -1,0 +1,175 @@
+"""Subscription users don't get asked for a USD daily budget (#128).
+
+`_prompt_daily_budget` is gated on the just-resolved plan tier: subscription
+tiers (`SUBSCRIPTION_PLAN_TIERS`) and local inference have a $0/day marginal
+cost, so the question ("Daily budget in USD...") right after the user just
+named a flat-rate plan contradicted the framing discipline `core/framing.py`
+already applies everywhere else. `api` (and `unknown`, if reachable) still get
+prompted, and `--budget` always wins regardless of tier.
+"""
+from __future__ import annotations
+
+import pytest
+from click.testing import CliRunner
+
+from tokenjam.cli.cmd_onboard import _prompt_daily_budget, cmd_onboard
+from tokenjam.otel.semconv import SUBSCRIPTION_PLAN_TIERS
+
+# --- Unit tests: _prompt_daily_budget ---------------------------------------
+
+
+def _forbid_prompt(monkeypatch):
+    """Fail loudly if the daily-budget prompt is reached when it shouldn't
+    be — a click.prompt refusal, not a lenient stub."""
+    import click as _click
+
+    def _boom(*a, **k):
+        raise AssertionError(f"unexpected click.prompt call: {a!r} {k!r}")
+
+    monkeypatch.setattr(_click, "prompt", _boom)
+
+
+@pytest.mark.parametrize("plan_tier", sorted(SUBSCRIPTION_PLAN_TIERS))
+def test_subscription_tiers_skip_prompt_silently(plan_tier, monkeypatch):
+    _forbid_prompt(monkeypatch)
+    assert _prompt_daily_budget(None, plan_tier) == 0.0
+
+
+def test_local_tier_skips_prompt_like_subscription(monkeypatch):
+    _forbid_prompt(monkeypatch)
+    assert _prompt_daily_budget(None, "local") == 0.0
+
+
+def test_api_tier_still_prompts(monkeypatch):
+    import click as _click
+
+    monkeypatch.setattr(_click, "prompt", lambda *a, **k: 42.0)
+    assert _prompt_daily_budget(None, "api") == 42.0
+
+
+def test_unknown_tier_still_prompts(monkeypatch):
+    # `unknown` isn't reachable from the current onboard choice menus, but if
+    # it ever is, it should behave like `api` — prompt, don't assume $0.
+    import click as _click
+
+    monkeypatch.setattr(_click, "prompt", lambda *a, **k: 7.0)
+    assert _prompt_daily_budget(None, "unknown") == 7.0
+
+
+@pytest.mark.parametrize(
+    "plan_tier", sorted(SUBSCRIPTION_PLAN_TIERS | {"local", "api", "unknown"}),
+)
+def test_budget_flag_wins_regardless_of_tier(plan_tier, monkeypatch):
+    _forbid_prompt(monkeypatch)
+    assert _prompt_daily_budget(5.0, plan_tier) == 5.0
+
+
+# --- CLI-level: fresh config (no existing ~/.config/tj/config.toml) --------
+
+
+@pytest.fixture
+def _isolated_home(monkeypatch, tmp_path):
+    monkeypatch.setattr("pathlib.Path.home", lambda: tmp_path)
+    monkeypatch.setattr(
+        "tokenjam.cli.cmd_onboard._stop_serve_for_db_write", lambda: False,
+    )
+    monkeypatch.setattr(
+        "tokenjam.cli.cmd_onboard._finish_onboard_serve", lambda *a, **k: None,
+    )
+    monkeypatch.setattr(
+        "tokenjam.cli.cmd_onboard._try_apply_declared_plans", lambda *a, **k: None,
+    )
+    monkeypatch.setattr("tokenjam.cli.cmd_onboard.shutil.which", lambda _x: None)
+    import tokenjam.core.backfill as backfill_mod
+    monkeypatch.setattr(
+        backfill_mod, "CLAUDE_CODE_PROJECTS_ROOT", tmp_path / "no-such-claude",
+    )
+
+
+def _invoke(tmp_path, *args, input_text: str = ""):
+    runner = CliRunner()
+    with runner.isolated_filesystem(temp_dir=tmp_path):
+        res = runner.invoke(cmd_onboard, ["--no-daemon", *args], input=input_text, obj={})
+        cfg = tmp_path / ".config" / "tj" / "config.toml"
+        return res, (cfg.read_text() if cfg.exists() else "")
+
+
+def test_claude_code_fresh_subscription_no_budget_prompt(_isolated_home, tmp_path):
+    res, cfg = _invoke(
+        tmp_path, "--claude-code", "--project", "testproj", "--plan", "max_5x",
+    )
+    assert res.exit_code == 0, res.output
+    assert "Daily budget in USD" not in res.output
+    assert "daily_usd" not in cfg
+
+
+def test_claude_code_fresh_api_prompts_and_writes_budget(_isolated_home, tmp_path):
+    res, cfg = _invoke(
+        tmp_path, "--claude-code", "--project", "testproj", "--plan", "api",
+        input_text="25\n",
+    )
+    assert res.exit_code == 0, res.output
+    assert "Daily budget in USD" in res.output
+    assert "daily_usd = 25" in cfg
+
+
+def test_claude_code_fresh_budget_flag_skips_prompt_for_api(_isolated_home, tmp_path):
+    res, cfg = _invoke(
+        tmp_path, "--claude-code", "--project", "testproj", "--plan", "api",
+        "--budget", "9",
+    )
+    assert res.exit_code == 0, res.output
+    assert "Daily budget in USD" not in res.output
+    assert "daily_usd = 9" in cfg
+
+
+def test_codex_fresh_subscription_no_budget_prompt(_isolated_home, tmp_path):
+    res, cfg = _invoke(tmp_path, "--codex", "--plan", "plus")
+    assert res.exit_code == 0, res.output
+    assert "Daily budget in USD" not in res.output
+    assert "daily_usd" not in cfg
+
+
+def test_codex_fresh_api_prompts_and_writes_budget(_isolated_home, tmp_path):
+    res, cfg = _invoke(tmp_path, "--codex", "--plan", "api", input_text="12\n")
+    assert res.exit_code == 0, res.output
+    assert "Daily budget in USD" in res.output
+    assert "daily_usd = 12" in cfg
+
+
+# --- CLI-level: existing config, plan tier already resolved -----------------
+#
+# Regression coverage for the `plan = existing_plan` fallback: when a plan was
+# set on a previous onboard and neither --plan nor --reconfigure is passed,
+# the plan-tier prompt block is skipped entirely, so `plan` must still be
+# bound (from the stored config) before `_prompt_daily_budget` reads it.
+
+
+def _seed_existing_config(tmp_path, *, provider: str, plan: str):
+    cfg_dir = tmp_path / ".config" / "tj"
+    cfg_dir.mkdir(parents=True)
+    (cfg_dir / "config.toml").write_text(
+        f'version = "1"\n'
+        f"[security]\ningest_secret = \"{'a' * 64}\"\n"
+        f"[budget.{provider}]\nplan = \"{plan}\"\ncycle_start_day = 1\n"
+    )
+
+
+def test_claude_code_existing_subscription_plan_no_reprompt(_isolated_home, tmp_path):
+    _seed_existing_config(tmp_path, provider="anthropic", plan="max_20x")
+    res, cfg = _invoke(
+        tmp_path, "--claude-code", "--project", "testproj",
+    )
+    assert res.exit_code == 0, res.output
+    assert "How do you pay for Claude?" not in res.output
+    assert "Daily budget in USD" not in res.output
+    assert "daily_usd" not in cfg
+
+
+def test_codex_existing_subscription_plan_no_reprompt(_isolated_home, tmp_path):
+    _seed_existing_config(tmp_path, provider="openai", plan="team")
+    res, cfg = _invoke(tmp_path, "--codex")
+    assert res.exit_code == 0, res.output
+    assert "How do you pay for OpenAI / Codex?" not in res.output
+    assert "Daily budget in USD" not in res.output
+    assert "daily_usd" not in cfg

--- a/tests/unit/test_onboard_budget_gate.py
+++ b/tests/unit/test_onboard_budget_gate.py
@@ -56,6 +56,15 @@ def test_unknown_tier_still_prompts(monkeypatch):
     assert _prompt_daily_budget(None, "unknown") == 7.0
 
 
+def test_none_tier_still_prompts(monkeypatch):
+    # `plan_tier=None` (no resolved tier) must behave like `unknown`, not like
+    # a subscription tier — never silently assume $0 for an unresolved plan.
+    import click as _click
+
+    monkeypatch.setattr(_click, "prompt", lambda *a, **k: 3.0)
+    assert _prompt_daily_budget(None, None) == 3.0
+
+
 @pytest.mark.parametrize(
     "plan_tier", sorted(SUBSCRIPTION_PLAN_TIERS | {"local", "api", "unknown"}),
 )

--- a/tests/unit/test_onboard_first_run.py
+++ b/tests/unit/test_onboard_first_run.py
@@ -132,8 +132,15 @@ def _run_claude_code(tmp_path, plan_choice: str):
 
 
 def test_claude_code_asks_plan_before_budget(_isolated_claude_code, tmp_path):
-    # Choice 3 == max_5x (subscription) → no API-ceiling prompt to interleave.
-    res = _run_claude_code(tmp_path, "3")
+    # Choice 1 == api: the only tier that still gets a daily-budget prompt
+    # (#128 — subscription tiers have $0 marginal cost and skip it silently).
+    # Answers: plan(1=api) → API spend ceiling(0) → daily budget(0).
+    runner = CliRunner()
+    with runner.isolated_filesystem(temp_dir=tmp_path):
+        res = runner.invoke(
+            cmd_onboard, ["--claude-code", "--no-daemon", "--project", "testproj"],
+            input="1\n0\n0\n", obj={},
+        )
     assert res.exit_code == 0, res.output
     out = res.output
     assert "How do you pay for Claude?" in out

--- a/tokenjam/cli/cmd_onboard.py
+++ b/tokenjam/cli/cmd_onboard.py
@@ -934,7 +934,7 @@ def _print_setup_complete_home(
     print_home()
 
 
-def _prompt_daily_budget(budget: float | None, plan_tier: str) -> float:
+def _prompt_daily_budget(budget: float | None, plan_tier: str | None) -> float:
     """Prompt for the per-agent daily-budget alert threshold, unless already
     supplied via --budget or the just-resolved plan tier has no marginal
     per-token cost. Called AFTER the plan prompt so onboard reads plan-first
@@ -946,12 +946,14 @@ def _prompt_daily_budget(budget: float | None, plan_tier: str) -> float:
     their plan contradicts the framing discipline ``core/framing.py`` already
     applies everywhere else (dollar figures suppressed for those tiers), and
     the ``[budget.<provider>]`` USD monthly ceiling already skips them by
-    design. Only ``api`` (and ``unknown``, if ever reachable here) get
-    prompted. ``--budget`` always wins regardless of tier.
+    design. Only ``api`` and ``unknown`` get prompted — and ``None`` (no
+    resolved tier, e.g. an existing config with no plan section yet) behaves
+    like ``unknown``: still prompt rather than assume $0. ``--budget`` always
+    wins regardless of tier.
     """
     if budget is not None:
         return budget
-    if plan_tier in SUBSCRIPTION_PLAN_TIERS or plan_tier == "local":
+    if plan_tier is not None and (plan_tier in SUBSCRIPTION_PLAN_TIERS or plan_tier == "local"):
         return 0.0
     return click.prompt(
         "Daily budget in USD (0 = no limit, default 0)",

--- a/tokenjam/cli/cmd_onboard.py
+++ b/tokenjam/cli/cmd_onboard.py
@@ -14,6 +14,7 @@ from rich.markup import escape
 from tokenjam.cli.banner import print_welcome_banner
 from tokenjam.cli.onboard_detect import SdkMatch, detect_stack, install_hint
 from tokenjam.core.config import find_config_file
+from tokenjam.otel.semconv import SUBSCRIPTION_PLAN_TIERS
 from tokenjam.utils.formatting import console, display_path
 
 # --- output-trim (`tj hook cap-output`) PostToolUse hook wiring --------------
@@ -933,12 +934,25 @@ def _print_setup_complete_home(
     print_home()
 
 
-def _prompt_daily_budget(budget: float | None) -> float:
+def _prompt_daily_budget(budget: float | None, plan_tier: str) -> float:
     """Prompt for the per-agent daily-budget alert threshold, unless already
-    supplied via --budget. Called AFTER the plan prompt so onboard reads
-    plan-first (#240)."""
+    supplied via --budget or the just-resolved plan tier has no marginal
+    per-token cost. Called AFTER the plan prompt so onboard reads plan-first
+    (#240).
+
+    Gated on plan_tier (#128): flat-rate subscription plans
+    (``SUBSCRIPTION_PLAN_TIERS``) and local inference have a $0/day marginal
+    cost, so asking for a USD budget ceiling right after the user just named
+    their plan contradicts the framing discipline ``core/framing.py`` already
+    applies everywhere else (dollar figures suppressed for those tiers), and
+    the ``[budget.<provider>]`` USD monthly ceiling already skips them by
+    design. Only ``api`` (and ``unknown``, if ever reachable here) get
+    prompted. ``--budget`` always wins regardless of tier.
+    """
     if budget is not None:
         return budget
+    if plan_tier in SUBSCRIPTION_PLAN_TIERS or plan_tier == "local":
+        return 0.0
     return click.prompt(
         "Daily budget in USD (0 = no limit, default 0)",
         type=float, default=0.0, show_default=False,
@@ -1156,6 +1170,7 @@ def _onboard_claude_code(
             if "anthropic" in config.budgets else None
         )
         plan_changed = False
+        plan = existing_plan
         # Prompt for plan tier when:
         #   - this is a fresh onboard for this agent (no existing plan), or
         #   - the user passed --reconfigure to explicitly re-prompt
@@ -1186,7 +1201,7 @@ def _onboard_claude_code(
                 config.budgets["anthropic"] = ProviderBudget(
                     usd=usd, cycle_start_day=1, plan=plan,
                 )
-        budget = _prompt_daily_budget(budget)
+        budget = _prompt_daily_budget(budget, plan)
         if budget and budget > 0:
             config.agents[agent_id].budget.daily_usd = budget
         config_path = global_config_path
@@ -1207,7 +1222,7 @@ def _onboard_claude_code(
             )
             if ceiling > 0:
                 usd = ceiling
-        budget = _prompt_daily_budget(budget)
+        budget = _prompt_daily_budget(budget, plan)
         daily_usd = budget if budget and budget > 0 else None
         agents = {agent_id: AgentConfig(budget=BudgetConfig(daily_usd=daily_usd), project=namespace)}
         config = TjConfig(
@@ -1615,6 +1630,7 @@ def _onboard_codex(
             if "openai" in config.budgets else None
         )
         plan_changed = False
+        plan = existing_plan
         if existing_plan is None or reconfigure or plan_override:
             if plan_override:
                 plan = plan_override
@@ -1638,7 +1654,7 @@ def _onboard_codex(
                 config.budgets["openai"] = ProviderBudget(
                     usd=usd, cycle_start_day=1, plan=plan,
                 )
-        budget = _prompt_daily_budget(budget)
+        budget = _prompt_daily_budget(budget, plan)
         if budget and budget > 0:
             config.agents[agent_id].budget.daily_usd = budget
         write_config(config, config_path)
@@ -1658,7 +1674,7 @@ def _onboard_codex(
             )
             if ceiling > 0:
                 usd = ceiling
-        budget = _prompt_daily_budget(budget)
+        budget = _prompt_daily_budget(budget, plan)
         daily_usd = budget if budget and budget > 0 else None
         agents = {agent_id: AgentConfig(budget=BudgetConfig(daily_usd=daily_usd))}
         config = TjConfig(


### PR DESCRIPTION
## Summary

`tj onboard` was asking subscription-plan users (Pro / Max 5x / Max 20x / Team / Enterprise) for a **"Daily budget in USD per agent"** immediately after they declared their plan — even though a subscription user's marginal per-token cost is $0/day. This contradicted the framing discipline `core/framing.py` already applies everywhere else (dollar figures suppressed for subscription tiers), and the existing `[budget.<provider>]` USD monthly ceiling already skips subscription users by design.

**Founder repro:** ran `npx tokenjam onboard`, chose "Max 5x plan ($100/mo subscription)", and was immediately asked "Daily budget in USD per agent (0 = no limit, default 0)". Confirmed on `main` — no plan gating existed.

## Fix

`_prompt_daily_budget(budget, plan_tier)` now takes the just-resolved plan tier:
- `budget` from `--budget` always wins, regardless of tier (unchanged).
- Tiers in `SUBSCRIPTION_PLAN_TIERS` (imported from `tokenjam/otel/semconv.py`, not hardcoded) and `"local"` (local inference — also $0 marginal cost, `core/framing.py` treats it the same as subscription) skip the prompt silently and write no `[defaults.budget]` / agent budget entry.
- `"api"` (and `"unknown"`, if it's ever reachable from onboard) still get prompted.

Applied at all four call sites in `cmd_onboard.py`: Claude Code existing-config leg, Claude Code fresh-config leg, Codex existing-config leg, Codex fresh-config leg. Both legs of the combination flow (`_onboard_combination`) delegate to these same two onboarders, so they're covered too — no separate call sites there.

One correctness fix needed to make the gating possible: in the "existing config, no `--reconfigure`/`--plan`" branch, `plan` was previously only assigned *inside* the `if existing_plan is None or reconfigure or plan_override:` block — when that block is skipped (plan already resolved from a prior onboard), `plan` was never bound. Added `plan = existing_plan` before the conditional so the resolved tier is always available for the budget-prompt gate. Covered by a dedicated regression test (`test_claude_code_existing_subscription_plan_no_reprompt` / `test_codex_existing_subscription_plan_no_reprompt`).

## Per-tier behavior table

| Plan tier | `--budget` passed | Prompted for daily budget? | Written to config |
|---|---|---|---|
| `api` | no | **yes** | user's answer (if > 0) |
| `unknown` | no | yes (not gated; not reachable from current onboard menus) | user's answer (if > 0) |
| `pro` / `max_5x` / `max_20x` / `plus` / `team` / `enterprise` | no | **no** | nothing (`daily_usd` stays unset) |
| `local` | no | **no** | nothing |
| any tier above | yes | no (flag always wins) | the flag's value (if > 0) |

## Conflict awareness

PR #444 (`onboard-backfill-ux`, open) also edits `cmd_onboard.py` — its changes are in the backfill section (~line 1241+ pre-this-PR) and flag validation near line 442. This PR's changes are confined to `_prompt_daily_budget` (~line 936) and the plan/budget section of the four onboard call sites (~1170–1225, ~1630–1680). No overlap; will rebase if #444 merges first and conflicts appear.

## Test plan

- [x] New `tests/unit/test_onboard_budget_gate.py` (25 tests): unit-level gating for every `SUBSCRIPTION_PLAN_TIERS` member + `local` (no prompt, `click.prompt` refusal pattern), `api`/`unknown` (prompted), `--budget` override for every tier, plus full-CLI coverage for both `--claude-code` and `--codex`, both fresh-config and existing-config branches.
- [x] Updated `tests/unit/test_onboard_first_run.py::test_claude_code_asks_plan_before_budget` and `tests/integration/test_cli.py::test_onboard_claude_code_prompts_for_budget` — both previously pinned the old buggy behavior (asserting the budget prompt fires for a subscription tier); now exercise the `api` tier for that assertion, plus a new sibling test (`test_onboard_claude_code_skips_budget_prompt_for_subscription_plan`) pinning the fixed behavior.
- [x] `make test` — 2262 passed, 1 skipped
- [x] `ruff check tokenjam/` — all checks passed
- [x] `mypy tokenjam/` — no issues found

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>

