### PR TITLE
Reframe retrospective quota-audit headline: misallocated, persona-gated

### DIFF
--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -129,7 +129,7 @@ Key flags: `--session`, `--last` (default when `--session` is omitted), `--json`
 
 ### `tj quota-audit`
 
-Retroactive audit of your premium (Opus/Fable) quota: which past premium-tier sessions were structurally Sonnet-shaped (small input/output, few tool calls)? Covers Fable (the tier above Opus) as well as Opus. Reports the percent of premium quota reclaimable, example sessions to spot-check, and an optional tuned routing-config export. Quota-share framing, never a dollar "saving" claim. Needs a direct DB connection (can't run against a live `tj serve`).
+Retroactive audit of your premium (Opus/Fable) quota: which past premium-tier sessions were structurally Sonnet-shaped (small input/output, few tool calls)? Covers Fable (the tier above Opus) as well as Opus. Reports the percent of premium quota that went to Sonnet-shaped sessions (a retrospective behaviour mirror — those tokens are already spent, so it is misallocated, not "reclaimable"), example sessions to spot-check, and an optional tuned routing-config export. Subscription users see a habit nudge; API-billed users additionally see the already-billed dollar counterfactual. Quota-share framing, never a dollar "saving" claim. The JSON field is `percent_quota_misallocated` (the pre-0.6 `percent_quota_reclaimable` key is still emitted as a deprecated alias for one release). Needs a direct DB connection (can't run against a live `tj serve`).
 
 ```bash
 tj quota-audit

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -129,7 +129,7 @@ Key flags: `--session`, `--last` (default when `--session` is omitted), `--json`
 
 ### `tj quota-audit`
 
-Retroactive audit of your Opus quota: which past Opus sessions were structurally Sonnet-shaped (small input/output, few tool calls)? Reports the percent of Opus quota reclaimable, example sessions to spot-check, and an optional tuned routing-config export. Quota-share framing, never a dollar "saving" claim. Needs a direct DB connection (can't run against a live `tj serve`).
+Retroactive audit of your premium (Opus/Fable) quota: which past premium-tier sessions were structurally Sonnet-shaped (small input/output, few tool calls)? Covers Fable (the tier above Opus) as well as Opus. Reports the percent of premium quota reclaimable, example sessions to spot-check, and an optional tuned routing-config export. Quota-share framing, never a dollar "saving" claim. Needs a direct DB connection (can't run against a live `tj serve`).
 
 ```bash
 tj quota-audit

--- a/tests/integration/test_data_access_parity.py
+++ b/tests/integration/test_data_access_parity.py
@@ -155,9 +155,15 @@ def test_quota_audit_parity(tmp_path, monkeypatch):
     s_audit, s_framing = serve.quota_audit(since="30d", agent_id=None)
 
     # The audit round-trips fully (modulo window_days clock skew).
-    assert _normalize_audit(audit_to_dict(d_audit)) == \
+    d_payload = audit_to_dict(d_audit)
+    assert _normalize_audit(d_payload) == \
         _normalize_audit(audit_to_dict(s_audit))
     assert d_framing.to_dict() == s_framing.to_dict()
     assert d_audit.opus_sessions == 3
     assert d_framing.pricing_mode == "subscription"
+    # The renamed headline key is present on both paths, and the deprecated
+    # 0.5.4 alias mirrors it byte-for-byte (so parity holds while it lives).
+    assert "percent_quota_misallocated" in d_payload
+    assert d_payload["percent_quota_reclaimable"] == \
+        d_payload["percent_quota_misallocated"]
     db.close()

--- a/tests/integration/test_quota_audit_serve.py
+++ b/tests/integration/test_quota_audit_serve.py
@@ -90,10 +90,13 @@ async def test_quota_audit_endpoint_computes_audit_server_side(tmp_path):
 
     assert resp.status_code == 200
     payload = resp.json()
-    # Three Opus sessions, all Sonnet-shaped → fully reclaimable.
+    # Three Opus sessions, all Sonnet-shaped → the whole premium quota went to
+    # Sonnet-shaped work.
     assert payload["opus_sessions"] == 3
     assert payload["candidate_sessions"] == 3
-    assert payload["percent_quota_reclaimable"] > 0
+    assert payload["percent_quota_misallocated"] > 0
+    # DEPRECATED alias still rides through the serve payload (0.5.4 compat).
+    assert payload["percent_quota_reclaimable"] == payload["percent_quota_misallocated"]
     # The mandatory honesty caveat rides through the payload.
     assert "spot-check" in payload["caveat"].lower()
     # Framing block present + subscription (max_5x budget).

--- a/tests/integration/test_quota_audit_serve.py
+++ b/tests/integration/test_quota_audit_serve.py
@@ -44,8 +44,9 @@ _STOP_DAEMON_ERROR = "direct database connection"
 def _seed(db) -> None:
     """Opus sessions whose spans are Sonnet-shaped (small in/out, no tools).
 
-    `claude-opus-4-7` has a known cheaper alternative, so `_is_opus` flags these
-    sessions; the small token shape makes them reclaim candidates. This is
+    `claude-opus-4-7` is premium-tier with a known cheaper alternative, so the
+    shared tier predicate flags these sessions; the small token shape makes them
+    reclaim candidates. This is
     exactly the per-session token/model aggregation the shim can't serve — the
     data path the endpoint has to cover.
     """
@@ -148,7 +149,7 @@ def test_quota_audit_cli_renders_through_serve(tmp_path, monkeypatch):
     # The old refuse-to-run error must be gone…
     assert _STOP_DAEMON_ERROR not in result.output
     # …and the audit must actually render.
-    assert "Opus quota audit" in result.output
+    assert "Premium quota audit" in result.output
     db.close()
 
 

--- a/tests/unit/test_model_tiers.py
+++ b/tests/unit/test_model_tiers.py
@@ -1,0 +1,56 @@
+"""Unit tests for the shared model-family tier predicate.
+
+This is the single source of truth for "which model families are premium"
+consumed by the downsize / quota-audit / subagent right-sizing analyzers, so it
+must classify Fable (the tier ABOVE Opus) as premium and tolerate the id shapes
+that show up in real telemetry (dates, `[1m]` tags, Bedrock prefixes).
+"""
+from __future__ import annotations
+
+import pytest
+
+from tokenjam.core.model_tiers import (
+    PREMIUM_TIERS,
+    is_premium_tier,
+    model_tier,
+)
+
+
+@pytest.mark.parametrize(
+    "model, tier",
+    [
+        ("claude-fable-5", "fable"),
+        ("claude-opus-4-8", "opus"),
+        ("claude-opus-4-7", "opus"),
+        ("claude-opus-4", "opus"),
+        ("claude-sonnet-4-6", "sonnet"),
+        ("claude-sonnet-5", "sonnet"),
+        ("claude-haiku-4-5", "haiku"),
+        # Tolerate dates, [1m] context tags, and Bedrock provider prefixes.
+        ("claude-opus-4-8-20260115", "opus"),
+        ("claude-opus-4-8[1m]", "opus"),
+        ("claude-fable-5[1m]", "fable"),
+        ("us-anthropic-claude-opus-4-1-20250805-v1", "opus"),
+        ("global-anthropic-claude-opus-4-5-20251101-v1", "opus"),
+    ],
+)
+def test_model_tier_classifies_known_families(model, tier):
+    assert model_tier(model) == tier
+
+
+@pytest.mark.parametrize("model", ["gpt-4o", "gemini-2-5-pro", "unknown", "", None])
+def test_model_tier_none_for_unrecognised(model):
+    assert model_tier(model) is None
+
+
+def test_fable_and_opus_are_premium():
+    assert is_premium_tier("claude-fable-5")
+    assert is_premium_tier("claude-opus-4-8")
+    assert {"fable", "opus"} <= PREMIUM_TIERS
+
+
+def test_sonnet_and_haiku_are_not_premium():
+    assert not is_premium_tier("claude-sonnet-4-6")
+    assert not is_premium_tier("claude-haiku-4-5")
+    assert not is_premium_tier("gpt-4o")
+    assert not is_premium_tier(None)

--- a/tests/unit/test_optimize.py
+++ b/tests/unit/test_optimize.py
@@ -117,6 +117,32 @@ def test_downgrade_flags_small_opus_but_not_large(db):
     assert finding.caveat == MODEL_DOWNGRADE_CAVEAT
 
 
+def test_downgrade_proposes_candidates_for_fable_and_opus_4_8(db):
+    """The downsize analyzer must route Fable (tier above Opus) and Opus 4.8 —
+    both previously missing from DOWNGRADE_CANDIDATES — to a cheaper same-family
+    model when the session is structurally small."""
+    start = utcnow() - timedelta(days=2)
+    db.insert_span(make_llm_span(
+        model="claude-fable-5", provider="anthropic",
+        input_tokens=1_000, output_tokens=200, cost_usd=0.10,
+        session_id="fable-s", start_time=start,
+    ))
+    db.insert_span(make_llm_span(
+        model="claude-opus-4-8", provider="anthropic",
+        input_tokens=1_000, output_tokens=200, cost_usd=0.05,
+        session_id="opus48-s", start_time=start,
+    ))
+    since = utcnow() - timedelta(days=30)
+    until = utcnow() + timedelta(hours=1)
+    finding = analyze_model_downgrade(
+        db.conn, since, until, agent_id=None, window_days=30.0,
+    )
+    assert finding is not None
+    assert finding.candidate_sessions == 2
+    assert finding.suggestions.get("claude-fable-5") == "claude-sonnet-4-6"
+    assert finding.suggestions.get("claude-opus-4-8") == "claude-haiku-4-5"
+
+
 def test_downgrade_returns_none_when_no_candidates(db):
     _insert_large_opus_session(db, session_id="b")
     since = utcnow() - timedelta(days=30)

--- a/tests/unit/test_optimize_subagent.py
+++ b/tests/unit/test_optimize_subagent.py
@@ -74,6 +74,30 @@ def test_flags_over_powered_and_over_provisioned_subagents():
         db.close()
 
 
+def test_flags_over_powered_fable_subagent():
+    """A Fable-powered subagent (the tier above Opus) doing trivial work must be
+    flagged over_powered — before the shared predicate, only "opus" matched, so
+    Fable spawns were invisible to right-sizing."""
+    db = InMemoryBackend()
+    try:
+        ctx, now = _ctx(db, window_cost_usd=2.0)
+        # Fable subagent: premium model, tiny output, few tools -> over_powered.
+        db.insert_span(make_llm_span(
+            model="claude-fable-5", input_tokens=4_000, output_tokens=150,
+            cost_usd=0.40, session_id="s1", sub_agent_id="fableA", start_time=now,
+        ))
+        run_subagent(ctx)
+        f = ctx.report.findings["subagent"]
+
+        assert len(f.flagged) == 1
+        a = f.flagged[0]
+        assert a.sub_agent_id == "fableA"
+        assert a.model == "claude-fable-5"
+        assert "over_powered" in a.flags
+    finally:
+        db.close()
+
+
 def test_no_finding_when_no_subagents():
     db = InMemoryBackend()
     try:

--- a/tests/unit/test_opus_quota_audit.py
+++ b/tests/unit/test_opus_quota_audit.py
@@ -1,7 +1,7 @@
 """Unit tests for the retroactive Opus quota audit (`tj quota-audit`, issue #5).
 
 Exercises the audit over a SYNTHETIC mix of Opus sessions proving:
-  * "% of Opus quota reclaimable" is computed as candidate-Opus-tokens over
+  * "% of premium quota misallocated" is computed as candidate-Opus-tokens over
     total-Opus-tokens (only Sonnet-shaped Opus sessions count);
   * Opus-shaped Opus sessions (big input/output, many tool calls) are NOT
     flagged, and non-Opus sessions are excluded from the denominator;
@@ -10,6 +10,7 @@ Exercises the audit over a SYNTHETIC mix of Opus sessions proving:
 """
 from __future__ import annotations
 
+import re
 from datetime import timedelta
 
 import pytest
@@ -44,10 +45,18 @@ def _max_config() -> TjConfig:
     )
 
 
+def _api_config() -> TjConfig:
+    """Config declaring an API plan so framing renders the dollar counterfactual."""
+    return TjConfig(
+        version="1",
+        budgets={"anthropic": ProviderBudget(plan="api")},
+    )
+
+
 def _add_session(db, session_id, *, model, input_tokens, output_tokens,
-                 cache_tokens=0, cost_usd=1.0, tool_calls=0):
+                 cache_tokens=0, cost_usd=1.0, tool_calls=0, plan_tier="max_5x"):
     """Seed one session: an LLM span plus N tool spans."""
-    sess = make_session(session_id=session_id, plan_tier="max_5x",
+    sess = make_session(session_id=session_id, plan_tier=plan_tier,
                         duration_seconds=60.0)
     db.upsert_session(sess)
     span = make_llm_span(
@@ -67,34 +76,37 @@ def _add_session(db, session_id, *, model, input_tokens, output_tokens,
         db.insert_span(tool)
 
 
-def _seed_mix(db) -> None:
+def _seed_mix(db, *, plan_tier="max_5x") -> None:
     """A mix of Opus + Sonnet sessions:
 
       * opus-thin-1 / opus-thin-2 — Opus, Sonnet-shaped (small in/out, ≤5 tools)
-        → quota-reclaim candidates.
+        → misallocation candidates.
       * opus-fat — Opus, genuinely Opus-shaped (big in/out, many tools) → NOT a
         candidate, but still in the Opus quota denominator.
       * sonnet-1 — already on Sonnet → excluded from the audit entirely (the
         audit only inspects Opus sessions).
+
+    ``plan_tier`` stamps every seeded session so the framing path resolves the
+    intended pricing mode (max_5x → subscription, api → api).
     """
     # 100k Opus tokens each, Sonnet-shaped → candidates.
     _add_session(db, "opus-thin-1", model="claude-opus-4-7",
                  input_tokens=2_000, output_tokens=300, cache_tokens=97_700,
-                 cost_usd=3.0, tool_calls=2)
+                 cost_usd=3.0, tool_calls=2, plan_tier=plan_tier)
     _add_session(db, "opus-thin-2", model="claude-opus-4-6",
                  input_tokens=1_000, output_tokens=200, cache_tokens=98_800,
-                 cost_usd=3.0, tool_calls=1)
+                 cost_usd=3.0, tool_calls=1, plan_tier=plan_tier)
     # 100k Opus tokens, Opus-shaped → in denominator, NOT a candidate.
     _add_session(db, "opus-fat", model="claude-opus-4-7",
                  input_tokens=40_000, output_tokens=20_000, cache_tokens=40_000,
-                 cost_usd=8.0, tool_calls=30)
+                 cost_usd=8.0, tool_calls=30, plan_tier=plan_tier)
     # Sonnet session → excluded from the audit (not Opus).
     _add_session(db, "sonnet-1", model="claude-sonnet-4-6",
                  input_tokens=2_000, output_tokens=300, cache_tokens=50_000,
-                 cost_usd=0.5, tool_calls=1)
+                 cost_usd=0.5, tool_calls=1, plan_tier=plan_tier)
 
 
-def test_percent_quota_reclaimable_counts_only_sonnet_shaped_opus(db):
+def test_percent_quota_misallocated_counts_only_sonnet_shaped_opus(db):
     _seed_mix(db)
     audit = audit_opus_quota(db.conn, SINCE, UNTIL, agent_id=None, window_days=30.0)
 
@@ -105,7 +117,7 @@ def test_percent_quota_reclaimable_counts_only_sonnet_shaped_opus(db):
     assert audit.candidate_sessions == 2
     assert audit.candidate_tokens == 200_000  # 2 × 100k
     # Headline: candidate Opus tokens / total Opus tokens.
-    assert audit.percent_quota_reclaimable == pytest.approx(66.7, abs=0.1)
+    assert audit.percent_quota_misallocated == pytest.approx(66.7, abs=0.1)
     assert audit.percent_sessions == pytest.approx(66.7, abs=0.1)
 
 
@@ -172,11 +184,12 @@ def test_no_opus_sessions_is_clean_empty_state(db):
     audit = audit_opus_quota(db.conn, SINCE, UNTIL, agent_id=None, window_days=30.0)
     assert not audit.has_opus
     assert audit.opus_sessions == 0
-    assert audit.percent_quota_reclaimable == 0.0
+    assert audit.percent_quota_misallocated == 0.0
 
 
 def test_cli_renders_quota_audit_with_caveat(db, monkeypatch):
-    """End-to-end: the card reports % of Opus quota reclaimable, lists the
+    """End-to-end: the card reports the % of premium quota that WENT to
+    Sonnet-shaped sessions (misallocated, not "reclaimable"), lists the
     spot-check sessions, and surfaces the honesty caveat — in quota (not dollar)
     language for a subscription (Max) plan."""
     _seed_mix(db)
@@ -196,16 +209,56 @@ def test_cli_renders_quota_audit_with_caveat(db, monkeypatch):
     )
     assert result.exit_code == 0, result.output
     out = result.output
-    # Quota framing headline (not dollars) — names both premium tiers.
-    assert "quota is reclaimable" in out
+    # Rich wraps panel text across lines and draws box borders between them;
+    # strip the border glyphs and collapse whitespace before matching multi-word
+    # phrases so a wrap between two words doesn't fail the assertion.
+    flat = " ".join(re.sub(r"[│╭╮╰╯─]", " ", out).split())
+    # Retrospective mirror headline (not dollars) — names both premium tiers and
+    # never says "reclaimable" (the tokens are already spent).
+    assert "went to Sonnet-shaped sessions" in flat
+    assert "reclaimable" not in flat.lower()
     assert "Opus/Fable" in out
     assert "67%" in out or "66" in out
+    # Subscription users get the habit nudge, not dollars.
+    assert "stays available for hard problems next window" in flat
+    assert "/model sonnet" in flat
     # Spot-check sessions listed.
     assert "spot-check" in out.lower()
     assert "opus-thin-1" in out
     # Honesty caveat present (the load-bearing honesty discipline).
     assert "spot-check" in OPUS_QUOTA_AUDIT_CAVEAT.lower()
     assert "Never \"safe to downgrade.\"" in out or "safe to downgrade" in out
+
+
+def test_cli_api_persona_shows_dollar_counterfactual(db, monkeypatch):
+    """API-billed users get the already-billed dollar counterfactual under the
+    measured headline instead of the subscription habit nudge."""
+    _seed_mix(db, plan_tier="api")
+    config = _api_config()
+
+    import tokenjam.cli.main as cli_main
+
+    monkeypatch.setattr(cli_main, "load_config", lambda *a, **k: config)
+    monkeypatch.setattr(cli_main, "open_db", lambda *a, **k: db)
+    monkeypatch.setattr(
+        "tokenjam.core.framing.config_declared_plan", lambda c: "api"
+    )
+
+    runner = CliRunner()
+    result = runner.invoke(
+        cli_main.cli, ["quota-audit", "--since", "30d"], catch_exceptions=False
+    )
+    assert result.exit_code == 0, result.output
+    out = result.output
+    flat = " ".join(re.sub(r"[│╭╮╰╯─]", " ", out).split())
+    # Same measured mirror headline for everyone.
+    assert "went to Sonnet-shaped sessions" in flat
+    assert "reclaimable" not in flat.lower()
+    # API persona: retrospective, already-billed counterfactual — NOT the
+    # subscription habit nudge.
+    assert "Same work at the suggested tiers" in flat
+    assert "already billed" in flat
+    assert "stays available for hard problems" not in flat
 
 
 def test_cli_json_output_has_quota_fields(db, monkeypatch):
@@ -228,6 +281,8 @@ def test_cli_json_output_has_quota_fields(db, monkeypatch):
     )
     assert result.exit_code == 0, result.output
     payload = json.loads(result.output)
+    assert payload["percent_quota_misallocated"] == pytest.approx(66.7, abs=0.1)
+    # DEPRECATED alias still emitted (shipped in 0.5.4) — same value, one release.
     assert payload["percent_quota_reclaimable"] == pytest.approx(66.7, abs=0.1)
     assert payload["candidate_sessions"] == 2
     assert len(payload["examples"]) == 2

--- a/tests/unit/test_opus_quota_audit.py
+++ b/tests/unit/test_opus_quota_audit.py
@@ -133,6 +133,38 @@ def test_example_sessions_surfaced_for_spot_check(db):
     assert "claude-opus-4-6" in audit.suggestions
 
 
+def test_fable_and_opus_4_8_sessions_are_audited(db):
+    """Fable (the tier above Opus) and Opus 4.8 must both be counted in the
+    premium denominator and flagged as reclaim candidates when Sonnet-shaped —
+    the whole point of routing tier membership through the shared predicate."""
+    # Fable, Sonnet-shaped → candidate; suggested alt is a cheaper same-family model.
+    _add_session(db, "fable-thin", model="claude-fable-5",
+                 input_tokens=1_500, output_tokens=250, cache_tokens=98_250,
+                 cost_usd=5.0, tool_calls=2)
+    # Opus 4.8, Sonnet-shaped → candidate (4.8 was missing from the map before).
+    _add_session(db, "opus48-thin", model="claude-opus-4-8",
+                 input_tokens=1_000, output_tokens=200, cache_tokens=98_800,
+                 cost_usd=3.0, tool_calls=1)
+    # Fable, genuinely large-shape → in denominator, NOT a candidate.
+    _add_session(db, "fable-fat", model="claude-fable-5",
+                 input_tokens=40_000, output_tokens=20_000, cache_tokens=40_000,
+                 cost_usd=12.0, tool_calls=30)
+
+    audit = audit_opus_quota(db.conn, SINCE, UNTIL, agent_id=None, window_days=30.0)
+
+    # All three premium sessions counted (Fable is premium, above Opus).
+    assert audit.opus_sessions == 3
+    assert audit.opus_tokens == 300_000
+    # The two Sonnet-shaped premium sessions are reclaim candidates.
+    assert audit.candidate_sessions == 2
+    assert {ex.session_id for ex in audit.examples} == {"fable-thin", "opus48-thin"}
+    # Each flagged premium session names a concrete cheaper routing target.
+    assert audit.suggestions["claude-fable-5"]
+    assert audit.suggestions["claude-opus-4-8"]
+    for ex in audit.examples:
+        assert ex.alt_model
+
+
 def test_no_opus_sessions_is_clean_empty_state(db):
     # Only a Sonnet session — nothing for the Opus audit to inspect.
     _add_session(db, "sonnet-only", model="claude-sonnet-4-6",
@@ -164,8 +196,9 @@ def test_cli_renders_quota_audit_with_caveat(db, monkeypatch):
     )
     assert result.exit_code == 0, result.output
     out = result.output
-    # Quota framing headline (not dollars).
-    assert "Opus quota is reclaimable" in out
+    # Quota framing headline (not dollars) — names both premium tiers.
+    assert "quota is reclaimable" in out
+    assert "Opus/Fable" in out
     assert "67%" in out or "66" in out
     # Spot-check sessions listed.
     assert "spot-check" in out.lower()

--- a/tests/unit/test_opus_quota_audit.py
+++ b/tests/unit/test_opus_quota_audit.py
@@ -261,6 +261,51 @@ def test_cli_api_persona_shows_dollar_counterfactual(db, monkeypatch):
     assert "stays available for hard problems" not in flat
 
 
+def test_api_nudge_without_pricing_data_stays_neutral():
+    """API mode + no pricing data (every candidate model absent from the pricing
+    table → actual_cost_usd == 0) must NOT fall through to the subscription
+    "next window" quota language — API billing has no rolling window. It gets a
+    neutral routing prompt instead of a dollar counterfactual or a habit nudge."""
+    from tokenjam.cli.cmd_quota_audit import _headline_nudge
+    from tokenjam.core.framing import Framing
+    from tokenjam.core.optimize.types import OpusQuotaAudit
+
+    audit = OpusQuotaAudit(
+        opus_sessions=3, opus_tokens=300_000,
+        candidate_sessions=2, candidate_tokens=200_000,
+        percent_quota_misallocated=66.7, percent_sessions=66.7,
+        actual_cost_usd=0.0, alternative_cost_usd=0.0,
+    )
+    framing = Framing(pricing_mode="api", plan_tier="api")
+    nudge = _headline_nudge(audit, framing).plain
+
+    # Neither the subscription quota language nor a fabricated dollar figure.
+    assert "next window" not in nudge
+    assert "stays available for hard problems" not in nudge
+    assert "$" not in nudge
+    assert "Review these sessions" in nudge
+
+
+def test_api_nudge_with_pricing_shows_dollar_counterfactual():
+    """API mode WITH pricing data gets the already-billed dollar counterfactual,
+    never the subscription 'next window' language."""
+    from tokenjam.cli.cmd_quota_audit import _headline_nudge
+    from tokenjam.core.framing import Framing
+    from tokenjam.core.optimize.types import OpusQuotaAudit
+
+    audit = OpusQuotaAudit(
+        opus_sessions=3, opus_tokens=300_000,
+        candidate_sessions=2, candidate_tokens=200_000,
+        percent_quota_misallocated=66.7, percent_sessions=66.7,
+        actual_cost_usd=12.0, alternative_cost_usd=3.0,
+    )
+    framing = Framing(pricing_mode="api", plan_tier="api")
+    nudge = _headline_nudge(audit, framing).plain
+
+    assert "already billed" in nudge
+    assert "next window" not in nudge
+
+
 def test_cli_json_output_has_quota_fields(db, monkeypatch):
     _seed_mix(db)
     config = _max_config()

--- a/tokenjam/cli/cmd_onboard.py
+++ b/tokenjam/cli/cmd_onboard.py
@@ -1131,7 +1131,7 @@ def _print_next_steps_nudge(
         )
     if persona == "claude_code":
         console.print("  [bold]tj context[/bold]     [dim]where your quota goes — re-read vs real work[/dim]")
-        console.print("  [bold]tj quota-audit[/bold] [dim]how much Opus went to Sonnet-shaped sessions[/dim]")
+        console.print("  [bold]tj quota-audit[/bold] [dim]how much Opus/Fable went to Sonnet-shaped sessions[/dim]")
         console.print(lens_line)
         console.print("  [bold]tj tokenmaxx[/bold]   [dim]your shareable efficiency tier[/dim]")
     else:

--- a/tokenjam/cli/cmd_quota_audit.py
+++ b/tokenjam/cli/cmd_quota_audit.py
@@ -1,14 +1,15 @@
-"""``tj quota-audit`` — the retroactive Opus quota audit over Claude Code sessions.
+"""``tj quota-audit`` — the retroactive premium-tier quota audit over Claude Code sessions.
 
 The accountability companion to ``opusplan`` / ``/model`` (issue #5). Those are
 forward-looking and say nothing about session history; nothing answers the
-backward-looking question "which of my PAST Opus sessions were Sonnet-shaped?".
-This command does: it runs the structural downsize heuristic
+backward-looking question "which of my PAST premium (Opus/Fable) sessions were
+Sonnet-shaped?". This command does: it runs the structural downsize heuristic
 (:func:`tokenjam.core.optimize.analyzers.model_downgrade.audit_opus_quota`)
-retroactively, scoped to Opus sessions, and reports:
+retroactively, scoped to premium-tier sessions (Fable + Opus), and reports:
 
-  * the headline — **% of your Opus quota reclaimable from Sonnet-shaped
-    sessions** (Opus token share, never a dollar "saving" — the subscription
+  * the headline — **% of your premium (Opus/Fable) quota reclaimable from
+    Sonnet-shaped sessions** (premium token share, never a dollar "saving" — the
+    subscription
     majority is on a flat fee; dollar framing mis-targets them, see
     ``research/evidence/subscription-vs-cost-framing.md``);
   * the specific example sessions to **spot-check**;
@@ -31,6 +32,7 @@ import click
 
 from tokenjam.cli.data_access import resolve_data_access
 from tokenjam.core.framing import Framing
+from tokenjam.core.model_tiers import PREMIUM_TIER_LABEL
 from tokenjam.core.optimize.types import (
     DowngradeFinding,
     OpusQuotaAudit,
@@ -98,22 +100,24 @@ def _render(audit: OpusQuotaAudit, framing: Framing, *, since: str) -> None:
 
     if not audit.has_opus:
         console.print(
-            "\n[yellow]No Opus sessions found in this window.[/yellow]\n"
-            "[dim]The quota audit only inspects Opus-family sessions (where "
-            "quota burn is acute). Run [bold]tj onboard --claude-code[/bold] to "
-            "ingest your Claude Code sessions, then re-run "
-            "[bold]tj quota-audit[/bold].[/dim]\n"
+            f"\n[yellow]No premium ({PREMIUM_TIER_LABEL}) sessions found in this "
+            "window.[/yellow]\n"
+            f"[dim]The quota audit only inspects premium-tier ({PREMIUM_TIER_LABEL}) "
+            "sessions (where quota burn is acute). Run "
+            "[bold]tj onboard --claude-code[/bold] to ingest your Claude Code "
+            "sessions, then re-run [bold]tj quota-audit[/bold].[/dim]\n"
         )
         return
 
     sections: list[Any] = []
 
     headline = Text()
-    headline.append("Opus quota audit", style="bold")
+    headline.append("Premium quota audit", style="bold")
     headline.append(
-        f"  ·  {audit.opus_sessions} Opus session"
+        f"  ·  {audit.opus_sessions} premium session"
         f"{'s' if audit.opus_sessions != 1 else ''} "
-        f"({format_tokens(audit.opus_tokens)} Opus tokens, last {since})",
+        f"({format_tokens(audit.opus_tokens)} {PREMIUM_TIER_LABEL} tokens, "
+        f"last {since})",
         style="dim",
     )
     sections.append(headline)
@@ -123,7 +127,7 @@ def _render(audit: OpusQuotaAudit, framing: Framing, *, since: str) -> None:
         clean = Text()
         clean.append("0% reclaimable", style="bold green")
         clean.append(
-            " — none of your Opus sessions match the Sonnet-shaped structure "
+            " — none of your premium sessions match the Sonnet-shaped structure "
             "(small input/output, few tool calls).",
             style="",
         )
@@ -132,9 +136,12 @@ def _render(audit: OpusQuotaAudit, framing: Framing, *, since: str) -> None:
         # The headline: quota share, never dollars (audit framing).
         big = Text()
         big.append(f"~{audit.percent_quota_reclaimable:.0f}% ", style="bold red")
-        big.append("of your Opus quota is reclaimable", style="bold")
         big.append(
-            f"\nfrom {audit.candidate_sessions} of {audit.opus_sessions} Opus "
+            f"of your premium ({PREMIUM_TIER_LABEL}) quota is reclaimable",
+            style="bold",
+        )
+        big.append(
+            f"\nfrom {audit.candidate_sessions} of {audit.opus_sessions} premium "
             f"session{'s' if audit.opus_sessions != 1 else ''} "
             f"({audit.percent_sessions:.0f}%) that are Sonnet-shaped",
             style="dim",
@@ -142,7 +149,7 @@ def _render(audit: OpusQuotaAudit, framing: Framing, *, since: str) -> None:
         sections.append(big)
 
         detail = Text()
-        detail.append("\nReclaimable Opus tokens:  ", style="dim")
+        detail.append("\nReclaimable premium tokens:  ", style="dim")
         detail.append(format_tokens(audit.candidate_tokens), style="bold")
         detail.append(
             f"  of {format_tokens(audit.opus_tokens)} total", style="dim"
@@ -202,7 +209,7 @@ def _render(audit: OpusQuotaAudit, framing: Framing, *, since: str) -> None:
     console.print()
     console.print(Panel(
         panel_body,
-        title="[bold]TokenJam Opus Quota Audit[/bold]",
+        title="[bold]TokenJam Premium Quota Audit[/bold]",
         title_align="left",
         border_style="dim",
         padding=(1, 2),

--- a/tokenjam/cli/cmd_quota_audit.py
+++ b/tokenjam/cli/cmd_quota_audit.py
@@ -7,10 +7,11 @@ Sonnet-shaped?". This command does: it runs the structural downsize heuristic
 (:func:`tokenjam.core.optimize.analyzers.model_downgrade.audit_opus_quota`)
 retroactively, scoped to premium-tier sessions (Fable + Opus), and reports:
 
-  * the headline — **% of your premium (Opus/Fable) quota reclaimable from
-    Sonnet-shaped sessions** (premium token share, never a dollar "saving" — the
-    subscription
-    majority is on a flat fee; dollar framing mis-targets them, see
+  * the headline — **% of your premium (Opus/Fable) quota that went to
+    Sonnet-shaped sessions** (a retrospective behaviour mirror in premium token
+    share — the tokens are already spent, so nothing is "reclaimed"; and never a
+    dollar "saving" — the subscription majority is on a flat fee, so dollar
+    framing mis-targets them, see
     ``research/evidence/subscription-vs-cost-framing.md``);
   * the specific example sessions to **spot-check**;
   * an optional tuned routing-config export (``--export-config claude-code``).
@@ -93,6 +94,37 @@ def cmd_quota_audit(ctx: click.Context, agent: str | None, since: str,
 # ───────────────────────────── rendering ──────────────────────────────────
 
 
+def _headline_nudge(audit: OpusQuotaAudit, framing: Framing) -> Any:
+    """Persona-specific takeaway under the measured misallocation headline.
+
+    Subscription / local users pay a flat fee, so the honest framing is a habit
+    nudge: that quota share is still available for hard problems next window.
+    API-billed users additionally get the retrospective counterfactual in
+    dollars — the same work priced at the suggested cheaper tiers, labelled as
+    already-billed so it never reads as a future "saving".
+    """
+    from rich.text import Text
+
+    if framing.pricing_mode == "api" and audit.actual_cost_usd > 0:
+        line = Text("\n→ ", style="dim")
+        line.append(
+            f"Same work at the suggested tiers ≈ "
+            f"{format_cost(audit.alternative_cost_usd)} vs your "
+            f"{format_cost(audit.actual_cost_usd)} actual "
+            "(retrospective — already billed).",
+            style="dim",
+        )
+        return line
+    # subscription / local / unknown — no dollars; behaviour-mirror habit nudge.
+    line = Text("\n→ ", style="green")
+    line.append(
+        "That share stays available for hard problems next window. Use "
+        "`/model sonnet` for mechanical work and right-size your subagents.",
+        style="green",
+    )
+    return line
+
+
 def _render(audit: OpusQuotaAudit, framing: Framing, *, since: str) -> None:
     from rich.console import Group
     from rich.panel import Panel
@@ -125,7 +157,7 @@ def _render(audit: OpusQuotaAudit, framing: Framing, *, since: str) -> None:
 
     if audit.candidate_sessions == 0:
         clean = Text()
-        clean.append("0% reclaimable", style="bold green")
+        clean.append("0% misallocated", style="bold green")
         clean.append(
             " — none of your premium sessions match the Sonnet-shaped structure "
             "(small input/output, few tool calls).",
@@ -133,11 +165,15 @@ def _render(audit: OpusQuotaAudit, framing: Framing, *, since: str) -> None:
         )
         sections.append(clean)
     else:
-        # The headline: quota share, never dollars (audit framing).
+        # The headline is a retrospective behaviour mirror: what SHARE of premium
+        # quota already WENT to Sonnet-shaped sessions. It is misallocated, not
+        # "reclaimable" — those tokens are spent. Quota share, never dollars for
+        # the subscription majority (audit framing).
         big = Text()
-        big.append(f"~{audit.percent_quota_reclaimable:.0f}% ", style="bold red")
+        big.append(f"~{audit.percent_quota_misallocated:.0f}% ", style="bold red")
         big.append(
-            f"of your premium ({PREMIUM_TIER_LABEL}) quota is reclaimable",
+            f"of your premium ({PREMIUM_TIER_LABEL}) quota went to "
+            "Sonnet-shaped sessions",
             style="bold",
         )
         big.append(
@@ -149,27 +185,18 @@ def _render(audit: OpusQuotaAudit, framing: Framing, *, since: str) -> None:
         sections.append(big)
 
         detail = Text()
-        detail.append("\nReclaimable premium tokens:  ", style="dim")
+        detail.append("\nSonnet-shaped premium tokens:  ", style="dim")
         detail.append(format_tokens(audit.candidate_tokens), style="bold")
         detail.append(
             f"  of {format_tokens(audit.opus_tokens)} total", style="dim"
         )
-        # Secondary implied-dollar calibration for API users only — never the
-        # headline. Suppressed for subscription / local / unknown plans.
-        if (
-            framing.pricing_mode == "api"
-            and audit.actual_cost_usd > 0
-        ):
-            detail.append("\nImplied API value:        ", style="dim")
-            detail.append(
-                f"{format_cost(audit.actual_cost_usd)}", style="bold"
-            )
-            detail.append(
-                f" → {format_cost(audit.alternative_cost_usd)} on the smaller "
-                f"model (calibration only)",
-                style="dim",
-            )
         sections.append(detail)
+
+        # Persona-gated takeaway. The measured mirror above is shown to everyone;
+        # this is the actionable framing for the user's billing reality.
+        nudge = _headline_nudge(audit, framing)
+        if nudge is not None:
+            sections.append(nudge)
 
         if audit.suggestions:
             pairs = ", ".join(
@@ -234,7 +261,7 @@ def _export_snippet(audit: OpusQuotaAudit, framing: Framing, *,
 
     Reuses the downsize snippet generator by adapting the audit into a
     ``DowngradeFinding`` shim carrying the observed model→alt suggestions and
-    the reclaimable token figure. No file outside the TokenJam config directory
+    the misallocated token figure. No file outside the TokenJam config directory
     is touched — the user merges the snippet manually.
     """
     from datetime import datetime, timezone
@@ -255,7 +282,7 @@ def _export_snippet(audit: OpusQuotaAudit, framing: Framing, *,
         suggestions=dict(audit.suggestions),
         candidate_tokens=audit.candidate_tokens,
         window_total_tokens=audit.opus_tokens,
-        percent_of_tokens=audit.percent_quota_reclaimable,
+        percent_of_tokens=audit.percent_quota_misallocated,
         monthly_tokens_in_candidates=audit.candidate_tokens,
     )
 
@@ -278,7 +305,9 @@ def _export_snippet(audit: OpusQuotaAudit, framing: Framing, *,
             "path": str(out_path),
             "plan_tier": framing.plan_tier,
             "pricing_mode": framing.pricing_mode,
-            "percent_quota_reclaimable": audit.percent_quota_reclaimable,
+            "percent_quota_misallocated": audit.percent_quota_misallocated,
+            # DEPRECATED alias (see audit_to_dict) — kept one release.
+            "percent_quota_reclaimable": audit.percent_quota_misallocated,
         }, default=str))
         return
 

--- a/tokenjam/cli/cmd_quota_audit.py
+++ b/tokenjam/cli/cmd_quota_audit.py
@@ -97,21 +97,34 @@ def cmd_quota_audit(ctx: click.Context, agent: str | None, since: str,
 def _headline_nudge(audit: OpusQuotaAudit, framing: Framing) -> Any:
     """Persona-specific takeaway under the measured misallocation headline.
 
-    Subscription / local users pay a flat fee, so the honest framing is a habit
-    nudge: that quota share is still available for hard problems next window.
-    API-billed users additionally get the retrospective counterfactual in
-    dollars — the same work priced at the suggested cheaper tiers, labelled as
-    already-billed so it never reads as a future "saving".
+    - API-billed with pricing data: the retrospective counterfactual in dollars
+      — the same work priced at the suggested cheaper tiers, labelled as
+      already-billed so it never reads as a future "saving".
+    - API-billed with NO pricing data (every candidate's model is absent from
+      the pricing table, so ``actual_cost_usd == 0``): a neutral routing prompt.
+      API billing has no rolling quota window, so the subscription "next window"
+      language below would be actively wrong for these users.
+    - Subscription / local (and the unknown-plan default): a habit nudge — that
+      quota share is still available for hard problems next window.
     """
     from rich.text import Text
 
-    if framing.pricing_mode == "api" and audit.actual_cost_usd > 0:
+    if framing.pricing_mode == "api":
+        if audit.actual_cost_usd > 0:
+            line = Text("\n→ ", style="dim")
+            line.append(
+                f"Same work at the suggested tiers ≈ "
+                f"{format_cost(audit.alternative_cost_usd)} vs your "
+                f"{format_cost(audit.actual_cost_usd)} actual "
+                "(retrospective — already billed).",
+                style="dim",
+            )
+            return line
+        # API mode but no pricing data — stay neutral, never subscription quota
+        # language (there is no rolling window to hold that share for).
         line = Text("\n→ ", style="dim")
         line.append(
-            f"Same work at the suggested tiers ≈ "
-            f"{format_cost(audit.alternative_cost_usd)} vs your "
-            f"{format_cost(audit.actual_cost_usd)} actual "
-            "(retrospective — already billed).",
+            "Review these sessions before adjusting your routing.",
             style="dim",
         )
         return line
@@ -194,9 +207,7 @@ def _render(audit: OpusQuotaAudit, framing: Framing, *, since: str) -> None:
 
         # Persona-gated takeaway. The measured mirror above is shown to everyone;
         # this is the actionable framing for the user's billing reality.
-        nudge = _headline_nudge(audit, framing)
-        if nudge is not None:
-            sections.append(nudge)
+        sections.append(_headline_nudge(audit, framing))
 
         if audit.suggestions:
             pairs = ", ".join(

--- a/tokenjam/cli/data_access.py
+++ b/tokenjam/cli/data_access.py
@@ -151,7 +151,7 @@ class ServeDataAccess:
         def build() -> tuple[OpusQuotaAudit, Framing]:
             payload = self._db.fetch_opus_quota_audit(since=since, agent_id=agent_id)
             return audit_from_dict(payload), _framing_from_payload(payload)
-        return _through_serve("Opus quota audit", build)
+        return _through_serve("premium quota audit", build)
 
 
 _T = TypeVar("_T")

--- a/tokenjam/core/model_tiers.py
+++ b/tokenjam/core/model_tiers.py
@@ -1,0 +1,50 @@
+"""Provider-agnostic model-family tier classification.
+
+One place that knows which Anthropic model families are *premium* (worth a
+quota audit / right-sizing flag) and how the tiers rank. The optimize analyzers
+consume this instead of each hardcoding an ``"opus"`` substring — so when a new
+family launches above the current top (as **Fable** launched above Opus), it is
+a one-line edit here, not a grep-and-patch across every analyzer.
+
+Membership is decided by a lowercased-substring match on the model id, which
+tolerates version suffixes, ``YYYYMMDD`` dates, provider prefixes (Bedrock's
+``us-anthropic-…`` / ``global-anthropic-…``), and ``[1m]`` context tags — e.g.
+``us-anthropic-claude-opus-4-8-20260115[1m]`` all resolve to ``"opus"``. This
+mirrors the tolerance the pricing layer already relies on and is the same
+matching the analyzers used before this module existed.
+"""
+from __future__ import annotations
+
+# Model-family tiers, most capable first. Fable sits ABOVE Opus. Each entry is
+# ``(substring, tier)``; the first substring found in the (lowercased) model id
+# wins. No model id contains two family names, so ordering only matters as a
+# tie-break that never fires in practice — but keeping it capability-ordered
+# documents the ladder for the downgrade suggestions below.
+TIER_SUBSTRINGS: tuple[tuple[str, str], ...] = (
+    ("fable", "fable"),
+    ("opus", "opus"),
+    ("sonnet", "sonnet"),
+    ("haiku", "haiku"),
+)
+
+# Tiers whose sessions are worth a premium-quota audit / right-sizing flag.
+# Extend this (and TIER_SUBSTRINGS) when a new premium family launches — that is
+# the single edit that teaches every consumer about the new tier.
+PREMIUM_TIERS: frozenset[str] = frozenset({"fable", "opus"})
+
+# Human-facing label for the premium tier, for copy that names what is audited.
+PREMIUM_TIER_LABEL = "Opus/Fable"
+
+
+def model_tier(model: str | None) -> str | None:
+    """Classify a model id into its family tier, or ``None`` if unrecognised."""
+    normalised = (model or "").lower()
+    for substring, tier in TIER_SUBSTRINGS:
+        if substring in normalised:
+            return tier
+    return None
+
+
+def is_premium_tier(model: str | None) -> bool:
+    """True when the model belongs to a premium tier (Fable or Opus today)."""
+    return model_tier(model) in PREMIUM_TIERS

--- a/tokenjam/core/optimize/analyzers/model_downgrade.py
+++ b/tokenjam/core/optimize/analyzers/model_downgrade.py
@@ -12,6 +12,7 @@ import re as _re
 from datetime import datetime
 from typing import Any
 
+from tokenjam.core.model_tiers import is_premium_tier
 from tokenjam.core.optimize.registry import register
 from tokenjam.core.optimize.stats import bootstrap_ci
 from tokenjam.core.optimize.types import (
@@ -30,21 +31,21 @@ SMALL_INPUT_TOKENS = 5_000
 SMALL_OUTPUT_TOKENS = 500
 SMALL_TOOL_CALLS = 5
 
-# Substring that identifies an Opus-family model name (after provider/date
-# normalisation). The quota audit scopes exclusively to Opus sessions — the
-# acute quota-burn class (research/evidence/feature-downsize.md). Matching on
-# the family substring tolerates version + date suffixes
-# (claude-opus-4-7, claude-opus-4-6-20260115, ...).
-OPUS_MODEL_SUBSTR = "opus"
-
 # Cap on the number of spot-check example sessions carried in the audit.
 OPUS_AUDIT_MAX_EXAMPLES = 5
 
 # Premium → cheaper alternative in the same provider family. Pricing for both
 # sides is resolved at runtime from pricing/models.toml; if either is missing
 # the candidate is silently skipped (we won't invent a savings number).
+# Premium-tier ladder: Fable → Sonnet and Opus → Haiku each drop two tiers, the
+# aggressive step justified because the quota audit only proposes these for
+# structurally tiny (Sonnet-shaped) sessions. Keep new premium families in sync
+# with tokenjam.core.model_tiers.PREMIUM_TIERS so every flagged session has a
+# real routing target.
 DOWNGRADE_CANDIDATES: dict[str, dict[str, str]] = {
     "anthropic": {
+        "claude-fable-5":    "claude-sonnet-4-6",
+        "claude-opus-4-8":   "claude-haiku-4-5",
         "claude-opus-4-7":   "claude-haiku-4-5",
         "claude-opus-4-6":   "claude-haiku-4-5",
         "claude-sonnet-4-6": "claude-haiku-4-5",
@@ -262,27 +263,35 @@ def run(ctx: AnalyzerContext) -> None:
 
 
 # ---------------------------------------------------------------------------
-# Opus quota audit (retroactive Downsize, reframed as accountability)
+# Premium-tier quota audit (retroactive Downsize, reframed as accountability)
 # ---------------------------------------------------------------------------
-# This runs the same structural heuristic as `downsize`, but scoped to Opus
-# sessions only and reframed as a "quota audit" rather than "cost optimization"
+# This runs the same structural heuristic as `downsize`, but scoped to
+# premium-tier sessions only (Fable + Opus, via the shared model_tiers
+# predicate) and reframed as a "quota audit" rather than "cost optimization"
 # (issue #5; research/evidence/feature-downsize.md). The headline is
-# "% of your Opus quota reclaimable from Sonnet-shaped sessions" — Opus token
-# share, not dollars — because the subscription majority is on flat-rate plans
-# where dollar framing mis-targets them (subscription-vs-cost-framing.md). It
-# complements opusplan / `/model` (forward-looking) by answering the
-# backward-looking question those tools can't: "which of my PAST Opus sessions
-# were Sonnet-shaped?" Honest framing throughout — candidates to spot-check,
-# never "safe to downgrade".
+# "% of your premium (Opus/Fable) quota reclaimable from Sonnet-shaped
+# sessions" — premium token share, not dollars — because the subscription
+# majority is on flat-rate plans where dollar framing mis-targets them
+# (subscription-vs-cost-framing.md). It complements opusplan / `/model`
+# (forward-looking) by answering the backward-looking question those tools
+# can't: "which of my PAST premium sessions were Sonnet-shaped?" Honest framing
+# throughout — candidates to spot-check, never "safe to downgrade".
+#
+# The `audit_opus_quota` name and the `opus_*` fields on OpusQuotaAudit are kept
+# for API/serialization stability; they now denote the whole premium tier, not
+# Opus alone (the audit counts and flags Fable sessions too).
 
 
-def _is_opus(provider: str, model: str) -> bool:
-    """True when the model is an Opus-family model worth auditing for downsize.
+def _is_premium_downsizable(provider: str, model: str) -> bool:
+    """True when the model is a premium-tier model worth auditing for downsize.
 
-    We only audit Opus sessions that ALSO have a known cheaper alternative in
-    `DOWNGRADE_CANDIDATES` (so the routing suggestion is real, not invented).
+    Premium-tier membership (Fable, Opus, and whatever launches above them next)
+    is resolved through the shared :func:`is_premium_tier` predicate — no
+    per-analyzer substring gate. We only audit premium sessions that ALSO have a
+    known cheaper alternative in `DOWNGRADE_CANDIDATES` (so the routing
+    suggestion is real, not invented).
     """
-    if OPUS_MODEL_SUBSTR not in (model or "").lower():
+    if not is_premium_tier(model):
         return False
     return _lookup_downgrade(provider, model) is not None
 
@@ -294,13 +303,15 @@ def audit_opus_quota(
     agent_id: str | None,
     window_days: float,
 ) -> OpusQuotaAudit:
-    """Retroactive Opus quota audit over Claude Code (and other) sessions.
+    """Retroactive premium-tier quota audit over Claude Code (and other) sessions.
 
-    Walks Opus sessions in the window and flags those whose structural shape
-    (small input, small output, few tool calls) matches a class of work where a
-    cheaper same-family model is worth a spot-check. Quantifies the result as a
-    **share of Opus quota** (candidate Opus tokens / total Opus tokens) — never
-    a dollar figure as the headline.
+    Walks premium-tier sessions (Fable + Opus, via the shared model_tiers
+    predicate) in the window and flags those whose structural shape (small
+    input, small output, few tool calls) matches a class of work where a cheaper
+    same-family model is worth a spot-check. Quantifies the result as a **share
+    of premium quota** (candidate premium tokens / total premium tokens) — never
+    a dollar figure as the headline. Field names retain the historical `opus_*`
+    prefix for serialization stability but count the whole premium tier.
 
     Computes purely from already-backfilled token/model metadata; does NOT
     depend on captured content (#3). Always returns an :class:`OpusQuotaAudit`
@@ -351,7 +362,7 @@ def audit_opus_quota(
             in_tok, out_tok, cache_tok, cost = row
         if not provider or not model:
             continue
-        if not _is_opus(provider, model):
+        if not _is_premium_downsizable(provider, model):
             continue
 
         session_tokens = int(in_tok or 0) + int(out_tok or 0) + int(cache_tok or 0)

--- a/tokenjam/core/optimize/analyzers/model_downgrade.py
+++ b/tokenjam/core/optimize/analyzers/model_downgrade.py
@@ -269,8 +269,9 @@ def run(ctx: AnalyzerContext) -> None:
 # premium-tier sessions only (Fable + Opus, via the shared model_tiers
 # predicate) and reframed as a "quota audit" rather than "cost optimization"
 # (issue #5; research/evidence/feature-downsize.md). The headline is
-# "% of your premium (Opus/Fable) quota reclaimable from Sonnet-shaped
-# sessions" — premium token share, not dollars — because the subscription
+# "% of your premium (Opus/Fable) quota that went to Sonnet-shaped sessions"
+# — a retrospective behaviour mirror in premium token share, not dollars and
+# not "reclaimable" (the tokens are already spent) — because the subscription
 # majority is on flat-rate plans where dollar framing mis-targets them
 # (subscription-vs-cost-framing.md). It complements opusplan / `/model`
 # (forward-looking) by answering the backward-looking question those tools
@@ -420,7 +421,7 @@ def audit_opus_quota(
     candidate_examples.sort(key=lambda pair: pair[0], reverse=True)
     audit.examples = [ex for _tokens, ex in candidate_examples[:OPUS_AUDIT_MAX_EXAMPLES]]
 
-    audit.percent_quota_reclaimable = (
+    audit.percent_quota_misallocated = (
         round(100.0 * audit.candidate_tokens / audit.opus_tokens, 1)
         if audit.opus_tokens > 0 else 0.0
     )

--- a/tokenjam/core/optimize/analyzers/subagent_rightsizing.py
+++ b/tokenjam/core/optimize/analyzers/subagent_rightsizing.py
@@ -12,10 +12,11 @@ This analyzer breaks a window's cost down per subagent and flags two structural
 right-sizing candidates (honesty discipline, CLAUDE.md Rule 14 — candidate
 flags only, never a quality judgment):
 
-  * over_powered     — ran on a premium (Opus-tier) model but produced little
-                       output and made few tool calls; a cheaper same-family
-                       model is worth a look (mirrors the downsize heuristic,
-                       scoped to one subagent).
+  * over_powered     — ran on a premium-tier model (Fable or Opus, via the
+                       shared model_tiers predicate) but produced little output
+                       and made few tool calls; a cheaper same-family model is
+                       worth a look (mirrors the downsize heuristic, scoped to
+                       one subagent).
   * over_provisioned — was handed a large context (input + cache reads) yet
                        produced little output; the prompt it was dispatched
                        with is likely larger than the task needed.
@@ -29,11 +30,9 @@ from __future__ import annotations
 from dataclasses import dataclass, field
 from typing import Any
 
+from tokenjam.core.model_tiers import is_premium_tier
 from tokenjam.core.optimize.registry import register
 from tokenjam.core.optimize.types import AnalyzerContext
-
-# Model-name substrings that mark the premium tier. Lowercased before matching.
-PREMIUM_MODEL_SUBSTRINGS = ("opus",)
 
 # "Produced little": total output tokens below this look like a small task.
 SMALL_OUTPUT_TOKENS = 2_000
@@ -115,8 +114,7 @@ def _flags_for(
     if cost_usd < MIN_FLAG_COST_USD:
         return []
     flags: list[str] = []
-    model_l = (model or "").lower()
-    is_premium = any(s in model_l for s in PREMIUM_MODEL_SUBSTRINGS)
+    is_premium = is_premium_tier(model)
     if is_premium and output_tokens < SMALL_OUTPUT_TOKENS and tool_calls <= FEW_TOOL_CALLS:
         flags.append("over_powered")
     if (input_tokens + cache_tokens) >= CONTEXT_HEAVY_TOKENS and output_tokens < SMALL_OUTPUT_TOKENS:

--- a/tokenjam/core/optimize/types.py
+++ b/tokenjam/core/optimize/types.py
@@ -16,7 +16,7 @@ MODEL_DOWNGRADE_CAVEAT = (
 # discipline (CLAUDE.md Rule 14): the audit flags Opus sessions whose STRUCTURE
 # matches Sonnet-shaped work — it is an accountability list to spot-check, never
 # a claim that the cheaper model would have produced the same answer. Surfaced
-# verbatim next to every "% of Opus quota reclaimable" headline.
+# verbatim next to every "% of premium quota misallocated" headline.
 OPUS_QUOTA_AUDIT_CAVEAT = (
     "Candidates to spot-check, not a verdict. Each flagged session merely has "
     "the structural shape (small input/output, few tool calls) of work a "
@@ -126,18 +126,21 @@ class OpusQuotaAudit:
     Reframes the structural downsize heuristic as an *accountability* audit
     scoped to Opus sessions: how much of your Opus quota was spent on sessions
     whose shape matches Sonnet-shaped work. The headline figure is
-    ``percent_quota_reclaimable`` (candidate Opus tokens / total Opus tokens) —
-    quota language, never a dollar "saving" (the subscription majority is on a
-    flat fee; dollar framing mis-targets them). Dollar fields are a best-effort
-    SECONDARY signal for API users only.
+    ``percent_quota_misallocated`` (candidate Opus tokens / total Opus tokens) —
+    retrospective quota is already SPENT, so this is a behaviour mirror (how much
+    premium quota went to Sonnet-shaped sessions), never a claim it can be
+    "reclaimed". Quota language, never a dollar "saving" (the subscription
+    majority is on a flat fee; dollar framing mis-targets them). Dollar fields
+    are a best-effort SECONDARY signal for API users only.
     """
     window_days: float = 0.0
     opus_sessions: int = 0
     opus_tokens: int = 0  # input + output + cache across all Opus sessions
     candidate_sessions: int = 0
     candidate_tokens: int = 0  # input + output + cache, candidates only
-    # The headline: % of Opus quota (tokens) held by Sonnet-shaped sessions.
-    percent_quota_reclaimable: float = 0.0
+    # The headline: % of premium quota (tokens) that went to Sonnet-shaped
+    # sessions — misallocated, not reclaimable (the tokens are already spent).
+    percent_quota_misallocated: float = 0.0
     percent_sessions: float = 0.0
     # model -> cheaper-alternative suggestions observed among the candidates.
     suggestions: dict[str, str] = field(default_factory=dict)
@@ -272,7 +275,13 @@ def audit_to_dict(audit: OpusQuotaAudit) -> dict[str, Any]:
         "opus_tokens": audit.opus_tokens,
         "candidate_sessions": audit.candidate_sessions,
         "candidate_tokens": audit.candidate_tokens,
-        "percent_quota_reclaimable": audit.percent_quota_reclaimable,
+        "percent_quota_misallocated": audit.percent_quota_misallocated,
+        # DEPRECATED alias — kept one release (through 0.6.x) because
+        # ``percent_quota_reclaimable`` shipped publicly in 0.5.4. Consumers
+        # should read ``percent_quota_misallocated``; this mirror will be
+        # removed. Emitted on BOTH the direct and serve paths so the parity
+        # contract (byte-identical audit_to_dict output) still holds.
+        "percent_quota_reclaimable": audit.percent_quota_misallocated,
         "percent_sessions": audit.percent_sessions,
         "suggestions": dict(audit.suggestions),
         "examples": [asdict(ex) for ex in audit.examples],
@@ -309,7 +318,12 @@ def audit_from_dict(data: dict[str, Any]) -> OpusQuotaAudit:
         opus_tokens=int(data.get("opus_tokens", 0) or 0),
         candidate_sessions=int(data.get("candidate_sessions", 0) or 0),
         candidate_tokens=int(data.get("candidate_tokens", 0) or 0),
-        percent_quota_reclaimable=float(data.get("percent_quota_reclaimable", 0.0) or 0.0),
+        # Prefer the new key; fall back to the deprecated alias so a payload
+        # produced by a pre-rename (0.5.4) daemon still reconstructs.
+        percent_quota_misallocated=float(
+            data.get("percent_quota_misallocated",
+                     data.get("percent_quota_reclaimable", 0.0)) or 0.0
+        ),
         percent_sessions=float(data.get("percent_sessions", 0.0) or 0.0),
         suggestions=dict(data.get("suggestions", {}) or {}),
         examples=examples,


### PR DESCRIPTION
The retroactive premium-tier quota audit rendered "~N% of your Opus quota is reclaimable". But retrospective quota is already **spent** — nothing is reclaimed. The audit's real product is a *behaviour mirror*: how much premium (Opus/Fable) quota was **misallocated** to Sonnet-shaped sessions, so the user adopts better routing habits next window.

**Stacked on PR #453 (`premium-tier-predicate`) — merge #453 first, then this.** When #453 merges to main, GitHub retargets this PR to main.

## Summary
- Rename the headline field `percent_quota_reclaimable` -> `percent_quota_misallocated` across the `OpusQuotaAudit` dataclass, `audit_to_dict` / `audit_from_dict`, the analyzer fill, the CLI, and the JSON/API payload.
- **Deprecated alias (not a clean rename).** The old key shipped publicly in **0.5.4** (verified live on PyPI), so `audit_to_dict` keeps emitting `percent_quota_reclaimable` as a documented deprecated alias for one release; `audit_from_dict` reads the new key with a fallback to the old. The alias is emitted on **both** the direct and serve paths, so the byte-identical `DataAccess` parity contract still holds.
- **Persona-gate the headline** via the existing `framing` plan-tier machinery:
  - subscription / local -> measured mirror + habit nudge ("that share stays available for hard problems next window — `/model sonnet` for mechanical work, right-size subagents").
  - api-billed -> measured mirror + honest retrospective, already-billed dollar counterfactual ("same work at the suggested tiers ≈ \$X vs your \$Y actual"). This replaces the old undifferentiated "Implied API value" calibration line.

## Release-timing decision
`percent_quota_reclaimable` is present in tag **v0.5.4**, which is the current latest release on PyPI. So it **has** shipped publicly → I kept the deprecated alias rather than doing a clean removal. It should be dropped one release later (0.7.x).

## Scope guard — deliberately untouched (honest as-is)
- `tj savings` "reclaimed" (measured avoided tokens)
- `estimated_recoverable_usd/tokens` in optimize findings (forward-looking, persona-contracted)
- the statusline "→ /compact to reclaim quota" (forward action in a live session)
- `cmd_optimize._reclaimable_share` / `cmd_tokenmaxx` `reclaimable` (different surfaces: DowngradeFinding / context-diagnostic)

The onboarding next-steps line already read "how much Opus/Fable went to Sonnet-shaped sessions" — consistent with the new framing, so no change needed.

## Tests / Verification
- Renamed `test_percent_quota_misallocated_*`; updated field/key assertions across `test_opus_quota_audit.py`, `test_quota_audit_serve.py`.
- Added per-persona CLI tests: subscription sees the habit nudge (no dollars); api sees the already-billed dollar counterfactual (no nudge). Both assert the headline says "went to Sonnet-shaped sessions" and never "reclaimable".
- **Parity:** `tests/integration/test_data_access_parity.py::test_quota_audit_parity` passes, and is strengthened to assert the new key is present and the deprecated alias mirrors it byte-for-byte.
- JSON / serve tests assert both the new key and the deprecated alias are emitted with the same value.
- `make test` (2367 passed, 1 skipped e2e), `make lint` (ruff clean), `make typecheck` (mypy clean, 191 files).

🤖 shipped by [shiploop](https://github.com/anshss/shiploop)