### PR TITLE
feat: add `tj session-story` CLI command + quickstart teaser

### DIFF
--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -115,6 +115,18 @@ tj context --json
 
 Key flags: `--since`, `--agent`, `--json`.
 
+### `tj session-story`
+
+Turn-by-turn reconstruction of *how* a Claude Code session attempted its task — its ordered moves (`delegate` / `dead_end` / `verify` / `act`), and for every subagent delegation, that subagent's mandate plus a factual tool-category tally (reads/edits/searches/commands) and its own recursively-rendered method spine. With no `--session`, auto-selects the most recent session with real activity. Reads the on-disk transcript, falling back to a persisted snapshot when the transcript was pruned; needs a direct DB connection or a running `tj serve` (the daemon does the reconstruction+fallback server-side when it holds the write lock).
+
+```bash
+tj session-story
+tj session-story --session <session-id>
+tj session-story --json
+```
+
+Key flags: `--session`, `--last` (default when `--session` is omitted), `--json`.
+
 ### `tj quota-audit`
 
 Retroactive audit of your Opus quota: which past Opus sessions were structurally Sonnet-shaped (small input/output, few tool calls)? Reports the percent of Opus quota reclaimable, example sessions to spot-check, and an optional tuned routing-config export. Quota-share framing, never a dollar "saving" claim. Needs a direct DB connection (can't run against a live `tj serve`).

--- a/tests/unit/test_cmd_session_story.py
+++ b/tests/unit/test_cmd_session_story.py
@@ -1,0 +1,252 @@
+"""Unit tests for `tj session-story` (cli/cmd_session_story.py).
+
+Exercises the full CLI path — session resolution (--session / default-to-most-
+recent-substantial), story loading (live transcript, honest "no transcript"
+fallback), rendering, and --json — via CliRunner + InMemoryBackend, mirroring
+test_cmd_cost.py's invocation pattern. Transcript fixtures are hand-written
+Claude Code JSONL records, mirroring test_transcript.py's fixture-builder style
+(these are on-disk transcript records, not NormalizedSpans, so the span
+factories don't apply).
+"""
+from __future__ import annotations
+
+import json
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from unittest.mock import patch
+
+from click.testing import CliRunner
+
+from tokenjam.cli.main import cli
+from tokenjam.core.config import ApiAuthConfig, ApiConfig, TjConfig
+from tokenjam.core.db import InMemoryBackend
+from tests.factories import make_session
+
+
+# --- Transcript fixture builders (mirrors test_transcript.py) ---------------
+
+def _user_prompt(text: str) -> dict:
+    return {"type": "user", "message": {"role": "user", "content": text}}
+
+
+def _tool_result(tool_use_id: str, is_error: bool = False) -> dict:
+    block: dict = {
+        "type": "tool_result", "tool_use_id": tool_use_id, "content": "(omitted)",
+    }
+    if is_error:
+        block["is_error"] = True
+    return {"type": "user", "message": {"role": "user", "content": [block]}}
+
+
+def _assistant(
+    text: str | None, tools: list[dict] | None = None,
+    model: str = "claude-opus-4-8", ts: str = "2026-06-15T09:11:36.133Z",
+) -> dict:
+    content: list[dict] = []
+    if text is not None:
+        content.append({"type": "text", "text": text})
+    for t in tools or []:
+        content.append({
+            "type": "tool_use", "id": t["id"], "name": t["name"],
+            "input": t.get("input", {}),
+        })
+    return {
+        "type": "assistant", "timestamp": ts,
+        "message": {"role": "assistant", "model": model, "content": content},
+    }
+
+
+def _write_transcript(projects_root: Path, session_id: str, records: list[dict]) -> Path:
+    project_dir = projects_root / "-Users-test-project"
+    project_dir.mkdir(parents=True, exist_ok=True)
+    path = project_dir / f"{session_id}.jsonl"
+    path.write_text("\n".join(json.dumps(r) for r in records), encoding="utf-8")
+    return path
+
+
+def _agent_tool_result(tool_use_id: str, agent_id: str) -> dict:
+    text = f"Agent (agentId: {agent_id}) finished. See results above."
+    block = {"type": "tool_result", "tool_use_id": tool_use_id, "content": text}
+    return {"type": "user", "message": {"role": "user", "content": [block]}}
+
+
+def _task_turn(text: str, tool_id: str, name: str = "do work") -> dict:
+    return _assistant(text, tools=[{"id": tool_id, "name": "Task", "input": {
+        "description": name, "subagent_type": "general-purpose", "prompt": "do the work",
+    }}])
+
+
+def _write_subagent(
+    projects_root: Path, root_session_id: str, agent_id: str,
+    records: list[dict], name: str | None = None,
+) -> None:
+    subdir = projects_root / "-Users-test-project" / root_session_id / "subagents"
+    subdir.mkdir(parents=True, exist_ok=True)
+    (subdir / f"agent-{agent_id}.jsonl").write_text(
+        "\n".join(json.dumps(r) for r in records), encoding="utf-8"
+    )
+    if name is not None:
+        meta = {"agentType": "general-purpose", "name": name,
+                "description": name, "toolUseId": "toolu_x"}
+        (subdir / f"agent-{agent_id}.meta.json").write_text(json.dumps(meta), encoding="utf-8")
+
+
+def _simple_session_records(task: str, outcome: str) -> list[dict]:
+    return [
+        _user_prompt(task),
+        _assistant("Let me look at that.", tools=[
+            {"id": "t1", "name": "Read", "input": {"file_path": "src/app.py"}}]),
+        _tool_result("t1"),
+        _assistant(outcome),
+    ]
+
+
+# --- Test scaffolding ---------------------------------------------------------
+
+def _config() -> TjConfig:
+    return TjConfig(version="1", api=ApiConfig(auth=ApiAuthConfig(enabled=False)))
+
+
+def _invoke(db, args):
+    runner = CliRunner()
+    with patch("tokenjam.cli.main.load_config", return_value=_config()), \
+         patch("tokenjam.cli.main.open_db", return_value=db):
+        return runner.invoke(cli, args)
+
+
+def _seed_session(db, *, session_id: str, tool_call_count: int = 3,
+                  started_at=None) -> None:
+    db.upsert_session(make_session(
+        agent_id="a", session_id=session_id, tool_call_count=tool_call_count,
+        started_at=started_at,
+    ))
+
+
+def db_fixture():
+    backend = InMemoryBackend()
+    return backend
+
+
+# --- Tests --------------------------------------------------------------------
+
+def test_no_sessions_shows_honest_message_not_a_crash():
+    db = db_fixture()
+    result = _invoke(db, ["session-story"])
+    assert result.exit_code == 0, result.output
+    assert "no sessions found" in result.output.lower()
+
+
+def test_default_picks_most_recent_substantial_session(tmp_path, monkeypatch):
+    monkeypatch.setenv("TJ_CLAUDE_PROJECTS_ROOT", str(tmp_path))
+    db = db_fixture()
+
+    now = datetime.now(timezone.utc)
+    _seed_session(db, session_id="sess-old", started_at=now - timedelta(days=2))
+    _seed_session(db, session_id="sess-recent", started_at=now)
+    _write_transcript(tmp_path, "sess-old", _simple_session_records(
+        "Old task.", "Old outcome."))
+    _write_transcript(tmp_path, "sess-recent", _simple_session_records(
+        "Fix the failing auth test.", "All tests pass now."))
+
+    result = _invoke(db, ["session-story"])
+    assert result.exit_code == 0, result.output
+    assert "sess-recent" in result.output
+    assert "Fix the failing auth test" in result.output
+    assert "Old task" not in result.output
+
+
+def test_explicit_session_flag_overrides_default(tmp_path, monkeypatch):
+    monkeypatch.setenv("TJ_CLAUDE_PROJECTS_ROOT", str(tmp_path))
+    db = db_fixture()
+
+    now = datetime.now(timezone.utc)
+    _seed_session(db, session_id="sess-old", started_at=now - timedelta(days=2))
+    _seed_session(db, session_id="sess-recent", started_at=now)
+    _write_transcript(tmp_path, "sess-old", _simple_session_records(
+        "Old task.", "Old outcome."))
+    _write_transcript(tmp_path, "sess-recent", _simple_session_records(
+        "Recent task.", "Recent outcome."))
+
+    result = _invoke(db, ["session-story", "--session", "sess-old"])
+    assert result.exit_code == 0, result.output
+    assert "sess-old" in result.output
+    assert "Old task" in result.output
+    assert "Recent task" not in result.output
+
+
+def test_session_with_no_transcript_and_no_snapshot_is_honest(tmp_path, monkeypatch):
+    monkeypatch.setenv("TJ_CLAUDE_PROJECTS_ROOT", str(tmp_path))
+    db = db_fixture()
+    _seed_session(db, session_id="sess-gone")
+    # No transcript written, no session_story snapshot row.
+
+    result = _invoke(db, ["session-story", "--session", "sess-gone"])
+    assert result.exit_code == 0, result.output
+    assert "no on-disk transcript" in result.output.lower()
+
+
+def test_json_output_shape(tmp_path, monkeypatch):
+    monkeypatch.setenv("TJ_CLAUDE_PROJECTS_ROOT", str(tmp_path))
+    db = db_fixture()
+    _seed_session(db, session_id="sess-json")
+    _write_transcript(tmp_path, "sess-json", _simple_session_records(
+        "Fix the bug.", "Bug fixed."))
+
+    result = _invoke(db, ["session-story", "--session", "sess-json", "--json"])
+    assert result.exit_code == 0, result.output
+    payload = json.loads(result.output)
+    assert payload["available"] is True
+    assert payload["session_id"] == "sess-json"
+    assert payload["task"] == "Fix the bug."
+    assert payload["outcome"] == "Bug fixed."
+    assert isinstance(payload["spine"], list)
+    assert payload["spine"][0]["kind"] == "act"
+    assert payload["from_snapshot"] is False
+
+
+def test_json_output_for_unavailable_session_is_honest(tmp_path, monkeypatch):
+    monkeypatch.setenv("TJ_CLAUDE_PROJECTS_ROOT", str(tmp_path))
+    db = db_fixture()
+    _seed_session(db, session_id="sess-gone")
+
+    result = _invoke(db, ["session-story", "--session", "sess-gone", "--json"])
+    assert result.exit_code == 0, result.output
+    payload = json.loads(result.output)
+    assert payload["available"] is False
+    assert "reason" in payload
+
+
+def test_subagent_delegation_renders_with_tool_tally(tmp_path, monkeypatch):
+    monkeypatch.setenv("TJ_CLAUDE_PROJECTS_ROOT", str(tmp_path))
+    db = db_fixture()
+    _seed_session(db, session_id="sess-deleg")
+
+    child = "abc123def456abc78"  # 17 hex, matches the agentId shape
+    parent = [
+        _user_prompt("Fix the failing auth test and make CI green."),
+        _task_turn("Delegating the fix to a worker.", "tt1", name="fix-auth"),
+        _agent_tool_result("tt1", child),
+        _assistant("All tests pass now. CI is green."),
+    ]
+    _write_transcript(tmp_path, "sess-deleg", parent)
+    _write_subagent(tmp_path, "sess-deleg", child, [
+        _user_prompt("Implement the fix."),
+        _assistant("Reading the auth module.", tools=[
+            {"id": "c1", "name": "Read", "input": {"file_path": "src/auth.py"}}]),
+        _tool_result("c1"),
+        _assistant("Editing the fix in.", tools=[
+            {"id": "c2", "name": "Edit", "input": {"file_path": "src/auth.py"}}]),
+        _tool_result("c2"),
+        _assistant("Done implementing."),
+    ], name="fix-auth")
+
+    result = _invoke(db, ["session-story", "--session", "sess-deleg"])
+    assert result.exit_code == 0, result.output
+    assert "delegate" in result.output
+    assert "fix-auth" in result.output
+    # Factual per-category tool tally over the subagent's own moves — never a
+    # value judgment ("wasted"/"good"/"bad"), per Critical Rule 14.
+    assert "1 read" in result.output
+    assert "1 edit" in result.output
+    assert "wasted" not in result.output.lower()
+    assert "good" not in result.output.lower()

--- a/tests/unit/test_cmd_session_story.py
+++ b/tests/unit/test_cmd_session_story.py
@@ -250,3 +250,53 @@ def test_subagent_delegation_renders_with_tool_tally(tmp_path, monkeypatch):
     assert "1 edit" in result.output
     assert "wasted" not in result.output.lower()
     assert "good" not in result.output.lower()
+
+
+# --- API-shim path (tj serve holds the DuckDB write lock) --------------------
+#
+# These exercise ApiBackend directly (mirrors test_drift.py's
+# TestApiBackendGetBaseline pattern: monkeypatch `_get` and assert on the call
+# args) rather than the full CLI, since the CLI-level dual-path selection is
+# just `hasattr(db, "conn")` / `isinstance(db, ApiBackend)` — already implicit
+# in every `_invoke(db, ...)` test above using a real InMemoryBackend.
+
+def test_find_last_substantial_session_requests_a_capped_page(monkeypatch):
+    """`/sessions` is NOT paginated by the caller unbounded — a user with
+    thousands of sessions must not have the whole table pulled over HTTP just
+    to find the first row with real activity (Greptile, PR #448)."""
+    from tokenjam.core.api_backend import ApiBackend
+
+    backend = ApiBackend("http://localhost:8000")
+    calls: list[tuple[str, dict | None]] = []
+
+    def _fake_get(path, params=None):
+        calls.append((path, params))
+        return {"sessions": [
+            {"session_id": "sess-1", "tool_call_count": 0},
+            {"session_id": "sess-2", "tool_call_count": 5},
+        ]}
+
+    monkeypatch.setattr(backend, "_get", _fake_get)
+    result = backend.find_last_substantial_session(min_tool_calls=1)
+
+    assert result == "sess-2"
+    assert len(calls) == 1
+    path, params = calls[0]
+    assert path == "/api/v1/sessions"
+    assert params == {"limit": backend._LAST_SESSION_PAGE_SIZE}
+    assert params["limit"] < 1000  # a real cap, not "everything"
+
+
+def test_find_last_substantial_session_none_when_page_has_no_qualifying_row(
+    monkeypatch,
+):
+    from tokenjam.core.api_backend import ApiBackend
+
+    backend = ApiBackend("http://localhost:8000")
+    monkeypatch.setattr(
+        backend, "_get",
+        lambda path, params=None: {"sessions": [
+            {"session_id": "sess-1", "tool_call_count": 0},
+        ]},
+    )
+    assert backend.find_last_substantial_session(min_tool_calls=1) is None

--- a/tests/unit/test_quickstart.py
+++ b/tests/unit/test_quickstart.py
@@ -536,3 +536,44 @@ def test_quickstart_preview_omitted_when_no_sessions(tmp_path):
     result = _invoke_quickstart(["--root", str(missing)])
     assert result.exit_code == 0, result.output
     assert "With the statusline installed" not in result.output
+
+
+# ── Session Story teaser (reuses `tj session-story`'s own renderer) ─────────
+
+def test_quickstart_session_story_teaser_appears_for_qualifying_session(
+    tmp_path, monkeypatch,
+):
+    """The teaser renders for the SAME session the statusline preview already
+    picked — no extra file globbing, just the shared renderer on that session's
+    already-confirmed-readable transcript."""
+    from tokenjam.cli import cmd_quickstart as q
+
+    monkeypatch.setattr(q, "PREVIEW_MIN_TURNS", 3)
+    root = tmp_path / "projects"
+    _session_with_crossing(
+        root, "sess-recent", "/Users/me/projB", "2026-06-25",
+        n_turns=5, crossing_turn=3,
+    )
+
+    result = _invoke_quickstart(["--root", str(root), "--since", "90d"])
+    assert result.exit_code == 0, result.output
+    assert "Session Story" in result.output
+    assert "tj session-story" in result.output
+    # The teaser follows the statusline preview in the output, not before it.
+    assert result.output.index("With the statusline installed") < result.output.index(
+        "Session Story"
+    )
+
+
+def test_quickstart_session_story_teaser_omitted_when_no_preview_candidate(tmp_path):
+    """Silent degrade: no crossing session -> no statusline preview -> no
+    Session Story teaser either (nothing to reuse the selection from)."""
+    root = tmp_path / "projects"
+    _make_session_file(root, "sess-a", "/Users/me/projA", [
+        _assistant("a1", "sess-a", "/Users/me/projA", "2026-06-20T10:00:00.000Z",
+                   input_tokens=1000, output_tokens=200, cache_read=10),
+    ])
+
+    result = _invoke_quickstart(["--root", str(root), "--since", "90d"])
+    assert result.exit_code == 0, result.output
+    assert "Session Story" not in result.output

--- a/tokenjam/api/routes/sessions.py
+++ b/tokenjam/api/routes/sessions.py
@@ -77,11 +77,16 @@ async def list_sessions(
     request: Request,
     status: str | None = None,
     agent_id: str | None = None,
+    limit: int | None = None,
 ) -> dict:
     """Enumerate sessions one row per session, newest first.
 
     `status` filters by session status (e.g. 'active'); `agent_id` scopes to a
-    single agent. Both are optional.
+    single agent. `limit` caps the number of rows returned (still newest-first)
+    — optional, default None returns every matching session as before. Added
+    for callers that only need the head of the list (e.g. `tj session-story`'s
+    ApiBackend.find_last_substantial_session, which otherwise pulled the whole
+    table just to inspect the first few rows).
     """
     db = request.app.state.db
     conn = getattr(db, "conn", None)
@@ -98,12 +103,16 @@ async def list_sessions(
         clauses.append(f"agent_id = ${len(params)}")
     where = (" WHERE " + " AND ".join(clauses)) if clauses else ""
 
-    rows = conn.execute(
+    query = (
         "SELECT session_id, agent_id, started_at, total_cost_usd, "
         "input_tokens, output_tokens, tool_call_count, error_count "
-        f"FROM sessions{where} ORDER BY started_at DESC",
-        params,
-    ).fetchall()
+        f"FROM sessions{where} ORDER BY started_at DESC"
+    )
+    if limit is not None:
+        params.append(limit)
+        query += f" LIMIT ${len(params)}"
+
+    rows = conn.execute(query, params).fetchall()
     sessions = [
         {
             "session_id": r[0],

--- a/tokenjam/cli/cmd_quickstart.py
+++ b/tokenjam/cli/cmd_quickstart.py
@@ -273,7 +273,11 @@ def _render(diag, timeline, *, since: str,
 
     # ── Statusline live preview (self-contained; omits silently if no
     # candidate session ever crosses the nudge threshold). ──
-    _render_statusline_preview(timeline, root)
+    picked = _render_statusline_preview(timeline, root)
+
+    # ── Session Story teaser: reuses the SAME renderer `tj session-story`
+    # uses, on the ALREADY-selected session (no extra DB/glob work). ──
+    _render_session_story_teaser(picked, root)
 
     # ── Session timeline. ──
     table = Table(box=box.SIMPLE, show_header=True, header_style="bold dim",
@@ -447,18 +451,24 @@ def _select_preview_session(
     return max(candidates, key=lambda c: c.turns)
 
 
-def _render_statusline_preview(timeline: SessionTimeline, root: Path | None) -> None:
+def _render_statusline_preview(
+    timeline: SessionTimeline, root: Path | None,
+) -> _PreviewCandidate | None:
     """"What you'd see live" preview section — self-contained; prints nothing
     when there is no session to preview (no history, no readable transcript,
-    or no session ever crossed the nudge threshold)."""
+    or no session ever crossed the nudge threshold).
+
+    Returns the selected ``_PreviewCandidate`` (or ``None``) so the caller can
+    reuse the already-picked session for the Session Story teaser instead of
+    re-walking transcripts."""
     if root is None or not timeline.sessions:
-        return
+        return None
 
     from rich.text import Text
 
     picked = _select_preview_session(timeline, root)
     if picked is None:
-        return
+        return None
     assert picked.crossing is not None  # invariant: only crossing candidates are ever selected
 
     turn_index, model_raw, usage = picked.crossing
@@ -480,4 +490,46 @@ def _render_statusline_preview(timeline: SessionTimeline, root: Path | None) -> 
     outro.append("tj onboard", style="bold cyan")
     outro.append(" sets it up.", style="dim")
     console.print(outro)
+    console.print()
+    return picked
+
+
+def _render_session_story_teaser(
+    picked: _PreviewCandidate | None, root: Path | None,
+) -> None:
+    """Session Story teaser: a compact preview of HOW the previewed session
+    attempted its work, reusing the exact ``tj session-story`` renderer.
+
+    Silent-degrades (prints nothing) when there is no picked session or root, or
+    when the session's story can't be built. Does NO extra file globbing or DB
+    work beyond building the story for the ALREADY-selected session, so it can't
+    blow quickstart's fast first-run budget."""
+    if picked is None or root is None:
+        return
+
+    from tokenjam.cli.cmd_session_story import render_session_story
+    from tokenjam.core.transcript import build_session_story
+
+    story = build_session_story(
+        picked.session.session_id, projects_root=root, include_subagents=True
+    )
+    if not story:
+        return
+
+    from rich.text import Text
+
+    header = Text()
+    header.append("Session Story", style="bold")
+    header.append("  ·  how that session actually attempted its work", style="dim")
+    console.print(header)
+    console.print()
+    render_session_story(
+        story, session_id=picked.session.session_id, max_moves=3
+    )
+    console.print()
+    pointer = Text()
+    pointer.append("See the full turn-by-turn method with ", style="dim")
+    pointer.append("tj session-story", style="bold cyan")
+    pointer.append(".", style="dim")
+    console.print(pointer)
     console.print()

--- a/tokenjam/cli/cmd_session_story.py
+++ b/tokenjam/cli/cmd_session_story.py
@@ -1,0 +1,378 @@
+"""``tj session-story`` — turn-by-turn reconstruction of *how* a Claude Code
+session attempted its task, with per-subagent attribution.
+
+A thin CLI view over the deterministic core reconstruction (``core/transcript``
++ ``core/method_spine``). It surfaces the agent's own narration + literal tool
+calls folded into ordered *moves* (``delegate`` / ``dead_end`` / ``verify`` /
+``act``), and — for every ``delegate`` move — the spawned subagent's own mandate,
+a factual tool-category tally over what it DID, and its recursively-rendered
+method spine one indent level deeper.
+
+Honesty discipline (CLAUDE.md Rule 14): the four move kinds are the ONLY intent
+this surfaces — all structurally determinable. It never claims a move was
+"good"/"bad"/"wasted", and it renders a capped/un-expanded delegation as exactly
+that (``not expanded``) rather than inventing moves it never captured. This is a
+behavioral view — what a subagent read/edited/searched/delegated/verified — so it
+carries no cost or dollar figures (that framing lives in ``tj cost`` / the Lens).
+
+Session resolution mirrors the two-path pattern the rest of the CLI uses:
+
+  * Direct DuckDB (``db.conn``): resolve ``--last`` via a ``sessions`` query and
+    build the story straight from the on-disk transcript, falling back to the
+    persisted method snapshot (``core/method_capture``) when the transcript was
+    pruned.
+  * API-shim (``ApiBackend``, when ``tj serve`` holds the write lock): the daemon
+    already did the reconstruction + snapshot fallback, so we fetch the ready
+    ``{"available", ...}`` payload over HTTP and render it verbatim.
+"""
+from __future__ import annotations
+
+import json
+from typing import Any
+
+import click
+from rich.markup import escape
+
+from tokenjam.core.method_capture import load_session_method
+from tokenjam.core.method_spine import build_method_spine
+from tokenjam.core.transcript import build_session_story, resolve_projects_root
+from tokenjam.core.workmap import (
+    _BASH_TOOLS,
+    _FILE_TOOLS,
+    _SEARCH_TOOLS,
+    _SPAWN_TOOLS,
+    _WEB_TOOLS,
+)
+from tokenjam.utils.formatting import console
+
+#: The whole of the "substantial" heuristic: a session is worth auto-selecting
+#: for the story view once it ran at least this many tool calls. Kept
+#: deliberately minimal (any real session clears it) — see the task brief.
+MIN_SUBSTANTIAL_TOOL_CALLS = 1
+
+#: Stable user-facing reason when a session has no on-disk CC transcript AND no
+#: persisted snapshot (mirrors ``api/routes/sessions._NO_TRANSCRIPT_REASON``).
+_NO_TRANSCRIPT_REASON = (
+    "No on-disk transcript for this session "
+    "(SDK session, or transcript pruned)."
+)
+
+#: Per-move-kind display colour. ``act`` is the uncoloured default.
+_KIND_STYLE = {
+    "delegate": "cyan",
+    "dead_end": "red",
+    "verify": "green",
+    "act": "",
+}
+
+
+@click.command("session-story")
+@click.option("--session", "session_id", default=None,
+              help="Reconstruct a specific session id (default: the most recent "
+                   "substantial session).")
+@click.option("--last", is_flag=True,
+              help="Reconstruct the most recent substantial session "
+                   "(the default when no --session is given).")
+@click.option("--json", "output_json", is_flag=True,
+              help="Emit machine-readable JSON (the folded method spine).")
+@click.pass_context
+def cmd_session_story(ctx: click.Context, session_id: str | None,
+                      last: bool, output_json: bool) -> None:
+    """Show turn-by-turn HOW a Claude Code session attempted its task.
+
+    Reconstructs the session's method — its ordered moves and, for each
+    delegation, the subagent's mandate + what it did — from the on-disk
+    transcript (or a persisted snapshot when the transcript was pruned). With no
+    ``--session``, auto-selects the most recent substantial session.
+    """
+    db = ctx.obj.get("db")
+    if db is None:
+        raise click.ClickException("session-story requires a database connection.")
+
+    conn = getattr(db, "conn", None)
+    if conn is None:
+        _run_via_serve(db, session_id=session_id, output_json=output_json)
+        return
+
+    # ── Direct DuckDB path. ──
+    if session_id is None:
+        session_id = _resolve_last_session_direct(conn)
+    if session_id is None:
+        _emit_unavailable("no sessions found", output_json)
+        return
+
+    projects_root = resolve_projects_root(None)
+    story = build_session_story(
+        session_id, projects_root=projects_root, include_subagents=True
+    )
+    from_snapshot = False
+    if story is None:
+        snapshot = load_session_method(db, session_id)
+        if snapshot and snapshot.get("story"):
+            story = snapshot["story"]
+            from_snapshot = True
+    if not story:
+        _emit_unavailable(_NO_TRANSCRIPT_REASON, output_json, session_id=session_id)
+        return
+
+    if output_json:
+        _emit_story_json(story, session_id=session_id, from_snapshot=from_snapshot)
+        return
+
+    render_session_story(story, session_id=session_id, from_snapshot=from_snapshot)
+
+
+def _run_via_serve(db: Any, *, session_id: str | None, output_json: bool) -> None:
+    """Render the story fetched from a running ``tj serve``.
+
+    The daemon holds the DuckDB write lock, so the CLI can't read the transcript
+    file or the snapshot table directly here — the daemon already did the
+    reconstruction + fallback, so we ask it for the ready payload and render it.
+    """
+    from tokenjam.core.api_backend import ApiBackend
+
+    if not isinstance(db, ApiBackend):
+        raise click.ClickException(
+            "tj session-story needs either a direct DuckDB connection or a "
+            "running tj serve at the configured api.{host,port}."
+        )
+
+    if session_id is None:
+        try:
+            session_id = db.find_last_substantial_session(MIN_SUBSTANTIAL_TOOL_CALLS)
+        except Exception as exc:  # noqa: BLE001 — surface any HTTP/transport error
+            raise click.ClickException(
+                f"Failed to list sessions from tj serve: {exc}"
+            ) from exc
+    if session_id is None:
+        _emit_unavailable("no sessions found", output_json)
+        return
+
+    try:
+        payload = db.fetch_session_story(session_id, subagents=True)
+    except Exception as exc:  # noqa: BLE001 — surface any HTTP/transport error
+        raise click.ClickException(
+            f"Failed to fetch the session story from tj serve: {exc}"
+        ) from exc
+
+    if not payload.get("available"):
+        reason = payload.get("reason") or _NO_TRANSCRIPT_REASON
+        _emit_unavailable(reason, output_json, session_id=session_id)
+        return
+
+    from_snapshot = bool(payload.get("from_snapshot"))
+    if output_json:
+        _emit_story_json(payload, session_id=session_id, from_snapshot=from_snapshot)
+        return
+
+    render_session_story(payload, session_id=session_id, from_snapshot=from_snapshot)
+
+
+def _resolve_last_session_direct(conn: Any) -> str | None:
+    """Most-recent substantial session id from the direct DuckDB connection."""
+    row = conn.execute(
+        "SELECT session_id FROM sessions WHERE tool_call_count >= $1 "
+        "ORDER BY started_at DESC LIMIT 1",
+        [MIN_SUBSTANTIAL_TOOL_CALLS],
+    ).fetchone()
+    return row[0] if row and row[0] else None
+
+
+# ───────────────────────────── JSON output ─────────────────────────────────
+
+def _emit_unavailable(reason: str, output_json: bool,
+                      *, session_id: str | None = None) -> None:
+    """Honest "no story" state — exit 0 on both paths, never an exception."""
+    if output_json:
+        payload: dict[str, Any] = {"available": False, "reason": reason}
+        if session_id is not None:
+            payload["session_id"] = session_id
+        click.echo(json.dumps(payload, default=str))
+        return
+    console.print(
+        f"\n[yellow]{escape(reason)}[/yellow]\n"
+        "[dim]Run [bold]tj onboard --claude-code[/bold] to ingest your Claude "
+        "Code sessions, then re-run [bold]tj session-story[/bold].[/dim]\n"
+    )
+
+
+def _emit_story_json(story: dict[str, Any], *, session_id: str,
+                     from_snapshot: bool) -> None:
+    payload = {
+        "session_id": session_id,
+        "available": True,
+        "task": story.get("task") or "",
+        "outcome": story.get("outcome") or "",
+        "spine": build_method_spine(story),
+        "from_snapshot": from_snapshot,
+    }
+    click.echo(json.dumps(payload, default=str))
+
+
+# ───────────────────────────── rendering ──────────────────────────────────
+
+def render_session_story(
+    story: dict[str, Any],
+    *,
+    session_id: str,
+    from_snapshot: bool = False,
+    max_moves: int | None = None,
+) -> None:
+    """Render a session's method spine turn-by-turn (Rich).
+
+    ``max_moves`` caps the number of TOP-LEVEL moves shown (compact mode, used by
+    the ``tj quickstart`` teaser) and appends a "+K more" trailer; nested
+    subagent spines always render in full. In compact mode the footer summary is
+    skipped so the teaser stays short.
+    """
+    spine = build_method_spine(story)
+    compact = max_moves is not None
+
+    _render_header(session_id, story, compact=compact)
+    _render_moves(spine, depth=0, max_moves=max_moves)
+    if not compact:
+        _render_footer(spine, from_snapshot)
+
+
+def _render_header(session_id: str, story: dict[str, Any], *, compact: bool) -> None:
+    short_id = session_id[:12]
+    task = (story.get("task") or "").strip()
+    header = f"[bold]session {escape(short_id)}[/bold]"
+    if task:
+        header += f"  {escape(task)}"
+    console.print(header)
+    if not compact:
+        outcome = (story.get("outcome") or "").strip()
+        if outcome:
+            console.print(f"[dim]outcome:[/dim] {escape(outcome)}")
+
+
+def _render_moves(
+    moves: list[dict[str, Any]], depth: int, max_moves: int | None = None,
+) -> None:
+    """Render an ordered list of moves at ``depth``; cap top-level when asked."""
+    shown = moves if max_moves is None else moves[:max_moves]
+    for i, move in enumerate(shown, 1):
+        _render_move(move, i, depth)
+    if max_moves is not None and len(moves) > max_moves:
+        extra = len(moves) - max_moves
+        console.print(
+            f"    [dim]… +{extra} more — see full detail with "
+            "`tj session-story`[/dim]"
+        )
+
+
+def _render_move(move: dict[str, Any], index: int, depth: int) -> None:
+    indent = "  " * depth
+    kind = move.get("kind") or "act"
+    style = _KIND_STYLE.get(kind, "")
+    kind_text = f"[{style}]{kind}[/{style}]" if style else kind
+    label = escape((move.get("label") or "").strip())
+    console.print(f"{indent}  {index}. {kind_text}  {label}")
+
+    if kind == "delegate":
+        for deleg in move.get("delegations") or []:
+            _render_delegation(deleg, depth)
+
+
+def _render_delegation(deleg: dict[str, Any], depth: int) -> None:
+    indent = "  " * (depth + 1)
+    name = deleg.get("name") or (deleg.get("agent_id") or "")[:8] or "subagent"
+    task = escape((deleg.get("task") or "").strip())
+    sub_line = f"{indent}    [cyan]{escape(str(name))}[/cyan]"
+    if task:
+        sub_line += f": [dim]{task}[/dim]"
+    console.print(sub_line)
+
+    capped = deleg.get("capped")
+    if capped:
+        console.print(f"{indent}    [dim](not expanded: {escape(str(capped))})[/dim]")
+        return
+
+    sub_spine = deleg.get("spine") or []
+    console.print(f"{indent}    [dim]{_tally_evidence(sub_spine)}[/dim]")
+    _render_moves(sub_spine, depth=depth + 2)
+
+
+def _tally_evidence(spine: list[dict[str, Any]]) -> str:
+    """Factual tool-category tally over a spine's top-level move evidence.
+
+    E.g. ``6 moves — 4 reads, 1 edit, 1 bash``. Categorizes each evidence entry
+    by the same tool-category sets ``method_spine`` uses. Descriptive only.
+    """
+    reads = edits = searches = commands = spawns = webs = others = 0
+    for move in spine:
+        for ev in move.get("evidence") or []:
+            name = ev.get("name")
+            if name == "Read":
+                reads += 1
+            elif name in _FILE_TOOLS:
+                edits += 1
+            elif name in _SEARCH_TOOLS:
+                searches += 1
+            elif name in _BASH_TOOLS:
+                commands += 1
+            elif name in _SPAWN_TOOLS:
+                spawns += 1
+            elif name in _WEB_TOOLS:
+                webs += 1
+            else:
+                others += 1
+
+    parts: list[str] = []
+    if reads:
+        parts.append(f"{reads} read{'s' if reads != 1 else ''}")
+    if edits:
+        parts.append(f"{edits} edit{'s' if edits != 1 else ''}")
+    if searches:
+        parts.append(f"{searches} search{'es' if searches != 1 else ''}")
+    if commands:
+        parts.append(f"{commands} bash")
+    if spawns:
+        parts.append(f"{spawns} delegation{'s' if spawns != 1 else ''}")
+    if webs:
+        parts.append(f"{webs} web fetch{'es' if webs != 1 else ''}")
+    if others:
+        parts.append(f"{others} other{'s' if others != 1 else ''}")
+
+    n = len(spine)
+    head = f"{n} move{'s' if n != 1 else ''}"
+    return f"{head} — {', '.join(parts)}" if parts else head
+
+
+def _count_spine(spine: list[dict[str, Any]]) -> dict[str, int]:
+    """Totals over the whole (recursive) spine: moves / delegations /
+    dead-ends / verifies. A small local count, not a reconstruction."""
+    counts = {"moves": 0, "delegations": 0, "dead_ends": 0, "verifies": 0}
+
+    def walk(moves: list[dict[str, Any]]) -> None:
+        for move in moves:
+            counts["moves"] += 1
+            kind = move.get("kind")
+            if kind == "dead_end":
+                counts["dead_ends"] += 1
+            elif kind == "verify":
+                counts["verifies"] += 1
+            for deleg in move.get("delegations") or []:
+                counts["delegations"] += 1
+                walk(deleg.get("spine") or [])
+
+    walk(spine)
+    return counts
+
+
+def _render_footer(spine: list[dict[str, Any]], from_snapshot: bool) -> None:
+    c = _count_spine(spine)
+    summary = (
+        f"{c['moves']} moves, {c['delegations']} delegations, "
+        f"{c['dead_ends']} dead-ends, {c['verifies']} verifies"
+    )
+    console.print(f"\n[dim]{summary}[/dim]")
+    if from_snapshot:
+        console.print(
+            "[dim](from a persisted snapshot — the live transcript was "
+            "pruned)[/dim]"
+        )
+
+
+__all__ = ["cmd_session_story", "render_session_story"]

--- a/tokenjam/cli/main.py
+++ b/tokenjam/cli/main.py
@@ -122,6 +122,7 @@ from tokenjam.cli.cmd_policy import cmd_policy  # noqa: E402
 from tokenjam.cli.cmd_pricing import cmd_pricing  # noqa: E402
 from tokenjam.cli.cmd_proxy import cmd_proxy  # noqa: E402
 from tokenjam.cli.cmd_context import cmd_context  # noqa: E402
+from tokenjam.cli.cmd_session_story import cmd_session_story  # noqa: E402
 from tokenjam.cli.cmd_quota_audit import cmd_quota_audit  # noqa: E402
 from tokenjam.cli.cmd_quickstart import cmd_quickstart  # noqa: E402
 from tokenjam.cli.cmd_otel import cmd_otel_resource_attrs  # noqa: E402
@@ -154,6 +155,7 @@ cli.add_command(cmd_policy, name="policy")
 cli.add_command(cmd_pricing, name="pricing")
 cli.add_command(cmd_proxy, name="proxy")
 cli.add_command(cmd_context, name="context")
+cli.add_command(cmd_session_story, name="session-story")
 cli.add_command(cmd_quota_audit, name="quota-audit")
 cli.add_command(cmd_quickstart, name="quickstart")
 cli.add_command(cmd_otel_resource_attrs, name="otel-resource-attrs")

--- a/tokenjam/core/api_backend.py
+++ b/tokenjam/core/api_backend.py
@@ -337,6 +337,13 @@ class ApiBackend:
             params["agent_id"] = agent_id
         return self._get("/api/v1/reuse/clusters", params)
 
+    #: `/sessions` page size for `find_last_substantial_session`. The floor is
+    #: usually 1 tool call, so the newest row almost always qualifies — this
+    #: cap just needs to survive a handful of non-substantial rows at the head
+    #: of the list without pulling a user's entire (possibly thousands-row)
+    #: sessions table over HTTP just to inspect the first few (Greptile, PR #448).
+    _LAST_SESSION_PAGE_SIZE = 25
+
     def find_last_substantial_session(
         self, min_tool_calls: int = 1
     ) -> str | None:
@@ -344,10 +351,16 @@ class ApiBackend:
 
         Mirrors the direct-DB `--last` resolution in `tj session-story` when the
         daemon holds the write lock. `/sessions` already returns rows newest
-        first, so the first qualifying row is the answer. Returns None when no
-        session clears the floor (or the list is empty).
+        first, so the first qualifying row within the fetched page is the
+        answer. Fetches only `_LAST_SESSION_PAGE_SIZE` rows via `/sessions`'
+        `limit` param, not the whole table. Returns None when no session in
+        that page clears the floor (or the list is empty) — a session further
+        back than the page never gets picked as "last", which is the honest
+        trade-off for not transferring a user's entire session history.
         """
-        data = self._get("/api/v1/sessions")
+        data = self._get(
+            "/api/v1/sessions", {"limit": self._LAST_SESSION_PAGE_SIZE}
+        )
         for s in data.get("sessions", []):
             if (s.get("tool_call_count") or 0) >= min_tool_calls:
                 sid = s.get("session_id")

--- a/tokenjam/core/api_backend.py
+++ b/tokenjam/core/api_backend.py
@@ -337,6 +337,41 @@ class ApiBackend:
             params["agent_id"] = agent_id
         return self._get("/api/v1/reuse/clusters", params)
 
+    def find_last_substantial_session(
+        self, min_tool_calls: int = 1
+    ) -> str | None:
+        """Most-recent session id with at least `min_tool_calls` tool calls.
+
+        Mirrors the direct-DB `--last` resolution in `tj session-story` when the
+        daemon holds the write lock. `/sessions` already returns rows newest
+        first, so the first qualifying row is the answer. Returns None when no
+        session clears the floor (or the list is empty).
+        """
+        data = self._get("/api/v1/sessions")
+        for s in data.get("sessions", []):
+            if (s.get("tool_call_count") or 0) >= min_tool_calls:
+                sid = s.get("session_id")
+                if sid:
+                    return sid
+        return None
+
+    def fetch_session_story(
+        self, session_id: str, subagents: bool = True
+    ) -> dict:
+        """Fetch a session's reconstructed story from `tj serve`.
+
+        Used by `tj session-story` when the local DuckDB connection is
+        unavailable (daemon holds the write lock). The daemon already did the
+        transcript reconstruction + snapshot fallback, so this returns the raw
+        `{"available": bool, ...}` payload (`available`/`reason`/`from_snapshot`
+        + the story fields) verbatim for the CLI to render. See issue #63 for
+        the same daemon-availability pattern behind `tj context`.
+        """
+        return self._get(
+            f"/api/v1/sessions/{session_id}/story",
+            {"subagents": subagents},
+        )
+
     def fetch_context_diagnostic(
         self,
         *,


### PR DESCRIPTION
## Summary

- Adds `tj session-story [--session <id>|--last] [--json]`: a thin CLI view over the existing Session Story reconstruction (`core/transcript.build_session_story` + `core/method_spine.build_method_spine`). Renders each session's ordered moves (`delegate`/`dead_end`/`verify`/`act`) turn-by-turn, and for every subagent delegation, the subagent's mandate plus a factual tool-category tally (reads/edits/searches/commands) and its own recursively-rendered method spine. No cost/dollar figures — this is a behavioral view of *how* the work was attempted, not a cost one.
- Defaults to the most recent session with real activity when `--session` is omitted; `--json` emits the folded spine.
- Mirrors `tj context`'s existing direct-DB / `tj serve` dual-path pattern: two small `ApiBackend` additions (`find_last_substantial_session`, `fetch_session_story`) so the command also works when the daemon holds the DuckDB write lock, relaying the daemon's own already-computed reconstruction+snapshot-fallback instead of re-deriving it client-side.
- Adds a 3-5 line Session Story teaser to `tj quickstart`, reusing the exact session the statusline preview already selected (no extra file globbing or DB work) and rendering it with the same renderer in compact mode.
- A previously published blog post already tells readers to run `tj session-story` — this closes that gap.

## Test plan

- [x] `make lint` — clean
- [x] `make typecheck` — clean (188 source files)
- [x] `make test-unit` — 1775 passed, 1 skipped (full suite, stable across repeated runs)
- [x] New `tests/unit/test_cmd_session_story.py` (7 tests): default session selection, explicit `--session`, honest "no transcript" fallback, `--json` shape (available + unavailable), subagent delegation rendering with tool tally
- [x] Two new tests in `tests/unit/test_quickstart.py`: teaser renders for a qualifying session (reusing the statusline preview's pick), silently omitted when no session qualifies
- [x] Manual smoke test of the renderer against a hand-built transcript with a subagent delegation (turn-by-turn + tally output confirmed correct)
- [x] Added a `### tj session-story` section to `docs/cli-reference.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)