### PR TITLE
fix: surface progress during tj quickstart's ingest

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,10 @@ classifiers = [
 ]
 
 dependencies = [
-    "click>=8.1",
+    # >=8.2: CliRunner separately captures stdout/stderr by default from this
+    # version on (result.stdout / result.stderr always populated); tests that
+    # assert stdout stays clean of stderr-routed output rely on this.
+    "click>=8.2",
     "rich>=13.0",
     "tomli>=2.0; python_version < '3.11'",
     "tomli-w>=1.0",

--- a/tests/unit/test_quickstart.py
+++ b/tests/unit/test_quickstart.py
@@ -250,6 +250,67 @@ def test_quickstart_no_logs_is_graceful(tmp_path):
     assert "No Claude Code logs" in result.output
 
 
+# ── Pre-ingest progress: ingest was previously the ONE silent stretch in the
+# whole command (~40s dead cursor on a large history, nothing printed until
+# after it returned). An honest status line now lands before ingest starts,
+# and the shared streaming counter (`backfill_progress`) advances per session
+# through to render. `--json` must stay byte-for-byte clean on stdout.
+
+def test_quickstart_prints_pre_ingest_status_before_render(tmp_path):
+    root = _fixture_root(tmp_path)
+    result = _invoke_quickstart(["--root", str(root), "--since", "90d"])
+
+    assert result.exit_code == 0, result.output
+    assert "Reading your last 90 days of Claude Code history" in result.output
+    assert "(most-recent 300 sessions)" in result.output
+    # It's the FIRST thing printed -- ahead of the quota-composition panel,
+    # not tacked on after ingest already finished.
+    assert result.output.index("Reading your last 90 days") < result.output.index(
+        "Where your quota goes"
+    )
+
+
+def test_quickstart_pre_ingest_status_omits_cap_when_full(tmp_path):
+    """`--full` lifts the session cap (#13) -- the status line must not claim
+    a "most-recent N sessions" scope that no longer applies."""
+    root = _fixture_root(tmp_path)
+    result = _invoke_quickstart(["--root", str(root), "--since", "90d", "--full"])
+
+    assert result.exit_code == 0, result.output
+    assert "Reading your last 90 days of Claude Code history…" in result.output
+    assert "most-recent" not in result.output.split("Where your quota goes")[0]
+
+
+def test_quickstart_json_stdout_stays_pure(tmp_path):
+    """`--json` must be pipeable straight into a JSON parser: stdout carries
+    ONLY the JSON payload, never the pre-ingest status line or the streaming
+    progress counter -- those route to stderr instead."""
+    root = _fixture_root(tmp_path)
+    result = _invoke_quickstart(["--root", str(root), "--since", "90d", "--json"])
+
+    assert result.exit_code == 0, result.output
+    # stdout parses as JSON on its own -- no leading/trailing progress noise.
+    payload = json.loads(result.stdout.strip())
+    assert "quota_composition" in payload
+    assert payload["backfill"]["sessions_ingested"] == 2
+    # The status line still printed -- just on stderr, never stdout.
+    assert "Reading your last 90 days of Claude Code history" in result.stderr
+    assert "Reading your last 90 days" not in result.stdout
+
+
+def test_quickstart_advancing_counter_on_large_history(tmp_path):
+    """On a large history the shared streaming counter keeps advancing
+    through ingest (not just a single static pre-ingest line) -- non-TTY
+    output (as under CliRunner) degrades to periodic plain prints every 100
+    sessions, mirroring `tj onboard --claude-code`'s backfill counter."""
+    root = _large_fixture_root(tmp_path, n_sessions=250)
+    result = _invoke_quickstart(["--root", str(root), "--since", "90d"])
+
+    assert result.exit_code == 0, result.output
+    assert "Backfilling 100/250 sessions" in result.output
+    assert "Backfilling 200/250 sessions" in result.output
+
+
 def _large_fixture_root(tmp_path: Path, n_sessions: int) -> Path:
     """A synthetic history with `n_sessions` sessions, two turns each, recent.
 

--- a/tokenjam/cli/backfill_progress.py
+++ b/tokenjam/cli/backfill_progress.py
@@ -14,10 +14,11 @@ from __future__ import annotations
 from contextlib import contextmanager
 from typing import Callable, Iterator
 
+from rich.console import Console
 from rich.progress import Progress, SpinnerColumn, TextColumn
 
 from tokenjam.core.backfill import BackfillResult, ParsedSession
-from tokenjam.utils.formatting import console
+from tokenjam.utils.formatting import console as _default_console
 from tokenjam.utils.humanize import format_tokens
 
 ProgressCallback = Callable[[ParsedSession, BackfillResult], None]
@@ -32,18 +33,25 @@ def _noop(_parsed: ParsedSession, _result: BackfillResult) -> None:
 
 
 @contextmanager
-def backfill_progress(total: int | None, *, quiet: bool = False) -> Iterator[ProgressCallback]:
+def backfill_progress(
+    total: int | None, *, quiet: bool = False, console: Console | None = None,
+) -> Iterator[ProgressCallback]:
     """Yield a `progress(parsed, result)` callback for `ingest_claude_code`.
 
     `total` is the cheap pre-count of in-scope sessions
     (`count_claude_code_sessions_in_scope`), or `None` when unknown — the
     counter then shows a running count with no "/total". `quiet=True` yields a
     no-op callback (mirrors `tj backfill claude-code --quiet`).
+
+    `console` overrides where the counter renders (default: the shared stdout
+    console) — `tj quickstart --json` passes the stderr console so the
+    counter never contaminates its machine-readable stdout.
     """
     if quiet:
         yield _noop
         return
 
+    target_console = console if console is not None else _default_console
     tokens_seen = 0
 
     def _line(result: BackfillResult) -> str:
@@ -61,11 +69,11 @@ def backfill_progress(total: int | None, *, quiet: bool = False) -> Iterator[Pro
             + parsed.total_cache_tokens
         )
 
-    if console.is_terminal:
+    if target_console.is_terminal:
         with Progress(
             SpinnerColumn(style="cyan"),
             TextColumn("[bold]◆[/bold] {task.description}"),
-            console=console,
+            console=target_console,
             transient=True,
         ) as progress:
             task_id = progress.add_task("Backfilling…", total=None)
@@ -80,7 +88,7 @@ def backfill_progress(total: int | None, *, quiet: bool = False) -> Iterator[Pro
     def _tick_plain(parsed: ParsedSession, result: BackfillResult) -> None:
         _accumulate(parsed)
         if result.sessions_seen % _PLAIN_PRINT_EVERY == 0:
-            console.print(f"  [dim]{_line(result)}[/dim]")
+            target_console.print(f"  [dim]{_line(result)}[/dim]")
 
     yield _tick_plain
 

--- a/tokenjam/cli/cmd_quickstart.py
+++ b/tokenjam/cli/cmd_quickstart.py
@@ -117,6 +117,11 @@ def cmd_quickstart(ctx: click.Context, since: str, root_path: str | None,
     # never suppressed outright, so a human watching a scripted run still
     # sees it's alive.
     status_console = err_console if output_json else console
+    # Best-effort pre-scan: a stat()-only count taken before ingest starts, so
+    # the progress counter's "of N" denominator can drift if files under
+    # `root` change mid-run (a session file appears/disappears between this
+    # count and the actual walk). Cosmetic only — never affects what's
+    # ingested, since `ingest_claude_code` re-walks `root` itself.
     total_in_scope = count_claude_code_sessions_in_scope(
         root=root, since=since_dt, max_sessions=max_sessions,
     )

--- a/tokenjam/cli/cmd_quickstart.py
+++ b/tokenjam/cli/cmd_quickstart.py
@@ -37,9 +37,11 @@ from pathlib import Path
 
 import click
 
+from tokenjam.cli.backfill_progress import backfill_progress
 from tokenjam.cli.cmd_statusline import REREAD_WARN, format_status_line
 from tokenjam.core.backfill import (
     CLAUDE_CODE_PROJECTS_ROOT,
+    count_claude_code_sessions_in_scope,
     ingest_claude_code,
 )
 from tokenjam.core.context_diagnostic import compute_context_diagnostic
@@ -51,7 +53,7 @@ from tokenjam.core.session_timeline import (
     timeline_to_dict,
 )
 from tokenjam.core.usage import AssistantUsage, iter_cumulative_usage
-from tokenjam.utils.formatting import console, format_cost, format_tokens
+from tokenjam.utils.formatting import console, err_console, format_cost, format_tokens
 from tokenjam.utils.time_parse import parse_since, utcnow
 
 # First-run cap (#13): on a large ~/.claude history a full backfill into the
@@ -105,8 +107,23 @@ def cmd_quickstart(ctx: click.Context, since: str, root_path: str | None,
     # Transient in-memory DB — nothing persisted, no config, no daemon.
     max_sessions = None if full else DEFAULT_MAX_SESSIONS
     db = InMemoryBackend()
-    result = ingest_claude_code(db, root=root, since=since_dt,
-                                max_sessions=max_sessions)
+
+    # Ingest is the only silent stretch in the whole command — on a large
+    # history it can run tens of seconds with zero output otherwise. An
+    # honest status line lands within ~1s of launch, then the shared
+    # streaming counter (#443/#444's `backfill_progress`) advances per
+    # session through to render. `--json` must keep stdout byte-for-byte
+    # clean, so both route to the stderr console when JSON is requested —
+    # never suppressed outright, so a human watching a scripted run still
+    # sees it's alive.
+    status_console = err_console if output_json else console
+    total_in_scope = count_claude_code_sessions_in_scope(
+        root=root, since=since_dt, max_sessions=max_sessions,
+    )
+    status_console.print(f"[dim]{_pre_ingest_status(since, max_sessions)}[/dim]")
+    with backfill_progress(total_in_scope, console=status_console) as progress_cb:
+        result = ingest_claude_code(db, root=root, since=since_dt,
+                                    max_sessions=max_sessions, progress=progress_cb)
 
     if result.sessions_ingested == 0:
         _render_no_sessions(result, since, output_json)
@@ -138,6 +155,36 @@ def cmd_quickstart(ctx: click.Context, since: str, root_path: str | None,
 
 
 # ───────────────────────────── rendering ──────────────────────────────────
+
+_SINCE_UNIT_WORDS = {"d": "days", "h": "hours", "m": "minutes"}
+
+
+def _describe_window(since: str) -> str:
+    """Human-readable window phrasing for the pre-ingest status line.
+
+    Special-cases the relative `Nd`/`Nh`/`Nm` shapes `--since` accepts (the
+    default is `30d`) into "last N days"; anything else (a literal date, an
+    ISO datetime) falls back to "history since <value>" rather than guessing.
+    """
+    m = _re.match(r"^(\d+)([mhd])$", since.strip())
+    if m:
+        amount, unit = m.groups()
+        return f"last {amount} {_SINCE_UNIT_WORDS[unit]}"
+    return f"history since {since}"
+
+
+def _pre_ingest_status(since: str, max_sessions: int | None) -> str:
+    """Honest status line printed BEFORE ingest starts.
+
+    Ingest was previously the one silent stretch in the whole command —
+    ~40s of dead cursor on a large history before any output. This line
+    lands within ~1s of launch; `backfill_progress`'s streaming counter
+    takes over immediately after.
+    """
+    window = _describe_window(since)
+    scope = f" (most-recent {max_sessions} sessions)" if max_sessions is not None else ""
+    return f"Reading your {window} of Claude Code history{scope}…"
+
 
 def _pct(value: float) -> str:
     return f"{value * 100:.1f}%"


### PR DESCRIPTION
\`tj quickstart\` — the zero-install, zero-config \`npx tokenjam\` demo — goes silent for its entire ingest. On a large \`~/.claude\` history that's tens of seconds of dead cursor before any output: indistinguishable from a hang at exactly the moment a brand-new user's trust is most fragile.

## Summary
- Prints an honest status line before ingest starts: \`Reading your last 30 days of Claude Code history (most-recent 300 sessions)…\`
- Wires the existing streaming per-session progress counter (\`backfill_progress\`, shipped for \`tj onboard --claude-code\`'s backfill) into quickstart's ingest call — reused, not rebuilt.
- \`--json\` stays byte-for-byte clean on stdout: both the status line and the counter route to the stderr console when \`--json\` is set, instead of contaminating the machine-readable payload or going fully silent for scripted callers.

## Root cause
\`ingest_claude_code(db, root=root, since=since_dt, max_sessions=max_sessions)\` was called in \`cli/cmd_quickstart.py\` with no \`progress=\` callback and no output printed before it returned — the first \`console.print\` of anything happened only after the (potentially tens-of-seconds) ingest finished.

\`tj onboard --claude-code\` hit the identical problem on its own backfill and already solved it: a pre-backfill status line plus a shared streaming counter module (\`tokenjam/cli/backfill_progress.py\`) that renders a live Rich progress line on a TTY and degrades to periodic plain prints (every 100 sessions) off a TTY. This PR wires that same machinery into quickstart instead of reinventing it.

## What changed
- \`tokenjam/cli/backfill_progress.py\`: \`backfill_progress()\` gained an optional \`console\` override parameter (default unchanged — \`tj onboard\`'s call site is untouched). This lets a caller redirect the counter to a different console (quickstart needs stderr under \`--json\`) without forking the shared module.
- \`tokenjam/cli/cmd_quickstart.py\`: added \`_describe_window\`/\`_pre_ingest_status\` helpers for the honest pre-ingest line, and wired \`count_claude_code_sessions_in_scope\` + \`backfill_progress\` around the \`ingest_claude_code\` call, choosing the stdout or stderr console based on \`--json\`.

## Tests / Verification
- New unit tests in \`tests/unit/test_quickstart.py\`:
  - the pre-ingest status line prints before the quota-composition render, with the correct window/cap phrasing
  - the status line correctly omits the cap phrasing under \`--full\`
  - \`--json\`'s stdout parses as pure JSON with **zero** extraneous lines (\`result.stdout\`, not the mixed \`result.output\`), while the status line still shows up on \`result.stderr\`
  - a large (250-session) history shows the streaming counter advancing (\`Backfilling 100/250…\`, \`Backfilling 200/250…\`)
- \`make test\`: 2347 passed, 2 pre-existing skips
- \`ruff check tokenjam/\`: clean
- \`mypy tokenjam/\`: clean (190 source files)
- Manual verification against a synthetic 400-session history: the fast/default (non-\`--json\`) path shows the status line + advancing counter within ~1s of launch, through to the render. \`tj quickstart --json --root ... > out.json 2> err.log\` confirmed \`out.json\` is a single valid JSON line with zero progress contamination, while \`err.log\` carries the status line and counter.

## What's NOT in this PR
- No change to the underlying ingest performance itself — this is purely a feedback/UX fix (the ingest was already bounded by the existing 300-session first-run cap, #13).

🤖 shipped by [shiploop](https://github.com/anshss/shiploop)