### PR TITLE
Shared premium-tier predicate: make Fable visible to quota audit, subagent right-sizing, and the downgrade map

### DIFF
--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -129,7 +129,7 @@ Key flags: `--session`, `--last` (default when `--session` is omitted), `--json`
 
 ### `tj quota-audit`
 
-Retroactive audit of your Opus quota: which past Opus sessions were structurally Sonnet-shaped (small input/output, few tool calls)? Reports the percent of Opus quota reclaimable, example sessions to spot-check, and an optional tuned routing-config export. Quota-share framing, never a dollar "saving" claim. Needs a direct DB connection (can't run against a live `tj serve`).
+Retroactive audit of your premium (Opus/Fable) quota: which past premium-tier sessions were structurally Sonnet-shaped (small input/output, few tool calls)? Covers Fable (the tier above Opus) as well as Opus. Reports the percent of premium quota reclaimable, example sessions to spot-check, and an optional tuned routing-config export. Quota-share framing, never a dollar "saving" claim. Needs a direct DB connection (can't run against a live `tj serve`).
 
 ```bash
 tj quota-audit

--- a/tests/integration/test_quota_audit_serve.py
+++ b/tests/integration/test_quota_audit_serve.py
@@ -44,8 +44,9 @@ _STOP_DAEMON_ERROR = "direct database connection"
 def _seed(db) -> None:
     """Opus sessions whose spans are Sonnet-shaped (small in/out, no tools).
 
-    `claude-opus-4-7` has a known cheaper alternative, so `_is_opus` flags these
-    sessions; the small token shape makes them reclaim candidates. This is
+    `claude-opus-4-7` is premium-tier with a known cheaper alternative, so the
+    shared tier predicate flags these sessions; the small token shape makes them
+    reclaim candidates. This is
     exactly the per-session token/model aggregation the shim can't serve — the
     data path the endpoint has to cover.
     """
@@ -148,7 +149,7 @@ def test_quota_audit_cli_renders_through_serve(tmp_path, monkeypatch):
     # The old refuse-to-run error must be gone…
     assert _STOP_DAEMON_ERROR not in result.output
     # …and the audit must actually render.
-    assert "Opus quota audit" in result.output
+    assert "Premium quota audit" in result.output
     db.close()
 
 

--- a/tests/unit/test_model_tiers.py
+++ b/tests/unit/test_model_tiers.py
@@ -1,0 +1,56 @@
+"""Unit tests for the shared model-family tier predicate.
+
+This is the single source of truth for "which model families are premium"
+consumed by the downsize / quota-audit / subagent right-sizing analyzers, so it
+must classify Fable (the tier ABOVE Opus) as premium and tolerate the id shapes
+that show up in real telemetry (dates, `[1m]` tags, Bedrock prefixes).
+"""
+from __future__ import annotations
+
+import pytest
+
+from tokenjam.core.model_tiers import (
+    PREMIUM_TIERS,
+    is_premium_tier,
+    model_tier,
+)
+
+
+@pytest.mark.parametrize(
+    "model, tier",
+    [
+        ("claude-fable-5", "fable"),
+        ("claude-opus-4-8", "opus"),
+        ("claude-opus-4-7", "opus"),
+        ("claude-opus-4", "opus"),
+        ("claude-sonnet-4-6", "sonnet"),
+        ("claude-sonnet-5", "sonnet"),
+        ("claude-haiku-4-5", "haiku"),
+        # Tolerate dates, [1m] context tags, and Bedrock provider prefixes.
+        ("claude-opus-4-8-20260115", "opus"),
+        ("claude-opus-4-8[1m]", "opus"),
+        ("claude-fable-5[1m]", "fable"),
+        ("us-anthropic-claude-opus-4-1-20250805-v1", "opus"),
+        ("global-anthropic-claude-opus-4-5-20251101-v1", "opus"),
+    ],
+)
+def test_model_tier_classifies_known_families(model, tier):
+    assert model_tier(model) == tier
+
+
+@pytest.mark.parametrize("model", ["gpt-4o", "gemini-2-5-pro", "unknown", "", None])
+def test_model_tier_none_for_unrecognised(model):
+    assert model_tier(model) is None
+
+
+def test_fable_and_opus_are_premium():
+    assert is_premium_tier("claude-fable-5")
+    assert is_premium_tier("claude-opus-4-8")
+    assert {"fable", "opus"} <= PREMIUM_TIERS
+
+
+def test_sonnet_and_haiku_are_not_premium():
+    assert not is_premium_tier("claude-sonnet-4-6")
+    assert not is_premium_tier("claude-haiku-4-5")
+    assert not is_premium_tier("gpt-4o")
+    assert not is_premium_tier(None)

--- a/tests/unit/test_optimize.py
+++ b/tests/unit/test_optimize.py
@@ -248,6 +248,26 @@ def test_cycle_bounds_before_start_day_uses_prior_month():
     assert ce.month == 5 and ce.day == 15
 
 
+def test_lookup_downgrade_normalizes_context_tag_and_bedrock():
+    """`_lookup_downgrade` must resolve the same id shapes `is_premium_tier`
+    accepts — [1m] context tags and Bedrock region/provider prefixes — or the
+    audit silently drops premium sessions the subagent analyzer flags."""
+    from tokenjam.core.optimize.analyzers.model_downgrade import _lookup_downgrade
+
+    # [1m] context tag (1M-context variant) resolves to the base model's alt.
+    assert _lookup_downgrade("anthropic", "claude-fable-5[1m]") == "claude-sonnet-4-6"
+    assert _lookup_downgrade("anthropic", "claude-opus-4-8[1m]") == "claude-haiku-4-5"
+    # Trailing date still works (regression guard).
+    assert _lookup_downgrade("anthropic", "claude-opus-4-8-20260115") == "claude-haiku-4-5"
+    # Bedrock-hosted Claude: region/provider prefix + version suffix, provider
+    # arrives as a bedrock alias — resolves via the base Anthropic model.
+    assert _lookup_downgrade(
+        "aws.bedrock", "us-anthropic-claude-opus-4-8-20260115-v1"
+    ) == "claude-haiku-4-5"
+    # Unrecognised model still returns None (no invented alt).
+    assert _lookup_downgrade("anthropic", "gpt-4o") is None
+
+
 def test_downgrade_candidates_have_pricing_for_alternative():
     # Sanity check: every alternative model is in the pricing table.
     from tokenjam.core.pricing import get_rates

--- a/tests/unit/test_optimize.py
+++ b/tests/unit/test_optimize.py
@@ -117,6 +117,32 @@ def test_downgrade_flags_small_opus_but_not_large(db):
     assert finding.caveat == MODEL_DOWNGRADE_CAVEAT
 
 
+def test_downgrade_proposes_candidates_for_fable_and_opus_4_8(db):
+    """The downsize analyzer must route Fable (tier above Opus) and Opus 4.8 —
+    both previously missing from DOWNGRADE_CANDIDATES — to a cheaper same-family
+    model when the session is structurally small."""
+    start = utcnow() - timedelta(days=2)
+    db.insert_span(make_llm_span(
+        model="claude-fable-5", provider="anthropic",
+        input_tokens=1_000, output_tokens=200, cost_usd=0.10,
+        session_id="fable-s", start_time=start,
+    ))
+    db.insert_span(make_llm_span(
+        model="claude-opus-4-8", provider="anthropic",
+        input_tokens=1_000, output_tokens=200, cost_usd=0.05,
+        session_id="opus48-s", start_time=start,
+    ))
+    since = utcnow() - timedelta(days=30)
+    until = utcnow() + timedelta(hours=1)
+    finding = analyze_model_downgrade(
+        db.conn, since, until, agent_id=None, window_days=30.0,
+    )
+    assert finding is not None
+    assert finding.candidate_sessions == 2
+    assert finding.suggestions.get("claude-fable-5") == "claude-sonnet-4-6"
+    assert finding.suggestions.get("claude-opus-4-8") == "claude-haiku-4-5"
+
+
 def test_downgrade_returns_none_when_no_candidates(db):
     _insert_large_opus_session(db, session_id="b")
     since = utcnow() - timedelta(days=30)

--- a/tests/unit/test_optimize_subagent.py
+++ b/tests/unit/test_optimize_subagent.py
@@ -74,6 +74,30 @@ def test_flags_over_powered_and_over_provisioned_subagents():
         db.close()
 
 
+def test_flags_over_powered_fable_subagent():
+    """A Fable-powered subagent (the tier above Opus) doing trivial work must be
+    flagged over_powered — before the shared predicate, only "opus" matched, so
+    Fable spawns were invisible to right-sizing."""
+    db = InMemoryBackend()
+    try:
+        ctx, now = _ctx(db, window_cost_usd=2.0)
+        # Fable subagent: premium model, tiny output, few tools -> over_powered.
+        db.insert_span(make_llm_span(
+            model="claude-fable-5", input_tokens=4_000, output_tokens=150,
+            cost_usd=0.40, session_id="s1", sub_agent_id="fableA", start_time=now,
+        ))
+        run_subagent(ctx)
+        f = ctx.report.findings["subagent"]
+
+        assert len(f.flagged) == 1
+        a = f.flagged[0]
+        assert a.sub_agent_id == "fableA"
+        assert a.model == "claude-fable-5"
+        assert "over_powered" in a.flags
+    finally:
+        db.close()
+
+
 def test_no_finding_when_no_subagents():
     db = InMemoryBackend()
     try:

--- a/tests/unit/test_opus_quota_audit.py
+++ b/tests/unit/test_opus_quota_audit.py
@@ -133,6 +133,38 @@ def test_example_sessions_surfaced_for_spot_check(db):
     assert "claude-opus-4-6" in audit.suggestions
 
 
+def test_fable_and_opus_4_8_sessions_are_audited(db):
+    """Fable (the tier above Opus) and Opus 4.8 must both be counted in the
+    premium denominator and flagged as reclaim candidates when Sonnet-shaped —
+    the whole point of routing tier membership through the shared predicate."""
+    # Fable, Sonnet-shaped → candidate; suggested alt is a cheaper same-family model.
+    _add_session(db, "fable-thin", model="claude-fable-5",
+                 input_tokens=1_500, output_tokens=250, cache_tokens=98_250,
+                 cost_usd=5.0, tool_calls=2)
+    # Opus 4.8, Sonnet-shaped → candidate (4.8 was missing from the map before).
+    _add_session(db, "opus48-thin", model="claude-opus-4-8",
+                 input_tokens=1_000, output_tokens=200, cache_tokens=98_800,
+                 cost_usd=3.0, tool_calls=1)
+    # Fable, genuinely large-shape → in denominator, NOT a candidate.
+    _add_session(db, "fable-fat", model="claude-fable-5",
+                 input_tokens=40_000, output_tokens=20_000, cache_tokens=40_000,
+                 cost_usd=12.0, tool_calls=30)
+
+    audit = audit_opus_quota(db.conn, SINCE, UNTIL, agent_id=None, window_days=30.0)
+
+    # All three premium sessions counted (Fable is premium, above Opus).
+    assert audit.opus_sessions == 3
+    assert audit.opus_tokens == 300_000
+    # The two Sonnet-shaped premium sessions are reclaim candidates.
+    assert audit.candidate_sessions == 2
+    assert {ex.session_id for ex in audit.examples} == {"fable-thin", "opus48-thin"}
+    # Each flagged premium session names a concrete cheaper routing target.
+    assert audit.suggestions["claude-fable-5"]
+    assert audit.suggestions["claude-opus-4-8"]
+    for ex in audit.examples:
+        assert ex.alt_model
+
+
 def test_no_opus_sessions_is_clean_empty_state(db):
     # Only a Sonnet session — nothing for the Opus audit to inspect.
     _add_session(db, "sonnet-only", model="claude-sonnet-4-6",
@@ -164,8 +196,9 @@ def test_cli_renders_quota_audit_with_caveat(db, monkeypatch):
     )
     assert result.exit_code == 0, result.output
     out = result.output
-    # Quota framing headline (not dollars).
-    assert "Opus quota is reclaimable" in out
+    # Quota framing headline (not dollars) — names both premium tiers.
+    assert "quota is reclaimable" in out
+    assert "Opus/Fable" in out
     assert "67%" in out or "66" in out
     # Spot-check sessions listed.
     assert "spot-check" in out.lower()

--- a/tests/unit/test_opus_quota_audit.py
+++ b/tests/unit/test_opus_quota_audit.py
@@ -165,6 +165,32 @@ def test_fable_and_opus_4_8_sessions_are_audited(db):
         assert ex.alt_model
 
 
+def test_context_tagged_and_bedrock_premium_sessions_are_audited(db):
+    """A premium session must be counted + flagged regardless of id SHAPE — a
+    [1m] context tag or a Bedrock region/provider prefix must not make it vanish
+    from the audit (it's still flagged by the subagent analyzer, so dropping it
+    here is a silent inconsistency)."""
+    # 1M-context Fable, Sonnet-shaped → candidate.
+    _add_session(db, "fable-1m", model="claude-fable-5[1m]",
+                 input_tokens=1_500, output_tokens=250, cache_tokens=98_250,
+                 cost_usd=5.0, tool_calls=2)
+    # Bedrock-hosted Opus 4.8, Sonnet-shaped → candidate.
+    _add_session(db, "bedrock-opus", model="us-anthropic-claude-opus-4-8-20260115-v1",
+                 input_tokens=1_000, output_tokens=200, cache_tokens=98_800,
+                 cost_usd=3.0, tool_calls=1)
+
+    audit = audit_opus_quota(db.conn, SINCE, UNTIL, agent_id=None, window_days=30.0)
+
+    # Both counted in the premium denominator (not silently dropped).
+    assert audit.opus_sessions == 2
+    assert audit.opus_tokens == 200_000
+    # Both are reclaim candidates with a concrete suggested model.
+    assert audit.candidate_sessions == 2
+    assert {ex.session_id for ex in audit.examples} == {"fable-1m", "bedrock-opus"}
+    assert audit.suggestions["claude-fable-5[1m]"] == "claude-sonnet-4-6"
+    assert audit.suggestions["us-anthropic-claude-opus-4-8-20260115-v1"] == "claude-haiku-4-5"
+
+
 def test_no_opus_sessions_is_clean_empty_state(db):
     # Only a Sonnet session — nothing for the Opus audit to inspect.
     _add_session(db, "sonnet-only", model="claude-sonnet-4-6",

--- a/tokenjam/cli/cmd_onboard.py
+++ b/tokenjam/cli/cmd_onboard.py
@@ -1131,7 +1131,7 @@ def _print_next_steps_nudge(
         )
     if persona == "claude_code":
         console.print("  [bold]tj context[/bold]     [dim]where your quota goes — re-read vs real work[/dim]")
-        console.print("  [bold]tj quota-audit[/bold] [dim]how much Opus went to Sonnet-shaped sessions[/dim]")
+        console.print("  [bold]tj quota-audit[/bold] [dim]how much Opus/Fable went to Sonnet-shaped sessions[/dim]")
         console.print(lens_line)
         console.print("  [bold]tj tokenmaxx[/bold]   [dim]your shareable efficiency tier[/dim]")
     else:

--- a/tokenjam/cli/cmd_quota_audit.py
+++ b/tokenjam/cli/cmd_quota_audit.py
@@ -1,14 +1,15 @@
-"""``tj quota-audit`` — the retroactive Opus quota audit over Claude Code sessions.
+"""``tj quota-audit`` — the retroactive premium-tier quota audit over Claude Code sessions.
 
 The accountability companion to ``opusplan`` / ``/model`` (issue #5). Those are
 forward-looking and say nothing about session history; nothing answers the
-backward-looking question "which of my PAST Opus sessions were Sonnet-shaped?".
-This command does: it runs the structural downsize heuristic
+backward-looking question "which of my PAST premium (Opus/Fable) sessions were
+Sonnet-shaped?". This command does: it runs the structural downsize heuristic
 (:func:`tokenjam.core.optimize.analyzers.model_downgrade.audit_opus_quota`)
-retroactively, scoped to Opus sessions, and reports:
+retroactively, scoped to premium-tier sessions (Fable + Opus), and reports:
 
-  * the headline — **% of your Opus quota reclaimable from Sonnet-shaped
-    sessions** (Opus token share, never a dollar "saving" — the subscription
+  * the headline — **% of your premium (Opus/Fable) quota reclaimable from
+    Sonnet-shaped sessions** (premium token share, never a dollar "saving" — the
+    subscription
     majority is on a flat fee; dollar framing mis-targets them, see
     ``research/evidence/subscription-vs-cost-framing.md``);
   * the specific example sessions to **spot-check**;
@@ -31,6 +32,7 @@ import click
 
 from tokenjam.cli.data_access import resolve_data_access
 from tokenjam.core.framing import Framing
+from tokenjam.core.model_tiers import PREMIUM_TIER_LABEL
 from tokenjam.core.optimize.types import (
     DowngradeFinding,
     OpusQuotaAudit,
@@ -98,22 +100,24 @@ def _render(audit: OpusQuotaAudit, framing: Framing, *, since: str) -> None:
 
     if not audit.has_opus:
         console.print(
-            "\n[yellow]No Opus sessions found in this window.[/yellow]\n"
-            "[dim]The quota audit only inspects Opus-family sessions (where "
-            "quota burn is acute). Run [bold]tj onboard --claude-code[/bold] to "
-            "ingest your Claude Code sessions, then re-run "
-            "[bold]tj quota-audit[/bold].[/dim]\n"
+            f"\n[yellow]No premium ({PREMIUM_TIER_LABEL}) sessions found in this "
+            "window.[/yellow]\n"
+            f"[dim]The quota audit only inspects premium-tier ({PREMIUM_TIER_LABEL}) "
+            "sessions (where quota burn is acute). Run "
+            "[bold]tj onboard --claude-code[/bold] to ingest your Claude Code "
+            "sessions, then re-run [bold]tj quota-audit[/bold].[/dim]\n"
         )
         return
 
     sections: list[Any] = []
 
     headline = Text()
-    headline.append("Opus quota audit", style="bold")
+    headline.append("Premium quota audit", style="bold")
     headline.append(
-        f"  ·  {audit.opus_sessions} Opus session"
+        f"  ·  {audit.opus_sessions} premium session"
         f"{'s' if audit.opus_sessions != 1 else ''} "
-        f"({format_tokens(audit.opus_tokens)} Opus tokens, last {since})",
+        f"({format_tokens(audit.opus_tokens)} {PREMIUM_TIER_LABEL} tokens, "
+        f"last {since})",
         style="dim",
     )
     sections.append(headline)
@@ -123,7 +127,7 @@ def _render(audit: OpusQuotaAudit, framing: Framing, *, since: str) -> None:
         clean = Text()
         clean.append("0% reclaimable", style="bold green")
         clean.append(
-            " — none of your Opus sessions match the Sonnet-shaped structure "
+            " — none of your premium sessions match the Sonnet-shaped structure "
             "(small input/output, few tool calls).",
             style="",
         )
@@ -132,9 +136,12 @@ def _render(audit: OpusQuotaAudit, framing: Framing, *, since: str) -> None:
         # The headline: quota share, never dollars (audit framing).
         big = Text()
         big.append(f"~{audit.percent_quota_reclaimable:.0f}% ", style="bold red")
-        big.append("of your Opus quota is reclaimable", style="bold")
         big.append(
-            f"\nfrom {audit.candidate_sessions} of {audit.opus_sessions} Opus "
+            f"of your premium ({PREMIUM_TIER_LABEL}) quota is reclaimable",
+            style="bold",
+        )
+        big.append(
+            f"\nfrom {audit.candidate_sessions} of {audit.opus_sessions} premium "
             f"session{'s' if audit.opus_sessions != 1 else ''} "
             f"({audit.percent_sessions:.0f}%) that are Sonnet-shaped",
             style="dim",
@@ -142,7 +149,7 @@ def _render(audit: OpusQuotaAudit, framing: Framing, *, since: str) -> None:
         sections.append(big)
 
         detail = Text()
-        detail.append("\nReclaimable Opus tokens:  ", style="dim")
+        detail.append("\nReclaimable premium tokens:  ", style="dim")
         detail.append(format_tokens(audit.candidate_tokens), style="bold")
         detail.append(
             f"  of {format_tokens(audit.opus_tokens)} total", style="dim"
@@ -202,7 +209,7 @@ def _render(audit: OpusQuotaAudit, framing: Framing, *, since: str) -> None:
     console.print()
     console.print(Panel(
         panel_body,
-        title="[bold]TokenJam Opus Quota Audit[/bold]",
+        title="[bold]TokenJam Premium Quota Audit[/bold]",
         title_align="left",
         border_style="dim",
         padding=(1, 2),

--- a/tokenjam/cli/data_access.py
+++ b/tokenjam/cli/data_access.py
@@ -151,7 +151,7 @@ class ServeDataAccess:
         def build() -> tuple[OpusQuotaAudit, Framing]:
             payload = self._db.fetch_opus_quota_audit(since=since, agent_id=agent_id)
             return audit_from_dict(payload), _framing_from_payload(payload)
-        return _through_serve("Opus quota audit", build)
+        return _through_serve("premium quota audit", build)
 
 
 _T = TypeVar("_T")

--- a/tokenjam/core/model_tiers.py
+++ b/tokenjam/core/model_tiers.py
@@ -1,0 +1,50 @@
+"""Provider-agnostic model-family tier classification.
+
+One place that knows which Anthropic model families are *premium* (worth a
+quota audit / right-sizing flag) and how the tiers rank. The optimize analyzers
+consume this instead of each hardcoding an ``"opus"`` substring — so when a new
+family launches above the current top (as **Fable** launched above Opus), it is
+a one-line edit here, not a grep-and-patch across every analyzer.
+
+Membership is decided by a lowercased-substring match on the model id, which
+tolerates version suffixes, ``YYYYMMDD`` dates, provider prefixes (Bedrock's
+``us-anthropic-…`` / ``global-anthropic-…``), and ``[1m]`` context tags — e.g.
+``us-anthropic-claude-opus-4-8-20260115[1m]`` all resolve to ``"opus"``. This
+mirrors the tolerance the pricing layer already relies on and is the same
+matching the analyzers used before this module existed.
+"""
+from __future__ import annotations
+
+# Model-family tiers, most capable first. Fable sits ABOVE Opus. Each entry is
+# ``(substring, tier)``; the first substring found in the (lowercased) model id
+# wins. No model id contains two family names, so ordering only matters as a
+# tie-break that never fires in practice — but keeping it capability-ordered
+# documents the ladder for the downgrade suggestions below.
+TIER_SUBSTRINGS: tuple[tuple[str, str], ...] = (
+    ("fable", "fable"),
+    ("opus", "opus"),
+    ("sonnet", "sonnet"),
+    ("haiku", "haiku"),
+)
+
+# Tiers whose sessions are worth a premium-quota audit / right-sizing flag.
+# Extend this (and TIER_SUBSTRINGS) when a new premium family launches — that is
+# the single edit that teaches every consumer about the new tier.
+PREMIUM_TIERS: frozenset[str] = frozenset({"fable", "opus"})
+
+# Human-facing label for the premium tier, for copy that names what is audited.
+PREMIUM_TIER_LABEL = "Opus/Fable"
+
+
+def model_tier(model: str | None) -> str | None:
+    """Classify a model id into its family tier, or ``None`` if unrecognised."""
+    normalised = (model or "").lower()
+    for substring, tier in TIER_SUBSTRINGS:
+        if substring in normalised:
+            return tier
+    return None
+
+
+def is_premium_tier(model: str | None) -> bool:
+    """True when the model belongs to a premium tier (Fable or Opus today)."""
+    return model_tier(model) in PREMIUM_TIERS

--- a/tokenjam/core/optimize/analyzers/model_downgrade.py
+++ b/tokenjam/core/optimize/analyzers/model_downgrade.py
@@ -61,14 +61,65 @@ DOWNGRADE_CANDIDATES: dict[str, dict[str, str]] = {
 }
 
 
+def _model_name_candidates(model: str) -> list[str]:
+    """Ordered DOWNGRADE_CANDIDATES keys to try for a raw model id.
+
+    Tolerates the same id shapes ``is_premium_tier`` accepts so the downgrade
+    lookup never disagrees with tier membership: bracketed context tags
+    (``claude-opus-4-8[1m]``), trailing ``-YYYYMMDD`` dates, and Bedrock
+    region/provider prefixes (``us-anthropic-claude-opus-4-8-20260115-v1`` →
+    ``claude-opus-4-8``). The exact name is tried first; more-aggressive
+    normalisations follow.
+    """
+    seen: list[str] = []
+
+    def _add(name: str | None) -> None:
+        if name and name not in seen:
+            seen.append(name)
+
+    _add(model)
+    # Strip a bracketed context tag ([1m]) and/or a trailing YYYYMMDD date, in
+    # both orders — mirrors pricing's own _lookup_candidates fallback.
+    no_tag = _re.match(r"^(.*?)\[[^\]]*\]$", model)
+    base_no_tag = no_tag.group(1) if (no_tag and no_tag.group(1)) else None
+    _add(base_no_tag)
+    for candidate in (model, base_no_tag):
+        if not candidate:
+            continue
+        dated = _re.match(r"^(.*)-(\d{8})$", candidate)
+        if dated:
+            _add(dated.group(1))
+    # Bedrock-hosted Claude ids embed the base Anthropic name amid a region/
+    # provider prefix and a -YYYYMMDD-vN suffix; pull it out so a Bedrock opus
+    # downgrades via the same base model as its first-party twin.
+    embedded = _re.search(r"(claude-[a-z]+(?:-\d+)+)", model.lower())
+    if embedded:
+        name = embedded.group(1)
+        redated = _re.match(r"^(.*)-(\d{8})$", name)
+        _add(redated.group(1) if redated else name)
+    return seen
+
+
 def _lookup_downgrade(provider: str, model: str) -> str | None:
-    """DOWNGRADE_CANDIDATES lookup that tolerates trailing YYYYMMDD suffixes."""
-    mapping = DOWNGRADE_CANDIDATES.get(provider, {})
-    if model in mapping:
-        return mapping[model]
-    m = _re.match(r"^(.*)-(\d{8})$", model)
-    if m and m.group(1) in mapping:
-        return mapping[m.group(1)]
+    """Cheaper same-family alternative for (provider, model), or None.
+
+    Resolves the id shapes ``is_premium_tier`` accepts (context tags, dates,
+    Bedrock prefixes) so the quota audit's premium recognition matches the
+    subagent analyzer's — otherwise a ``claude-fable-5[1m]`` or Bedrock-hosted
+    premium session is flagged by one and silently dropped by the other.
+    """
+    candidates = _model_name_candidates(model)
+    # The raw provider first; fall back to "anthropic" for Bedrock-hosted Claude
+    # ids whose provider arrives as an aws/bedrock alias but whose downgrade
+    # target is the same first-party Anthropic model.
+    providers = [provider]
+    if provider != "anthropic" and any(c.startswith("claude-") for c in candidates):
+        providers.append("anthropic")
+    for prov in providers:
+        mapping = DOWNGRADE_CANDIDATES.get(prov, {})
+        for name in candidates:
+            if name in mapping:
+                return mapping[name]
     return None
 
 

--- a/tokenjam/core/optimize/analyzers/model_downgrade.py
+++ b/tokenjam/core/optimize/analyzers/model_downgrade.py
@@ -12,6 +12,7 @@ import re as _re
 from datetime import datetime
 from typing import Any
 
+from tokenjam.core.model_tiers import is_premium_tier
 from tokenjam.core.optimize.registry import register
 from tokenjam.core.optimize.stats import bootstrap_ci
 from tokenjam.core.optimize.types import (
@@ -30,21 +31,21 @@ SMALL_INPUT_TOKENS = 5_000
 SMALL_OUTPUT_TOKENS = 500
 SMALL_TOOL_CALLS = 5
 
-# Substring that identifies an Opus-family model name (after provider/date
-# normalisation). The quota audit scopes exclusively to Opus sessions — the
-# acute quota-burn class (research/evidence/feature-downsize.md). Matching on
-# the family substring tolerates version + date suffixes
-# (claude-opus-4-7, claude-opus-4-6-20260115, ...).
-OPUS_MODEL_SUBSTR = "opus"
-
 # Cap on the number of spot-check example sessions carried in the audit.
 OPUS_AUDIT_MAX_EXAMPLES = 5
 
 # Premium → cheaper alternative in the same provider family. Pricing for both
 # sides is resolved at runtime from pricing/models.toml; if either is missing
 # the candidate is silently skipped (we won't invent a savings number).
+# Premium-tier ladder: Fable → Sonnet and Opus → Haiku each drop two tiers, the
+# aggressive step justified because the quota audit only proposes these for
+# structurally tiny (Sonnet-shaped) sessions. Keep new premium families in sync
+# with tokenjam.core.model_tiers.PREMIUM_TIERS so every flagged session has a
+# real routing target.
 DOWNGRADE_CANDIDATES: dict[str, dict[str, str]] = {
     "anthropic": {
+        "claude-fable-5":    "claude-sonnet-4-6",
+        "claude-opus-4-8":   "claude-haiku-4-5",
         "claude-opus-4-7":   "claude-haiku-4-5",
         "claude-opus-4-6":   "claude-haiku-4-5",
         "claude-sonnet-4-6": "claude-haiku-4-5",
@@ -262,27 +263,35 @@ def run(ctx: AnalyzerContext) -> None:
 
 
 # ---------------------------------------------------------------------------
-# Opus quota audit (retroactive Downsize, reframed as accountability)
+# Premium-tier quota audit (retroactive Downsize, reframed as accountability)
 # ---------------------------------------------------------------------------
-# This runs the same structural heuristic as `downsize`, but scoped to Opus
-# sessions only and reframed as a "quota audit" rather than "cost optimization"
+# This runs the same structural heuristic as `downsize`, but scoped to
+# premium-tier sessions only (Fable + Opus, via the shared model_tiers
+# predicate) and reframed as a "quota audit" rather than "cost optimization"
 # (issue #5; research/evidence/feature-downsize.md). The headline is
-# "% of your Opus quota reclaimable from Sonnet-shaped sessions" — Opus token
-# share, not dollars — because the subscription majority is on flat-rate plans
-# where dollar framing mis-targets them (subscription-vs-cost-framing.md). It
-# complements opusplan / `/model` (forward-looking) by answering the
-# backward-looking question those tools can't: "which of my PAST Opus sessions
-# were Sonnet-shaped?" Honest framing throughout — candidates to spot-check,
-# never "safe to downgrade".
+# "% of your premium (Opus/Fable) quota reclaimable from Sonnet-shaped
+# sessions" — premium token share, not dollars — because the subscription
+# majority is on flat-rate plans where dollar framing mis-targets them
+# (subscription-vs-cost-framing.md). It complements opusplan / `/model`
+# (forward-looking) by answering the backward-looking question those tools
+# can't: "which of my PAST premium sessions were Sonnet-shaped?" Honest framing
+# throughout — candidates to spot-check, never "safe to downgrade".
+#
+# The `audit_opus_quota` name and the `opus_*` fields on OpusQuotaAudit are kept
+# for API/serialization stability; they now denote the whole premium tier, not
+# Opus alone (the audit counts and flags Fable sessions too).
 
 
-def _is_opus(provider: str, model: str) -> bool:
-    """True when the model is an Opus-family model worth auditing for downsize.
+def _is_premium_downsizable(provider: str, model: str) -> bool:
+    """True when the model is a premium-tier model worth auditing for downsize.
 
-    We only audit Opus sessions that ALSO have a known cheaper alternative in
-    `DOWNGRADE_CANDIDATES` (so the routing suggestion is real, not invented).
+    Premium-tier membership (Fable, Opus, and whatever launches above them next)
+    is resolved through the shared :func:`is_premium_tier` predicate — no
+    per-analyzer substring gate. We only audit premium sessions that ALSO have a
+    known cheaper alternative in `DOWNGRADE_CANDIDATES` (so the routing
+    suggestion is real, not invented).
     """
-    if OPUS_MODEL_SUBSTR not in (model or "").lower():
+    if not is_premium_tier(model):
         return False
     return _lookup_downgrade(provider, model) is not None
 
@@ -294,13 +303,15 @@ def audit_opus_quota(
     agent_id: str | None,
     window_days: float,
 ) -> OpusQuotaAudit:
-    """Retroactive Opus quota audit over Claude Code (and other) sessions.
+    """Retroactive premium-tier quota audit over Claude Code (and other) sessions.
 
-    Walks Opus sessions in the window and flags those whose structural shape
-    (small input, small output, few tool calls) matches a class of work where a
-    cheaper same-family model is worth a spot-check. Quantifies the result as a
-    **share of Opus quota** (candidate Opus tokens / total Opus tokens) — never
-    a dollar figure as the headline.
+    Walks premium-tier sessions (Fable + Opus, via the shared model_tiers
+    predicate) in the window and flags those whose structural shape (small
+    input, small output, few tool calls) matches a class of work where a cheaper
+    same-family model is worth a spot-check. Quantifies the result as a **share
+    of premium quota** (candidate premium tokens / total premium tokens) — never
+    a dollar figure as the headline. Field names retain the historical `opus_*`
+    prefix for serialization stability but count the whole premium tier.
 
     Computes purely from already-backfilled token/model metadata; does NOT
     depend on captured content (#3). Always returns an :class:`OpusQuotaAudit`
@@ -351,7 +362,7 @@ def audit_opus_quota(
             in_tok, out_tok, cache_tok, cost = row
         if not provider or not model:
             continue
-        if not _is_opus(provider, model):
+        if not _is_premium_downsizable(provider, model):
             continue
 
         session_tokens = int(in_tok or 0) + int(out_tok or 0) + int(cache_tok or 0)

--- a/tokenjam/core/optimize/analyzers/subagent_rightsizing.py
+++ b/tokenjam/core/optimize/analyzers/subagent_rightsizing.py
@@ -12,10 +12,11 @@ This analyzer breaks a window's cost down per subagent and flags two structural
 right-sizing candidates (honesty discipline, CLAUDE.md Rule 14 — candidate
 flags only, never a quality judgment):
 
-  * over_powered     — ran on a premium (Opus-tier) model but produced little
-                       output and made few tool calls; a cheaper same-family
-                       model is worth a look (mirrors the downsize heuristic,
-                       scoped to one subagent).
+  * over_powered     — ran on a premium-tier model (Fable or Opus, via the
+                       shared model_tiers predicate) but produced little output
+                       and made few tool calls; a cheaper same-family model is
+                       worth a look (mirrors the downsize heuristic, scoped to
+                       one subagent).
   * over_provisioned — was handed a large context (input + cache reads) yet
                        produced little output; the prompt it was dispatched
                        with is likely larger than the task needed.
@@ -29,11 +30,9 @@ from __future__ import annotations
 from dataclasses import dataclass, field
 from typing import Any
 
+from tokenjam.core.model_tiers import is_premium_tier
 from tokenjam.core.optimize.registry import register
 from tokenjam.core.optimize.types import AnalyzerContext
-
-# Model-name substrings that mark the premium tier. Lowercased before matching.
-PREMIUM_MODEL_SUBSTRINGS = ("opus",)
 
 # "Produced little": total output tokens below this look like a small task.
 SMALL_OUTPUT_TOKENS = 2_000
@@ -115,8 +114,7 @@ def _flags_for(
     if cost_usd < MIN_FLAG_COST_USD:
         return []
     flags: list[str] = []
-    model_l = (model or "").lower()
-    is_premium = any(s in model_l for s in PREMIUM_MODEL_SUBSTRINGS)
+    is_premium = is_premium_tier(model)
     if is_premium and output_tokens < SMALL_OUTPUT_TOKENS and tool_calls <= FEW_TOOL_CALLS:
         flags.append("over_powered")
     if (input_tokens + cache_tokens) >= CONTEXT_HEAVY_TOKENS and output_tokens < SMALL_OUTPUT_TOKENS:


### PR DESCRIPTION
## Problem

Premium-tier awareness was hardcoded to an `"opus"` substring in three separate places, so **Fable — the model tier above Opus — was invisible** to every consumer:

- the **quota audit** skipped Fable sessions entirely (never counted, never flagged);
- **subagent right-sizing** never flagged a Fable-powered subagent doing trivial work as `over_powered`;
- the **downgrade map** had no Fable entry — and was independently **stale for Opus**, stopping at `claude-opus-4-7` with `claude-opus-4-8` missing.

## Fix

One shared tier predicate, consumed by all three sites — no more per-analyzer substrings.

- **New `core/model_tiers.py`** — `model_tier()` / `is_premium_tier()` classify a model id into a family tier via a lowercased-substring match that tolerates version suffixes, `YYYYMMDD` dates, `[1m]` context tags, and Bedrock provider prefixes. `PREMIUM_TIERS = {fable, opus}`; the next premium family is a one-line add here.
- **Quota audit** (`model_downgrade.py`) resolves premium membership through the shared predicate; Fable sessions are now counted in the denominator and flagged as reclaim candidates.
- **Subagent right-sizing** flags `over_powered` for Fable spawns, not just Opus.
- **`DOWNGRADE_CANDIDATES`** gains `claude-fable-5 → claude-sonnet-4-6` and the missing `claude-opus-4-8 → claude-haiku-4-5` (each drops two tiers — the aggressive step is justified because these are only proposed for structurally tiny, Sonnet-shaped sessions).
- **Copy/docs** name both tiers (Opus/Fable) in the audit render, the onboarding next-steps line, the serve error label, and the CLI reference.

The audit's `audit_opus_quota` name and the `opus_*` serialization fields are kept for API stability but now denote the whole premium tier; docstrings say so.

## Tests

Fixture-backed coverage across all three consumers:
- `test_model_tiers.py` — classification incl. dates / `[1m]` / Bedrock prefixes.
- quota audit counts + flags a Fable session **and** an Opus 4.8 session (mixed corpus).
- subagent analyzer flags an `over_powered` Fable spawn.
- downsize proposes candidates for Fable **and** Opus 4.8.

`make test` (2365 passed, 2 skipped), `make lint`, `make typecheck` all green.

🤖 shipped by [shiploop](https://github.com/anshss/shiploop)