### PR TITLE
docs: sync MCP tool list with server registry

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -305,7 +305,7 @@ The `TjConfig` dataclass tree in `tokenjam/core/config.py` defines the full hier
 
 ## MCP server (SDK / API integration)
 
-`tj mcp` is a stdio-based MCP (Model Context Protocol) server that gives an SDK / API integration direct access to TokenJam observability data. It exposes 13 tools. It is **not** wired up for Claude Code or Codex — an in-loop MCP is a per-turn quota tax on subscription users (+36% measured, ticket #59); those agents get tj out-of-band via the statusline + OTel capture instead. Wire it manually only for an SDK / API integration that already sits in the request path: `claude mcp add tj --scope user -- tj mcp`.
+`tj mcp` is a stdio-based MCP (Model Context Protocol) server that gives an SDK / API integration direct access to TokenJam observability data. It exposes 23 tools. It is **not** wired up for Claude Code or Codex — an in-loop MCP is a per-turn quota tax on subscription users (+36% measured, ticket #59); those agents get tj out-of-band via the statusline + OTel capture instead. Wire it manually only for an SDK / API integration that already sits in the request path: `claude mcp add tj --scope user -- tj mcp`.
 
 ### Dual-mode operation
 

--- a/docs/claude-code-integration.md
+++ b/docs/claude-code-integration.md
@@ -53,7 +53,7 @@ The wiring is non-destructive: if you already have a `statusLine` (hand-authored
 
 ## MCP server — for SDK / API users, not Claude Code
 
-The MCP is tj's **in-request-path** surface, meant for **SDK / API** integrations where tj already sits in the loop (real-time enforcement, policy, budgets). It is **not** wired for Claude Code by `tj onboard --claude-code`, and you shouldn't add it as a Claude Code subscription user: an in-loop MCP is a **per-turn quota burden** (a measured A/B showed **+36%** model-weighted quota vs a no-tj control) — the exact tax the out-of-band statusline above avoids. SDK / API users who want the in-loop tools can wire it manually with `claude mcp add tj --scope user -- tj mcp`. After doing so you have 13 tools available in every session:
+The MCP is tj's **in-request-path** surface, meant for **SDK / API** integrations where tj already sits in the loop (real-time enforcement, policy, budgets). It is **not** wired for Claude Code by `tj onboard --claude-code`, and you shouldn't add it as a Claude Code subscription user: an in-loop MCP is a **per-turn quota burden** (a measured A/B showed **+36%** model-weighted quota vs a no-tj control) — the exact tax the out-of-band statusline above avoids. SDK / API users who want the in-loop tools can wire it manually with `claude mcp add tj --scope user -- tj mcp`. After doing so you have 23 tools available in every session:
 
 | Tool | What it does |
 |---|---|
@@ -69,7 +69,17 @@ The MCP is tj's **in-request-path** surface, meant for **SDK / API** integration
 | `get_drift_report` | Behavioral drift baseline vs latest session |
 | `acknowledge_alert` | Mark an alert as acknowledged |
 | `setup_project` | Configure a project to send telemetry to TokenJam |
+| `setup_harness` | Wire a fan-out harness into TokenJam's run grouping |
+| `get_optimize_report` | Cost-saving candidates and budget projections |
 | `open_dashboard` | Open the web UI — starts `tj serve` on demand if needed |
+| `get_policy_status` | Active policies and recent policy decisions |
+| `get_savings_summary` | Estimated savings from configured policies |
+| `suggest_policies` | Policy recommendations from usage patterns |
+| `list_summarize_candidates` | Prompt files worth summarizing for token reduction |
+| `summarize_prep` | Prepare a prompt for structure-aware summarization |
+| `summarize_check` | Verify a summary and stage for review |
+| `summarize_apply` | Apply staged summarization results to files |
+| `summarize_undo` | Restore the most recent summarization backup |
 
 The MCP server opens the DuckDB file read-only — no lock conflicts with `tj serve` if both are running. The single write operation (`acknowledge_alert`) opens a short-lived read-write connection only for its UPDATE.
 

--- a/tests/unit/test_mcp_server.py
+++ b/tests/unit/test_mcp_server.py
@@ -971,3 +971,32 @@ def test_summarize_apply_then_undo_roundtrip(tmp_path):
 
 def test_summarize_apply_no_config():
     assert "error" in _tool_summarize_apply(None, None, False)
+
+
+def test_mcp_server_tool_count():
+    """Verify that the MCP server registers the expected number of tools.
+    This catches documentation drift when new tools are added or removed.
+    If this test fails, update docs/claude-code-integration.md and
+    docs/architecture.md with the new tool count and tool list.
+    """
+    import re
+    from pathlib import Path
+    from tokenjam.mcp import server as mcp_module
+
+    # Read server.py and count @mcp.tool() decorators
+    server_path = Path(mcp_module.__file__)
+    server_src = server_path.read_text()
+
+    # Find all @mcp.tool() decorators followed by function definitions
+    tool_pattern = r'@mcp\.tool\(\)\s*\ndef\s+(\w+)\s*\('
+    tools_found = re.findall(tool_pattern, server_src)
+
+    # The expected tool count; update this when new tools are added
+    expected_count = 23
+    tool_count = len(tools_found)
+    assert tool_count == expected_count, (
+        f"MCP tool count mismatch: found {tool_count}, expected {expected_count}. "
+        f"Update docs/claude-code-integration.md (tool table) and "
+        f"docs/architecture.md (tool count reference) to match. "
+        f"Tools: {sorted(tools_found)}"
+    )

--- a/tests/unit/test_mcp_server.py
+++ b/tests/unit/test_mcp_server.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 import json
+import re
 from pathlib import Path
 
 import pytest
@@ -974,29 +975,43 @@ def test_summarize_apply_no_config():
 
 
 def test_mcp_server_tool_count():
-    """Verify that the MCP server registers the expected number of tools.
-    This catches documentation drift when new tools are added or removed.
-    If this test fails, update docs/claude-code-integration.md and
-    docs/architecture.md with the new tool count and tool list.
+    """Verify MCP server tool count matches documentation.
+    Parses docs to extract the stated tool count, then verifies the server.py
+    registers exactly that many @mcp.tool() decorators. This catches drift in
+    both directions: adding tools without updating docs, or updating docs
+    without implementing tools.
     """
-    import re
-    from pathlib import Path
     from tokenjam.mcp import server as mcp_module
 
     # Read server.py and count @mcp.tool() decorators
     server_path = Path(mcp_module.__file__)
     server_src = server_path.read_text()
-
-    # Find all @mcp.tool() decorators followed by function definitions
     tool_pattern = r'@mcp\.tool\(\)\s*\ndef\s+(\w+)\s*\('
     tools_found = re.findall(tool_pattern, server_src)
+    actual_count = len(tools_found)
 
-    # The expected tool count; update this when new tools are added
-    expected_count = 23
-    tool_count = len(tools_found)
-    assert tool_count == expected_count, (
-        f"MCP tool count mismatch: found {tool_count}, expected {expected_count}. "
-        f"Update docs/claude-code-integration.md (tool table) and "
-        f"docs/architecture.md (tool count reference) to match. "
-        f"Tools: {sorted(tools_found)}"
+    # Parse docs/claude-code-integration.md for stated tool count
+    doc_path = server_path.parent.parent.parent / "docs" / "claude-code-integration.md"
+    doc_src = doc_path.read_text()
+    # Look for "you have X tools available in every session:"
+    doc_match = re.search(r'you have (\d+) tools available in every session:', doc_src)
+    assert doc_match, "Could not find tool count statement in claude-code-integration.md"
+    doc_stated_count = int(doc_match.group(1))
+
+    # Parse docs/architecture.md for stated tool count
+    arch_path = doc_path.parent / "architecture.md"
+    arch_src = arch_path.read_text()
+    # Look for "It exposes X tools."
+    arch_match = re.search(r'It exposes (\d+) tools\.', arch_src)
+    assert arch_match, "Could not find tool count statement in architecture.md"
+    arch_stated_count = int(arch_match.group(1))
+
+    # All three must match: server reality, claude-code-integration docs, architecture docs
+    assert actual_count == doc_stated_count == arch_stated_count, (
+        f"MCP tool count mismatch:\n"
+        f"  Actual in server.py: {actual_count} tools\n"
+        f"  Stated in claude-code-integration.md: {doc_stated_count}\n"
+        f"  Stated in architecture.md: {arch_stated_count}\n"
+        f"  Tools found: {sorted(tools_found)}\n"
+        f"If you added a tool, update both docs with the new count and tool list."
     )


### PR DESCRIPTION
## Summary

The MCP documentation claimed 13 available tools, but the server actually registers 23 tools. This PR updates the documentation and adds a test to prevent future drift.

**Changes:**
- Updated `docs/claude-code-integration.md` tool table from 13 to 23 tools
- Updated `docs/architecture.md` tool count reference from 13 to 23
- Added `test_mcp_server_tool_count()` test to verify tool count stays in sync with server.py

**Missing tools now documented:**
- `setup_harness` — wire fan-out harnesses into run grouping
- `get_optimize_report` — cost-saving candidates and budget projections
- `get_policy_status` — active policies and recent decisions
- `get_savings_summary` — estimated recoverable savings from policies
- `suggest_policies` — policy recommendations from usage patterns
- `list_summarize_candidates` — prompt files worth summarizing
- `summarize_prep` — prepare prompts for structure-aware summarization
- `summarize_check` — verify summaries and stage for review
- `summarize_apply` — apply staged results to files
- `summarize_undo` — restore summarization backups

## Test plan

- [x] All 54 MCP server tests pass
- [x] New `test_mcp_server_tool_count` test passes
- [x] Tool count matches actual @mcp.tool() decorators in server.py

🤖 Generated with [Claude Code](https://claude.com/claude-code)