### PR TITLE
Quota-audit tier/segment/vocabulary overhaul + ingest UX & 11× backfill (bundles 5 PRs)

### DIFF
--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -129,7 +129,7 @@ Key flags: `--session`, `--last` (default when `--session` is omitted), `--json`
 
 ### `tj quota-audit`
 
-Retroactive audit of your premium (Opus/Fable) quota: which past premium-tier sessions were structurally Sonnet-shaped (small input/output, few tool calls)? Covers Fable (the tier above Opus) as well as Opus. Reports the percent of premium quota reclaimable, example sessions to spot-check, and an optional tuned routing-config export. Quota-share framing, never a dollar "saving" claim. Needs a direct DB connection (can't run against a live `tj serve`).
+Retroactive audit of your premium (Opus/Fable) quota: which past premium-tier sessions were structurally Sonnet-shaped (small input/output, few tool calls)? Covers Fable (the tier above Opus) as well as Opus. Reports the percent of premium quota that went to Sonnet-shaped sessions (a retrospective behaviour mirror — those tokens are already spent, so it is misallocated, not "reclaimable"), example sessions to spot-check, and an optional tuned routing-config export. Subscription users see a habit nudge; API-billed users additionally see the already-billed dollar counterfactual. Quota-share framing, never a dollar "saving" claim. The JSON field is `percent_quota_misallocated` (the pre-0.6 `percent_quota_reclaimable` key is still emitted as a deprecated alias for one release). Needs a direct DB connection (can't run against a live `tj serve`).
 
 ```bash
 tj quota-audit

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -129,7 +129,7 @@ Key flags: `--session`, `--last` (default when `--session` is omitted), `--json`
 
 ### `tj quota-audit`
 
-Retroactive audit of your Opus quota: which past Opus sessions were structurally Sonnet-shaped (small input/output, few tool calls)? Reports the percent of Opus quota reclaimable, example sessions to spot-check, and an optional tuned routing-config export. Quota-share framing, never a dollar "saving" claim. Needs a direct DB connection (can't run against a live `tj serve`).
+Retroactive audit of your premium (Opus/Fable) quota: which past premium-tier sessions were structurally Sonnet-shaped (small input/output, few tool calls)? Covers Fable (the tier above Opus) as well as Opus. Reports the percent of premium quota reclaimable, example sessions to spot-check, and an optional tuned routing-config export. Quota-share framing, never a dollar "saving" claim. Needs a direct DB connection (can't run against a live `tj serve`).
 
 ```bash
 tj quota-audit

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,10 @@ classifiers = [
 ]
 
 dependencies = [
-    "click>=8.1",
+    # >=8.2: CliRunner separately captures stdout/stderr by default from this
+    # version on (result.stdout / result.stderr always populated); tests that
+    # assert stdout stays clean of stderr-routed output rely on this.
+    "click>=8.2",
     "rich>=13.0",
     "tomli>=2.0; python_version < '3.11'",
     "tomli-w>=1.0",

--- a/tests/integration/test_data_access_parity.py
+++ b/tests/integration/test_data_access_parity.py
@@ -155,9 +155,15 @@ def test_quota_audit_parity(tmp_path, monkeypatch):
     s_audit, s_framing = serve.quota_audit(since="30d", agent_id=None)
 
     # The audit round-trips fully (modulo window_days clock skew).
-    assert _normalize_audit(audit_to_dict(d_audit)) == \
+    d_payload = audit_to_dict(d_audit)
+    assert _normalize_audit(d_payload) == \
         _normalize_audit(audit_to_dict(s_audit))
     assert d_framing.to_dict() == s_framing.to_dict()
     assert d_audit.opus_sessions == 3
     assert d_framing.pricing_mode == "subscription"
+    # The renamed headline key is present on both paths, and the deprecated
+    # 0.5.4 alias mirrors it byte-for-byte (so parity holds while it lives).
+    assert "percent_quota_misallocated" in d_payload
+    assert d_payload["percent_quota_reclaimable"] == \
+        d_payload["percent_quota_misallocated"]
     db.close()

--- a/tests/integration/test_quota_audit_serve.py
+++ b/tests/integration/test_quota_audit_serve.py
@@ -90,10 +90,13 @@ async def test_quota_audit_endpoint_computes_audit_server_side(tmp_path):
 
     assert resp.status_code == 200
     payload = resp.json()
-    # Three Opus sessions, all Sonnet-shaped → fully reclaimable.
+    # Three Opus sessions, all Sonnet-shaped → the whole premium quota went to
+    # Sonnet-shaped work.
     assert payload["opus_sessions"] == 3
     assert payload["candidate_sessions"] == 3
-    assert payload["percent_quota_reclaimable"] > 0
+    assert payload["percent_quota_misallocated"] > 0
+    # DEPRECATED alias still rides through the serve payload (0.5.4 compat).
+    assert payload["percent_quota_reclaimable"] == payload["percent_quota_misallocated"]
     # The mandatory honesty caveat rides through the payload.
     assert "spot-check" in payload["caveat"].lower()
     # Framing block present + subscription (max_5x budget).

--- a/tests/integration/test_quota_audit_serve.py
+++ b/tests/integration/test_quota_audit_serve.py
@@ -44,8 +44,9 @@ _STOP_DAEMON_ERROR = "direct database connection"
 def _seed(db) -> None:
     """Opus sessions whose spans are Sonnet-shaped (small in/out, no tools).
 
-    `claude-opus-4-7` has a known cheaper alternative, so `_is_opus` flags these
-    sessions; the small token shape makes them reclaim candidates. This is
+    `claude-opus-4-7` is premium-tier with a known cheaper alternative, so the
+    shared tier predicate flags these sessions; the small token shape makes them
+    reclaim candidates. This is
     exactly the per-session token/model aggregation the shim can't serve — the
     data path the endpoint has to cover.
     """
@@ -148,7 +149,7 @@ def test_quota_audit_cli_renders_through_serve(tmp_path, monkeypatch):
     # The old refuse-to-run error must be gone…
     assert _STOP_DAEMON_ERROR not in result.output
     # …and the audit must actually render.
-    assert "Opus quota audit" in result.output
+    assert "Premium quota audit" in result.output
     db.close()
 
 

--- a/tests/integration/test_storage_backend_parity.py
+++ b/tests/integration/test_storage_backend_parity.py
@@ -101,6 +101,7 @@ SHIM_KNOWN_GAPS = {
 # implementing one, ``test_unimplemented_methods_have_no_silent_shim`` fails so
 # the new method cannot land without parity coverage or an explicit gap entry.
 SHIM_NOT_IMPLEMENTED = {
+    "bulk_insert_spans",
     "close_session_by_id",
     "close_sessions_by_instance",
     "count_traces",

--- a/tests/unit/test_backfill.py
+++ b/tests/unit/test_backfill.py
@@ -1448,6 +1448,34 @@ def test_bulk_batch_flush_boundary_matches_single_flush(tmp_path, monkeypatch):
         chunked.close()
 
 
+def test_bulk_progress_counts_increase_monotonically(tmp_path):
+    """Regression: in the bulk path the progress callback must observe
+    `spans_ingested` climbing per session — not sit at flat zero until a single
+    end-of-run flush, which would make a live backfill display (onboard) show 0
+    the whole run then jump. Uses the DEFAULT (large) flush target so every
+    insert is deferred to ONE flush at the end — the exact scenario that exposed
+    the bug — and asserts the callback still saw increasing counts."""
+    _multi_session_tree(tmp_path, n_sessions=6)  # 6 sessions × 2 spans each
+
+    observed: list[int] = []
+
+    def _capture(parsed, result):
+        observed.append(result.spans_ingested)
+
+    db = InMemoryBackend()
+    try:
+        ingest_claude_code(db, root=tmp_path, progress=_capture)
+        # One callback per session; counts advance 2 per session (LLM + tool),
+        # never flat-zero-then-jump.
+        assert observed == [2, 4, 6, 8, 10, 12]
+        assert observed[0] > 0
+        assert all(b > a for a, b in zip(observed, observed[1:]))
+        # And the spans really did land (deferred flush committed at the end).
+        assert db.conn.execute("SELECT COUNT(*) FROM spans").fetchone()[0] == 12
+    finally:
+        db.close()
+
+
 def test_bulk_batch_is_idempotent_across_flush_boundary(tmp_path, monkeypatch):
     """Re-running the backfill with a tiny flush target inserts nothing new and
     leaves the spans unchanged — idempotency holds across batch boundaries."""

--- a/tests/unit/test_backfill.py
+++ b/tests/unit/test_backfill.py
@@ -1382,3 +1382,88 @@ def test_reconcile_never_touches_other_sessions_or_sources(tmp_path):
         ).fetchone()[0] == 1
     finally:
         db.close()
+
+
+# --- columnar bulk-append batching: parity across the flush boundary --------- #
+
+def _multi_session_tree(tmp_path, n_sessions: int = 6) -> None:
+    """A handful of small sessions, each with an LLM turn + a tool_use — enough
+    that a small flush target forces several batch flushes."""
+    for i in range(n_sessions):
+        sid = f"batch-sess-{i:02d}"
+        _make_session_file(
+            tmp_path, session_id=sid, cwd="/Users/me/proj",
+            records=[_assistant_record(
+                f"m-{i}", "claude-opus-4-7", 1000 + i, 200 + i,
+                "2026-04-01T10:00:00.000Z", sid, "/Users/me/proj",
+                tool_uses=[(f"tu-{i}", "Read")], cache_read=i, cache_creation=2 * i,
+            )],
+        )
+
+
+def _dump_spans(db) -> list[tuple]:
+    return db.conn.execute(
+        "SELECT span_id, session_id, name, input_tokens, output_tokens, "
+        "cache_tokens, cache_write_tokens, cost_usd, tool_name "
+        "FROM spans ORDER BY span_id"
+    ).fetchall()
+
+
+def _dump_sessions(db) -> list[tuple]:
+    return db.conn.execute(
+        "SELECT session_id, input_tokens, output_tokens, cache_tokens, "
+        "cache_write_tokens, total_cost_usd, tool_call_count "
+        "FROM sessions ORDER BY session_id"
+    ).fetchall()
+
+
+def test_bulk_batch_flush_boundary_matches_single_flush(tmp_path, monkeypatch):
+    """A tiny flush target (multiple batch flushes, sessions split across
+    boundaries) must produce byte-for-byte the same spans + session rows as a
+    single-flush ingest — the whole point of set-based batching is that where the
+    flush boundary lands is invisible in the result."""
+    import tokenjam.core.backfill as bf
+
+    _multi_session_tree(tmp_path, n_sessions=6)
+
+    # Reference: one big batch (target far above the total span count).
+    ref = InMemoryBackend()
+    # Forced multi-flush: target of 1 span flushes essentially per session.
+    chunked = InMemoryBackend()
+    try:
+        monkeypatch.setattr(bf, "_BULK_FLUSH_SPAN_TARGET", 10_000)
+        r_ref = ingest_claude_code(ref, root=tmp_path)
+
+        monkeypatch.setattr(bf, "_BULK_FLUSH_SPAN_TARGET", 1)
+        r_chunked = ingest_claude_code(chunked, root=tmp_path)
+
+        assert _dump_spans(chunked) == _dump_spans(ref)
+        assert _dump_sessions(chunked) == _dump_sessions(ref)
+        # Reported counts agree too (6 sessions × 2 spans each).
+        assert r_chunked.spans_ingested == r_ref.spans_ingested == 12
+        assert r_chunked.sessions_ingested == r_ref.sessions_ingested == 6
+        assert r_chunked.sessions_new == r_ref.sessions_new == 6
+    finally:
+        ref.close()
+        chunked.close()
+
+
+def test_bulk_batch_is_idempotent_across_flush_boundary(tmp_path, monkeypatch):
+    """Re-running the backfill with a tiny flush target inserts nothing new and
+    leaves the spans unchanged — idempotency holds across batch boundaries."""
+    import tokenjam.core.backfill as bf
+
+    _multi_session_tree(tmp_path, n_sessions=5)
+    db = InMemoryBackend()
+    try:
+        monkeypatch.setattr(bf, "_BULK_FLUSH_SPAN_TARGET", 3)
+        r1 = ingest_claude_code(db, root=tmp_path)
+        before = _dump_spans(db)
+
+        r2 = ingest_claude_code(db, root=tmp_path)
+        assert r1.spans_ingested == 10          # 5 sessions × 2 spans
+        assert r2.spans_ingested == 0
+        assert r2.spans_skipped_existing == 10
+        assert _dump_spans(db) == before        # untouched
+    finally:
+        db.close()

--- a/tests/unit/test_bulk_insert_spans.py
+++ b/tests/unit/test_bulk_insert_spans.py
@@ -1,0 +1,104 @@
+"""Parity + idempotency tests for `DuckDBBackend.bulk_insert_spans`.
+
+The columnar bulk-append (newline-delimited JSON + DuckDB `read_json`) is the
+backfill hot path — it must land rows byte-for-byte identical to the per-row
+`insert_span`, and must be idempotent (skip span_ids already present).
+"""
+from __future__ import annotations
+
+import dataclasses
+import json
+
+from tokenjam.core.db import InMemoryBackend
+from tokenjam.core.models import NormalizedSpan
+
+from tests.factories import make_llm_span, make_tool_span
+
+# The columns we compare; JSON columns are pulled as text and re-parsed so the
+# comparison is on semantic JSON, not DuckDB's internal whitespace.
+_COMPARE_SQL = (
+    "SELECT span_id, trace_id, parent_span_id, session_id, agent_id, name, kind, "
+    "status_code, status_message, start_time, end_time, duration_ms, "
+    "attributes::VARCHAR, provider, model, tool_name, input_tokens, output_tokens, "
+    "cache_tokens, cost_usd, request_type, conversation_id, events::VARCHAR, "
+    "billing_account, cache_write_tokens, request_params::VARCHAR, "
+    "request_tools::VARCHAR, sub_agent_id "
+    "FROM spans ORDER BY span_id"
+)
+_JSON_COL_IDX = (12, 22, 25, 26)  # attributes, events, request_params, request_tools
+
+
+def _snapshot(db) -> list[tuple]:
+    rows = db.conn.execute(_COMPARE_SQL).fetchall()
+    normalized = []
+    for row in rows:
+        row = list(row)
+        for i in _JSON_COL_IDX:
+            row[i] = json.loads(row[i]) if row[i] is not None else None
+        normalized.append(tuple(row))
+    return normalized
+
+
+def _sample_spans() -> list[NormalizedSpan]:
+    llm = make_llm_span(
+        span_id="s-1", session_id="sess", conversation_id="sess",
+        input_tokens=1000, output_tokens=200, cache_tokens=42, cost_usd=0.0123456789,
+        model="claude-opus-4-7",
+        extra_attributes={"source": "backfill.claude_code",
+                          "gen_ai.prompt.content": "unicode: héllo 世界 \" \\ /",
+                          "nested": {"a": [1, 2, {"b": True}]}},
+    )
+    tool = dataclasses.replace(
+        make_tool_span(session_id="sess", conversation_id="sess", tool_name="Read",
+                       tool_input={"file_path": "/etc/x", "深": "value"}),
+        span_id="s-2", parent_span_id="s-1",
+    )
+    # A span exercising request_params/request_tools + NULL end_time/duration_ms.
+    rich = dataclasses.replace(
+        llm, span_id="s-3", parent_span_id="s-1", sub_agent_id="ag-9",
+        end_time=None, duration_ms=None,
+        request_params={"temperature": 0.7, "stop": ["\n", "END"]},
+        request_tools={"tools": [{"name": "Read"}, {"name": "Edit"}]},
+    )
+    return [llm, tool, rich]
+
+
+def test_bulk_insert_matches_per_row_insert_span():
+    spans = _sample_spans()
+
+    ref = InMemoryBackend()
+    bulk = InMemoryBackend()
+    try:
+        for span in spans:
+            ref.insert_span(span)
+        bulk.bulk_insert_spans(spans)
+        assert _snapshot(bulk) == _snapshot(ref)
+    finally:
+        ref.close()
+        bulk.close()
+
+
+def test_bulk_insert_is_idempotent_on_span_id():
+    spans = _sample_spans()
+    db = InMemoryBackend()
+    try:
+        db.bulk_insert_spans(spans)
+        first = _snapshot(db)
+        # Re-appending the same spans (plus a fresh one) inserts only the new id;
+        # the existing three are skipped by the anti-join, not duplicated.
+        extra = dataclasses.replace(spans[0], span_id="s-4")
+        db.bulk_insert_spans([*spans, extra])
+        assert db.conn.execute("SELECT COUNT(*) FROM spans").fetchone()[0] == 4
+        # The originally-inserted rows are unchanged.
+        assert _snapshot(db)[:3] == first
+    finally:
+        db.close()
+
+
+def test_bulk_insert_empty_is_noop():
+    db = InMemoryBackend()
+    try:
+        db.bulk_insert_spans([])
+        assert db.conn.execute("SELECT COUNT(*) FROM spans").fetchone()[0] == 0
+    finally:
+        db.close()

--- a/tests/unit/test_context_diagnostic.py
+++ b/tests/unit/test_context_diagnostic.py
@@ -636,3 +636,45 @@ def test_subagent_accounting_fields_in_json_payload(db):
     assert payload["delegating_sessions"] == 1
     assert payload["unaccounted_subagent_sessions"] == ["sess-blind"]
     assert payload["subagent_accounting_partial"] is True
+
+
+def test_attach_tool_activity_does_not_truncate_on_null_start_time():
+    """A turn with a missing start_time must be treated as earliest (consistent
+    with the sort key), NOT truncate attribution: a later, genuinely-preceding
+    turn still receives the tool span. A `break` on the null turn would drop
+    every real turn after it and mis-attribute the tool to the null turn."""
+    from tokenjam.core.context_diagnostic import (
+        TurnComposition,
+        _attach_tool_activity,
+    )
+    from tokenjam.utils.time_parse import utcnow
+
+    t0 = utcnow()
+
+    def _turn_comp(start_time):
+        return TurnComposition(
+            session_id="s", sub_agent_id=None, model="claude-opus-4-8",
+            reread_tokens=0, new_input_tokens=100, output_tokens=50,
+            cache_write_tokens=0, cost_usd=0.0, start_time=start_time,
+        )
+
+    null_turn = _turn_comp(None)
+    real_turn = _turn_comp(t0)
+
+    class _FakeConn:
+        def execute(self, _sql, _params):
+            # One Read tool span AFTER the real turn (and after any turn).
+            self._rows = [("s", "Read", t0 + timedelta(seconds=5))]
+            return self
+
+        def fetchall(self):
+            return self._rows
+
+    _attach_tool_activity(
+        _FakeConn(), t0 - timedelta(days=1), t0 + timedelta(days=1), None,
+        [null_turn, real_turn],
+    )
+
+    # The tool span attributes to the real preceding turn, not the null turn.
+    assert real_turn.tool_fanout == 1
+    assert null_turn.tool_fanout == 0

--- a/tests/unit/test_model_tiers.py
+++ b/tests/unit/test_model_tiers.py
@@ -1,0 +1,56 @@
+"""Unit tests for the shared model-family tier predicate.
+
+This is the single source of truth for "which model families are premium"
+consumed by the downsize / quota-audit / subagent right-sizing analyzers, so it
+must classify Fable (the tier ABOVE Opus) as premium and tolerate the id shapes
+that show up in real telemetry (dates, `[1m]` tags, Bedrock prefixes).
+"""
+from __future__ import annotations
+
+import pytest
+
+from tokenjam.core.model_tiers import (
+    PREMIUM_TIERS,
+    is_premium_tier,
+    model_tier,
+)
+
+
+@pytest.mark.parametrize(
+    "model, tier",
+    [
+        ("claude-fable-5", "fable"),
+        ("claude-opus-4-8", "opus"),
+        ("claude-opus-4-7", "opus"),
+        ("claude-opus-4", "opus"),
+        ("claude-sonnet-4-6", "sonnet"),
+        ("claude-sonnet-5", "sonnet"),
+        ("claude-haiku-4-5", "haiku"),
+        # Tolerate dates, [1m] context tags, and Bedrock provider prefixes.
+        ("claude-opus-4-8-20260115", "opus"),
+        ("claude-opus-4-8[1m]", "opus"),
+        ("claude-fable-5[1m]", "fable"),
+        ("us-anthropic-claude-opus-4-1-20250805-v1", "opus"),
+        ("global-anthropic-claude-opus-4-5-20251101-v1", "opus"),
+    ],
+)
+def test_model_tier_classifies_known_families(model, tier):
+    assert model_tier(model) == tier
+
+
+@pytest.mark.parametrize("model", ["gpt-4o", "gemini-2-5-pro", "unknown", "", None])
+def test_model_tier_none_for_unrecognised(model):
+    assert model_tier(model) is None
+
+
+def test_fable_and_opus_are_premium():
+    assert is_premium_tier("claude-fable-5")
+    assert is_premium_tier("claude-opus-4-8")
+    assert {"fable", "opus"} <= PREMIUM_TIERS
+
+
+def test_sonnet_and_haiku_are_not_premium():
+    assert not is_premium_tier("claude-sonnet-4-6")
+    assert not is_premium_tier("claude-haiku-4-5")
+    assert not is_premium_tier("gpt-4o")
+    assert not is_premium_tier(None)

--- a/tests/unit/test_optimize.py
+++ b/tests/unit/test_optimize.py
@@ -248,6 +248,26 @@ def test_cycle_bounds_before_start_day_uses_prior_month():
     assert ce.month == 5 and ce.day == 15
 
 
+def test_lookup_downgrade_normalizes_context_tag_and_bedrock():
+    """`_lookup_downgrade` must resolve the same id shapes `is_premium_tier`
+    accepts — [1m] context tags and Bedrock region/provider prefixes — or the
+    audit silently drops premium sessions the subagent analyzer flags."""
+    from tokenjam.core.optimize.analyzers.model_downgrade import _lookup_downgrade
+
+    # [1m] context tag (1M-context variant) resolves to the base model's alt.
+    assert _lookup_downgrade("anthropic", "claude-fable-5[1m]") == "claude-sonnet-4-6"
+    assert _lookup_downgrade("anthropic", "claude-opus-4-8[1m]") == "claude-haiku-4-5"
+    # Trailing date still works (regression guard).
+    assert _lookup_downgrade("anthropic", "claude-opus-4-8-20260115") == "claude-haiku-4-5"
+    # Bedrock-hosted Claude: region/provider prefix + version suffix, provider
+    # arrives as a bedrock alias — resolves via the base Anthropic model.
+    assert _lookup_downgrade(
+        "aws.bedrock", "us-anthropic-claude-opus-4-8-20260115-v1"
+    ) == "claude-haiku-4-5"
+    # Unrecognised model still returns None (no invented alt).
+    assert _lookup_downgrade("anthropic", "gpt-4o") is None
+
+
 def test_downgrade_candidates_have_pricing_for_alternative():
     # Sanity check: every alternative model is in the pricing table.
     from tokenjam.core.pricing import get_rates

--- a/tests/unit/test_optimize.py
+++ b/tests/unit/test_optimize.py
@@ -117,6 +117,32 @@ def test_downgrade_flags_small_opus_but_not_large(db):
     assert finding.caveat == MODEL_DOWNGRADE_CAVEAT
 
 
+def test_downgrade_proposes_candidates_for_fable_and_opus_4_8(db):
+    """The downsize analyzer must route Fable (tier above Opus) and Opus 4.8 —
+    both previously missing from DOWNGRADE_CANDIDATES — to a cheaper same-family
+    model when the session is structurally small."""
+    start = utcnow() - timedelta(days=2)
+    db.insert_span(make_llm_span(
+        model="claude-fable-5", provider="anthropic",
+        input_tokens=1_000, output_tokens=200, cost_usd=0.10,
+        session_id="fable-s", start_time=start,
+    ))
+    db.insert_span(make_llm_span(
+        model="claude-opus-4-8", provider="anthropic",
+        input_tokens=1_000, output_tokens=200, cost_usd=0.05,
+        session_id="opus48-s", start_time=start,
+    ))
+    since = utcnow() - timedelta(days=30)
+    until = utcnow() + timedelta(hours=1)
+    finding = analyze_model_downgrade(
+        db.conn, since, until, agent_id=None, window_days=30.0,
+    )
+    assert finding is not None
+    assert finding.candidate_sessions == 2
+    assert finding.suggestions.get("claude-fable-5") == "claude-sonnet-4-6"
+    assert finding.suggestions.get("claude-opus-4-8") == "claude-haiku-4-5"
+
+
 def test_downgrade_returns_none_when_no_candidates(db):
     _insert_large_opus_session(db, session_id="b")
     since = utcnow() - timedelta(days=30)

--- a/tests/unit/test_optimize_subagent.py
+++ b/tests/unit/test_optimize_subagent.py
@@ -74,6 +74,30 @@ def test_flags_over_powered_and_over_provisioned_subagents():
         db.close()
 
 
+def test_flags_over_powered_fable_subagent():
+    """A Fable-powered subagent (the tier above Opus) doing trivial work must be
+    flagged over_powered — before the shared predicate, only "opus" matched, so
+    Fable spawns were invisible to right-sizing."""
+    db = InMemoryBackend()
+    try:
+        ctx, now = _ctx(db, window_cost_usd=2.0)
+        # Fable subagent: premium model, tiny output, few tools -> over_powered.
+        db.insert_span(make_llm_span(
+            model="claude-fable-5", input_tokens=4_000, output_tokens=150,
+            cost_usd=0.40, session_id="s1", sub_agent_id="fableA", start_time=now,
+        ))
+        run_subagent(ctx)
+        f = ctx.report.findings["subagent"]
+
+        assert len(f.flagged) == 1
+        a = f.flagged[0]
+        assert a.sub_agent_id == "fableA"
+        assert a.model == "claude-fable-5"
+        assert "over_powered" in a.flags
+    finally:
+        db.close()
+
+
 def test_no_finding_when_no_subagents():
     db = InMemoryBackend()
     try:

--- a/tests/unit/test_opus_quota_audit.py
+++ b/tests/unit/test_opus_quota_audit.py
@@ -1,7 +1,7 @@
 """Unit tests for the retroactive Opus quota audit (`tj quota-audit`, issue #5).
 
 Exercises the audit over a SYNTHETIC mix of Opus sessions proving:
-  * "% of Opus quota reclaimable" is computed as candidate-Opus-tokens over
+  * "% of premium quota misallocated" is computed as candidate-Opus-tokens over
     total-Opus-tokens (only Sonnet-shaped Opus sessions count);
   * Opus-shaped Opus sessions (big input/output, many tool calls) are NOT
     flagged, and non-Opus sessions are excluded from the denominator;
@@ -10,6 +10,7 @@ Exercises the audit over a SYNTHETIC mix of Opus sessions proving:
 """
 from __future__ import annotations
 
+import re
 from datetime import timedelta
 
 import pytest
@@ -44,10 +45,18 @@ def _max_config() -> TjConfig:
     )
 
 
+def _api_config() -> TjConfig:
+    """Config declaring an API plan so framing renders the dollar counterfactual."""
+    return TjConfig(
+        version="1",
+        budgets={"anthropic": ProviderBudget(plan="api")},
+    )
+
+
 def _add_session(db, session_id, *, model, input_tokens, output_tokens,
-                 cache_tokens=0, cost_usd=1.0, tool_calls=0):
+                 cache_tokens=0, cost_usd=1.0, tool_calls=0, plan_tier="max_5x"):
     """Seed one session: an LLM span plus N tool spans."""
-    sess = make_session(session_id=session_id, plan_tier="max_5x",
+    sess = make_session(session_id=session_id, plan_tier=plan_tier,
                         duration_seconds=60.0)
     db.upsert_session(sess)
     span = make_llm_span(
@@ -67,34 +76,37 @@ def _add_session(db, session_id, *, model, input_tokens, output_tokens,
         db.insert_span(tool)
 
 
-def _seed_mix(db) -> None:
+def _seed_mix(db, *, plan_tier="max_5x") -> None:
     """A mix of Opus + Sonnet sessions:
 
       * opus-thin-1 / opus-thin-2 — Opus, Sonnet-shaped (small in/out, ≤5 tools)
-        → quota-reclaim candidates.
+        → misallocation candidates.
       * opus-fat — Opus, genuinely Opus-shaped (big in/out, many tools) → NOT a
         candidate, but still in the Opus quota denominator.
       * sonnet-1 — already on Sonnet → excluded from the audit entirely (the
         audit only inspects Opus sessions).
+
+    ``plan_tier`` stamps every seeded session so the framing path resolves the
+    intended pricing mode (max_5x → subscription, api → api).
     """
     # 100k Opus tokens each, Sonnet-shaped → candidates.
     _add_session(db, "opus-thin-1", model="claude-opus-4-7",
                  input_tokens=2_000, output_tokens=300, cache_tokens=97_700,
-                 cost_usd=3.0, tool_calls=2)
+                 cost_usd=3.0, tool_calls=2, plan_tier=plan_tier)
     _add_session(db, "opus-thin-2", model="claude-opus-4-6",
                  input_tokens=1_000, output_tokens=200, cache_tokens=98_800,
-                 cost_usd=3.0, tool_calls=1)
+                 cost_usd=3.0, tool_calls=1, plan_tier=plan_tier)
     # 100k Opus tokens, Opus-shaped → in denominator, NOT a candidate.
     _add_session(db, "opus-fat", model="claude-opus-4-7",
                  input_tokens=40_000, output_tokens=20_000, cache_tokens=40_000,
-                 cost_usd=8.0, tool_calls=30)
+                 cost_usd=8.0, tool_calls=30, plan_tier=plan_tier)
     # Sonnet session → excluded from the audit (not Opus).
     _add_session(db, "sonnet-1", model="claude-sonnet-4-6",
                  input_tokens=2_000, output_tokens=300, cache_tokens=50_000,
-                 cost_usd=0.5, tool_calls=1)
+                 cost_usd=0.5, tool_calls=1, plan_tier=plan_tier)
 
 
-def test_percent_quota_reclaimable_counts_only_sonnet_shaped_opus(db):
+def test_percent_quota_misallocated_counts_only_sonnet_shaped_opus(db):
     _seed_mix(db)
     audit = audit_opus_quota(db.conn, SINCE, UNTIL, agent_id=None, window_days=30.0)
 
@@ -105,7 +117,7 @@ def test_percent_quota_reclaimable_counts_only_sonnet_shaped_opus(db):
     assert audit.candidate_sessions == 2
     assert audit.candidate_tokens == 200_000  # 2 × 100k
     # Headline: candidate Opus tokens / total Opus tokens.
-    assert audit.percent_quota_reclaimable == pytest.approx(66.7, abs=0.1)
+    assert audit.percent_quota_misallocated == pytest.approx(66.7, abs=0.1)
     assert audit.percent_sessions == pytest.approx(66.7, abs=0.1)
 
 
@@ -172,11 +184,12 @@ def test_no_opus_sessions_is_clean_empty_state(db):
     audit = audit_opus_quota(db.conn, SINCE, UNTIL, agent_id=None, window_days=30.0)
     assert not audit.has_opus
     assert audit.opus_sessions == 0
-    assert audit.percent_quota_reclaimable == 0.0
+    assert audit.percent_quota_misallocated == 0.0
 
 
 def test_cli_renders_quota_audit_with_caveat(db, monkeypatch):
-    """End-to-end: the card reports % of Opus quota reclaimable, lists the
+    """End-to-end: the card reports the % of premium quota that WENT to
+    Sonnet-shaped sessions (misallocated, not "reclaimable"), lists the
     spot-check sessions, and surfaces the honesty caveat — in quota (not dollar)
     language for a subscription (Max) plan."""
     _seed_mix(db)
@@ -196,16 +209,56 @@ def test_cli_renders_quota_audit_with_caveat(db, monkeypatch):
     )
     assert result.exit_code == 0, result.output
     out = result.output
-    # Quota framing headline (not dollars) — names both premium tiers.
-    assert "quota is reclaimable" in out
+    # Rich wraps panel text across lines and draws box borders between them;
+    # strip the border glyphs and collapse whitespace before matching multi-word
+    # phrases so a wrap between two words doesn't fail the assertion.
+    flat = " ".join(re.sub(r"[│╭╮╰╯─]", " ", out).split())
+    # Retrospective mirror headline (not dollars) — names both premium tiers and
+    # never says "reclaimable" (the tokens are already spent).
+    assert "went to Sonnet-shaped sessions" in flat
+    assert "reclaimable" not in flat.lower()
     assert "Opus/Fable" in out
     assert "67%" in out or "66" in out
+    # Subscription users get the habit nudge, not dollars.
+    assert "stays available for hard problems next window" in flat
+    assert "/model sonnet" in flat
     # Spot-check sessions listed.
     assert "spot-check" in out.lower()
     assert "opus-thin-1" in out
     # Honesty caveat present (the load-bearing honesty discipline).
     assert "spot-check" in OPUS_QUOTA_AUDIT_CAVEAT.lower()
     assert "Never \"safe to downgrade.\"" in out or "safe to downgrade" in out
+
+
+def test_cli_api_persona_shows_dollar_counterfactual(db, monkeypatch):
+    """API-billed users get the already-billed dollar counterfactual under the
+    measured headline instead of the subscription habit nudge."""
+    _seed_mix(db, plan_tier="api")
+    config = _api_config()
+
+    import tokenjam.cli.main as cli_main
+
+    monkeypatch.setattr(cli_main, "load_config", lambda *a, **k: config)
+    monkeypatch.setattr(cli_main, "open_db", lambda *a, **k: db)
+    monkeypatch.setattr(
+        "tokenjam.core.framing.config_declared_plan", lambda c: "api"
+    )
+
+    runner = CliRunner()
+    result = runner.invoke(
+        cli_main.cli, ["quota-audit", "--since", "30d"], catch_exceptions=False
+    )
+    assert result.exit_code == 0, result.output
+    out = result.output
+    flat = " ".join(re.sub(r"[│╭╮╰╯─]", " ", out).split())
+    # Same measured mirror headline for everyone.
+    assert "went to Sonnet-shaped sessions" in flat
+    assert "reclaimable" not in flat.lower()
+    # API persona: retrospective, already-billed counterfactual — NOT the
+    # subscription habit nudge.
+    assert "Same work at the suggested tiers" in flat
+    assert "already billed" in flat
+    assert "stays available for hard problems" not in flat
 
 
 def test_cli_json_output_has_quota_fields(db, monkeypatch):
@@ -228,6 +281,8 @@ def test_cli_json_output_has_quota_fields(db, monkeypatch):
     )
     assert result.exit_code == 0, result.output
     payload = json.loads(result.output)
+    assert payload["percent_quota_misallocated"] == pytest.approx(66.7, abs=0.1)
+    # DEPRECATED alias still emitted (shipped in 0.5.4) — same value, one release.
     assert payload["percent_quota_reclaimable"] == pytest.approx(66.7, abs=0.1)
     assert payload["candidate_sessions"] == 2
     assert len(payload["examples"]) == 2

--- a/tests/unit/test_opus_quota_audit.py
+++ b/tests/unit/test_opus_quota_audit.py
@@ -133,6 +133,38 @@ def test_example_sessions_surfaced_for_spot_check(db):
     assert "claude-opus-4-6" in audit.suggestions
 
 
+def test_fable_and_opus_4_8_sessions_are_audited(db):
+    """Fable (the tier above Opus) and Opus 4.8 must both be counted in the
+    premium denominator and flagged as reclaim candidates when Sonnet-shaped —
+    the whole point of routing tier membership through the shared predicate."""
+    # Fable, Sonnet-shaped → candidate; suggested alt is a cheaper same-family model.
+    _add_session(db, "fable-thin", model="claude-fable-5",
+                 input_tokens=1_500, output_tokens=250, cache_tokens=98_250,
+                 cost_usd=5.0, tool_calls=2)
+    # Opus 4.8, Sonnet-shaped → candidate (4.8 was missing from the map before).
+    _add_session(db, "opus48-thin", model="claude-opus-4-8",
+                 input_tokens=1_000, output_tokens=200, cache_tokens=98_800,
+                 cost_usd=3.0, tool_calls=1)
+    # Fable, genuinely large-shape → in denominator, NOT a candidate.
+    _add_session(db, "fable-fat", model="claude-fable-5",
+                 input_tokens=40_000, output_tokens=20_000, cache_tokens=40_000,
+                 cost_usd=12.0, tool_calls=30)
+
+    audit = audit_opus_quota(db.conn, SINCE, UNTIL, agent_id=None, window_days=30.0)
+
+    # All three premium sessions counted (Fable is premium, above Opus).
+    assert audit.opus_sessions == 3
+    assert audit.opus_tokens == 300_000
+    # The two Sonnet-shaped premium sessions are reclaim candidates.
+    assert audit.candidate_sessions == 2
+    assert {ex.session_id for ex in audit.examples} == {"fable-thin", "opus48-thin"}
+    # Each flagged premium session names a concrete cheaper routing target.
+    assert audit.suggestions["claude-fable-5"]
+    assert audit.suggestions["claude-opus-4-8"]
+    for ex in audit.examples:
+        assert ex.alt_model
+
+
 def test_no_opus_sessions_is_clean_empty_state(db):
     # Only a Sonnet session — nothing for the Opus audit to inspect.
     _add_session(db, "sonnet-only", model="claude-sonnet-4-6",
@@ -164,8 +196,9 @@ def test_cli_renders_quota_audit_with_caveat(db, monkeypatch):
     )
     assert result.exit_code == 0, result.output
     out = result.output
-    # Quota framing headline (not dollars).
-    assert "Opus quota is reclaimable" in out
+    # Quota framing headline (not dollars) — names both premium tiers.
+    assert "quota is reclaimable" in out
+    assert "Opus/Fable" in out
     assert "67%" in out or "66" in out
     # Spot-check sessions listed.
     assert "spot-check" in out.lower()

--- a/tests/unit/test_opus_quota_audit.py
+++ b/tests/unit/test_opus_quota_audit.py
@@ -165,6 +165,32 @@ def test_fable_and_opus_4_8_sessions_are_audited(db):
         assert ex.alt_model
 
 
+def test_context_tagged_and_bedrock_premium_sessions_are_audited(db):
+    """A premium session must be counted + flagged regardless of id SHAPE — a
+    [1m] context tag or a Bedrock region/provider prefix must not make it vanish
+    from the audit (it's still flagged by the subagent analyzer, so dropping it
+    here is a silent inconsistency)."""
+    # 1M-context Fable, Sonnet-shaped → candidate.
+    _add_session(db, "fable-1m", model="claude-fable-5[1m]",
+                 input_tokens=1_500, output_tokens=250, cache_tokens=98_250,
+                 cost_usd=5.0, tool_calls=2)
+    # Bedrock-hosted Opus 4.8, Sonnet-shaped → candidate.
+    _add_session(db, "bedrock-opus", model="us-anthropic-claude-opus-4-8-20260115-v1",
+                 input_tokens=1_000, output_tokens=200, cache_tokens=98_800,
+                 cost_usd=3.0, tool_calls=1)
+
+    audit = audit_opus_quota(db.conn, SINCE, UNTIL, agent_id=None, window_days=30.0)
+
+    # Both counted in the premium denominator (not silently dropped).
+    assert audit.opus_sessions == 2
+    assert audit.opus_tokens == 200_000
+    # Both are reclaim candidates with a concrete suggested model.
+    assert audit.candidate_sessions == 2
+    assert {ex.session_id for ex in audit.examples} == {"fable-1m", "bedrock-opus"}
+    assert audit.suggestions["claude-fable-5[1m]"] == "claude-sonnet-4-6"
+    assert audit.suggestions["us-anthropic-claude-opus-4-8-20260115-v1"] == "claude-haiku-4-5"
+
+
 def test_no_opus_sessions_is_clean_empty_state(db):
     # Only a Sonnet session — nothing for the Opus audit to inspect.
     _add_session(db, "sonnet-only", model="claude-sonnet-4-6",

--- a/tests/unit/test_opus_quota_audit.py
+++ b/tests/unit/test_opus_quota_audit.py
@@ -1,12 +1,19 @@
-"""Unit tests for the retroactive Opus quota audit (`tj quota-audit`, issue #5).
+"""Unit tests for the segment-level premium quota audit (`tj quota-audit`, issue #5).
 
-Exercises the audit over a SYNTHETIC mix of Opus sessions proving:
-  * "% of premium quota misallocated" is computed as candidate-Opus-tokens over
-    total-Opus-tokens (only Sonnet-shaped Opus sessions count);
-  * Opus-shaped Opus sessions (big input/output, many tool calls) are NOT
-    flagged, and non-Opus sessions are excluded from the denominator;
-  * the spot-check example list surfaces the candidate sessions;
-  * the CLI renders the audit in quota terms with the honesty caveat present.
+The audit walks assistant turns per session in ``start_time`` order and reports
+ONE honest figure (founder D1): the share of premium (Opus/Fable) quota that
+went to Sonnet-shaped *work* — whole Sonnet-shaped sessions PLUS mechanical
+stretches inside otherwise-hard sessions — on exact per-turn model attribution
+(D2), as a labelled estimate with a wide bootstrap CI (D3).
+
+These pin the load-bearing behaviour:
+  * a mechanical stretch inside a hard session is flagged (the old whole-session
+    audit structurally missed it);
+  * a mixed-model session attributes tokens per actual span model, not MODE;
+  * min-stretch + contiguity + delegation gate which stretches count;
+  * the headline carries the confidence label + CI;
+  * the honesty caveat / estimate basis stay Rule-14;
+  * new fields round-trip; the CLI renders per-persona copy correctly.
 """
 from __future__ import annotations
 
@@ -16,10 +23,15 @@ from datetime import timedelta
 import pytest
 from click.testing import CliRunner
 
+import tokenjam.core.optimize.analyzers.model_downgrade as md
 from tokenjam.core.config import ProviderBudget, TjConfig
 from tokenjam.core.db import InMemoryBackend
 from tokenjam.core.optimize.analyzers.model_downgrade import audit_opus_quota
-from tokenjam.core.optimize.types import OPUS_QUOTA_AUDIT_CAVEAT
+from tokenjam.core.optimize.types import (
+    OPUS_QUOTA_AUDIT_CAVEAT,
+    audit_from_dict,
+    audit_to_dict,
+)
 from tokenjam.utils.time_parse import utcnow
 from tests.factories import make_llm_span, make_session, make_tool_span
 
@@ -39,252 +51,401 @@ def db():
 
 def _max_config() -> TjConfig:
     """Config declaring a Max-5x plan so framing renders quota-share."""
-    return TjConfig(
-        version="1",
-        budgets={"anthropic": ProviderBudget(plan="max_5x")},
-    )
+    return TjConfig(version="1", budgets={"anthropic": ProviderBudget(plan="max_5x")})
 
 
 def _api_config() -> TjConfig:
     """Config declaring an API plan so framing renders the dollar counterfactual."""
-    return TjConfig(
-        version="1",
-        budgets={"anthropic": ProviderBudget(plan="api")},
-    )
+    return TjConfig(version="1", budgets={"anthropic": ProviderBudget(plan="api")})
 
 
-def _add_session(db, session_id, *, model, input_tokens, output_tokens,
-                 cache_tokens=0, cost_usd=1.0, tool_calls=0, plan_tier="max_5x"):
-    """Seed one session: an LLM span plus N tool spans."""
-    sess = make_session(session_id=session_id, plan_tier=plan_tier,
-                        duration_seconds=60.0)
-    db.upsert_session(sess)
+def _new_session(db, session_id, *, plan_tier="max_5x") -> None:
+    db.upsert_session(make_session(session_id=session_id, plan_tier=plan_tier,
+                                   duration_seconds=600.0))
+
+
+def _turn(db, session_id, seq, *, model="claude-opus-4-7", input_tokens=500,
+          output_tokens=100, cache_tokens=0, cost_usd=1.0, tool_calls=0,
+          delegate=False) -> None:
+    """Append one assistant turn (an LLM span + optional tool/Task spans) to a
+    session, at minute ``seq`` — so turns order deterministically by start_time
+    and their tool spans attribute to the enclosing turn (nearest-preceding)."""
     span = make_llm_span(
-        model=model,
-        input_tokens=input_tokens,
-        output_tokens=output_tokens,
-        cache_tokens=cache_tokens,
-        cost_usd=cost_usd,
-        session_id=session_id,
+        model=model, input_tokens=input_tokens, output_tokens=output_tokens,
+        cache_tokens=cache_tokens, cost_usd=cost_usd, session_id=session_id,
     )
-    span.start_time = BASE
+    span.start_time = BASE + timedelta(minutes=seq)
     db.insert_span(span)
-    for _ in range(tool_calls):
+    for j in range(tool_calls):
         tool = make_tool_span(tool_name="Read")
         tool.session_id = session_id
-        tool.start_time = BASE + timedelta(seconds=1)
+        tool.start_time = BASE + timedelta(minutes=seq, seconds=1 + j)
         db.insert_span(tool)
+    if delegate:
+        task = make_tool_span(tool_name="Task")
+        task.session_id = session_id
+        task.start_time = BASE + timedelta(minutes=seq, seconds=30)
+        db.insert_span(task)
 
 
-def _seed_mix(db, *, plan_tier="max_5x") -> None:
-    """A mix of Opus + Sonnet sessions:
-
-      * opus-thin-1 / opus-thin-2 — Opus, Sonnet-shaped (small in/out, ≤5 tools)
-        → misallocation candidates.
-      * opus-fat — Opus, genuinely Opus-shaped (big in/out, many tools) → NOT a
-        candidate, but still in the Opus quota denominator.
-      * sonnet-1 — already on Sonnet → excluded from the audit entirely (the
-        audit only inspects Opus sessions).
-
-    ``plan_tier`` stamps every seeded session so the framing path resolves the
-    intended pricing mode (max_5x → subscription, api → api).
-    """
-    # 100k Opus tokens each, Sonnet-shaped → candidates.
-    _add_session(db, "opus-thin-1", model="claude-opus-4-7",
-                 input_tokens=2_000, output_tokens=300, cache_tokens=97_700,
-                 cost_usd=3.0, tool_calls=2, plan_tier=plan_tier)
-    _add_session(db, "opus-thin-2", model="claude-opus-4-6",
-                 input_tokens=1_000, output_tokens=200, cache_tokens=98_800,
-                 cost_usd=3.0, tool_calls=1, plan_tier=plan_tier)
-    # 100k Opus tokens, Opus-shaped → in denominator, NOT a candidate.
-    _add_session(db, "opus-fat", model="claude-opus-4-7",
-                 input_tokens=40_000, output_tokens=20_000, cache_tokens=40_000,
-                 cost_usd=8.0, tool_calls=30, plan_tier=plan_tier)
-    # Sonnet session → excluded from the audit (not Opus).
-    _add_session(db, "sonnet-1", model="claude-sonnet-4-6",
-                 input_tokens=2_000, output_tokens=300, cache_tokens=50_000,
-                 cost_usd=0.5, tool_calls=1, plan_tier=plan_tier)
+def _audit(db):
+    return audit_opus_quota(db.conn, SINCE, UNTIL, agent_id=None, window_days=30.0)
 
 
-def test_percent_quota_misallocated_counts_only_sonnet_shaped_opus(db):
-    _seed_mix(db)
-    audit = audit_opus_quota(db.conn, SINCE, UNTIL, agent_id=None, window_days=30.0)
+# ── (a) the core fix: a mechanical stretch inside a hard session ─────────────
 
-    # Three Opus sessions in the denominator (the Sonnet session is excluded).
+def test_mechanical_stretch_inside_hard_session_is_flagged(db):
+    """A session that is 2 hard turns + a 2-turn cheap stretch: the stretch is
+    flagged even though the WHOLE-session sums (17.9K input) blow past the
+    session-level threshold the old audit used — exactly the case (a) miss."""
+    _new_session(db, "mixed")
+    _turn(db, "mixed", 0, input_tokens=8_000, output_tokens=1_000)   # hard
+    _turn(db, "mixed", 1, input_tokens=500, output_tokens=100)        # cheap
+    _turn(db, "mixed", 2, input_tokens=400, output_tokens=90)         # cheap
+    _turn(db, "mixed", 3, input_tokens=9_000, output_tokens=1_200)    # hard
+
+    audit = _audit(db)
+
+    assert audit.opus_sessions == 1
+    assert audit.candidate_sessions == 1
+    assert audit.segment_count == 1
+    # Quota-weighted numerator = the two cheap turns; denominator = all four.
+    #   cheap: (500 + 100*5) + (400 + 90*5) = 1000 + 850 = 1850
+    #   hard:  (8000 + 1000*5) + (9000 + 1200*5) = 13000 + 15000 = 28000
+    assert audit.candidate_tokens == 1_850
+    assert audit.opus_tokens == 29_850
+    assert audit.percent_quota_misallocated == pytest.approx(6.2, abs=0.1)
+    # The old whole-session heuristic (input < 5K) would never flag this session.
+    assert 8_000 + 500 + 400 + 9_000 > md.SMALL_INPUT_TOKENS
+
+
+# ── (b) per-span attribution: mixed-model session ───────────────────────────
+
+def test_mixed_model_session_attributes_tokens_per_actual_model(db):
+    """An Opus turn + a Sonnet turn in ONE session. The Sonnet turn's tokens must
+    land in NEITHER the premium denominator nor the misallocated numerator — the
+    old MODE(model) sum would have collapsed both under the dominant model."""
+    _new_session(db, "mm")
+    _turn(db, "mm", 0, model="claude-opus-4-7",
+          input_tokens=500, output_tokens=100, cache_tokens=50_000)   # premium
+    _turn(db, "mm", 1, model="claude-sonnet-4-6",
+          input_tokens=500, output_tokens=100, cache_tokens=50_000)   # not premium
+
+    audit = _audit(db)
+
+    # Only the Opus turn is premium: quota = 500 + 100*5 + 50000*0.1 = 6000.
+    assert audit.opus_tokens == 6_000
+    # Both turns are cheap → one whole-session segment; only the premium turn
+    # inside it counts toward misallocation.
+    assert audit.candidate_tokens == 6_000
+    assert audit.percent_quota_misallocated == pytest.approx(100.0, abs=0.1)
+    assert audit.opus_sessions == 1
+
+
+# ── (c) the headline is a labelled estimate + CI ────────────────────────────
+
+def test_headline_carries_confidence_label_and_ci(db):
+    """Two flagged segments → the estimate is bracketed by a bootstrap CI over
+    resampled segments, and marked an explicit 'estimate'."""
+    _new_session(db, "c1")
+    _turn(db, "c1", 0, input_tokens=500, output_tokens=100)
+    _turn(db, "c1", 1, input_tokens=500, output_tokens=100)
+    _new_session(db, "c2")
+    _turn(db, "c2", 0, input_tokens=1_500, output_tokens=250)
+    _turn(db, "c2", 1, input_tokens=1_500, output_tokens=250)
+
+    audit = _audit(db)
+
+    assert audit.segment_count == 2
+    assert audit.segment_estimate_confidence == "estimate"
+    assert audit.segment_ci_low is not None
+    assert audit.segment_ci_high is not None
+    assert audit.segment_ci_high >= audit.segment_ci_low
+
+
+def test_single_segment_has_no_ci_but_stays_labelled(db):
+    """A lone flagged segment has no spread to bootstrap — the CI bounds stay
+    None (inherently wide) while the estimate label persists (design §9)."""
+    _new_session(db, "solo")
+    _turn(db, "solo", 0, input_tokens=500, output_tokens=100)
+    _turn(db, "solo", 1, input_tokens=500, output_tokens=100)
+
+    audit = _audit(db)
+
+    assert audit.segment_count == 1
+    assert audit.segment_ci_low is None
+    assert audit.segment_ci_high is None
+    assert audit.segment_estimate_confidence == "estimate"
+
+
+# ── contiguity + min-stretch gate ───────────────────────────────────────────
+
+def test_lone_cheap_turn_between_hard_turns_is_not_flagged(db):
+    """A single cheap turn wedged between two hard turns is noise, not a
+    reclaimable stretch (MIN_STRETCH_TURNS = 2), and does not span the session."""
+    _new_session(db, "lone")
+    _turn(db, "lone", 0, input_tokens=8_000, output_tokens=1_000)  # hard
+    _turn(db, "lone", 1, input_tokens=500, output_tokens=100)       # lone cheap
+    _turn(db, "lone", 2, input_tokens=9_000, output_tokens=1_200)  # hard
+
+    audit = _audit(db)
+    assert audit.opus_sessions == 1
+    assert audit.candidate_sessions == 0
+    assert audit.segment_count == 0
+    assert audit.percent_quota_misallocated == 0.0
+
+
+def test_min_stretch_of_one_flags_the_lone_turn(db, monkeypatch):
+    """Flipping MIN_STRETCH_TURNS to 1 recovers 'every cheap turn counts'."""
+    monkeypatch.setattr(md, "MIN_STRETCH_TURNS", 1)
+    _new_session(db, "lone")
+    _turn(db, "lone", 0, input_tokens=8_000, output_tokens=1_000)  # hard
+    _turn(db, "lone", 1, input_tokens=500, output_tokens=100)       # lone cheap
+    _turn(db, "lone", 2, input_tokens=9_000, output_tokens=1_200)  # hard
+
+    audit = _audit(db)
+    assert audit.candidate_sessions == 1
+    assert audit.segment_count == 1
+
+
+def test_tool_fanout_breaks_the_cheap_shape(db):
+    """A turn with more than TURN_SMALL_TOOL_CALLS tool calls is not cheap-shaped,
+    so it breaks a stretch even with small input/output — the per-turn fan-out is
+    measured from the real interleaved tool spans."""
+    _new_session(db, "fan")
+    _turn(db, "fan", 0, input_tokens=500, output_tokens=100)                 # cheap
+    _turn(db, "fan", 1, input_tokens=500, output_tokens=100, tool_calls=5)   # busy
+    _turn(db, "fan", 2, input_tokens=500, output_tokens=100)                 # cheap
+
+    audit = _audit(db)
+    # Two length-1 segments, session has 3 turns → neither counts.
+    assert audit.segment_count == 0
+    assert audit.candidate_sessions == 0
+
+
+# ── delegation gate ─────────────────────────────────────────────────────────
+
+def test_task_delegation_breaks_the_stretch(db):
+    """A Task handoff mid-stretch disqualifies the delegating turn (design §2.4
+    Option B), splitting the run so neither half is a countable stretch — while
+    an otherwise-identical non-delegating session IS flagged."""
+    _new_session(db, "deleg")
+    _turn(db, "deleg", 0, input_tokens=500, output_tokens=100)
+    _turn(db, "deleg", 1, input_tokens=500, output_tokens=100, delegate=True)
+    _turn(db, "deleg", 2, input_tokens=500, output_tokens=100)
+    _new_session(db, "nodeleg")
+    _turn(db, "nodeleg", 0, input_tokens=500, output_tokens=100)
+    _turn(db, "nodeleg", 1, input_tokens=500, output_tokens=100)
+    _turn(db, "nodeleg", 2, input_tokens=500, output_tokens=100)
+
+    audit = _audit(db)
+
+    flagged = {ex.session_id for ex in audit.examples}
+    assert "nodeleg" in flagged
+    assert "deleg" not in flagged
+    assert audit.segment_count == 1
+
+
+# ── backward-compat derivation (the nesting invariant, equality case) ───────
+
+def test_fully_cheap_sessions_yield_hundred_percent(db):
+    """Fully cheap single-model sessions: every premium token is inside a cheap
+    segment, so the segment share equals the whole-session share (100%) — the
+    ``segment% >= whole-session%`` invariant at equality."""
+    for i in range(3):
+        _new_session(db, f"f{i}")
+        _turn(db, f"f{i}", 0, input_tokens=500, output_tokens=100)
+
+    audit = _audit(db)
     assert audit.opus_sessions == 3
-    assert audit.opus_tokens == 300_000  # 3 × 100k Opus tokens
-    # Two are Sonnet-shaped candidates.
-    assert audit.candidate_sessions == 2
-    assert audit.candidate_tokens == 200_000  # 2 × 100k
-    # Headline: candidate Opus tokens / total Opus tokens.
-    assert audit.percent_quota_misallocated == pytest.approx(66.7, abs=0.1)
-    assert audit.percent_sessions == pytest.approx(66.7, abs=0.1)
+    assert audit.candidate_sessions == 3
+    assert audit.percent_quota_misallocated == pytest.approx(100.0, abs=0.1)
 
 
-def test_opus_shaped_session_not_flagged(db):
-    _seed_mix(db)
-    audit = audit_opus_quota(db.conn, SINCE, UNTIL, agent_id=None, window_days=30.0)
-    flagged_ids = {ex.session_id for ex in audit.examples}
-    # The genuinely Opus-shaped session is never a spot-check candidate.
-    assert "opus-fat" not in flagged_ids
-    # The Sonnet session is excluded from the audit entirely.
-    assert "sonnet-1" not in flagged_ids
+# ── honesty discipline (Rule 14) ────────────────────────────────────────────
+
+def test_estimate_basis_and_caveat_are_honest(db):
+    _new_session(db, "f0")
+    _turn(db, "f0", 0, input_tokens=500, output_tokens=100)
+    audit = _audit(db)
+
+    assert "no quality validation" in audit.estimate_basis
+    assert audit.segment_estimate_confidence == "estimate"
+    caveat = audit.caveat.lower()
+    assert "spot-check" in caveat
+    assert "wasted" not in caveat
+    assert "safe to downgrade" in caveat  # only ever as "Never safe to downgrade"
 
 
-def test_example_sessions_surfaced_for_spot_check(db):
-    _seed_mix(db)
-    audit = audit_opus_quota(db.conn, SINCE, UNTIL, agent_id=None, window_days=30.0)
+# ── round-trip (a dropped new field must fail the parity guard) ─────────────
 
-    assert {ex.session_id for ex in audit.examples} == {"opus-thin-1", "opus-thin-2"}
-    # Each example carries the cheaper-model routing suggestion + shape data.
-    for ex in audit.examples:
-        assert ex.alt_model  # a concrete cheaper model is named
-        assert ex.tool_calls <= 5
-    # Suggestions aggregate the observed model→alt mapping.
-    assert "claude-opus-4-7" in audit.suggestions
-    assert "claude-opus-4-6" in audit.suggestions
+def test_new_fields_round_trip_with_ci(db):
+    _new_session(db, "c1")
+    _turn(db, "c1", 0, input_tokens=500, output_tokens=100)
+    _turn(db, "c1", 1, input_tokens=1_500, output_tokens=250)
+    _new_session(db, "c2")
+    _turn(db, "c2", 0, input_tokens=800, output_tokens=200)
+    _turn(db, "c2", 1, input_tokens=600, output_tokens=150)
+    audit = _audit(db)
 
-
-def test_fable_and_opus_4_8_sessions_are_audited(db):
-    """Fable (the tier above Opus) and Opus 4.8 must both be counted in the
-    premium denominator and flagged as reclaim candidates when Sonnet-shaped —
-    the whole point of routing tier membership through the shared predicate."""
-    # Fable, Sonnet-shaped → candidate; suggested alt is a cheaper same-family model.
-    _add_session(db, "fable-thin", model="claude-fable-5",
-                 input_tokens=1_500, output_tokens=250, cache_tokens=98_250,
-                 cost_usd=5.0, tool_calls=2)
-    # Opus 4.8, Sonnet-shaped → candidate (4.8 was missing from the map before).
-    _add_session(db, "opus48-thin", model="claude-opus-4-8",
-                 input_tokens=1_000, output_tokens=200, cache_tokens=98_800,
-                 cost_usd=3.0, tool_calls=1)
-    # Fable, genuinely large-shape → in denominator, NOT a candidate.
-    _add_session(db, "fable-fat", model="claude-fable-5",
-                 input_tokens=40_000, output_tokens=20_000, cache_tokens=40_000,
-                 cost_usd=12.0, tool_calls=30)
-
-    audit = audit_opus_quota(db.conn, SINCE, UNTIL, agent_id=None, window_days=30.0)
-
-    # All three premium sessions counted (Fable is premium, above Opus).
-    assert audit.opus_sessions == 3
-    assert audit.opus_tokens == 300_000
-    # The two Sonnet-shaped premium sessions are reclaim candidates.
-    assert audit.candidate_sessions == 2
-    assert {ex.session_id for ex in audit.examples} == {"fable-thin", "opus48-thin"}
-    # Each flagged premium session names a concrete cheaper routing target.
-    assert audit.suggestions["claude-fable-5"]
-    assert audit.suggestions["claude-opus-4-8"]
-    for ex in audit.examples:
-        assert ex.alt_model
+    round_tripped = audit_from_dict(audit_to_dict(audit))
+    assert round_tripped.segment_count == audit.segment_count
+    assert round_tripped.segment_estimate_confidence == audit.segment_estimate_confidence
+    assert round_tripped.estimate_basis == audit.estimate_basis
+    assert round_tripped.segment_ci_low == audit.segment_ci_low
+    assert round_tripped.segment_ci_high == audit.segment_ci_high
+    assert round_tripped.percent_quota_misallocated == audit.percent_quota_misallocated
 
 
-def test_no_opus_sessions_is_clean_empty_state(db):
-    # Only a Sonnet session — nothing for the Opus audit to inspect.
-    _add_session(db, "sonnet-only", model="claude-sonnet-4-6",
-                 input_tokens=2_000, output_tokens=300, cache_tokens=50_000)
-    audit = audit_opus_quota(db.conn, SINCE, UNTIL, agent_id=None, window_days=30.0)
+def test_none_ci_round_trips_as_none(db):
+    _new_session(db, "solo")
+    _turn(db, "solo", 0, input_tokens=500, output_tokens=100)
+    _turn(db, "solo", 1, input_tokens=500, output_tokens=100)
+    audit = _audit(db)
+    assert audit.segment_ci_low is None
+
+    round_tripped = audit_from_dict(audit_to_dict(audit))
+    assert round_tripped.segment_ci_low is None
+    assert round_tripped.segment_ci_high is None
+
+
+# ── empty / honest states ───────────────────────────────────────────────────
+
+def test_no_premium_sessions_is_clean_empty(db):
+    _new_session(db, "sonnet-only")
+    _turn(db, "sonnet-only", 0, model="claude-sonnet-4-6",
+          input_tokens=500, output_tokens=100)
+    audit = _audit(db)
     assert not audit.has_opus
     assert audit.opus_sessions == 0
     assert audit.percent_quota_misallocated == 0.0
 
 
+def test_all_hard_premium_session_flags_nothing(db):
+    _new_session(db, "hard")
+    _turn(db, "hard", 0, input_tokens=8_000, output_tokens=1_000)
+    _turn(db, "hard", 1, input_tokens=9_000, output_tokens=1_200)
+    audit = _audit(db)
+    assert audit.opus_sessions == 1
+    assert audit.candidate_sessions == 0
+    assert audit.segment_count == 0
+    assert audit.percent_quota_misallocated == 0.0
+
+
+def test_fable_and_opus_4_8_stretches_are_audited(db):
+    """Fable (above Opus) and Opus 4.8 must both count in the premium denominator
+    and be flagged when their turns form a Sonnet-shaped stretch — the point of
+    routing tier membership through the shared predicate, not a substring gate."""
+    _new_session(db, "fable")
+    _turn(db, "fable", 0, model="claude-fable-5", input_tokens=500, output_tokens=100)
+    _turn(db, "fable", 1, model="claude-fable-5", input_tokens=600, output_tokens=120)
+    _new_session(db, "opus48")
+    _turn(db, "opus48", 0, model="claude-opus-4-8", input_tokens=500, output_tokens=100)
+    _turn(db, "opus48", 1, model="claude-opus-4-8", input_tokens=400, output_tokens=90)
+
+    audit = _audit(db)
+    assert audit.opus_sessions == 2
+    assert audit.candidate_sessions == 2
+    assert {ex.session_id for ex in audit.examples} == {"fable", "opus48"}
+    assert audit.suggestions["claude-fable-5"]
+    assert audit.suggestions["claude-opus-4-8"]
+
+
+# ── CLI rendering (per-persona copy) ────────────────────────────────────────
+
+def _seed_cli(db, *, plan_tier="max_5x") -> None:
+    """A mixed session (hard + a flagged cheap stretch) plus a fully cheap
+    session → 2 flagged segments so the render exercises the CI + persona copy."""
+    _new_session(db, "cli-mixed", plan_tier=plan_tier)
+    _turn(db, "cli-mixed", 0, input_tokens=8_000, output_tokens=1_000, cost_usd=4.0)
+    _turn(db, "cli-mixed", 1, input_tokens=500, output_tokens=100, cost_usd=1.0)
+    _turn(db, "cli-mixed", 2, input_tokens=400, output_tokens=90, cost_usd=1.0)
+    _new_session(db, "cli-cheap", plan_tier=plan_tier)
+    _turn(db, "cli-cheap", 0, input_tokens=500, output_tokens=100, cost_usd=1.0)
+    _turn(db, "cli-cheap", 1, input_tokens=600, output_tokens=120, cost_usd=1.0)
+
+
 def test_cli_renders_quota_audit_with_caveat(db, monkeypatch):
-    """End-to-end: the card reports the % of premium quota that WENT to
-    Sonnet-shaped sessions (misallocated, not "reclaimable"), lists the
-    spot-check sessions, and surfaces the honesty caveat — in quota (not dollar)
-    language for a subscription (Max) plan."""
-    _seed_mix(db)
+    """The card reports the % of premium quota that WENT to Sonnet-shaped WORK
+    (misallocated, not 'reclaimable'), labels it an estimate, lists spot-check
+    sessions, and surfaces the honesty caveat — in quota (not dollar) language
+    for a subscription (Max) plan."""
+    _seed_cli(db)
     config = _max_config()
 
     import tokenjam.cli.main as cli_main
-
     monkeypatch.setattr(cli_main, "load_config", lambda *a, **k: config)
     monkeypatch.setattr(cli_main, "open_db", lambda *a, **k: db)
-    monkeypatch.setattr(
-        "tokenjam.core.framing.config_declared_plan", lambda c: "max_5x"
-    )
+    monkeypatch.setattr("tokenjam.core.framing.config_declared_plan", lambda c: "max_5x")
 
-    runner = CliRunner()
-    result = runner.invoke(
-        cli_main.cli, ["quota-audit", "--since", "30d"], catch_exceptions=False
+    result = CliRunner().invoke(
+        cli_main.cli, ["quota-audit", "--since", "30d"], catch_exceptions=False,
     )
     assert result.exit_code == 0, result.output
     out = result.output
-    # Rich wraps panel text across lines and draws box borders between them;
-    # strip the border glyphs and collapse whitespace before matching multi-word
-    # phrases so a wrap between two words doesn't fail the assertion.
     flat = " ".join(re.sub(r"[│╭╮╰╯─]", " ", out).split())
-    # Retrospective mirror headline (not dollars) — names both premium tiers and
-    # never says "reclaimable" (the tokens are already spent).
-    assert "went to Sonnet-shaped sessions" in flat
+    # Retrospective mirror headline (not dollars), new grain-accurate noun.
+    assert "went to Sonnet-shaped work" in flat
     assert "reclaimable" not in flat.lower()
     assert "Opus/Fable" in out
-    assert "67%" in out or "66" in out
+    # The single number is presented as a labelled estimate.
+    assert "estimate" in flat
     # Subscription users get the habit nudge, not dollars.
     assert "stays available for hard problems next window" in flat
     assert "/model sonnet" in flat
     # Spot-check sessions listed.
     assert "spot-check" in out.lower()
-    assert "opus-thin-1" in out
-    # Honesty caveat present (the load-bearing honesty discipline).
+    assert "cli-mixed" in out
+    # Honesty caveat present.
     assert "spot-check" in OPUS_QUOTA_AUDIT_CAVEAT.lower()
-    assert "Never \"safe to downgrade.\"" in out or "safe to downgrade" in out
+    assert "safe to downgrade" in out
 
 
 def test_cli_api_persona_shows_dollar_counterfactual(db, monkeypatch):
     """API-billed users get the already-billed dollar counterfactual under the
     measured headline instead of the subscription habit nudge."""
-    _seed_mix(db, plan_tier="api")
+    _seed_cli(db, plan_tier="api")
     config = _api_config()
 
     import tokenjam.cli.main as cli_main
-
     monkeypatch.setattr(cli_main, "load_config", lambda *a, **k: config)
     monkeypatch.setattr(cli_main, "open_db", lambda *a, **k: db)
-    monkeypatch.setattr(
-        "tokenjam.core.framing.config_declared_plan", lambda c: "api"
-    )
+    monkeypatch.setattr("tokenjam.core.framing.config_declared_plan", lambda c: "api")
 
-    runner = CliRunner()
-    result = runner.invoke(
-        cli_main.cli, ["quota-audit", "--since", "30d"], catch_exceptions=False
+    result = CliRunner().invoke(
+        cli_main.cli, ["quota-audit", "--since", "30d"], catch_exceptions=False,
     )
     assert result.exit_code == 0, result.output
-    out = result.output
-    flat = " ".join(re.sub(r"[│╭╮╰╯─]", " ", out).split())
-    # Same measured mirror headline for everyone.
-    assert "went to Sonnet-shaped sessions" in flat
-    assert "reclaimable" not in flat.lower()
-    # API persona: retrospective, already-billed counterfactual — NOT the
-    # subscription habit nudge.
+    flat = " ".join(re.sub(r"[│╭╮╰╯─]", " ", result.output).split())
+    assert "went to Sonnet-shaped work" in flat
     assert "Same work at the suggested tiers" in flat
     assert "already billed" in flat
     assert "stays available for hard problems" not in flat
 
 
-def test_cli_json_output_has_quota_fields(db, monkeypatch):
-    _seed_mix(db)
+def test_cli_json_output_has_segment_fields(db, monkeypatch):
+    _seed_cli(db)
     config = _max_config()
     import json
 
     import tokenjam.cli.main as cli_main
-
     monkeypatch.setattr(cli_main, "load_config", lambda *a, **k: config)
     monkeypatch.setattr(cli_main, "open_db", lambda *a, **k: db)
-    monkeypatch.setattr(
-        "tokenjam.core.framing.config_declared_plan", lambda c: "max_5x"
-    )
+    monkeypatch.setattr("tokenjam.core.framing.config_declared_plan", lambda c: "max_5x")
 
-    runner = CliRunner()
-    result = runner.invoke(
+    result = CliRunner().invoke(
         cli_main.cli, ["quota-audit", "--since", "30d", "--json"],
         catch_exceptions=False,
     )
     assert result.exit_code == 0, result.output
     payload = json.loads(result.output)
-    assert payload["percent_quota_misallocated"] == pytest.approx(66.7, abs=0.1)
-    # DEPRECATED alias still emitted (shipped in 0.5.4) — same value, one release.
-    assert payload["percent_quota_reclaimable"] == pytest.approx(66.7, abs=0.1)
-    assert payload["candidate_sessions"] == 2
-    assert len(payload["examples"]) == 2
+    assert payload["percent_quota_misallocated"] > 0
+    # DEPRECATED alias still mirrors the headline (0.5.4 compat).
+    assert payload["percent_quota_reclaimable"] == payload["percent_quota_misallocated"]
+    assert payload["candidate_sessions"] >= 1
+    assert payload["segment_count"] >= 1
+    assert payload["segment_estimate_confidence"] == "estimate"
+    assert "estimate_basis" in payload
+    assert len(payload["examples"]) >= 1
     assert payload["framing"]["pricing_mode"] == "subscription"
     assert payload["caveat"] == OPUS_QUOTA_AUDIT_CAVEAT

--- a/tests/unit/test_opus_quota_audit.py
+++ b/tests/unit/test_opus_quota_audit.py
@@ -119,6 +119,29 @@ def test_mechanical_stretch_inside_hard_session_is_flagged(db):
     assert 8_000 + 500 + 400 + 9_000 > md.SMALL_INPUT_TOKENS
 
 
+def test_multi_model_session_example_labels_dominant_model(db):
+    """A flagged session spanning two premium models must label its spot-check
+    example (and routing hint) with the model carrying the MOST misallocated
+    quota — not whichever premium turn appeared first. The first turn here is a
+    small Fable turn, so the old first-turn-frozen label would mislabel it."""
+    _new_session(db, "multi")
+    _turn(db, "multi", 0, model="claude-fable-5",
+          input_tokens=400, output_tokens=80)                        # ~800 quota
+    _turn(db, "multi", 1, model="claude-opus-4-8",
+          input_tokens=1_500, output_tokens=250)                     # ~2750 quota
+    _turn(db, "multi", 2, model="claude-opus-4-8",
+          input_tokens=1_500, output_tokens=250)                     # ~2750 quota
+
+    audit = _audit(db)
+    assert len(audit.examples) == 1
+    ex = audit.examples[0]
+    # Opus 4.8 carries ~5500 of ~6300 flagged quota → the dominant label.
+    assert ex.model == "claude-opus-4-8"
+    assert ex.alt_model == "claude-haiku-4-5"
+    # Both premium models still appear in the aggregate suggestions.
+    assert set(audit.suggestions) == {"claude-fable-5", "claude-opus-4-8"}
+
+
 # ── (b) per-span attribution: mixed-model session ───────────────────────────
 
 def test_mixed_model_session_attributes_tokens_per_actual_model(db):

--- a/tests/unit/test_opus_quota_audit.py
+++ b/tests/unit/test_opus_quota_audit.py
@@ -261,6 +261,51 @@ def test_cli_api_persona_shows_dollar_counterfactual(db, monkeypatch):
     assert "stays available for hard problems" not in flat
 
 
+def test_api_nudge_without_pricing_data_stays_neutral():
+    """API mode + no pricing data (every candidate model absent from the pricing
+    table → actual_cost_usd == 0) must NOT fall through to the subscription
+    "next window" quota language — API billing has no rolling window. It gets a
+    neutral routing prompt instead of a dollar counterfactual or a habit nudge."""
+    from tokenjam.cli.cmd_quota_audit import _headline_nudge
+    from tokenjam.core.framing import Framing
+    from tokenjam.core.optimize.types import OpusQuotaAudit
+
+    audit = OpusQuotaAudit(
+        opus_sessions=3, opus_tokens=300_000,
+        candidate_sessions=2, candidate_tokens=200_000,
+        percent_quota_misallocated=66.7, percent_sessions=66.7,
+        actual_cost_usd=0.0, alternative_cost_usd=0.0,
+    )
+    framing = Framing(pricing_mode="api", plan_tier="api")
+    nudge = _headline_nudge(audit, framing).plain
+
+    # Neither the subscription quota language nor a fabricated dollar figure.
+    assert "next window" not in nudge
+    assert "stays available for hard problems" not in nudge
+    assert "$" not in nudge
+    assert "Review these sessions" in nudge
+
+
+def test_api_nudge_with_pricing_shows_dollar_counterfactual():
+    """API mode WITH pricing data gets the already-billed dollar counterfactual,
+    never the subscription 'next window' language."""
+    from tokenjam.cli.cmd_quota_audit import _headline_nudge
+    from tokenjam.core.framing import Framing
+    from tokenjam.core.optimize.types import OpusQuotaAudit
+
+    audit = OpusQuotaAudit(
+        opus_sessions=3, opus_tokens=300_000,
+        candidate_sessions=2, candidate_tokens=200_000,
+        percent_quota_misallocated=66.7, percent_sessions=66.7,
+        actual_cost_usd=12.0, alternative_cost_usd=3.0,
+    )
+    framing = Framing(pricing_mode="api", plan_tier="api")
+    nudge = _headline_nudge(audit, framing).plain
+
+    assert "already billed" in nudge
+    assert "next window" not in nudge
+
+
 def test_cli_json_output_has_quota_fields(db, monkeypatch):
     _seed_mix(db)
     config = _max_config()

--- a/tests/unit/test_quickstart.py
+++ b/tests/unit/test_quickstart.py
@@ -250,6 +250,67 @@ def test_quickstart_no_logs_is_graceful(tmp_path):
     assert "No Claude Code logs" in result.output
 
 
+# ── Pre-ingest progress: ingest was previously the ONE silent stretch in the
+# whole command (~40s dead cursor on a large history, nothing printed until
+# after it returned). An honest status line now lands before ingest starts,
+# and the shared streaming counter (`backfill_progress`) advances per session
+# through to render. `--json` must stay byte-for-byte clean on stdout.
+
+def test_quickstart_prints_pre_ingest_status_before_render(tmp_path):
+    root = _fixture_root(tmp_path)
+    result = _invoke_quickstart(["--root", str(root), "--since", "90d"])
+
+    assert result.exit_code == 0, result.output
+    assert "Reading your last 90 days of Claude Code history" in result.output
+    assert "(most-recent 300 sessions)" in result.output
+    # It's the FIRST thing printed -- ahead of the quota-composition panel,
+    # not tacked on after ingest already finished.
+    assert result.output.index("Reading your last 90 days") < result.output.index(
+        "Where your quota goes"
+    )
+
+
+def test_quickstart_pre_ingest_status_omits_cap_when_full(tmp_path):
+    """`--full` lifts the session cap (#13) -- the status line must not claim
+    a "most-recent N sessions" scope that no longer applies."""
+    root = _fixture_root(tmp_path)
+    result = _invoke_quickstart(["--root", str(root), "--since", "90d", "--full"])
+
+    assert result.exit_code == 0, result.output
+    assert "Reading your last 90 days of Claude Code history…" in result.output
+    assert "most-recent" not in result.output.split("Where your quota goes")[0]
+
+
+def test_quickstart_json_stdout_stays_pure(tmp_path):
+    """`--json` must be pipeable straight into a JSON parser: stdout carries
+    ONLY the JSON payload, never the pre-ingest status line or the streaming
+    progress counter -- those route to stderr instead."""
+    root = _fixture_root(tmp_path)
+    result = _invoke_quickstart(["--root", str(root), "--since", "90d", "--json"])
+
+    assert result.exit_code == 0, result.output
+    # stdout parses as JSON on its own -- no leading/trailing progress noise.
+    payload = json.loads(result.stdout.strip())
+    assert "quota_composition" in payload
+    assert payload["backfill"]["sessions_ingested"] == 2
+    # The status line still printed -- just on stderr, never stdout.
+    assert "Reading your last 90 days of Claude Code history" in result.stderr
+    assert "Reading your last 90 days" not in result.stdout
+
+
+def test_quickstart_advancing_counter_on_large_history(tmp_path):
+    """On a large history the shared streaming counter keeps advancing
+    through ingest (not just a single static pre-ingest line) -- non-TTY
+    output (as under CliRunner) degrades to periodic plain prints every 100
+    sessions, mirroring `tj onboard --claude-code`'s backfill counter."""
+    root = _large_fixture_root(tmp_path, n_sessions=250)
+    result = _invoke_quickstart(["--root", str(root), "--since", "90d"])
+
+    assert result.exit_code == 0, result.output
+    assert "Backfilling 100/250 sessions" in result.output
+    assert "Backfilling 200/250 sessions" in result.output
+
+
 def _large_fixture_root(tmp_path: Path, n_sessions: int) -> Path:
     """A synthetic history with `n_sessions` sessions, two turns each, recent.
 

--- a/tokenjam/cli/backfill_progress.py
+++ b/tokenjam/cli/backfill_progress.py
@@ -14,10 +14,11 @@ from __future__ import annotations
 from contextlib import contextmanager
 from typing import Callable, Iterator
 
+from rich.console import Console
 from rich.progress import Progress, SpinnerColumn, TextColumn
 
 from tokenjam.core.backfill import BackfillResult, ParsedSession
-from tokenjam.utils.formatting import console
+from tokenjam.utils.formatting import console as _default_console
 from tokenjam.utils.humanize import format_tokens
 
 ProgressCallback = Callable[[ParsedSession, BackfillResult], None]
@@ -32,18 +33,25 @@ def _noop(_parsed: ParsedSession, _result: BackfillResult) -> None:
 
 
 @contextmanager
-def backfill_progress(total: int | None, *, quiet: bool = False) -> Iterator[ProgressCallback]:
+def backfill_progress(
+    total: int | None, *, quiet: bool = False, console: Console | None = None,
+) -> Iterator[ProgressCallback]:
     """Yield a `progress(parsed, result)` callback for `ingest_claude_code`.
 
     `total` is the cheap pre-count of in-scope sessions
     (`count_claude_code_sessions_in_scope`), or `None` when unknown — the
     counter then shows a running count with no "/total". `quiet=True` yields a
     no-op callback (mirrors `tj backfill claude-code --quiet`).
+
+    `console` overrides where the counter renders (default: the shared stdout
+    console) — `tj quickstart --json` passes the stderr console so the
+    counter never contaminates its machine-readable stdout.
     """
     if quiet:
         yield _noop
         return
 
+    target_console = console if console is not None else _default_console
     tokens_seen = 0
 
     def _line(result: BackfillResult) -> str:
@@ -61,11 +69,11 @@ def backfill_progress(total: int | None, *, quiet: bool = False) -> Iterator[Pro
             + parsed.total_cache_tokens
         )
 
-    if console.is_terminal:
+    if target_console.is_terminal:
         with Progress(
             SpinnerColumn(style="cyan"),
             TextColumn("[bold]◆[/bold] {task.description}"),
-            console=console,
+            console=target_console,
             transient=True,
         ) as progress:
             task_id = progress.add_task("Backfilling…", total=None)
@@ -80,7 +88,7 @@ def backfill_progress(total: int | None, *, quiet: bool = False) -> Iterator[Pro
     def _tick_plain(parsed: ParsedSession, result: BackfillResult) -> None:
         _accumulate(parsed)
         if result.sessions_seen % _PLAIN_PRINT_EVERY == 0:
-            console.print(f"  [dim]{_line(result)}[/dim]")
+            target_console.print(f"  [dim]{_line(result)}[/dim]")
 
     yield _tick_plain
 

--- a/tokenjam/cli/cmd_onboard.py
+++ b/tokenjam/cli/cmd_onboard.py
@@ -1131,7 +1131,7 @@ def _print_next_steps_nudge(
         )
     if persona == "claude_code":
         console.print("  [bold]tj context[/bold]     [dim]where your quota goes — re-read vs real work[/dim]")
-        console.print("  [bold]tj quota-audit[/bold] [dim]how much Opus went to Sonnet-shaped sessions[/dim]")
+        console.print("  [bold]tj quota-audit[/bold] [dim]how much Opus/Fable went to Sonnet-shaped sessions[/dim]")
         console.print(lens_line)
         console.print("  [bold]tj tokenmaxx[/bold]   [dim]your shareable efficiency tier[/dim]")
     else:

--- a/tokenjam/cli/cmd_quickstart.py
+++ b/tokenjam/cli/cmd_quickstart.py
@@ -117,6 +117,11 @@ def cmd_quickstart(ctx: click.Context, since: str, root_path: str | None,
     # never suppressed outright, so a human watching a scripted run still
     # sees it's alive.
     status_console = err_console if output_json else console
+    # Best-effort pre-scan: a stat()-only count taken before ingest starts, so
+    # the progress counter's "of N" denominator can drift if files under
+    # `root` change mid-run (a session file appears/disappears between this
+    # count and the actual walk). Cosmetic only — never affects what's
+    # ingested, since `ingest_claude_code` re-walks `root` itself.
     total_in_scope = count_claude_code_sessions_in_scope(
         root=root, since=since_dt, max_sessions=max_sessions,
     )

--- a/tokenjam/cli/cmd_quickstart.py
+++ b/tokenjam/cli/cmd_quickstart.py
@@ -37,9 +37,11 @@ from pathlib import Path
 
 import click
 
+from tokenjam.cli.backfill_progress import backfill_progress
 from tokenjam.cli.cmd_statusline import REREAD_WARN, format_status_line
 from tokenjam.core.backfill import (
     CLAUDE_CODE_PROJECTS_ROOT,
+    count_claude_code_sessions_in_scope,
     ingest_claude_code,
 )
 from tokenjam.core.context_diagnostic import compute_context_diagnostic
@@ -51,7 +53,7 @@ from tokenjam.core.session_timeline import (
     timeline_to_dict,
 )
 from tokenjam.core.usage import AssistantUsage, iter_cumulative_usage
-from tokenjam.utils.formatting import console, format_cost, format_tokens
+from tokenjam.utils.formatting import console, err_console, format_cost, format_tokens
 from tokenjam.utils.time_parse import parse_since, utcnow
 
 # First-run cap (#13): on a large ~/.claude history a full backfill into the
@@ -105,8 +107,23 @@ def cmd_quickstart(ctx: click.Context, since: str, root_path: str | None,
     # Transient in-memory DB — nothing persisted, no config, no daemon.
     max_sessions = None if full else DEFAULT_MAX_SESSIONS
     db = InMemoryBackend()
-    result = ingest_claude_code(db, root=root, since=since_dt,
-                                max_sessions=max_sessions)
+
+    # Ingest is the only silent stretch in the whole command — on a large
+    # history it can run tens of seconds with zero output otherwise. An
+    # honest status line lands within ~1s of launch, then the shared
+    # streaming counter (#443/#444's `backfill_progress`) advances per
+    # session through to render. `--json` must keep stdout byte-for-byte
+    # clean, so both route to the stderr console when JSON is requested —
+    # never suppressed outright, so a human watching a scripted run still
+    # sees it's alive.
+    status_console = err_console if output_json else console
+    total_in_scope = count_claude_code_sessions_in_scope(
+        root=root, since=since_dt, max_sessions=max_sessions,
+    )
+    status_console.print(f"[dim]{_pre_ingest_status(since, max_sessions)}[/dim]")
+    with backfill_progress(total_in_scope, console=status_console) as progress_cb:
+        result = ingest_claude_code(db, root=root, since=since_dt,
+                                    max_sessions=max_sessions, progress=progress_cb)
 
     if result.sessions_ingested == 0:
         _render_no_sessions(result, since, output_json)
@@ -138,6 +155,36 @@ def cmd_quickstart(ctx: click.Context, since: str, root_path: str | None,
 
 
 # ───────────────────────────── rendering ──────────────────────────────────
+
+_SINCE_UNIT_WORDS = {"d": "days", "h": "hours", "m": "minutes"}
+
+
+def _describe_window(since: str) -> str:
+    """Human-readable window phrasing for the pre-ingest status line.
+
+    Special-cases the relative `Nd`/`Nh`/`Nm` shapes `--since` accepts (the
+    default is `30d`) into "last N days"; anything else (a literal date, an
+    ISO datetime) falls back to "history since <value>" rather than guessing.
+    """
+    m = _re.match(r"^(\d+)([mhd])$", since.strip())
+    if m:
+        amount, unit = m.groups()
+        return f"last {amount} {_SINCE_UNIT_WORDS[unit]}"
+    return f"history since {since}"
+
+
+def _pre_ingest_status(since: str, max_sessions: int | None) -> str:
+    """Honest status line printed BEFORE ingest starts.
+
+    Ingest was previously the one silent stretch in the whole command —
+    ~40s of dead cursor on a large history before any output. This line
+    lands within ~1s of launch; `backfill_progress`'s streaming counter
+    takes over immediately after.
+    """
+    window = _describe_window(since)
+    scope = f" (most-recent {max_sessions} sessions)" if max_sessions is not None else ""
+    return f"Reading your {window} of Claude Code history{scope}…"
+
 
 def _pct(value: float) -> str:
     return f"{value * 100:.1f}%"

--- a/tokenjam/cli/cmd_quota_audit.py
+++ b/tokenjam/cli/cmd_quota_audit.py
@@ -1,14 +1,15 @@
-"""``tj quota-audit`` — the retroactive Opus quota audit over Claude Code sessions.
+"""``tj quota-audit`` — the retroactive premium-tier quota audit over Claude Code sessions.
 
 The accountability companion to ``opusplan`` / ``/model`` (issue #5). Those are
 forward-looking and say nothing about session history; nothing answers the
-backward-looking question "which of my PAST Opus sessions were Sonnet-shaped?".
-This command does: it runs the structural downsize heuristic
+backward-looking question "which of my PAST premium (Opus/Fable) sessions were
+Sonnet-shaped?". This command does: it runs the structural downsize heuristic
 (:func:`tokenjam.core.optimize.analyzers.model_downgrade.audit_opus_quota`)
-retroactively, scoped to Opus sessions, and reports:
+retroactively, scoped to premium-tier sessions (Fable + Opus), and reports:
 
-  * the headline — **% of your Opus quota reclaimable from Sonnet-shaped
-    sessions** (Opus token share, never a dollar "saving" — the subscription
+  * the headline — **% of your premium (Opus/Fable) quota reclaimable from
+    Sonnet-shaped sessions** (premium token share, never a dollar "saving" — the
+    subscription
     majority is on a flat fee; dollar framing mis-targets them, see
     ``research/evidence/subscription-vs-cost-framing.md``);
   * the specific example sessions to **spot-check**;
@@ -31,6 +32,7 @@ import click
 
 from tokenjam.cli.data_access import resolve_data_access
 from tokenjam.core.framing import Framing
+from tokenjam.core.model_tiers import PREMIUM_TIER_LABEL
 from tokenjam.core.optimize.types import (
     DowngradeFinding,
     OpusQuotaAudit,
@@ -98,22 +100,24 @@ def _render(audit: OpusQuotaAudit, framing: Framing, *, since: str) -> None:
 
     if not audit.has_opus:
         console.print(
-            "\n[yellow]No Opus sessions found in this window.[/yellow]\n"
-            "[dim]The quota audit only inspects Opus-family sessions (where "
-            "quota burn is acute). Run [bold]tj onboard --claude-code[/bold] to "
-            "ingest your Claude Code sessions, then re-run "
-            "[bold]tj quota-audit[/bold].[/dim]\n"
+            f"\n[yellow]No premium ({PREMIUM_TIER_LABEL}) sessions found in this "
+            "window.[/yellow]\n"
+            f"[dim]The quota audit only inspects premium-tier ({PREMIUM_TIER_LABEL}) "
+            "sessions (where quota burn is acute). Run "
+            "[bold]tj onboard --claude-code[/bold] to ingest your Claude Code "
+            "sessions, then re-run [bold]tj quota-audit[/bold].[/dim]\n"
         )
         return
 
     sections: list[Any] = []
 
     headline = Text()
-    headline.append("Opus quota audit", style="bold")
+    headline.append("Premium quota audit", style="bold")
     headline.append(
-        f"  ·  {audit.opus_sessions} Opus session"
+        f"  ·  {audit.opus_sessions} premium session"
         f"{'s' if audit.opus_sessions != 1 else ''} "
-        f"({format_tokens(audit.opus_tokens)} Opus tokens, last {since})",
+        f"({format_tokens(audit.opus_tokens)} {PREMIUM_TIER_LABEL} tokens, "
+        f"last {since})",
         style="dim",
     )
     sections.append(headline)
@@ -123,7 +127,7 @@ def _render(audit: OpusQuotaAudit, framing: Framing, *, since: str) -> None:
         clean = Text()
         clean.append("0% reclaimable", style="bold green")
         clean.append(
-            " — none of your Opus sessions match the Sonnet-shaped structure "
+            " — none of your premium sessions match the Sonnet-shaped structure "
             "(small input/output, few tool calls).",
             style="",
         )
@@ -132,9 +136,12 @@ def _render(audit: OpusQuotaAudit, framing: Framing, *, since: str) -> None:
         # The headline: quota share, never dollars (audit framing).
         big = Text()
         big.append(f"~{audit.percent_quota_reclaimable:.0f}% ", style="bold red")
-        big.append("of your Opus quota is reclaimable", style="bold")
         big.append(
-            f"\nfrom {audit.candidate_sessions} of {audit.opus_sessions} Opus "
+            f"of your premium ({PREMIUM_TIER_LABEL}) quota is reclaimable",
+            style="bold",
+        )
+        big.append(
+            f"\nfrom {audit.candidate_sessions} of {audit.opus_sessions} premium "
             f"session{'s' if audit.opus_sessions != 1 else ''} "
             f"({audit.percent_sessions:.0f}%) that are Sonnet-shaped",
             style="dim",
@@ -142,7 +149,7 @@ def _render(audit: OpusQuotaAudit, framing: Framing, *, since: str) -> None:
         sections.append(big)
 
         detail = Text()
-        detail.append("\nReclaimable Opus tokens:  ", style="dim")
+        detail.append("\nReclaimable premium tokens:  ", style="dim")
         detail.append(format_tokens(audit.candidate_tokens), style="bold")
         detail.append(
             f"  of {format_tokens(audit.opus_tokens)} total", style="dim"
@@ -202,7 +209,7 @@ def _render(audit: OpusQuotaAudit, framing: Framing, *, since: str) -> None:
     console.print()
     console.print(Panel(
         panel_body,
-        title="[bold]TokenJam Opus Quota Audit[/bold]",
+        title="[bold]TokenJam Premium Quota Audit[/bold]",
         title_align="left",
         border_style="dim",
         padding=(1, 2),

--- a/tokenjam/cli/cmd_quota_audit.py
+++ b/tokenjam/cli/cmd_quota_audit.py
@@ -7,10 +7,11 @@ Sonnet-shaped?". This command does: it runs the structural downsize heuristic
 (:func:`tokenjam.core.optimize.analyzers.model_downgrade.audit_opus_quota`)
 retroactively, scoped to premium-tier sessions (Fable + Opus), and reports:
 
-  * the headline — **% of your premium (Opus/Fable) quota reclaimable from
-    Sonnet-shaped sessions** (premium token share, never a dollar "saving" — the
-    subscription
-    majority is on a flat fee; dollar framing mis-targets them, see
+  * the headline — **% of your premium (Opus/Fable) quota that went to
+    Sonnet-shaped sessions** (a retrospective behaviour mirror in premium token
+    share — the tokens are already spent, so nothing is "reclaimed"; and never a
+    dollar "saving" — the subscription majority is on a flat fee, so dollar
+    framing mis-targets them, see
     ``research/evidence/subscription-vs-cost-framing.md``);
   * the specific example sessions to **spot-check**;
   * an optional tuned routing-config export (``--export-config claude-code``).
@@ -93,6 +94,37 @@ def cmd_quota_audit(ctx: click.Context, agent: str | None, since: str,
 # ───────────────────────────── rendering ──────────────────────────────────
 
 
+def _headline_nudge(audit: OpusQuotaAudit, framing: Framing) -> Any:
+    """Persona-specific takeaway under the measured misallocation headline.
+
+    Subscription / local users pay a flat fee, so the honest framing is a habit
+    nudge: that quota share is still available for hard problems next window.
+    API-billed users additionally get the retrospective counterfactual in
+    dollars — the same work priced at the suggested cheaper tiers, labelled as
+    already-billed so it never reads as a future "saving".
+    """
+    from rich.text import Text
+
+    if framing.pricing_mode == "api" and audit.actual_cost_usd > 0:
+        line = Text("\n→ ", style="dim")
+        line.append(
+            f"Same work at the suggested tiers ≈ "
+            f"{format_cost(audit.alternative_cost_usd)} vs your "
+            f"{format_cost(audit.actual_cost_usd)} actual "
+            "(retrospective — already billed).",
+            style="dim",
+        )
+        return line
+    # subscription / local / unknown — no dollars; behaviour-mirror habit nudge.
+    line = Text("\n→ ", style="green")
+    line.append(
+        "That share stays available for hard problems next window. Use "
+        "`/model sonnet` for mechanical work and right-size your subagents.",
+        style="green",
+    )
+    return line
+
+
 def _render(audit: OpusQuotaAudit, framing: Framing, *, since: str) -> None:
     from rich.console import Group
     from rich.panel import Panel
@@ -125,7 +157,7 @@ def _render(audit: OpusQuotaAudit, framing: Framing, *, since: str) -> None:
 
     if audit.candidate_sessions == 0:
         clean = Text()
-        clean.append("0% reclaimable", style="bold green")
+        clean.append("0% misallocated", style="bold green")
         clean.append(
             " — none of your premium sessions match the Sonnet-shaped structure "
             "(small input/output, few tool calls).",
@@ -133,11 +165,15 @@ def _render(audit: OpusQuotaAudit, framing: Framing, *, since: str) -> None:
         )
         sections.append(clean)
     else:
-        # The headline: quota share, never dollars (audit framing).
+        # The headline is a retrospective behaviour mirror: what SHARE of premium
+        # quota already WENT to Sonnet-shaped sessions. It is misallocated, not
+        # "reclaimable" — those tokens are spent. Quota share, never dollars for
+        # the subscription majority (audit framing).
         big = Text()
-        big.append(f"~{audit.percent_quota_reclaimable:.0f}% ", style="bold red")
+        big.append(f"~{audit.percent_quota_misallocated:.0f}% ", style="bold red")
         big.append(
-            f"of your premium ({PREMIUM_TIER_LABEL}) quota is reclaimable",
+            f"of your premium ({PREMIUM_TIER_LABEL}) quota went to "
+            "Sonnet-shaped sessions",
             style="bold",
         )
         big.append(
@@ -149,27 +185,18 @@ def _render(audit: OpusQuotaAudit, framing: Framing, *, since: str) -> None:
         sections.append(big)
 
         detail = Text()
-        detail.append("\nReclaimable premium tokens:  ", style="dim")
+        detail.append("\nSonnet-shaped premium tokens:  ", style="dim")
         detail.append(format_tokens(audit.candidate_tokens), style="bold")
         detail.append(
             f"  of {format_tokens(audit.opus_tokens)} total", style="dim"
         )
-        # Secondary implied-dollar calibration for API users only — never the
-        # headline. Suppressed for subscription / local / unknown plans.
-        if (
-            framing.pricing_mode == "api"
-            and audit.actual_cost_usd > 0
-        ):
-            detail.append("\nImplied API value:        ", style="dim")
-            detail.append(
-                f"{format_cost(audit.actual_cost_usd)}", style="bold"
-            )
-            detail.append(
-                f" → {format_cost(audit.alternative_cost_usd)} on the smaller "
-                f"model (calibration only)",
-                style="dim",
-            )
         sections.append(detail)
+
+        # Persona-gated takeaway. The measured mirror above is shown to everyone;
+        # this is the actionable framing for the user's billing reality.
+        nudge = _headline_nudge(audit, framing)
+        if nudge is not None:
+            sections.append(nudge)
 
         if audit.suggestions:
             pairs = ", ".join(
@@ -234,7 +261,7 @@ def _export_snippet(audit: OpusQuotaAudit, framing: Framing, *,
 
     Reuses the downsize snippet generator by adapting the audit into a
     ``DowngradeFinding`` shim carrying the observed model→alt suggestions and
-    the reclaimable token figure. No file outside the TokenJam config directory
+    the misallocated token figure. No file outside the TokenJam config directory
     is touched — the user merges the snippet manually.
     """
     from datetime import datetime, timezone
@@ -255,7 +282,7 @@ def _export_snippet(audit: OpusQuotaAudit, framing: Framing, *,
         suggestions=dict(audit.suggestions),
         candidate_tokens=audit.candidate_tokens,
         window_total_tokens=audit.opus_tokens,
-        percent_of_tokens=audit.percent_quota_reclaimable,
+        percent_of_tokens=audit.percent_quota_misallocated,
         monthly_tokens_in_candidates=audit.candidate_tokens,
     )
 
@@ -278,7 +305,9 @@ def _export_snippet(audit: OpusQuotaAudit, framing: Framing, *,
             "path": str(out_path),
             "plan_tier": framing.plan_tier,
             "pricing_mode": framing.pricing_mode,
-            "percent_quota_reclaimable": audit.percent_quota_reclaimable,
+            "percent_quota_misallocated": audit.percent_quota_misallocated,
+            # DEPRECATED alias (see audit_to_dict) — kept one release.
+            "percent_quota_reclaimable": audit.percent_quota_misallocated,
         }, default=str))
         return
 

--- a/tokenjam/cli/cmd_quota_audit.py
+++ b/tokenjam/cli/cmd_quota_audit.py
@@ -173,15 +173,32 @@ def _render(audit: OpusQuotaAudit, framing: Framing, *, since: str) -> None:
         big.append(f"~{audit.percent_quota_misallocated:.0f}% ", style="bold red")
         big.append(
             f"of your premium ({PREMIUM_TIER_LABEL}) quota went to "
-            "Sonnet-shaped sessions",
+            "Sonnet-shaped work",
             style="bold",
         )
-        big.append(
-            f"\nfrom {audit.candidate_sessions} of {audit.opus_sessions} premium "
-            f"session{'s' if audit.opus_sessions != 1 else ''} "
-            f"({audit.percent_sessions:.0f}%) that are Sonnet-shaped",
+        # The number is a single labelled ESTIMATE (founder D1/D3): the "estimate"
+        # tag + a wide bootstrap CI (resampled segments) so it never reads as a
+        # settled figure. Below 2 segments there's no spread to bracket.
+        est = Text("\n", style="dim")
+        est.append(f"{audit.segment_estimate_confidence}", style="italic yellow")
+        if audit.segment_ci_low is not None and audit.segment_ci_high is not None:
+            est.append(
+                f" · 95% CI {audit.segment_ci_low:.0f}–{audit.segment_ci_high:.0f}%",
+                style="dim",
+            )
+        else:
+            est.append(
+                " · single stretch — interval too wide to bracket",
+                style="dim",
+            )
+        est.append(
+            f" · from {audit.segment_count} Sonnet-shaped "
+            f"stretch{'es' if audit.segment_count != 1 else ''} across "
+            f"{audit.candidate_sessions} of {audit.opus_sessions} premium "
+            f"session{'s' if audit.opus_sessions != 1 else ''}",
             style="dim",
         )
+        big.append(est)
         sections.append(big)
 
         detail = Text()

--- a/tokenjam/cli/cmd_quota_audit.py
+++ b/tokenjam/cli/cmd_quota_audit.py
@@ -97,21 +97,34 @@ def cmd_quota_audit(ctx: click.Context, agent: str | None, since: str,
 def _headline_nudge(audit: OpusQuotaAudit, framing: Framing) -> Any:
     """Persona-specific takeaway under the measured misallocation headline.
 
-    Subscription / local users pay a flat fee, so the honest framing is a habit
-    nudge: that quota share is still available for hard problems next window.
-    API-billed users additionally get the retrospective counterfactual in
-    dollars — the same work priced at the suggested cheaper tiers, labelled as
-    already-billed so it never reads as a future "saving".
+    - API-billed with pricing data: the retrospective counterfactual in dollars
+      — the same work priced at the suggested cheaper tiers, labelled as
+      already-billed so it never reads as a future "saving".
+    - API-billed with NO pricing data (every candidate's model is absent from
+      the pricing table, so ``actual_cost_usd == 0``): a neutral routing prompt.
+      API billing has no rolling quota window, so the subscription "next window"
+      language below would be actively wrong for these users.
+    - Subscription / local (and the unknown-plan default): a habit nudge — that
+      quota share is still available for hard problems next window.
     """
     from rich.text import Text
 
-    if framing.pricing_mode == "api" and audit.actual_cost_usd > 0:
+    if framing.pricing_mode == "api":
+        if audit.actual_cost_usd > 0:
+            line = Text("\n→ ", style="dim")
+            line.append(
+                f"Same work at the suggested tiers ≈ "
+                f"{format_cost(audit.alternative_cost_usd)} vs your "
+                f"{format_cost(audit.actual_cost_usd)} actual "
+                "(retrospective — already billed).",
+                style="dim",
+            )
+            return line
+        # API mode but no pricing data — stay neutral, never subscription quota
+        # language (there is no rolling window to hold that share for).
         line = Text("\n→ ", style="dim")
         line.append(
-            f"Same work at the suggested tiers ≈ "
-            f"{format_cost(audit.alternative_cost_usd)} vs your "
-            f"{format_cost(audit.actual_cost_usd)} actual "
-            "(retrospective — already billed).",
+            "Review these sessions before adjusting your routing.",
             style="dim",
         )
         return line
@@ -194,9 +207,7 @@ def _render(audit: OpusQuotaAudit, framing: Framing, *, since: str) -> None:
 
         # Persona-gated takeaway. The measured mirror above is shown to everyone;
         # this is the actionable framing for the user's billing reality.
-        nudge = _headline_nudge(audit, framing)
-        if nudge is not None:
-            sections.append(nudge)
+        sections.append(_headline_nudge(audit, framing))
 
         if audit.suggestions:
             pairs = ", ".join(

--- a/tokenjam/cli/data_access.py
+++ b/tokenjam/cli/data_access.py
@@ -151,7 +151,7 @@ class ServeDataAccess:
         def build() -> tuple[OpusQuotaAudit, Framing]:
             payload = self._db.fetch_opus_quota_audit(since=since, agent_id=agent_id)
             return audit_from_dict(payload), _framing_from_payload(payload)
-        return _through_serve("Opus quota audit", build)
+        return _through_serve("premium quota audit", build)
 
 
 _T = TypeVar("_T")

--- a/tokenjam/core/backfill.py
+++ b/tokenjam/core/backfill.py
@@ -598,11 +598,13 @@ def session_record_from_parsed(
 
 # --- Ingest -----------------------------------------------------------------
 
-# Spans accumulated before a columnar bulk-append flush. Batching across sessions
-# amortizes `read_json`'s per-call fixed cost and collapses the existence check
-# into ONE set-based query per flush (vs one per session) — the win on a history
-# of thousands of small sessions. A batch is a few MB of NDJSON, streamed to a
-# temp file, so memory stays flat regardless of total history size.
+# New spans accumulated before a columnar bulk-append flush. Batching the INSERT
+# across sessions amortizes `read_json`'s per-call fixed cost — measured ~1.5×
+# faster than a flush-per-session on a history of thousands of tiny sessions. A
+# batch is a few MB of NDJSON, streamed to a temp file, so memory stays flat
+# regardless of total history size. (Existence-check + counting stay PER SESSION
+# so `result` — and any live progress display reading it — advances monotonically
+# instead of sitting at zero until the final flush.)
 _BULK_FLUSH_SPAN_TARGET = 25_000
 
 
@@ -636,63 +638,35 @@ def _apply_session(
     _record_insert_outcome(result, parsed, inserted, retagged)
 
 
-def _bulk_apply_batch(
-    db, batch: list[ParsedSession], plan_tier: str, result: BackfillResult
-) -> None:
-    """Insert an accumulated batch of sessions with ONE set-based existence
-    check and ONE columnar bulk-append, then upsert each session row.
+def _dedup_new_spans(conn, parsed: ParsedSession) -> list[NormalizedSpan]:
+    """Return `parsed`'s spans not already present in the DB — a cheap, indexed,
+    chunked existence check. Kept PER SESSION (not batched) so `spans_ingested`
+    can be counted the moment a session is processed, giving the progress
+    callback monotonically-increasing counts while the actual columnar INSERT is
+    deferred to a batched flush."""
+    existing = _existing_span_ids(conn, [s.span_id for s in parsed.spans])
+    return [s for s in parsed.spans if s.span_id not in existing]
 
-    Idempotency is IDENTICAL to the per-session path: a span already in the DB
-    is skipped (existence check + the bulk-append anti-join), so a re-run inserts
-    nothing. Session upserts stay per-file, in order, so `started_at` is set by
-    the first-processed file exactly as before; `recompute_session_totals_from_spans`
-    (run after the loop) reconciles token/cost totals from the spans regardless.
-    """
-    conn = db.conn
-    # ONE existence check for the whole batch. span_ids are deterministic and
-    # session-scoped so they're unique across distinct sessions, but a session
-    # split across sibling files is yielded as separate ParsedSessions sharing a
-    # session_id — guard intra-batch duplicates defensively so the bulk-append
-    # never carries the same span_id twice.
-    all_ids: list[str] = []
-    seen: set[str] = set()
-    for parsed in batch:
-        for span in parsed.spans:
-            if span.span_id not in seen:
-                seen.add(span.span_id)
-                all_ids.append(span.span_id)
-    existing = _existing_span_ids(conn, all_ids)
 
-    new_spans: list[NormalizedSpan] = []
-    queued: set[str] = set()
-    outcomes: list[tuple[ParsedSession, int]] = []
-    for parsed in batch:
-        inserted = 0
-        for span in parsed.spans:
-            if span.span_id in existing or span.span_id in queued:
-                continue
-            queued.add(span.span_id)
-            new_spans.append(span)
-            inserted += 1
-        outcomes.append((parsed, inserted))
-
-    try:
-        db.bulk_insert_spans(new_spans)
-    except Exception:
-        # The INSERT..SELECT is atomic, so nothing landed — degrade to the
-        # slow-but-safe per-session path (which also records files_failed) rather
-        # than aborting the whole ingest. Re-running per session double-counts
-        # nothing because no batch row was inserted.
-        logger.warning(
-            "bulk span append failed; falling back to per-session", exc_info=True
-        )
-        for parsed in batch:
-            _apply_session(db, parsed, plan_tier, reingest=False, result=result)
+def _flush_pending_spans(db, pending: list[NormalizedSpan]) -> None:
+    """Columnar bulk-append of the accumulated new spans (deferred from the
+    per-session loop so many small sessions share one `read_json` scan). On the
+    rare catastrophic append error, degrade to per-row inserts so the ingest
+    keeps making progress rather than aborting — every pending span was already
+    dedup'd as new, so nothing double-inserts."""
+    if not pending:
         return
-
-    for parsed, inserted in outcomes:
-        db.upsert_session(session_record_from_parsed(parsed, plan_tier))
-        _record_insert_outcome(result, parsed, inserted, 0)
+    try:
+        db.bulk_insert_spans(pending)
+    except Exception:
+        logger.warning(
+            "bulk span append failed; falling back to per-row insert", exc_info=True
+        )
+        for span in pending:
+            try:
+                db.insert_span(span)
+            except Exception:
+                pass
 
 
 def ingest_claude_code(
@@ -740,23 +714,22 @@ def ingest_claude_code(
     # since they carry the same session_id + source tag (#294/#300).
     keep_by_session: dict[str, set[str]] = {}
 
-    # A fresh full backfill (the ~8min/5.6GB hot path) accumulates spans across
-    # sessions and flushes them through the columnar bulk-append: ONE set-based
-    # existence check + ONE `read_json` vectorized insert per batch instead of a
-    # dedup query + insert per session. `reingest` keeps the per-session path (its
-    # per-span attribute overlay is not a bulk op); a backend without a `conn`
-    # (defensive) also falls back per session.
+    # A fresh full backfill (the ~8min/5.6GB hot path) dedups + counts + upserts
+    # each session eagerly (so `result` — and any live progress display reading it
+    # — advances monotonically), but DEFERS the actual span INSERT into a
+    # cross-session buffer flushed through the columnar bulk-append. `reingest`
+    # keeps the fully per-session path (its per-span attribute overlay is not a
+    # bulk op); a backend without a `conn` (defensive) also falls back per session.
     conn = getattr(db, "conn", None)
     use_bulk = conn is not None and not reingest
-    batch: list[ParsedSession] = []
-    batch_spans = 0
+    pending: list[NormalizedSpan] = []
+    pending_ids: set[str] = set()
 
-    def _flush_batch() -> None:
-        nonlocal batch, batch_spans
-        if batch:
-            _bulk_apply_batch(db, batch, plan_tier, result)
-            batch = []
-            batch_spans = 0
+    def _flush_pending() -> None:
+        if pending:
+            _flush_pending_spans(db, pending)
+            pending.clear()
+            pending_ids.clear()
 
     for parsed in iter_claude_code_sessions(
         root=root, since=since, capture=capture, max_sessions=max_sessions,
@@ -780,10 +753,29 @@ def ingest_claude_code(
             result.latest = parsed.ended_at
 
         if use_bulk:
-            batch.append(parsed)
-            batch_spans += len(parsed.spans)
-            if batch_spans >= _BULK_FLUSH_SPAN_TARGET:
-                _flush_batch()
+            try:
+                new_spans = _dedup_new_spans(conn, parsed)
+                db.upsert_session(session_record_from_parsed(parsed, plan_tier))
+            except Exception as exc:
+                result.files_failed += 1
+                if len(result.sample_errors) < 5:
+                    result.sample_errors.append(f"{parsed.session_id}: {exc}")
+                continue
+            # Queue the new spans for the batched INSERT, but count them NOW so the
+            # progress callback sees an increasing `spans_ingested` instead of a
+            # flat zero that only jumps at the final flush. The `pending_ids` guard
+            # keeps the same span_id out of one `read_json` batch twice (span_ids
+            # are session-scoped and unique in practice — this is belt-and-braces).
+            queued = 0
+            for span in new_spans:
+                if span.span_id in pending_ids:
+                    continue
+                pending_ids.add(span.span_id)
+                pending.append(span)
+                queued += 1
+            _record_insert_outcome(result, parsed, queued, 0)
+            if len(pending) >= _BULK_FLUSH_SPAN_TARGET:
+                _flush_pending()
         else:
             _apply_session(db, parsed, plan_tier, reingest, result)
 
@@ -793,7 +785,7 @@ def ingest_claude_code(
             except Exception:
                 pass
 
-    _flush_batch()
+    _flush_pending()
 
     # Self-heal stale-scheme duplicates (#294/#300 cross-version). A DB written
     # by <=v0.5.1 keyed backfill span_ids on the record `uuid`; current code keys

--- a/tokenjam/core/backfill.py
+++ b/tokenjam/core/backfill.py
@@ -598,6 +598,103 @@ def session_record_from_parsed(
 
 # --- Ingest -----------------------------------------------------------------
 
+# Spans accumulated before a columnar bulk-append flush. Batching across sessions
+# amortizes `read_json`'s per-call fixed cost and collapses the existence check
+# into ONE set-based query per flush (vs one per session) — the win on a history
+# of thousands of small sessions. A batch is a few MB of NDJSON, streamed to a
+# temp file, so memory stays flat regardless of total history size.
+_BULK_FLUSH_SPAN_TARGET = 25_000
+
+
+def _record_insert_outcome(
+    result: BackfillResult, parsed: ParsedSession, inserted: int, retagged: int
+) -> None:
+    """Fold one session's insert counts into the running `BackfillResult`."""
+    result.spans_ingested += inserted
+    result.spans_retagged += retagged
+    result.spans_skipped_existing += len(parsed.spans) - inserted - retagged
+    if inserted > 0:
+        result.sessions_ingested += 1
+        result.new_session_ids.add(parsed.session_id)
+
+
+def _apply_session(
+    db, parsed: ParsedSession, plan_tier: str, reingest: bool, result: BackfillResult
+) -> None:
+    """Per-session insert path (reingest, no-conn fallback, and the bulk-flush
+    error fallback). Mirrors the historical per-file behavior including the
+    `files_failed` / `sample_errors` accounting on a DB error."""
+    try:
+        inserted, retagged = _insert_session_idempotent(
+            db, parsed, plan_tier=plan_tier, reingest=reingest
+        )
+    except Exception as exc:
+        result.files_failed += 1
+        if len(result.sample_errors) < 5:
+            result.sample_errors.append(f"{parsed.session_id}: {exc}")
+        return
+    _record_insert_outcome(result, parsed, inserted, retagged)
+
+
+def _bulk_apply_batch(
+    db, batch: list[ParsedSession], plan_tier: str, result: BackfillResult
+) -> None:
+    """Insert an accumulated batch of sessions with ONE set-based existence
+    check and ONE columnar bulk-append, then upsert each session row.
+
+    Idempotency is IDENTICAL to the per-session path: a span already in the DB
+    is skipped (existence check + the bulk-append anti-join), so a re-run inserts
+    nothing. Session upserts stay per-file, in order, so `started_at` is set by
+    the first-processed file exactly as before; `recompute_session_totals_from_spans`
+    (run after the loop) reconciles token/cost totals from the spans regardless.
+    """
+    conn = db.conn
+    # ONE existence check for the whole batch. span_ids are deterministic and
+    # session-scoped so they're unique across distinct sessions, but a session
+    # split across sibling files is yielded as separate ParsedSessions sharing a
+    # session_id — guard intra-batch duplicates defensively so the bulk-append
+    # never carries the same span_id twice.
+    all_ids: list[str] = []
+    seen: set[str] = set()
+    for parsed in batch:
+        for span in parsed.spans:
+            if span.span_id not in seen:
+                seen.add(span.span_id)
+                all_ids.append(span.span_id)
+    existing = _existing_span_ids(conn, all_ids)
+
+    new_spans: list[NormalizedSpan] = []
+    queued: set[str] = set()
+    outcomes: list[tuple[ParsedSession, int]] = []
+    for parsed in batch:
+        inserted = 0
+        for span in parsed.spans:
+            if span.span_id in existing or span.span_id in queued:
+                continue
+            queued.add(span.span_id)
+            new_spans.append(span)
+            inserted += 1
+        outcomes.append((parsed, inserted))
+
+    try:
+        db.bulk_insert_spans(new_spans)
+    except Exception:
+        # The INSERT..SELECT is atomic, so nothing landed — degrade to the
+        # slow-but-safe per-session path (which also records files_failed) rather
+        # than aborting the whole ingest. Re-running per session double-counts
+        # nothing because no batch row was inserted.
+        logger.warning(
+            "bulk span append failed; falling back to per-session", exc_info=True
+        )
+        for parsed in batch:
+            _apply_session(db, parsed, plan_tier, reingest=False, result=result)
+        return
+
+    for parsed, inserted in outcomes:
+        db.upsert_session(session_record_from_parsed(parsed, plan_tier))
+        _record_insert_outcome(result, parsed, inserted, 0)
+
+
 def ingest_claude_code(
     db,
     root: Path | None = None,
@@ -611,7 +708,8 @@ def ingest_claude_code(
     Ingest Claude Code sessions into the storage backend.
 
     `db` is a DuckDBBackend (or compatible). Writes are idempotent: spans whose
-    span_id already exists are skipped via INSERT … ON CONFLICT DO NOTHING.
+    span_id already exists are skipped (a batched existence check plus the
+    columnar bulk-append's anti-join), so a re-run inserts no duplicates.
 
     `config` (a TjConfig) supplies the declared plan tier so backfilled sessions
     carry the same `plan_tier` the live ingest path would set (#176). When None
@@ -641,6 +739,25 @@ def ingest_claude_code(
     # a per-file DELETE scoped to session_id would wipe the sibling files' spans,
     # since they carry the same session_id + source tag (#294/#300).
     keep_by_session: dict[str, set[str]] = {}
+
+    # A fresh full backfill (the ~8min/5.6GB hot path) accumulates spans across
+    # sessions and flushes them through the columnar bulk-append: ONE set-based
+    # existence check + ONE `read_json` vectorized insert per batch instead of a
+    # dedup query + insert per session. `reingest` keeps the per-session path (its
+    # per-span attribute overlay is not a bulk op); a backend without a `conn`
+    # (defensive) also falls back per session.
+    conn = getattr(db, "conn", None)
+    use_bulk = conn is not None and not reingest
+    batch: list[ParsedSession] = []
+    batch_spans = 0
+
+    def _flush_batch() -> None:
+        nonlocal batch, batch_spans
+        if batch:
+            _bulk_apply_batch(db, batch, plan_tier, result)
+            batch = []
+            batch_spans = 0
+
     for parsed in iter_claude_code_sessions(
         root=root, since=since, capture=capture, max_sessions=max_sessions,
     ):
@@ -651,37 +768,32 @@ def ingest_claude_code(
         )
         if parsed.cwd:
             projects_seen.add(parsed.cwd)
-        try:
-            inserted, retagged = _insert_session_idempotent(
-                db, parsed, plan_tier=plan_tier, reingest=reingest
-            )
-        except Exception as exc:
-            result.files_failed += 1
-            if len(result.sample_errors) < 5:
-                result.sample_errors.append(f"{parsed.session_id}: {exc}")
-            continue
 
-        result.spans_ingested += inserted
-        result.spans_retagged += retagged
-        result.spans_skipped_existing += len(parsed.spans) - inserted - retagged
-        if inserted > 0:
-            result.sessions_ingested += 1
-            result.new_session_ids.add(parsed.session_id)
-        # Accumulate cost for every parsed file (not just files with new spans)
-        # so the summary reports the full in-window total, not a new-only figure
-        # that reads as "barely worked" on an idempotent re-run (#238).
+        # Cost + window bounds are per-file totals, independent of whether the
+        # spans are new. Accumulate for every parsed file so the summary reports
+        # the full in-window total, not a new-only figure that reads as "barely
+        # worked" on an idempotent re-run (#238).
         result.total_cost_usd += parsed.total_cost_usd
-
         if result.earliest is None or parsed.started_at < result.earliest:
             result.earliest = parsed.started_at
         if result.latest is None or parsed.ended_at > result.latest:
             result.latest = parsed.ended_at
+
+        if use_bulk:
+            batch.append(parsed)
+            batch_spans += len(parsed.spans)
+            if batch_spans >= _BULK_FLUSH_SPAN_TARGET:
+                _flush_batch()
+        else:
+            _apply_session(db, parsed, plan_tier, reingest, result)
 
         if progress is not None:
             try:
                 progress(parsed, result)
             except Exception:
                 pass
+
+    _flush_batch()
 
     # Self-heal stale-scheme duplicates (#294/#300 cross-version). A DB written
     # by <=v0.5.1 keyed backfill span_ids on the record `uuid`; current code keys
@@ -768,35 +880,6 @@ def _merge_attributes(exists_attributes: dict, parsed_attributes: dict) -> dict:
     return {**exists_attributes, **parsed_attributes}
 
 
-# Column order for the bulk span INSERT — kept in lock-step with the named-column
-# INSERT in `DuckDBBackend.insert_span`. A named-column list (not positional) so a
-# future migration adding a column at the end doesn't silently shift binding order.
-_SPAN_INSERT_SQL = (
-    "INSERT INTO spans ("
-    "span_id, trace_id, parent_span_id, session_id, agent_id, "
-    "name, kind, status_code, status_message, start_time, end_time, "
-    "duration_ms, attributes, provider, model, tool_name, "
-    "input_tokens, output_tokens, cache_tokens, cost_usd, "
-    "request_type, conversation_id, events, billing_account, "
-    "cache_write_tokens, sub_agent_id"
-    ") VALUES "
-    "($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12,$13,$14,$15,$16,$17,$18,$19,$20,$21,$22,$23,$24,$25,$26)"
-)
-
-
-def _span_insert_params(span: NormalizedSpan) -> list:
-    """Positional bind params for `_SPAN_INSERT_SQL`, in column order."""
-    return [
-        span.span_id, span.trace_id, span.parent_span_id, span.session_id,
-        span.agent_id, span.name, span.kind.value, span.status_code.value,
-        span.status_message, span.start_time, span.end_time, span.duration_ms,
-        json.dumps(span.attributes), span.provider, span.model, span.tool_name,
-        span.input_tokens, span.output_tokens, span.cache_tokens, span.cost_usd,
-        span.request_type, span.conversation_id, json.dumps(span.events),
-        span.billing_account, span.cache_write_tokens, span.sub_agent_id,
-    ]
-
-
 def _existing_span_ids(conn, span_ids: list[str]) -> set[str]:
     """Return the subset of `span_ids` that already exist in `spans`, in ONE
     query (replacing the per-span existence SELECT). Chunked so an enormous
@@ -823,13 +906,15 @@ def _insert_session_idempotent(
     Insert spans + session record; skip spans already present.
     Returns (newly_inserted, retagged).
 
-    Bulk path (#15): instead of one SELECT + one INSERT per span (~2 round-trips
-    × N spans → ~100s over a large history), the whole session is processed in a
-    bounded number of statements regardless of span count — ONE (chunked)
-    `WHERE span_id IN (...)` partitions spans into new-vs-existing, then the new
-    spans are inserted in a single `executemany`. PRIMARY KEY conflicts on
-    (span_id) mean a previous backfill (or live ingest) already covered the span,
-    so it is skipped.
+    Per-session path: ONE (chunked) `WHERE span_id IN (...)` partitions spans
+    into new-vs-existing, then the new spans are appended via the columnar
+    `db.bulk_insert_spans` (newline-delimited JSON + DuckDB `read_json`, ~350×
+    faster than per-row binding). Its anti-join skips any span_id already present
+    (a previous backfill or live ingest already covered it). The full backfill
+    (`reingest=False`) drives the even faster cross-session batch path in
+    `ingest_claude_code`; this per-session routine remains the `reingest=True`
+    path (its per-span attribute overlay is not a bulk op) and the fallback for a
+    backend without a `conn`.
 
     When `reingest` is True, spans that already exist are UPDATEd instead of
     being skipped — this backfills two things onto rows an older/leaner backfill
@@ -868,9 +953,7 @@ def _insert_session_idempotent(
     existing = _existing_span_ids(conn, span_ids)
     new_spans = [s for s in parsed.spans if s.span_id not in existing]
     if new_spans:
-        conn.executemany(
-            _SPAN_INSERT_SQL, [_span_insert_params(s) for s in new_spans]
-        )
+        db.bulk_insert_spans(new_spans)
         inserted = len(new_spans)
 
     if reingest and existing:

--- a/tokenjam/core/context_diagnostic.py
+++ b/tokenjam/core/context_diagnostic.py
@@ -74,7 +74,7 @@ from __future__ import annotations
 import json
 from collections import defaultdict
 from dataclasses import dataclass, field
-from datetime import datetime
+from datetime import datetime, timezone
 from typing import Any
 
 from tokenjam.otel.semconv import GenAIAttributes
@@ -199,6 +199,17 @@ class TurnComposition:
     output_tokens: int  # work produced
     cache_write_tokens: int  # cache-creation (first-time caching of a prefix)
     cost_usd: float
+    # Ordering + per-turn tool activity — populated by
+    # ``load_turn_compositions(..., ordered=True, with_tool_activity=True)`` for
+    # the segment-level quota audit (contiguity needs start_time; the cheap-shape
+    # test needs a real per-turn tool fan-out and a delegation signal). Default to
+    # inert values so the context-diagnostic path — which never asks for them — is
+    # byte-for-byte unchanged, and so the serialized round-trip (which omits them)
+    # rebuilds cleanly.
+    start_time: datetime | None = None
+    provider: str | None = None
+    tool_fanout: int = 0
+    delegates: bool = False
 
     @property
     def total_tokens(self) -> int:
@@ -553,7 +564,7 @@ def compute_context_diagnostic(
         tool_outputs_captured=tool_outputs_captured,
     )
 
-    turns = _load_turns(conn, since, until, agent_id)
+    turns = load_turn_compositions(conn, since, until, agent_id)
     if not turns:
         return result
 
@@ -599,13 +610,30 @@ def compute_context_diagnostic(
     return result
 
 
-def _load_turns(
+def load_turn_compositions(
     conn: Any,
     since: datetime,
     until: datetime,
     agent_id: str | None,
+    *,
+    ordered: bool = False,
+    with_tool_activity: bool = False,
 ) -> list[TurnComposition]:
-    """One row per assistant LLM turn, with its token composition."""
+    """One :class:`TurnComposition` per assistant LLM turn in the window.
+
+    The single source of the per-turn shape ``tj context`` established, reused by
+    the segment-level quota audit rather than duplicating the SQL. The bare call
+    (both flags off) is exactly the historical ``_load_turns`` — same columns,
+    same order — so the context diagnostic is unchanged.
+
+    ``ordered`` sorts turns by ``(session_id, start_time)`` so a caller can walk a
+    session's turns in wall-clock order (the contiguity key for cheap-stretch
+    detection). ``with_tool_activity`` additionally interleaves the window's tool
+    spans onto the turn timeline, giving each turn a real ``tool_fanout`` and a
+    ``delegates`` flag — attributing each tool span to the nearest preceding turn
+    in its session (the same span data ``tj context`` already reads, keyed
+    finer). Both are opt-in so the diagnostic path pays for neither.
+    """
     clauses = [
         "name = $1",
         "start_time >= $2",
@@ -622,17 +650,20 @@ def _load_turns(
     # accounting reads (and the `heaviest_turns[].sub_agent_id` JSON emits);
     # before this fix the query selected `agent_id` and bound it to that field,
     # so the metric never actually saw which turns were subagent turns.
+    # `start_time` + `provider` are additive columns the audit needs (contiguity
+    # ordering; per-turn downgrade lookup) and the context path simply ignores.
     rows = conn.execute(
         "SELECT session_id, sub_agent_id, model, "
         "COALESCE(input_tokens, 0), COALESCE(output_tokens, 0), "
         "COALESCE(cache_tokens, 0), COALESCE(cache_write_tokens, 0), "
-        "COALESCE(cost_usd, 0.0) "
+        "COALESCE(cost_usd, 0.0), start_time, provider "
         "FROM spans WHERE " + where,
         params,
     ).fetchall()
 
     turns: list[TurnComposition] = []
-    for (sid, said, model, in_tok, out_tok, cache_tok, cache_w_tok, cost) in rows:
+    for (sid, said, model, in_tok, out_tok, cache_tok, cache_w_tok, cost,
+         start_time, provider) in rows:
         turns.append(
             TurnComposition(
                 session_id=str(sid) if sid is not None else "unknown",
@@ -643,9 +674,81 @@ def _load_turns(
                 output_tokens=int(out_tok or 0),
                 cache_write_tokens=int(cache_w_tok or 0),
                 cost_usd=float(cost or 0.0),
+                start_time=start_time,
+                provider=str(provider) if provider is not None else None,
             )
         )
+
+    if with_tool_activity:
+        _attach_tool_activity(conn, since, until, agent_id, turns)
+    if ordered:
+        turns.sort(key=lambda t: (t.session_id, _turn_sort_key(t.start_time)))
     return turns
+
+
+# Sentinel used to order turns whose start_time is somehow missing (real spans
+# always carry one) — keeps the sort total without raising on None.
+_EPOCH = datetime(1970, 1, 1, tzinfo=timezone.utc)
+
+
+def _turn_sort_key(start_time: datetime | None) -> datetime:
+    return start_time if start_time is not None else _EPOCH
+
+
+def _attach_tool_activity(
+    conn: Any,
+    since: datetime,
+    until: datetime,
+    agent_id: str | None,
+    turns: list[TurnComposition],
+) -> None:
+    """Interleave tool spans onto the turn timeline (design §2.4 Option B).
+
+    Each tool span is attributed to the nearest preceding LLM turn in the same
+    session (the turn whose ``start_time`` is the latest at or before the tool
+    span's), giving that turn a real per-turn ``tool_fanout`` and — when the tool
+    is a ``Task`` handoff — a ``delegates`` flag. Falls back to the session's
+    first turn for a tool span that precedes every turn.
+    """
+    clauses = [
+        "name = $1",
+        "start_time >= $2",
+        "start_time < $3",
+        "tool_name IS NOT NULL",
+    ]
+    params: list[Any] = [GenAIAttributes.SPAN_TOOL_CALL, since, until]
+    if agent_id:
+        clauses.append("agent_id = $" + str(len(params) + 1))
+        params.append(agent_id)
+    where = " AND ".join(clauses)
+    tool_rows = conn.execute(
+        "SELECT session_id, tool_name, start_time FROM spans WHERE " + where
+        + " ORDER BY start_time",
+        params,
+    ).fetchall()
+    if not tool_rows:
+        return
+
+    by_session: dict[str, list[TurnComposition]] = defaultdict(list)
+    for t in turns:
+        by_session[t.session_id].append(t)
+    for sess_turns in by_session.values():
+        sess_turns.sort(key=lambda t: _turn_sort_key(t.start_time))
+
+    for sid, tool_name, tstart in tool_rows:
+        sess_turns = by_session.get(str(sid) if sid is not None else "unknown")
+        if not sess_turns:
+            continue
+        target = sess_turns[0]
+        if tstart is not None:
+            for t in sess_turns:
+                if t.start_time is not None and t.start_time <= tstart:
+                    target = t
+                else:
+                    break
+        target.tool_fanout += 1
+        if str(tool_name or "").lower() == DELEGATION_TOOL_NAME:
+            target.delegates = True
 
 
 def _delegating_session_ids(
@@ -690,8 +793,9 @@ def _apply_subagent_accounting(
 ) -> None:
     """Populate the subagent-accounting fields + partial-quota note (#60).
 
-    The weighted quota already includes captured subagent turns (``_load_turns``
-    never filters ``sub_agent_id``). This adds the honesty half the ticket asks
+    The weighted quota already includes captured subagent turns
+    (``load_turn_compositions`` never filters ``sub_agent_id``). This adds the
+    honesty half the ticket asks
     for: when a session *delegated* (a ``Task`` tool span in the parent) but no
     subagent turns were captured for it, its weighted quota is a lower bound —
     so we flag it instead of letting the number read as complete (Rule 14).

--- a/tokenjam/core/context_diagnostic.py
+++ b/tokenjam/core/context_diagnostic.py
@@ -741,8 +741,13 @@ def _attach_tool_activity(
             continue
         target = sess_turns[0]
         if tstart is not None:
+            # Walk in start_time order and keep the latest turn at or before the
+            # tool span. Compare through _turn_sort_key so a turn with a missing
+            # start_time is treated as earliest (consistent with the sort above)
+            # and does NOT truncate attribution — a `break` on a None-start turn
+            # would drop every later, genuinely-preceding turn on the floor.
             for t in sess_turns:
-                if t.start_time is not None and t.start_time <= tstart:
+                if _turn_sort_key(t.start_time) <= tstart:
                     target = t
                 else:
                     break

--- a/tokenjam/core/db.py
+++ b/tokenjam/core/db.py
@@ -6,10 +6,12 @@ from __future__ import annotations
 
 import json
 import logging
+import os
+import tempfile
 import threading
 from datetime import date, datetime
 from pathlib import Path
-from typing import Protocol, runtime_checkable
+from typing import Protocol, Sequence, runtime_checkable
 
 import duckdb
 
@@ -44,6 +46,7 @@ logger = logging.getLogger("tokenjam.db")
 @runtime_checkable
 class StorageBackend(Protocol):
     def insert_span(self, span: NormalizedSpan) -> None: ...
+    def bulk_insert_spans(self, spans: Sequence[NormalizedSpan]) -> None: ...
     def insert_alert(self, alert: Alert) -> None: ...
     def insert_validation(self, result: SchemaValidationResult) -> None: ...
     def insert_policy_decision(self, decision: PolicyDecisionRecord) -> None: ...
@@ -146,6 +149,122 @@ SPANS_INDEX_SQL = (
     "CREATE INDEX IF NOT EXISTS idx_spans_tool_name   ON spans(tool_name);\n"
     "CREATE INDEX IF NOT EXISTS idx_spans_conv_id     ON spans(conversation_id)"
 )
+
+# ---------------------------------------------------------------------------
+# Columnar bulk-append of spans (backfill hot path)
+# ---------------------------------------------------------------------------
+#
+# The per-row `insert_span` (and `executemany`) marshals every span across the
+# Python<->DuckDB boundary one row at a time — measured ~350x slower than the
+# path below and the dominant cost of a full-history backfill. `bulk_insert_spans`
+# instead writes the whole batch once as newline-delimited JSON and lets DuckDB's
+# native `read_json` scan it in a single vectorized INSERT..SELECT. This is
+# dependency-free (no pandas/pyarrow — DuckDB reads JSON natively), so the lean
+# base install is unchanged.
+#
+# `_SPAN_BULK_COLUMNS` mirrors `insert_span`'s named-column list exactly (same 28
+# columns, same order). `_SPAN_BULK_READ_TYPES` gives `read_json` an explicit
+# schema so key order / type inference can never drift: JSON columns stay JSON,
+# timestamps arrive as strings and are cast to TIMESTAMPTZ in the SELECT, numerics
+# are pinned. Keep all three in lock-step with the table + `insert_span`.
+_SPAN_BULK_COLUMNS: tuple[str, ...] = (
+    "span_id", "trace_id", "parent_span_id", "session_id", "agent_id",
+    "name", "kind", "status_code", "status_message", "start_time", "end_time",
+    "duration_ms", "attributes", "provider", "model", "tool_name",
+    "input_tokens", "output_tokens", "cache_tokens", "cost_usd",
+    "request_type", "conversation_id", "events", "billing_account",
+    "cache_write_tokens", "request_params", "request_tools", "sub_agent_id",
+)
+
+# read_json column -> type. Timestamps are read as VARCHAR and cast to TIMESTAMPTZ
+# in the projection (matches how binding a tz-aware datetime lands the same UTC
+# instant). JSON columns stay JSON so nested objects/arrays are stored as JSON
+# values — NOT as double-encoded strings.
+_SPAN_BULK_READ_TYPES: dict[str, str] = {
+    "span_id": "VARCHAR", "trace_id": "VARCHAR", "parent_span_id": "VARCHAR",
+    "session_id": "VARCHAR", "agent_id": "VARCHAR", "name": "VARCHAR",
+    "kind": "VARCHAR", "status_code": "VARCHAR", "status_message": "VARCHAR",
+    "start_time": "VARCHAR", "end_time": "VARCHAR", "duration_ms": "DOUBLE",
+    "attributes": "JSON", "provider": "VARCHAR", "model": "VARCHAR",
+    "tool_name": "VARCHAR", "input_tokens": "BIGINT", "output_tokens": "BIGINT",
+    "cache_tokens": "BIGINT", "cost_usd": "DOUBLE", "request_type": "VARCHAR",
+    "conversation_id": "VARCHAR", "events": "JSON", "billing_account": "VARCHAR",
+    "cache_write_tokens": "BIGINT", "request_params": "JSON",
+    "request_tools": "JSON", "sub_agent_id": "VARCHAR",
+}
+
+# Columns that need a cast in the SELECT (read as VARCHAR, stored as TIMESTAMPTZ).
+_SPAN_BULK_CAST = {"start_time": "TIMESTAMPTZ", "end_time": "TIMESTAMPTZ"}
+
+# read_json objects are tiny per span, but a captured-content span can be large;
+# give read_json generous headroom so a fat prompt never trips the default cap.
+_SPAN_BULK_MAX_OBJECT_BYTES = 256 * 1024 * 1024
+
+
+def _build_bulk_span_insert_sql() -> str:
+    cols = ", ".join(_SPAN_BULK_COLUMNS)
+    projection = ", ".join(
+        f"{c}::{_SPAN_BULK_CAST[c]}" if c in _SPAN_BULK_CAST else c
+        for c in _SPAN_BULK_COLUMNS
+    )
+    read_cols = ", ".join(
+        f"'{c}': '{_SPAN_BULK_READ_TYPES[c]}'" for c in _SPAN_BULK_COLUMNS
+    )
+    return (
+        f"INSERT INTO spans ({cols})\n"
+        f"SELECT {projection} FROM read_json(\n"
+        f"    ?, format='newline_delimited', records='true',\n"
+        f"    columns={{{read_cols}}},\n"
+        f"    maximum_object_size={_SPAN_BULK_MAX_OBJECT_BYTES}\n"
+        f") AS src\n"
+        # Idempotent anti-join: skip any span_id already present so a span another
+        # writer (or an earlier backfill) inserted between the caller's dedup pass
+        # and this call is silently skipped rather than raising a PK conflict.
+        f"WHERE NOT EXISTS (SELECT 1 FROM spans t WHERE t.span_id = src.span_id)"
+    )
+
+
+_BULK_SPAN_INSERT_SQL = _build_bulk_span_insert_sql()
+
+
+def _span_to_json_obj(span: NormalizedSpan) -> dict:
+    """Serialize a span to the JSON object `read_json` expects — one key per
+    bulk column. Enums are unwrapped to their `.value`; datetimes to ISO-8601
+    (tz-aware, so the offset survives); `attributes`/`events`/`request_params`/
+    `request_tools` stay NESTED (objects/arrays, never pre-stringified) so DuckDB
+    stores them as JSON values identical to what `insert_span` binds.
+    """
+    return {
+        "span_id": span.span_id,
+        "trace_id": span.trace_id,
+        "parent_span_id": span.parent_span_id,
+        "session_id": span.session_id,
+        "agent_id": span.agent_id,
+        "name": span.name,
+        "kind": span.kind.value,
+        "status_code": span.status_code.value,
+        "status_message": span.status_message,
+        "start_time": span.start_time.isoformat() if span.start_time else None,
+        "end_time": span.end_time.isoformat() if span.end_time else None,
+        "duration_ms": span.duration_ms,
+        "attributes": span.attributes,
+        "provider": span.provider,
+        "model": span.model,
+        "tool_name": span.tool_name,
+        "input_tokens": span.input_tokens,
+        "output_tokens": span.output_tokens,
+        "cache_tokens": span.cache_tokens,
+        "cost_usd": span.cost_usd,
+        "request_type": span.request_type,
+        "conversation_id": span.conversation_id,
+        "events": span.events,
+        "billing_account": span.billing_account,
+        "cache_write_tokens": span.cache_write_tokens,
+        "request_params": span.request_params,
+        "request_tools": span.request_tools,
+        "sub_agent_id": span.sub_agent_id,
+    }
+
 
 INITIAL_SCHEMA_SQL = (
     """\
@@ -1052,6 +1171,39 @@ class DuckDBBackend:
                     span.sub_agent_id,
                 ],
             )
+
+    def bulk_insert_spans(self, spans: Sequence[NormalizedSpan]) -> None:
+        """Columnar bulk-append of many spans in a single vectorized statement.
+
+        Replaces the per-row `insert_span`/`executemany` marshalling on the
+        backfill hot path: the whole batch is written once as newline-delimited
+        JSON and DuckDB's native `read_json` scans it in one `INSERT..SELECT`, so
+        a multi-GB Claude Code history ingests in seconds instead of minutes.
+        Dependency-free (DuckDB reads JSON natively — no pandas/pyarrow).
+
+        Idempotent: a `WHERE NOT EXISTS` anti-join skips any `span_id` already
+        present, so callers that pre-filter for counting still get correct DB
+        contents even if a concurrent writer inserts the same id mid-flight
+        (no PRIMARY KEY conflict is raised). Resulting rows — columns, JSON, and
+        TIMESTAMPTZ instants — are identical to the per-row path.
+        """
+        if not spans:
+            return
+        # Write the NDJSON payload OUTSIDE the write lock (pure CPU/IO, no DB),
+        # then hold the lock only for the single vectorized INSERT..SELECT.
+        fd, path = tempfile.mkstemp(prefix="tj-spans-", suffix=".ndjson")
+        try:
+            with os.fdopen(fd, "w", encoding="utf-8") as fh:
+                for span in spans:
+                    fh.write(json.dumps(_span_to_json_obj(span)))
+                    fh.write("\n")
+            with self._write_lock:
+                self.conn.execute(_BULK_SPAN_INSERT_SQL, [path])
+        finally:
+            try:
+                os.remove(path)
+            except OSError:
+                pass
 
     def insert_alert(self, alert: Alert) -> None:
         with self._write_lock:

--- a/tokenjam/core/model_tiers.py
+++ b/tokenjam/core/model_tiers.py
@@ -1,0 +1,50 @@
+"""Provider-agnostic model-family tier classification.
+
+One place that knows which Anthropic model families are *premium* (worth a
+quota audit / right-sizing flag) and how the tiers rank. The optimize analyzers
+consume this instead of each hardcoding an ``"opus"`` substring — so when a new
+family launches above the current top (as **Fable** launched above Opus), it is
+a one-line edit here, not a grep-and-patch across every analyzer.
+
+Membership is decided by a lowercased-substring match on the model id, which
+tolerates version suffixes, ``YYYYMMDD`` dates, provider prefixes (Bedrock's
+``us-anthropic-…`` / ``global-anthropic-…``), and ``[1m]`` context tags — e.g.
+``us-anthropic-claude-opus-4-8-20260115[1m]`` all resolve to ``"opus"``. This
+mirrors the tolerance the pricing layer already relies on and is the same
+matching the analyzers used before this module existed.
+"""
+from __future__ import annotations
+
+# Model-family tiers, most capable first. Fable sits ABOVE Opus. Each entry is
+# ``(substring, tier)``; the first substring found in the (lowercased) model id
+# wins. No model id contains two family names, so ordering only matters as a
+# tie-break that never fires in practice — but keeping it capability-ordered
+# documents the ladder for the downgrade suggestions below.
+TIER_SUBSTRINGS: tuple[tuple[str, str], ...] = (
+    ("fable", "fable"),
+    ("opus", "opus"),
+    ("sonnet", "sonnet"),
+    ("haiku", "haiku"),
+)
+
+# Tiers whose sessions are worth a premium-quota audit / right-sizing flag.
+# Extend this (and TIER_SUBSTRINGS) when a new premium family launches — that is
+# the single edit that teaches every consumer about the new tier.
+PREMIUM_TIERS: frozenset[str] = frozenset({"fable", "opus"})
+
+# Human-facing label for the premium tier, for copy that names what is audited.
+PREMIUM_TIER_LABEL = "Opus/Fable"
+
+
+def model_tier(model: str | None) -> str | None:
+    """Classify a model id into its family tier, or ``None`` if unrecognised."""
+    normalised = (model or "").lower()
+    for substring, tier in TIER_SUBSTRINGS:
+        if substring in normalised:
+            return tier
+    return None
+
+
+def is_premium_tier(model: str | None) -> bool:
+    """True when the model belongs to a premium tier (Fable or Opus today)."""
+    return model_tier(model) in PREMIUM_TIERS

--- a/tokenjam/core/optimize/analyzers/model_downgrade.py
+++ b/tokenjam/core/optimize/analyzers/model_downgrade.py
@@ -12,6 +12,10 @@ import re as _re
 from datetime import datetime
 from typing import Any
 
+from tokenjam.core.context_diagnostic import (
+    TurnComposition,
+    load_turn_compositions,
+)
 from tokenjam.core.model_tiers import is_premium_tier
 from tokenjam.core.optimize.registry import register
 from tokenjam.core.optimize.stats import bootstrap_ci
@@ -30,6 +34,25 @@ from tokenjam.core.pricing import get_rates
 SMALL_INPUT_TOKENS = 5_000
 SMALL_OUTPUT_TOKENS = 500
 SMALL_TOOL_CALLS = 5
+
+# Per-TURN cheap-shape thresholds for the segment-level premium quota audit. A
+# turn is a fraction of a session, so these sit well below the session-level
+# constants above. Measured on NEW work (uncached input + output + this turn's
+# tool fan-out), deliberately NOT on re-read/cache tokens: a mechanical turn can
+# still re-read a huge context — that cache-read quota is exactly what a cheaper
+# model would have burned more cheaply, so it belongs in the reclaimable metric,
+# not the shape test. Starting calibration (non-blocking follow-up); left as
+# named constants so a real-DB sweep can retune them in one place.
+TURN_SMALL_INPUT = 2_000
+TURN_SMALL_OUTPUT = 300
+TURN_SMALL_TOOL_CALLS = 2
+
+# A cheap segment is a maximal contiguous run of cheap-shaped turns. A run of at
+# least this many is a flagged stretch; a shorter run is only flagged when it
+# spans the session's ENTIRE set of turns (the whole-session floor — a session
+# that was Sonnet-shaped end to end, which the old audit already flagged). This
+# stops a lone mechanical turn wedged between two hard turns from counting.
+MIN_STRETCH_TURNS = 2
 
 # Cap on the number of spot-check example sessions carried in the audit.
 OPUS_AUDIT_MAX_EXAMPLES = 5
@@ -61,8 +84,13 @@ DOWNGRADE_CANDIDATES: dict[str, dict[str, str]] = {
 }
 
 
-def _lookup_downgrade(provider: str, model: str) -> str | None:
-    """DOWNGRADE_CANDIDATES lookup that tolerates trailing YYYYMMDD suffixes."""
+def lookup_downgrade(provider: str, model: str) -> str | None:
+    """The cheaper same-family alternative for ``(provider, model)``, or ``None``.
+
+    Tolerates trailing ``-YYYYMMDD`` date suffixes on the model id. Public (the
+    premium quota audit and its routing export both need it); the underscore
+    alias is kept so existing internal call sites don't churn.
+    """
     mapping = DOWNGRADE_CANDIDATES.get(provider, {})
     if model in mapping:
         return mapping[model]
@@ -70,6 +98,10 @@ def _lookup_downgrade(provider: str, model: str) -> str | None:
     if m and m.group(1) in mapping:
         return mapping[m.group(1)]
     return None
+
+
+# Backward-compatible private alias — internal call sites predate the promotion.
+_lookup_downgrade = lookup_downgrade
 
 
 def _alt_unit_cost(provider: str, original_model: str, alt_model: str,
@@ -265,36 +297,103 @@ def run(ctx: AnalyzerContext) -> None:
 # ---------------------------------------------------------------------------
 # Premium-tier quota audit (retroactive Downsize, reframed as accountability)
 # ---------------------------------------------------------------------------
-# This runs the same structural heuristic as `downsize`, but scoped to
-# premium-tier sessions only (Fable + Opus, via the shared model_tiers
-# predicate) and reframed as a "quota audit" rather than "cost optimization"
-# (issue #5; research/evidence/feature-downsize.md). The headline is
-# "% of your premium (Opus/Fable) quota that went to Sonnet-shaped sessions"
-# — a retrospective behaviour mirror in premium token share, not dollars and
-# not "reclaimable" (the tokens are already spent) — because the subscription
+# This reframes the structural downsize heuristic as an accountability "quota
+# audit" scoped to premium-tier work (Fable + Opus, via the shared model_tiers
+# predicate; issue #5, research/evidence/feature-downsize.md). The headline is
+# "% of your premium (Opus/Fable) quota that went to Sonnet-shaped work" — a
+# retrospective behaviour mirror in premium token share, not dollars and not
+# "reclaimable" (the tokens are already spent) — because the subscription
 # majority is on flat-rate plans where dollar framing mis-targets them
 # (subscription-vs-cost-framing.md). It complements opusplan / `/model`
 # (forward-looking) by answering the backward-looking question those tools
-# can't: "which of my PAST premium sessions were Sonnet-shaped?" Honest framing
-# throughout — candidates to spot-check, never "safe to downgrade".
+# can't: "which stretches of my PAST premium work were Sonnet-shaped?" Honest
+# framing throughout — candidates to spot-check, never "safe to downgrade".
+#
+# Grain: a PER-TURN walk over the `TurnComposition` rows `tj context` already
+# produces, NOT the old whole-session `MODE(model)` + SUM aggregate. Two
+# structural fixes fall out:
+#   (a) a mechanical STRETCH inside an otherwise-hard session is now detectable
+#       (the whole-session heuristic structurally missed it — the hard part blew
+#       the sums past the thresholds); and
+#   (b) each turn's tokens count under ITS OWN model, so a Sonnet turn inside an
+#       Opus session no longer inflates the premium numerator or denominator.
 #
 # The `audit_opus_quota` name and the `opus_*` fields on OpusQuotaAudit are kept
 # for API/serialization stability; they now denote the whole premium tier, not
-# Opus alone (the audit counts and flags Fable sessions too).
+# Opus alone (the audit counts and flags Fable turns too), and are quota-weighted
+# (the #119 weighting) rather than raw token sums.
 
 
-def _is_premium_downsizable(provider: str, model: str) -> bool:
-    """True when the model is a premium-tier model worth auditing for downsize.
+def _is_cheap_shaped(turn: TurnComposition) -> bool:
+    """True when a turn's *reasoning* footprint is Sonnet-shaped (design §2.1).
 
-    Premium-tier membership (Fable, Opus, and whatever launches above them next)
-    is resolved through the shared :func:`is_premium_tier` predicate — no
-    per-analyzer substring gate. We only audit premium sessions that ALSO have a
-    known cheaper alternative in `DOWNGRADE_CANDIDATES` (so the routing
-    suggestion is real, not invented).
+    Measured on NEW work — uncached input, output, this turn's tool fan-out — and
+    on the absence of a Task delegation. Deliberately NOT gated on re-read /
+    cache-write tokens: a mechanical turn can still re-read a huge context, and
+    that cache-read quota is exactly what a cheaper model would have burned more
+    cheaply — it belongs in the reclaimable metric, not the shape test.
     """
-    if not is_premium_tier(model):
-        return False
-    return _lookup_downgrade(provider, model) is not None
+    return (
+        turn.new_input_tokens < TURN_SMALL_INPUT
+        and turn.output_tokens < TURN_SMALL_OUTPUT
+        and turn.tool_fanout <= TURN_SMALL_TOOL_CALLS
+        and not turn.delegates
+    )
+
+
+def _cheap_segments(
+    session_turns: list[TurnComposition],
+) -> list[list[TurnComposition]]:
+    """Maximal contiguous runs of cheap-shaped turns (design §2.2).
+
+    A non-cheap turn (or a delegation, which makes a turn non-cheap) breaks the
+    run. Turns must already be ordered by ``start_time``.
+    """
+    segments: list[list[TurnComposition]] = []
+    run: list[TurnComposition] = []
+    for turn in session_turns:
+        if _is_cheap_shaped(turn):
+            run.append(turn)
+        elif run:
+            segments.append(run)
+            run = []
+    if run:
+        segments.append(run)
+    return segments
+
+
+def _segment_counts(segment: list[TurnComposition], session_turn_count: int) -> bool:
+    """Whether a cheap segment is flagged (design §2.2 + the whole-session floor).
+
+    A stretch of at least ``MIN_STRETCH_TURNS`` counts; a shorter run counts only
+    when it spans the session's ENTIRE turn set (a session that was Sonnet-shaped
+    end to end — the whole-session floor the old audit already flagged, and the
+    reason a single-turn cheap session is still counted). This is what keeps a
+    lone mechanical turn wedged between two hard turns from being flagged.
+    """
+    return (
+        len(segment) >= MIN_STRETCH_TURNS
+        or len(segment) == session_turn_count
+    )
+
+
+class _SessionAgg:
+    """Per-session aggregate of the flagged cheap-segment PREMIUM turns, for the
+    spot-check example list (largest-quota first)."""
+
+    __slots__ = ("session_id", "model", "provider", "quota", "new_input",
+                 "output", "reread", "tool_calls", "cost")
+
+    def __init__(self, session_id: str) -> None:
+        self.session_id = session_id
+        self.model = ""
+        self.provider: str | None = None
+        self.quota = 0.0
+        self.new_input = 0
+        self.output = 0
+        self.reread = 0
+        self.tool_calls = 0
+        self.cost = 0.0
 
 
 def audit_opus_quota(
@@ -304,131 +403,144 @@ def audit_opus_quota(
     agent_id: str | None,
     window_days: float,
 ) -> OpusQuotaAudit:
-    """Retroactive premium-tier quota audit over Claude Code (and other) sessions.
+    """Retroactive segment-level premium-tier quota audit (issue #5).
 
-    Walks premium-tier sessions (Fable + Opus, via the shared model_tiers
-    predicate) in the window and flags those whose structural shape (small
-    input, small output, few tool calls) matches a class of work where a cheaper
-    same-family model is worth a spot-check. Quantifies the result as a **share
-    of premium quota** (candidate premium tokens / total premium tokens) — never
-    a dollar figure as the headline. Field names retain the historical `opus_*`
-    prefix for serialization stability but count the whole premium tier.
+    Walks the window's assistant turns per session in ``start_time`` order and
+    reports ONE honest figure (founder decision D1): the share of premium
+    (Opus/Fable) quota that went to Sonnet-shaped *work* — whole Sonnet-shaped
+    sessions PLUS mechanical stretches inside otherwise-hard sessions — on
+    exact per-turn model attribution (D2). Quota-weighted (the #119 weighting),
+    never a dollar headline; the `opus_*` field names are kept for serialization
+    stability but denote the whole premium tier.
 
-    Computes purely from already-backfilled token/model metadata; does NOT
-    depend on captured content (#3). Always returns an :class:`OpusQuotaAudit`
-    (never ``None``) so the renderer can show an honest empty state.
+    The figure is a labelled ESTIMATE (D3): `segment_estimate_confidence` +
+    `estimate_basis` mark it heuristic, and a WIDE bootstrap CI over resampled
+    SEGMENTS brackets it (`segment_ci_low/high`) so the band widens honestly when
+    few segments carry it.
+
+    Computes purely from already-backfilled token/model metadata — no captured
+    content (#3). Always returns an :class:`OpusQuotaAudit` (never ``None``) so
+    the renderer can show an honest empty state.
     """
-    clauses = ["start_time >= $1", "start_time < $2", "session_id IS NOT NULL"]
-    params: list[Any] = [since, until]
-    if agent_id:
-        clauses.append(f"agent_id = ${len(params) + 1}")
-        params.append(agent_id)
-    where = " AND ".join(clauses)
-
-    # LLM spans grouped by session (one row per session, dominant model).
-    llm_rows = conn.execute(
-        f"SELECT session_id, "
-        f"FIRST(trace_id) AS trace_id, "
-        f"FIRST(agent_id) AS agent_id, "
-        f"MIN(start_time) AS start_time, MAX(end_time) AS end_time, "
-        f"MIN(provider) AS provider, "
-        f"MODE(model) AS model, "
-        f"COALESCE(SUM(input_tokens),0)  AS input_tokens, "
-        f"COALESCE(SUM(output_tokens),0) AS output_tokens, "
-        f"COALESCE(SUM(cache_tokens),0)  AS cache_tokens, "
-        f"COALESCE(SUM(cost_usd),0.0)    AS cost_usd "
-        f"FROM spans WHERE {where} AND model IS NOT NULL "
-        f"GROUP BY session_id",
-        params,
-    ).fetchall()
-
+    turns = load_turn_compositions(
+        conn, since, until, agent_id,
+        ordered=True, with_tool_activity=True,
+    )
     audit = OpusQuotaAudit(window_days=window_days)
-    if not llm_rows:
+    if not turns:
         return audit
 
-    # Tool span counts per session (tool spans have model=NULL).
-    tool_rows = conn.execute(
-        f"SELECT session_id, COUNT(*) FROM spans "
-        f"WHERE {where} AND tool_name IS NOT NULL "
-        f"GROUP BY session_id",
-        params,
-    ).fetchall()
-    tool_counts: dict[str, int] = {r[0]: int(r[1] or 0) for r in tool_rows if r[0]}
+    # Group into sessions, preserving the (already-applied) start_time ordering.
+    by_session: dict[str, list[TurnComposition]] = {}
+    for turn in turns:
+        by_session.setdefault(turn.session_id, []).append(turn)
 
-    candidate_examples: list[tuple[int, OpusAuditExample]] = []
+    premium_quota = 0.0            # denominator: quota-weighted premium turns
+    misallocated_quota = 0.0       # numerator: premium turns in flagged segments
+    segment_values: list[float] = []   # one premium-quota value per flagged segment
     suggestions: dict[str, str] = {}
+    aggs: dict[str, _SessionAgg] = {}
+    actual_cost = 0.0
+    alt_cost = 0.0
 
-    for row in llm_rows:
-        session_id, trace_id, _agent, start_time, end_time, provider, model, \
-            in_tok, out_tok, cache_tok, cost = row
-        if not provider or not model:
+    for session_id, session_turns in by_session.items():
+        premium_turns = [t for t in session_turns if is_premium_tier(t.model)]
+        if not premium_turns:
             continue
-        if not _is_premium_downsizable(provider, model):
-            continue
-
-        session_tokens = int(in_tok or 0) + int(out_tok or 0) + int(cache_tok or 0)
         audit.opus_sessions += 1
-        audit.opus_tokens += session_tokens
+        premium_quota += sum(t.quota_weighted_tokens for t in premium_turns)
 
-        alt = _lookup_downgrade(provider, model)
-        tool_calls = tool_counts.get(session_id, 0)
-        is_candidate = (
-            alt is not None
-            and in_tok < SMALL_INPUT_TOKENS
-            and out_tok < SMALL_OUTPUT_TOKENS
-            and tool_calls <= SMALL_TOOL_CALLS
-        )
-        if not is_candidate:
+        session_flagged = False
+        for segment in _cheap_segments(session_turns):
+            if not _segment_counts(segment, len(session_turns)):
+                continue
+            seg_premium = [t for t in segment if is_premium_tier(t.model)]
+            if not seg_premium:
+                continue
+            seg_quota = sum(t.quota_weighted_tokens for t in seg_premium)
+            misallocated_quota += seg_quota
+            segment_values.append(seg_quota)
+            audit.segment_count += 1
+            session_flagged = True
+
+            agg = aggs.setdefault(session_id, _SessionAgg(session_id))
+            for t in seg_premium:
+                agg.quota += t.quota_weighted_tokens
+                agg.new_input += t.new_input_tokens
+                agg.output += t.output_tokens
+                agg.reread += t.reread_tokens
+                agg.tool_calls += t.tool_fanout
+                agg.cost += t.cost_usd
+                if not agg.model:
+                    agg.model = t.model
+                    agg.provider = t.provider
+                alt = (
+                    lookup_downgrade(t.provider, t.model)
+                    if t.provider else None
+                )
+                if alt:
+                    suggestions[t.model] = alt
+
+        if session_flagged:
+            audit.candidate_sessions += 1
+
+    # Secondary API-only implied-dollar counterfactual, aggregated over the
+    # flagged premium turns (never the headline).
+    for agg in aggs.values():
+        alt = lookup_downgrade(agg.provider, agg.model) if agg.provider else None
+        if not alt:
             continue
+        alt_unit = _alt_unit_cost(
+            agg.provider, agg.model, alt, agg.new_input, agg.output, agg.reread,
+        )
+        if alt_unit is not None:
+            actual_cost += agg.cost
+            alt_cost += alt_unit
 
-        audit.candidate_sessions += 1
-        audit.candidate_tokens += session_tokens
-        if alt:
-            suggestions[str(model)] = alt
-            # Best-effort implied dollar value (secondary signal for API users).
-            alt_unit = _alt_unit_cost(
-                provider, str(model), alt,
-                int(in_tok or 0), int(out_tok or 0), int(cache_tok or 0),
-            )
-            if alt_unit is not None:
-                audit.actual_cost_usd += float(cost or 0.0)
-                audit.alternative_cost_usd += alt_unit
-
-        duration = None
-        try:
-            if start_time and end_time:
-                duration = (end_time - start_time).total_seconds()
-        except Exception:  # noqa: BLE001
-            duration = None
-        candidate_examples.append((
-            session_tokens,
-            OpusAuditExample(
-                trace_id=str(trace_id) if trace_id else "",
-                session_id=str(session_id) if session_id else None,
-                model=str(model),
-                alt_model=str(alt) if alt else "",
-                input_tokens=int(in_tok or 0),
-                output_tokens=int(out_tok or 0),
-                cache_tokens=int(cache_tok or 0),
-                tool_calls=tool_calls,
-                duration_seconds=duration,
-                cost_usd=float(cost or 0.0),
-            ),
-        ))
-
+    audit.opus_tokens = int(round(premium_quota))
+    audit.candidate_tokens = int(round(misallocated_quota))
     audit.suggestions = suggestions
-    # Largest-quota candidates first — those are the most worthwhile spot-checks.
-    candidate_examples.sort(key=lambda pair: pair[0], reverse=True)
-    audit.examples = [ex for _tokens, ex in candidate_examples[:OPUS_AUDIT_MAX_EXAMPLES]]
-
     audit.percent_quota_misallocated = (
-        round(100.0 * audit.candidate_tokens / audit.opus_tokens, 1)
-        if audit.opus_tokens > 0 else 0.0
+        round(100.0 * misallocated_quota / premium_quota, 1)
+        if premium_quota > 0 else 0.0
     )
     audit.percent_sessions = (
         round(100.0 * audit.candidate_sessions / audit.opus_sessions, 1)
         if audit.opus_sessions > 0 else 0.0
     )
-    audit.actual_cost_usd = round(audit.actual_cost_usd, 6)
-    audit.alternative_cost_usd = round(audit.alternative_cost_usd, 6)
+    audit.actual_cost_usd = round(actual_cost, 6)
+    audit.alternative_cost_usd = round(alt_cost, 6)
+
+    # Confidence interval on the HEADLINE PERCENT (design §6, founder D3). Each
+    # flagged segment contributes its premium-quota value; scaling the resampled
+    # SUM by 100/premium_quota turns the bootstrap into an interval on the share.
+    # Resampling segments (not sessions) widens the band honestly when the
+    # estimate rests on few stretches; below 2 segments there is no spread to
+    # bracket, so the bounds stay None (the estimate is inherently wide).
+    if premium_quota > 0 and len(segment_values) >= 2:
+        ci = bootstrap_ci(segment_values, scale=100.0 / premium_quota)
+        if ci is not None:
+            audit.segment_ci_low = round(ci[0], 1)
+            audit.segment_ci_high = round(ci[1], 1)
+
+    # Largest-quota candidate sessions first — the most worthwhile spot-checks.
+    ordered_aggs = sorted(aggs.values(), key=lambda a: a.quota, reverse=True)
+    audit.examples = [
+        OpusAuditExample(
+            trace_id="",
+            session_id=agg.session_id,
+            model=agg.model,
+            alt_model=(
+                lookup_downgrade(agg.provider, agg.model)
+                if agg.provider else None
+            ) or "",
+            input_tokens=agg.new_input,
+            output_tokens=agg.output,
+            cache_tokens=agg.reread,
+            tool_calls=agg.tool_calls,
+            duration_seconds=None,
+            cost_usd=round(agg.cost, 6),
+        )
+        for agg in ordered_aggs[:OPUS_AUDIT_MAX_EXAMPLES]
+    ]
     return audit

--- a/tokenjam/core/optimize/analyzers/model_downgrade.py
+++ b/tokenjam/core/optimize/analyzers/model_downgrade.py
@@ -381,19 +381,30 @@ class _SessionAgg:
     """Per-session aggregate of the flagged cheap-segment PREMIUM turns, for the
     spot-check example list (largest-quota first)."""
 
-    __slots__ = ("session_id", "model", "provider", "quota", "new_input",
+    __slots__ = ("session_id", "quota_by_model", "quota", "new_input",
                  "output", "reread", "tool_calls", "cost")
 
     def __init__(self, session_id: str) -> None:
         self.session_id = session_id
-        self.model = ""
-        self.provider: str | None = None
+        # (provider, model) -> flagged premium quota, so the example reports the
+        # model that actually carried the most misallocated quota in this session
+        # rather than freezing on whichever premium turn happened to appear first
+        # (a mixed-model session could otherwise mislabel the routing suggestion).
+        self.quota_by_model: dict[tuple[str | None, str], float] = {}
         self.quota = 0.0
         self.new_input = 0
         self.output = 0
         self.reread = 0
         self.tool_calls = 0
         self.cost = 0.0
+
+    def dominant_model(self) -> tuple[str | None, str]:
+        """The (provider, model) carrying the most flagged premium quota in this
+        session — the honest label for the spot-check example + routing hint."""
+        provider, model = max(
+            self.quota_by_model.items(), key=lambda kv: kv[1],
+        )[0]
+        return provider, model
 
 
 def audit_opus_quota(
@@ -471,9 +482,10 @@ def audit_opus_quota(
                 agg.reread += t.reread_tokens
                 agg.tool_calls += t.tool_fanout
                 agg.cost += t.cost_usd
-                if not agg.model:
-                    agg.model = t.model
-                    agg.provider = t.provider
+                key = (t.provider, t.model)
+                agg.quota_by_model[key] = (
+                    agg.quota_by_model.get(key, 0.0) + t.quota_weighted_tokens
+                )
                 alt = (
                     lookup_downgrade(t.provider, t.model)
                     if t.provider else None
@@ -485,13 +497,15 @@ def audit_opus_quota(
             audit.candidate_sessions += 1
 
     # Secondary API-only implied-dollar counterfactual, aggregated over the
-    # flagged premium turns (never the headline).
+    # flagged premium turns and priced at each session's dominant premium model's
+    # cheaper alternative (never the headline).
     for agg in aggs.values():
-        alt = lookup_downgrade(agg.provider, agg.model) if agg.provider else None
+        provider, model = agg.dominant_model()
+        alt = lookup_downgrade(provider, model) if provider else None
         if not alt:
             continue
         alt_unit = _alt_unit_cost(
-            agg.provider, agg.model, alt, agg.new_input, agg.output, agg.reread,
+            provider, model, alt, agg.new_input, agg.output, agg.reread,
         )
         if alt_unit is not None:
             actual_cost += agg.cost
@@ -526,21 +540,25 @@ def audit_opus_quota(
     # Largest-quota candidate sessions first — the most worthwhile spot-checks.
     ordered_aggs = sorted(aggs.values(), key=lambda a: a.quota, reverse=True)
     audit.examples = [
-        OpusAuditExample(
-            trace_id="",
-            session_id=agg.session_id,
-            model=agg.model,
-            alt_model=(
-                lookup_downgrade(agg.provider, agg.model)
-                if agg.provider else None
-            ) or "",
-            input_tokens=agg.new_input,
-            output_tokens=agg.output,
-            cache_tokens=agg.reread,
-            tool_calls=agg.tool_calls,
-            duration_seconds=None,
-            cost_usd=round(agg.cost, 6),
-        )
-        for agg in ordered_aggs[:OPUS_AUDIT_MAX_EXAMPLES]
+        _example_for(agg) for agg in ordered_aggs[:OPUS_AUDIT_MAX_EXAMPLES]
     ]
     return audit
+
+
+def _example_for(agg: _SessionAgg) -> OpusAuditExample:
+    """Build a spot-check example labelled with the session's DOMINANT premium
+    model (and its cheaper alternative), not whichever premium turn came first."""
+    provider, model = agg.dominant_model()
+    alt = (lookup_downgrade(provider, model) if provider else None) or ""
+    return OpusAuditExample(
+        trace_id="",
+        session_id=agg.session_id,
+        model=model,
+        alt_model=alt,
+        input_tokens=agg.new_input,
+        output_tokens=agg.output,
+        cache_tokens=agg.reread,
+        tool_calls=agg.tool_calls,
+        duration_seconds=None,
+        cost_usd=round(agg.cost, 6),
+    )

--- a/tokenjam/core/optimize/analyzers/model_downgrade.py
+++ b/tokenjam/core/optimize/analyzers/model_downgrade.py
@@ -61,14 +61,65 @@ DOWNGRADE_CANDIDATES: dict[str, dict[str, str]] = {
 }
 
 
+def _model_name_candidates(model: str) -> list[str]:
+    """Ordered DOWNGRADE_CANDIDATES keys to try for a raw model id.
+
+    Tolerates the same id shapes ``is_premium_tier`` accepts so the downgrade
+    lookup never disagrees with tier membership: bracketed context tags
+    (``claude-opus-4-8[1m]``), trailing ``-YYYYMMDD`` dates, and Bedrock
+    region/provider prefixes (``us-anthropic-claude-opus-4-8-20260115-v1`` →
+    ``claude-opus-4-8``). The exact name is tried first; more-aggressive
+    normalisations follow.
+    """
+    seen: list[str] = []
+
+    def _add(name: str | None) -> None:
+        if name and name not in seen:
+            seen.append(name)
+
+    _add(model)
+    # Strip a bracketed context tag ([1m]) and/or a trailing YYYYMMDD date, in
+    # both orders — mirrors pricing's own _lookup_candidates fallback.
+    no_tag = _re.match(r"^(.*?)\[[^\]]*\]$", model)
+    base_no_tag = no_tag.group(1) if (no_tag and no_tag.group(1)) else None
+    _add(base_no_tag)
+    for candidate in (model, base_no_tag):
+        if not candidate:
+            continue
+        dated = _re.match(r"^(.*)-(\d{8})$", candidate)
+        if dated:
+            _add(dated.group(1))
+    # Bedrock-hosted Claude ids embed the base Anthropic name amid a region/
+    # provider prefix and a -YYYYMMDD-vN suffix; pull it out so a Bedrock opus
+    # downgrades via the same base model as its first-party twin.
+    embedded = _re.search(r"(claude-[a-z]+(?:-\d+)+)", model.lower())
+    if embedded:
+        name = embedded.group(1)
+        redated = _re.match(r"^(.*)-(\d{8})$", name)
+        _add(redated.group(1) if redated else name)
+    return seen
+
+
 def _lookup_downgrade(provider: str, model: str) -> str | None:
-    """DOWNGRADE_CANDIDATES lookup that tolerates trailing YYYYMMDD suffixes."""
-    mapping = DOWNGRADE_CANDIDATES.get(provider, {})
-    if model in mapping:
-        return mapping[model]
-    m = _re.match(r"^(.*)-(\d{8})$", model)
-    if m and m.group(1) in mapping:
-        return mapping[m.group(1)]
+    """Cheaper same-family alternative for (provider, model), or None.
+
+    Resolves the id shapes ``is_premium_tier`` accepts (context tags, dates,
+    Bedrock prefixes) so the quota audit's premium recognition matches the
+    subagent analyzer's — otherwise a ``claude-fable-5[1m]`` or Bedrock-hosted
+    premium session is flagged by one and silently dropped by the other.
+    """
+    candidates = _model_name_candidates(model)
+    # The raw provider first; fall back to "anthropic" for Bedrock-hosted Claude
+    # ids whose provider arrives as an aws/bedrock alias but whose downgrade
+    # target is the same first-party Anthropic model.
+    providers = [provider]
+    if provider != "anthropic" and any(c.startswith("claude-") for c in candidates):
+        providers.append("anthropic")
+    for prov in providers:
+        mapping = DOWNGRADE_CANDIDATES.get(prov, {})
+        for name in candidates:
+            if name in mapping:
+                return mapping[name]
     return None
 
 

--- a/tokenjam/core/optimize/analyzers/model_downgrade.py
+++ b/tokenjam/core/optimize/analyzers/model_downgrade.py
@@ -12,6 +12,7 @@ import re as _re
 from datetime import datetime
 from typing import Any
 
+from tokenjam.core.model_tiers import is_premium_tier
 from tokenjam.core.optimize.registry import register
 from tokenjam.core.optimize.stats import bootstrap_ci
 from tokenjam.core.optimize.types import (
@@ -30,21 +31,21 @@ SMALL_INPUT_TOKENS = 5_000
 SMALL_OUTPUT_TOKENS = 500
 SMALL_TOOL_CALLS = 5
 
-# Substring that identifies an Opus-family model name (after provider/date
-# normalisation). The quota audit scopes exclusively to Opus sessions — the
-# acute quota-burn class (research/evidence/feature-downsize.md). Matching on
-# the family substring tolerates version + date suffixes
-# (claude-opus-4-7, claude-opus-4-6-20260115, ...).
-OPUS_MODEL_SUBSTR = "opus"
-
 # Cap on the number of spot-check example sessions carried in the audit.
 OPUS_AUDIT_MAX_EXAMPLES = 5
 
 # Premium → cheaper alternative in the same provider family. Pricing for both
 # sides is resolved at runtime from pricing/models.toml; if either is missing
 # the candidate is silently skipped (we won't invent a savings number).
+# Premium-tier ladder: Fable → Sonnet and Opus → Haiku each drop two tiers, the
+# aggressive step justified because the quota audit only proposes these for
+# structurally tiny (Sonnet-shaped) sessions. Keep new premium families in sync
+# with tokenjam.core.model_tiers.PREMIUM_TIERS so every flagged session has a
+# real routing target.
 DOWNGRADE_CANDIDATES: dict[str, dict[str, str]] = {
     "anthropic": {
+        "claude-fable-5":    "claude-sonnet-4-6",
+        "claude-opus-4-8":   "claude-haiku-4-5",
         "claude-opus-4-7":   "claude-haiku-4-5",
         "claude-opus-4-6":   "claude-haiku-4-5",
         "claude-sonnet-4-6": "claude-haiku-4-5",
@@ -262,27 +263,35 @@ def run(ctx: AnalyzerContext) -> None:
 
 
 # ---------------------------------------------------------------------------
-# Opus quota audit (retroactive Downsize, reframed as accountability)
+# Premium-tier quota audit (retroactive Downsize, reframed as accountability)
 # ---------------------------------------------------------------------------
-# This runs the same structural heuristic as `downsize`, but scoped to Opus
-# sessions only and reframed as a "quota audit" rather than "cost optimization"
+# This runs the same structural heuristic as `downsize`, but scoped to
+# premium-tier sessions only (Fable + Opus, via the shared model_tiers
+# predicate) and reframed as a "quota audit" rather than "cost optimization"
 # (issue #5; research/evidence/feature-downsize.md). The headline is
-# "% of your Opus quota reclaimable from Sonnet-shaped sessions" — Opus token
-# share, not dollars — because the subscription majority is on flat-rate plans
-# where dollar framing mis-targets them (subscription-vs-cost-framing.md). It
-# complements opusplan / `/model` (forward-looking) by answering the
-# backward-looking question those tools can't: "which of my PAST Opus sessions
-# were Sonnet-shaped?" Honest framing throughout — candidates to spot-check,
-# never "safe to downgrade".
+# "% of your premium (Opus/Fable) quota reclaimable from Sonnet-shaped
+# sessions" — premium token share, not dollars — because the subscription
+# majority is on flat-rate plans where dollar framing mis-targets them
+# (subscription-vs-cost-framing.md). It complements opusplan / `/model`
+# (forward-looking) by answering the backward-looking question those tools
+# can't: "which of my PAST premium sessions were Sonnet-shaped?" Honest framing
+# throughout — candidates to spot-check, never "safe to downgrade".
+#
+# The `audit_opus_quota` name and the `opus_*` fields on OpusQuotaAudit are kept
+# for API/serialization stability; they now denote the whole premium tier, not
+# Opus alone (the audit counts and flags Fable sessions too).
 
 
-def _is_opus(provider: str, model: str) -> bool:
-    """True when the model is an Opus-family model worth auditing for downsize.
+def _is_premium_downsizable(provider: str, model: str) -> bool:
+    """True when the model is a premium-tier model worth auditing for downsize.
 
-    We only audit Opus sessions that ALSO have a known cheaper alternative in
-    `DOWNGRADE_CANDIDATES` (so the routing suggestion is real, not invented).
+    Premium-tier membership (Fable, Opus, and whatever launches above them next)
+    is resolved through the shared :func:`is_premium_tier` predicate — no
+    per-analyzer substring gate. We only audit premium sessions that ALSO have a
+    known cheaper alternative in `DOWNGRADE_CANDIDATES` (so the routing
+    suggestion is real, not invented).
     """
-    if OPUS_MODEL_SUBSTR not in (model or "").lower():
+    if not is_premium_tier(model):
         return False
     return _lookup_downgrade(provider, model) is not None
 
@@ -294,13 +303,15 @@ def audit_opus_quota(
     agent_id: str | None,
     window_days: float,
 ) -> OpusQuotaAudit:
-    """Retroactive Opus quota audit over Claude Code (and other) sessions.
+    """Retroactive premium-tier quota audit over Claude Code (and other) sessions.
 
-    Walks Opus sessions in the window and flags those whose structural shape
-    (small input, small output, few tool calls) matches a class of work where a
-    cheaper same-family model is worth a spot-check. Quantifies the result as a
-    **share of Opus quota** (candidate Opus tokens / total Opus tokens) — never
-    a dollar figure as the headline.
+    Walks premium-tier sessions (Fable + Opus, via the shared model_tiers
+    predicate) in the window and flags those whose structural shape (small
+    input, small output, few tool calls) matches a class of work where a cheaper
+    same-family model is worth a spot-check. Quantifies the result as a **share
+    of premium quota** (candidate premium tokens / total premium tokens) — never
+    a dollar figure as the headline. Field names retain the historical `opus_*`
+    prefix for serialization stability but count the whole premium tier.
 
     Computes purely from already-backfilled token/model metadata; does NOT
     depend on captured content (#3). Always returns an :class:`OpusQuotaAudit`
@@ -351,7 +362,7 @@ def audit_opus_quota(
             in_tok, out_tok, cache_tok, cost = row
         if not provider or not model:
             continue
-        if not _is_opus(provider, model):
+        if not _is_premium_downsizable(provider, model):
             continue
 
         session_tokens = int(in_tok or 0) + int(out_tok or 0) + int(cache_tok or 0)

--- a/tokenjam/core/optimize/analyzers/model_downgrade.py
+++ b/tokenjam/core/optimize/analyzers/model_downgrade.py
@@ -269,8 +269,9 @@ def run(ctx: AnalyzerContext) -> None:
 # premium-tier sessions only (Fable + Opus, via the shared model_tiers
 # predicate) and reframed as a "quota audit" rather than "cost optimization"
 # (issue #5; research/evidence/feature-downsize.md). The headline is
-# "% of your premium (Opus/Fable) quota reclaimable from Sonnet-shaped
-# sessions" — premium token share, not dollars — because the subscription
+# "% of your premium (Opus/Fable) quota that went to Sonnet-shaped sessions"
+# — a retrospective behaviour mirror in premium token share, not dollars and
+# not "reclaimable" (the tokens are already spent) — because the subscription
 # majority is on flat-rate plans where dollar framing mis-targets them
 # (subscription-vs-cost-framing.md). It complements opusplan / `/model`
 # (forward-looking) by answering the backward-looking question those tools
@@ -420,7 +421,7 @@ def audit_opus_quota(
     candidate_examples.sort(key=lambda pair: pair[0], reverse=True)
     audit.examples = [ex for _tokens, ex in candidate_examples[:OPUS_AUDIT_MAX_EXAMPLES]]
 
-    audit.percent_quota_reclaimable = (
+    audit.percent_quota_misallocated = (
         round(100.0 * audit.candidate_tokens / audit.opus_tokens, 1)
         if audit.opus_tokens > 0 else 0.0
     )

--- a/tokenjam/core/optimize/analyzers/subagent_rightsizing.py
+++ b/tokenjam/core/optimize/analyzers/subagent_rightsizing.py
@@ -12,10 +12,11 @@ This analyzer breaks a window's cost down per subagent and flags two structural
 right-sizing candidates (honesty discipline, CLAUDE.md Rule 14 — candidate
 flags only, never a quality judgment):
 
-  * over_powered     — ran on a premium (Opus-tier) model but produced little
-                       output and made few tool calls; a cheaper same-family
-                       model is worth a look (mirrors the downsize heuristic,
-                       scoped to one subagent).
+  * over_powered     — ran on a premium-tier model (Fable or Opus, via the
+                       shared model_tiers predicate) but produced little output
+                       and made few tool calls; a cheaper same-family model is
+                       worth a look (mirrors the downsize heuristic, scoped to
+                       one subagent).
   * over_provisioned — was handed a large context (input + cache reads) yet
                        produced little output; the prompt it was dispatched
                        with is likely larger than the task needed.
@@ -29,11 +30,9 @@ from __future__ import annotations
 from dataclasses import dataclass, field
 from typing import Any
 
+from tokenjam.core.model_tiers import is_premium_tier
 from tokenjam.core.optimize.registry import register
 from tokenjam.core.optimize.types import AnalyzerContext
-
-# Model-name substrings that mark the premium tier. Lowercased before matching.
-PREMIUM_MODEL_SUBSTRINGS = ("opus",)
 
 # "Produced little": total output tokens below this look like a small task.
 SMALL_OUTPUT_TOKENS = 2_000
@@ -115,8 +114,7 @@ def _flags_for(
     if cost_usd < MIN_FLAG_COST_USD:
         return []
     flags: list[str] = []
-    model_l = (model or "").lower()
-    is_premium = any(s in model_l for s in PREMIUM_MODEL_SUBSTRINGS)
+    is_premium = is_premium_tier(model)
     if is_premium and output_tokens < SMALL_OUTPUT_TOKENS and tool_calls <= FEW_TOOL_CALLS:
         flags.append("over_powered")
     if (input_tokens + cache_tokens) >= CONTEXT_HEAVY_TOKENS and output_tokens < SMALL_OUTPUT_TOKENS:

--- a/tokenjam/core/optimize/types.py
+++ b/tokenjam/core/optimize/types.py
@@ -18,10 +18,26 @@ MODEL_DOWNGRADE_CAVEAT = (
 # a claim that the cheaper model would have produced the same answer. Surfaced
 # verbatim next to every "% of premium quota misallocated" headline.
 OPUS_QUOTA_AUDIT_CAVEAT = (
-    "Candidates to spot-check, not a verdict. Each flagged session merely has "
-    "the structural shape (small input/output, few tool calls) of work a "
-    "smaller model often handles — review the example sessions before changing "
-    "your routing. Never \"safe to downgrade.\""
+    "Candidates to spot-check, not a verdict. Each flagged stretch merely has "
+    "the structural shape (small new input/output, low tool fan-out, no "
+    "delegation) of work a smaller model often handles — review the example "
+    "sessions before changing your routing. Segment percentages flag stretches "
+    "whose shape looks mechanical; the surrounding session context is not "
+    "evaluated and may have justified the larger model. Never \"safe to "
+    "downgrade.\""
+)
+
+# Confidence label for the segment-level misallocation estimate. The headline is
+# a per-turn heuristic over contiguous mechanical stretches with no quality
+# validation, so it is surfaced as an explicit "estimate" (with a wide bootstrap
+# interval), never as a settled figure (CLAUDE.md Rule 14).
+SEGMENT_ESTIMATE_CONFIDENCE = "estimate"
+
+# The `estimate_basis` string surfaced behind the "estimate" label (Rule 14).
+SEGMENT_ESTIMATE_BASIS = (
+    "contiguous turn-stretches whose per-turn shape (small new input/output, low "
+    "tool fan-out, no delegation) looks mechanical — surrounding session context "
+    "not evaluated; no quality validation"
 )
 
 # Mandatory caveat string for the Reuse analyzer. Honesty discipline
@@ -135,13 +151,32 @@ class OpusQuotaAudit:
     """
     window_days: float = 0.0
     opus_sessions: int = 0
-    opus_tokens: int = 0  # input + output + cache across all Opus sessions
+    # Quota-weighted premium token-equivalents (cache reads at 0.1x, output at
+    # 5x — the #119 weighting) attributed per-turn to the turn's OWN model, so a
+    # Sonnet turn inside an Opus session never lands in this premium total. This
+    # is the denominator of the headline share.
+    opus_tokens: int = 0
     candidate_sessions: int = 0
-    candidate_tokens: int = 0  # input + output + cache, candidates only
-    # The headline: % of premium quota (tokens) that went to Sonnet-shaped
-    # sessions — misallocated, not reclaimable (the tokens are already spent).
+    # Quota-weighted premium token-equivalents inside flagged cheap segments —
+    # the numerator. Segment-inclusive: a mechanical stretch inside an otherwise
+    # hard session counts, which the old whole-session audit structurally missed.
+    candidate_tokens: int = 0
+    # THE headline (founder decision D1): ONE segment-inclusive misallocation
+    # figure — the share of premium quota that went to Sonnet-shaped work,
+    # computed on the corrected per-turn attribution. It is a labelled estimate
+    # (segment_estimate_confidence + the bootstrap CI below), not two numbers.
     percent_quota_misallocated: float = 0.0
     percent_sessions: float = 0.0
+    # Segment accounting + confidence (design §5.2 / §6, founder D3). The number
+    # is a heuristic estimate, shown with an explicit label + a WIDE bootstrap
+    # interval that resamples SEGMENTS (not sessions), so the band widens honestly
+    # when few segments carry the estimate. ci low/high are None below 2 segments
+    # (a single point has no spread — the estimate is inherently wide).
+    segment_count: int = 0
+    segment_estimate_confidence: str = SEGMENT_ESTIMATE_CONFIDENCE
+    estimate_basis: str = SEGMENT_ESTIMATE_BASIS
+    segment_ci_low: float | None = None
+    segment_ci_high: float | None = None
     # model -> cheaper-alternative suggestions observed among the candidates.
     suggestions: dict[str, str] = field(default_factory=dict)
     examples: list[OpusAuditExample] = field(default_factory=list)
@@ -283,6 +318,14 @@ def audit_to_dict(audit: OpusQuotaAudit) -> dict[str, Any]:
         # contract (byte-identical audit_to_dict output) still holds.
         "percent_quota_reclaimable": audit.percent_quota_misallocated,
         "percent_sessions": audit.percent_sessions,
+        # Segment accounting + confidence (design §5.2 / §6). Every key here must
+        # survive the round-trip below, or the data-access parity test fails —
+        # the silent-drift guard for a new DB-computed field.
+        "segment_count": audit.segment_count,
+        "segment_estimate_confidence": audit.segment_estimate_confidence,
+        "estimate_basis": audit.estimate_basis,
+        "segment_ci_low": audit.segment_ci_low,
+        "segment_ci_high": audit.segment_ci_high,
         "suggestions": dict(audit.suggestions),
         "examples": [asdict(ex) for ex in audit.examples],
         "actual_cost_usd": audit.actual_cost_usd,
@@ -325,9 +368,22 @@ def audit_from_dict(data: dict[str, Any]) -> OpusQuotaAudit:
                      data.get("percent_quota_reclaimable", 0.0)) or 0.0
         ),
         percent_sessions=float(data.get("percent_sessions", 0.0) or 0.0),
+        segment_count=int(data.get("segment_count", 0) or 0),
+        segment_estimate_confidence=str(
+            data.get("segment_estimate_confidence", SEGMENT_ESTIMATE_CONFIDENCE)
+        ),
+        estimate_basis=str(data.get("estimate_basis", SEGMENT_ESTIMATE_BASIS)),
+        segment_ci_low=_opt_float(data.get("segment_ci_low")),
+        segment_ci_high=_opt_float(data.get("segment_ci_high")),
         suggestions=dict(data.get("suggestions", {}) or {}),
         examples=examples,
         actual_cost_usd=float(data.get("actual_cost_usd", 0.0) or 0.0),
         alternative_cost_usd=float(data.get("alternative_cost_usd", 0.0) or 0.0),
         caveat=str(data.get("caveat", OPUS_QUOTA_AUDIT_CAVEAT)),
     )
+
+
+def _opt_float(raw: Any) -> float | None:
+    """Coerce a JSON value to ``float`` while preserving ``None`` (the CI bounds
+    are ``None`` below 2 segments — that must round-trip as ``None``, not 0.0)."""
+    return None if raw is None else float(raw)

--- a/tokenjam/core/optimize/types.py
+++ b/tokenjam/core/optimize/types.py
@@ -16,7 +16,7 @@ MODEL_DOWNGRADE_CAVEAT = (
 # discipline (CLAUDE.md Rule 14): the audit flags Opus sessions whose STRUCTURE
 # matches Sonnet-shaped work — it is an accountability list to spot-check, never
 # a claim that the cheaper model would have produced the same answer. Surfaced
-# verbatim next to every "% of Opus quota reclaimable" headline.
+# verbatim next to every "% of premium quota misallocated" headline.
 OPUS_QUOTA_AUDIT_CAVEAT = (
     "Candidates to spot-check, not a verdict. Each flagged session merely has "
     "the structural shape (small input/output, few tool calls) of work a "
@@ -126,18 +126,21 @@ class OpusQuotaAudit:
     Reframes the structural downsize heuristic as an *accountability* audit
     scoped to Opus sessions: how much of your Opus quota was spent on sessions
     whose shape matches Sonnet-shaped work. The headline figure is
-    ``percent_quota_reclaimable`` (candidate Opus tokens / total Opus tokens) —
-    quota language, never a dollar "saving" (the subscription majority is on a
-    flat fee; dollar framing mis-targets them). Dollar fields are a best-effort
-    SECONDARY signal for API users only.
+    ``percent_quota_misallocated`` (candidate Opus tokens / total Opus tokens) —
+    retrospective quota is already SPENT, so this is a behaviour mirror (how much
+    premium quota went to Sonnet-shaped sessions), never a claim it can be
+    "reclaimed". Quota language, never a dollar "saving" (the subscription
+    majority is on a flat fee; dollar framing mis-targets them). Dollar fields
+    are a best-effort SECONDARY signal for API users only.
     """
     window_days: float = 0.0
     opus_sessions: int = 0
     opus_tokens: int = 0  # input + output + cache across all Opus sessions
     candidate_sessions: int = 0
     candidate_tokens: int = 0  # input + output + cache, candidates only
-    # The headline: % of Opus quota (tokens) held by Sonnet-shaped sessions.
-    percent_quota_reclaimable: float = 0.0
+    # The headline: % of premium quota (tokens) that went to Sonnet-shaped
+    # sessions — misallocated, not reclaimable (the tokens are already spent).
+    percent_quota_misallocated: float = 0.0
     percent_sessions: float = 0.0
     # model -> cheaper-alternative suggestions observed among the candidates.
     suggestions: dict[str, str] = field(default_factory=dict)
@@ -272,7 +275,13 @@ def audit_to_dict(audit: OpusQuotaAudit) -> dict[str, Any]:
         "opus_tokens": audit.opus_tokens,
         "candidate_sessions": audit.candidate_sessions,
         "candidate_tokens": audit.candidate_tokens,
-        "percent_quota_reclaimable": audit.percent_quota_reclaimable,
+        "percent_quota_misallocated": audit.percent_quota_misallocated,
+        # DEPRECATED alias — kept one release (through 0.6.x) because
+        # ``percent_quota_reclaimable`` shipped publicly in 0.5.4. Consumers
+        # should read ``percent_quota_misallocated``; this mirror will be
+        # removed. Emitted on BOTH the direct and serve paths so the parity
+        # contract (byte-identical audit_to_dict output) still holds.
+        "percent_quota_reclaimable": audit.percent_quota_misallocated,
         "percent_sessions": audit.percent_sessions,
         "suggestions": dict(audit.suggestions),
         "examples": [asdict(ex) for ex in audit.examples],
@@ -309,7 +318,12 @@ def audit_from_dict(data: dict[str, Any]) -> OpusQuotaAudit:
         opus_tokens=int(data.get("opus_tokens", 0) or 0),
         candidate_sessions=int(data.get("candidate_sessions", 0) or 0),
         candidate_tokens=int(data.get("candidate_tokens", 0) or 0),
-        percent_quota_reclaimable=float(data.get("percent_quota_reclaimable", 0.0) or 0.0),
+        # Prefer the new key; fall back to the deprecated alias so a payload
+        # produced by a pre-rename (0.5.4) daemon still reconstructs.
+        percent_quota_misallocated=float(
+            data.get("percent_quota_misallocated",
+                     data.get("percent_quota_reclaimable", 0.0)) or 0.0
+        ),
         percent_sessions=float(data.get("percent_sessions", 0.0) or 0.0),
         suggestions=dict(data.get("suggestions", {}) or {}),
         examples=examples,


### PR DESCRIPTION
Bundles five reviewed PRs so this lands in a single merge. **Each component PR stays open and will auto-mark MERGED when this anchor lands** — individual review threads remain intact. Nothing was closed.

## What's in the batch
- **Premium-tier predicate** (#453): new `core/model_tiers.py` is the single tier source (`model_tier`/`is_premium_tier`, `PREMIUM_TIERS={fable,opus}`) — makes Fable visible to quota audit, subagent right-sizing, and the downgrade map; adds `claude-opus-4-8`; normalizes `[1m]`/Bedrock ids so the audit stops silently dropping them.
- **Misallocated reframe** (#454): the retrospective quota-audit headline now says "misallocated", persona-gated (subscription mirror+habit-nudge / API dollar counterfactual / neutral fallback when pricing data is absent); keeps the deprecated `percent_quota_reclaimable` alias for one release.
- **Segment-level audit** (#456, this branch): replaces the whole-session MODE+aggregate heuristic with a per-turn `TurnComposition` walk; a single labeled misallocation estimate with a segment-resampled bootstrap CI; per-span attribution so a Sonnet turn inside an Opus session inflates neither numerator nor denominator.
- **Quickstart progress** (#452): pre-ingest status line + streaming per-session counter so the headline demo isn't silent for tens of seconds; `--json` stdout stays pure; `click>=8.2` pin.
- **Backfill 11×** (#455): columnar `read_json` bulk-append cuts full-history ingest ~11× (56s→5.1s / 32k spans) with byte-identical parity, plus monotonic progress in the bulk path.

## Stack / reconciliation note
Developed as a stack (#453 ← #454 ← #456) plus two independents (#452, #455), all reconciled here. The one cross-PR overlap — #456 renamed `_lookup_downgrade`→`lookup_downgrade` while #453 fixed that function's body to normalize `[1m]`/Bedrock ids — was resolved so the fix survives under the new name (alias retained).

## Union verification
`make test` 2392 passed / 2 skipped; `make lint` clean; `make typecheck` clean (191 files). All five features' tests coexist green.

🤖 shipped by [shiploop](https://github.com/anshss/shiploop)
