### PR TITLE
fix(onboard): collect all combination-run questions before any long-running work

### DIFF
--- a/tests/unit/test_onboard_path_branch.py
+++ b/tests/unit/test_onboard_path_branch.py
@@ -294,6 +294,14 @@ class TestCombinationPathNoDoubleRun:
             "tokenjam.cli.cmd_onboard._print_instrument_agent_snippet",
             lambda *a, **k: None,
         )
+        # The billing questions are now collected up front (before the legs run);
+        # these tests drive the legs as stubs and only assert backfill/banner
+        # counts, so short-circuit the up-front collection to a fixed answer
+        # instead of reading stdin for the plan prompts.
+        monkeypatch.setattr(
+            "tokenjam.cli.cmd_onboard._collect_combination_billing",
+            lambda *a, **k: ("max_5x", None, 0.0),
+        )
         # The Codex backfill leg loads the global config; make it a no-op path so
         # the stubbed `_try_backfill_codex` (not disk) is what runs.
         monkeypatch.setattr(
@@ -349,3 +357,282 @@ class TestCombinationPathNoDoubleRun:
         counters = self._run(monkeypatch, [False, True, False], tmp_path)
         assert counters["banner"] == 1
         assert counters["codex_backfill"] == 1
+
+
+# --- Combination prompt order: all questions before any long-running work ----
+
+
+class TestCombinationBillingHoistedUpFront:
+    """A combination run must ask EVERY question before any leg's long-running
+    backfill starts: Claude billing → Codex billing → project → backfill scope →
+    execution. The old shape ran each leg to completion in turn, so the Codex
+    plan prompt fired only AFTER the Claude leg's backfill had already run — a
+    question stranded behind minutes of ingest. Both legs' billing is now hoisted
+    to the top and threaded in, so no leg re-asks.
+    """
+
+    def _fresh_home(self, monkeypatch, tmp_path):
+        """Isolate HOME to a config-less dir so both legs read as fresh (their
+        billing gets collected up front)."""
+        home = tmp_path / "home"
+        home.mkdir()
+        monkeypatch.setattr("pathlib.Path.home", lambda: home)
+        monkeypatch.setattr(
+            "tokenjam.cli.cmd_onboard._is_interactive", lambda: True,
+        )
+        return home
+
+    class _Ctx:
+        def exit(self, code=0):
+            raise SystemExit(code)
+
+    def test_codex_billing_asked_before_claude_leg_runs(
+        self, monkeypatch, tmp_path, capsys,
+    ):
+        """The core fix: the Codex plan question is asked before the Claude leg
+        (and its backfill) executes — proven by sentinels the stubbed legs
+        print."""
+        import click as _click
+
+        self._fresh_home(monkeypatch, tmp_path)
+
+        from tokenjam.utils.formatting import console
+
+        monkeypatch.setattr(
+            "tokenjam.cli.cmd_onboard._onboard_claude_code",
+            lambda *a, **k: console.print("::CC_LEG_RAN::"),
+        )
+        monkeypatch.setattr(
+            "tokenjam.cli.cmd_onboard._onboard_codex",
+            lambda *a, **k: console.print("::CODEX_LEG_RAN::"),
+        )
+        monkeypatch.setattr(
+            "tokenjam.cli.cmd_onboard._try_backfill_codex",
+            lambda _cfg: (None, False, 0),
+        )
+        monkeypatch.setattr(
+            "tokenjam.cli.cmd_onboard._print_setup_complete_home",
+            lambda *a, **k: None,
+        )
+        monkeypatch.setattr(
+            "tokenjam.cli.cmd_onboard._print_instrument_agent_snippet",
+            lambda *a, **k: None,
+        )
+
+        # Which do you use? → Claude Code yes, Codex yes, SDK no.
+        confirms = iter([True, True, False])
+        monkeypatch.setattr(_click, "confirm", lambda *a, **k: next(confirms))
+        # Plan prompts: Claude=3 (max_5x, subscription — no ceiling/budget),
+        # OpenAI=2 (plus, subscription — no ceiling/budget).
+        prompts = iter([3, 2])
+        monkeypatch.setattr(_click, "prompt", lambda *a, **k: next(prompts))
+
+        _onboard_combination(
+            self._Ctx(), None, True, False,
+            plan_override=None, project_override=None, verify=False,
+        )
+        out = capsys.readouterr().out
+        assert "How do you pay for Claude?" in out
+        assert "How do you pay for OpenAI / Codex?" in out
+        # Both billing prompts precede either leg's execution.
+        i_claude = out.index("How do you pay for Claude?")
+        i_openai = out.index("How do you pay for OpenAI / Codex?")
+        i_cc = out.index("::CC_LEG_RAN::")
+        i_codex = out.index("::CODEX_LEG_RAN::")
+        assert i_claude < i_openai, out
+        # The reported bug: Codex billing came AFTER the Claude backfill. It must
+        # now come before the Claude leg runs at all.
+        assert i_openai < i_cc, out
+        assert i_cc < i_codex, out
+
+    def test_collected_answers_threaded_into_legs(
+        self, monkeypatch, tmp_path,
+    ):
+        """The hoisted billing answers (plan tier, API ceiling, daily budget) are
+        threaded into each leg via plan_override / plan_usd_override / budget, so
+        the legs re-ask nothing."""
+        import click as _click
+
+        self._fresh_home(monkeypatch, tmp_path)
+
+        seen: dict[str, dict] = {}
+        monkeypatch.setattr(
+            "tokenjam.cli.cmd_onboard._onboard_claude_code",
+            lambda *a, **k: seen.__setitem__("cc", {"args": a, "kw": k}),
+        )
+        monkeypatch.setattr(
+            "tokenjam.cli.cmd_onboard._onboard_codex",
+            lambda *a, **k: seen.__setitem__("codex", {"args": a, "kw": k}),
+        )
+        monkeypatch.setattr(
+            "tokenjam.cli.cmd_onboard._try_backfill_codex",
+            lambda _cfg: (None, False, 0),
+        )
+        monkeypatch.setattr(
+            "tokenjam.cli.cmd_onboard._print_setup_complete_home",
+            lambda *a, **k: None,
+        )
+
+        confirms = iter([True, True, False])
+        monkeypatch.setattr(_click, "confirm", lambda *a, **k: next(confirms))
+        # Claude=1 (api) → ceiling 50 → daily budget 0 ; OpenAI=2 (plus).
+        prompts = iter([1, 50.0, 0.0, 2])
+        monkeypatch.setattr(_click, "prompt", lambda *a, **k: next(prompts))
+
+        _onboard_combination(
+            self._Ctx(), None, True, False,
+            plan_override=None, project_override=None, verify=False,
+        )
+
+        cc_kw = seen["cc"]["kw"]
+        assert cc_kw["plan_override"] == "api"
+        assert cc_kw["plan_usd_override"] == 50.0
+        # Daily budget threaded via the positional budget arg (2nd positional).
+        assert seen["cc"]["args"][1] == 0.0
+        assert cc_kw["standalone"] is False
+        codex_kw = seen["codex"]["kw"]
+        assert codex_kw["plan_override"] == "plus"
+        # Subscription tier → no API ceiling collected.
+        assert codex_kw["plan_usd_override"] is None
+
+    def test_existing_stored_plan_not_reprompted(self, monkeypatch, tmp_path):
+        """An existing-config re-run keeps a stored plan without re-asking — the
+        up-front hoist only fires for a leg the standalone flow would prompt (a
+        fresh config or an explicit --plan). No click.prompt is patched here, so
+        any stray plan prompt would raise."""
+        import click as _click
+
+        home = tmp_path / "home"
+        (home / ".config" / "tj").mkdir(parents=True)
+        # A config that already stores an anthropic plan → CC billing must NOT be
+        # re-collected up front.
+        (home / ".config" / "tj" / "config.toml").write_text(
+            'version = "1"\n\n[budget.anthropic]\nplan = "max_5x"\n'
+        )
+        monkeypatch.setattr("pathlib.Path.home", lambda: home)
+        monkeypatch.setattr(
+            "tokenjam.cli.cmd_onboard._is_interactive", lambda: True,
+        )
+
+        fired: dict[str, dict] = {}
+        monkeypatch.setattr(
+            "tokenjam.cli.cmd_onboard._onboard_claude_code",
+            lambda *a, **k: fired.__setitem__("cc", k),
+        )
+        monkeypatch.setattr(
+            "tokenjam.cli.cmd_onboard._print_setup_complete_home",
+            lambda *a, **k: None,
+        )
+        monkeypatch.setattr(
+            "tokenjam.cli.cmd_onboard._print_instrument_agent_snippet",
+            lambda *a, **k: None,
+        )
+
+        # Claude Code yes, Codex no, SDK no.
+        confirms = iter([True, False, False])
+        monkeypatch.setattr(_click, "confirm", lambda *a, **k: next(confirms))
+
+        _onboard_combination(
+            self._Ctx(), None, True, False,
+            plan_override=None, project_override=None, verify=False,
+        )
+        # No up-front plan override was collected — the leg keeps its stored plan.
+        assert fired["cc"]["plan_override"] is None
+        assert fired["cc"]["plan_usd_override"] is None
+
+    def test_full_combined_order_with_real_claude_leg(
+        self, monkeypatch, tmp_path,
+    ):
+        """End-to-end order with the REAL Claude leg running (driven through the
+        CLI with real stdin, so every prompt's text renders): Claude billing →
+        Codex billing → project → backfill scope → execution. Project name and
+        backfill scope stay inside the Claude leg but now follow BOTH billing
+        prompts and precede the (sentinel) Codex leg."""
+        from contextlib import contextmanager
+
+        home = tmp_path / "home"
+        home.mkdir()
+        monkeypatch.setattr("pathlib.Path.home", lambda: home)
+        # Force the interactive routing (bare onboard → path question →
+        # combination) and the interactive backfill-scope menu.
+        monkeypatch.setattr(
+            "tokenjam.cli.cmd_onboard._is_interactive", lambda: True,
+        )
+        monkeypatch.setattr(
+            "tokenjam.cli.cmd_onboard.shutil.which", lambda _x: None,
+        )
+        monkeypatch.setattr(
+            "tokenjam.cli.cmd_onboard._stop_serve_for_db_write", lambda: False,
+        )
+        monkeypatch.setattr(
+            "tokenjam.cli.cmd_onboard._finish_onboard_serve", lambda *a, **k: None,
+        )
+        monkeypatch.setattr(
+            "tokenjam.cli.cmd_onboard._try_apply_declared_plans", lambda *a, **k: None,
+        )
+        # Real Claude leg, but a no-op backfill: the scope menu still fires
+        # (root exists) while the ingest itself touches nothing.
+        cc_root = home / "claude-projects"
+        cc_root.mkdir()
+        monkeypatch.setattr(backfill_mod, "CLAUDE_CODE_PROJECTS_ROOT", cc_root)
+        monkeypatch.setattr(
+            backfill_mod, "count_claude_code_sessions_in_scope", lambda **k: 0,
+        )
+
+        class _Result:
+            limit_reached = False
+            sessions_total = 0
+
+        monkeypatch.setattr(
+            backfill_mod, "ingest_claude_code", lambda *a, **k: _Result(),
+        )
+
+        class _DB:
+            def close(self):
+                pass
+
+        monkeypatch.setattr("tokenjam.core.db.open_db", lambda storage: _DB())
+
+        @contextmanager
+        def _fake_progress(total):
+            yield lambda *a, **k: None
+
+        monkeypatch.setattr(
+            "tokenjam.cli.backfill_progress.backfill_progress", _fake_progress,
+        )
+
+        from tokenjam.utils.formatting import console
+
+        monkeypatch.setattr(
+            "tokenjam.cli.cmd_onboard._onboard_codex",
+            lambda *a, **k: console.print("::CODEX_LEG_RAN::"),
+        )
+        monkeypatch.setattr(
+            "tokenjam.cli.cmd_onboard._try_backfill_codex",
+            lambda _cfg: (None, False, 0),
+        )
+        monkeypatch.setattr(
+            "tokenjam.cli.cmd_onboard._print_setup_complete_home",
+            lambda *a, **k: None,
+        )
+
+        runner = CliRunner()
+        with runner.isolated_filesystem(temp_dir=tmp_path):
+            # path=4 (combination) → Claude yes → Codex yes → SDK no →
+            # Claude plan 3 (max_5x) → OpenAI plan 2 (plus) → project name →
+            # backfill scope 1 (recent). Subscription tiers skip ceiling/budget.
+            res = runner.invoke(
+                cmd_onboard, ["--no-daemon"],
+                input="4\ny\ny\nn\n3\n2\nmyproj\n1\n", obj={},
+            )
+        assert res.exit_code == 0, res.output
+        out = res.output
+        order = [
+            "How do you pay for Claude?",
+            "How do you pay for OpenAI / Codex?",
+            "Project name",
+            "Backfill your Claude Code history",
+            "::CODEX_LEG_RAN::",
+        ]
+        indices = [out.index(s) for s in order]
+        assert indices == sorted(indices), (order, indices, out)

--- a/tokenjam/cli/cmd_onboard.py
+++ b/tokenjam/cli/cmd_onboard.py
@@ -1277,6 +1277,7 @@ def _onboard_claude_code(
     standalone: bool = True,
     backfill_days: int | None = None,
     backfill_all: bool = False,
+    plan_usd_override: float | None = None,
 ) -> None:
     """Configure Claude Code to send telemetry to tj.
 
@@ -1285,6 +1286,13 @@ def _onboard_claude_code(
     combination path the closing home banner must print exactly once, at the end
     of `_onboard_combination` — so we suppress it here when not standalone. The
     inline Claude Code backfill still runs (it is only ever invoked from here).
+
+    ``plan_usd_override`` is the pre-collected API monthly spend ceiling that
+    pairs with ``plan_override``: when the combination flow hoists the billing
+    questions up front (so every leg's plan is asked before any leg's
+    long-running backfill), it threads the ceiling it already collected in here
+    instead of the leg re-prompting for it. It is only consulted when
+    ``plan_override`` is set, so the standalone flow (no overrides) is unchanged.
     """
     from tokenjam.core.config import (
         AgentConfig, BudgetConfig, ProviderBudget, TjConfig, SecurityConfig,
@@ -1327,7 +1335,9 @@ def _onboard_claude_code(
                 plan = _prompt_plan("Claude", _ANTHROPIC_PLAN_CHOICES, current=existing_plan)
             plan_changed = plan != existing_plan
             # Subscription plans don't get an auto-written budget ceiling.
-            usd: float | None = None
+            # A pre-collected ceiling (combination flow) rides in via
+            # plan_usd_override; standalone leaves it None and prompts below.
+            usd: float | None = plan_usd_override
             if plan == "api" and not plan_override:
                 # API users may want a self-imposed soft ceiling — only prompt
                 # when interactive (no --plan flag).
@@ -1363,7 +1373,7 @@ def _onboard_claude_code(
         else:
             plan = _prompt_plan("Claude", _ANTHROPIC_PLAN_CHOICES)
         plan_changed = False
-        usd: float | None = None  # type: ignore[no-redef]
+        usd: float | None = plan_usd_override  # type: ignore[no-redef]
         if plan == "api" and not plan_override:
             ceiling = click.prompt(
                 "Monthly Anthropic API spend ceiling in USD (0 = no limit)",
@@ -1777,6 +1787,7 @@ def _onboard_codex(
     force: bool,
     reconfigure: bool = False,
     plan_override: str | None = None,
+    plan_usd_override: float | None = None,
     verify: bool = False,
     standalone: bool = True,
 ) -> None:
@@ -1789,6 +1800,12 @@ def _onboard_codex(
     and prints the banner exactly once at the very end. Running the backfill
     here too would double-run it, and printing the banner here would show it up
     to three times.
+
+    ``plan_usd_override`` mirrors the same param on ``_onboard_claude_code``:
+    the combination flow hoists the OpenAI billing questions up front and
+    threads the pre-collected API spend ceiling in here (consulted only when
+    ``plan_override`` is set), so this leg re-asks nothing on the combination
+    path. Standalone (no overrides) is unchanged.
     """
     try:
         import tomllib  # type: ignore[import]
@@ -1838,7 +1855,7 @@ def _onboard_codex(
             else:
                 plan = _prompt_plan("OpenAI / Codex", _OPENAI_PLAN_CHOICES, current=existing_plan)
             plan_changed = plan != existing_plan
-            usd: float | None = None
+            usd: float | None = plan_usd_override
             if plan == "api" and not plan_override:
                 ceiling = click.prompt(
                     "Monthly OpenAI API spend ceiling in USD (0 = no limit)",
@@ -1867,7 +1884,7 @@ def _onboard_codex(
         else:
             plan = _prompt_plan("OpenAI / Codex", _OPENAI_PLAN_CHOICES)
         plan_changed = False
-        usd: float | None = None  # type: ignore[no-redef]
+        usd: float | None = plan_usd_override  # type: ignore[no-redef]
         if plan == "api" and not plan_override:
             ceiling = click.prompt(
                 "Monthly OpenAI API spend ceiling in USD (0 = no limit)",
@@ -2092,6 +2109,61 @@ def _onboard_codex(
         )
 
 
+def _global_provider_plan(provider_key: str) -> str | None:
+    """Return the plan tier already stored for ``provider_key`` (``anthropic`` /
+    ``openai``) in the global tj config, or None when there's no config or no
+    plan for that provider yet.
+
+    The combination flow uses this to decide whether a leg would prompt for its
+    plan at all — a leg with an already-stored plan keeps it without asking. So
+    the flow only hoists the billing question up front when the leg would
+    actually ask it (a fresh config, or an explicit ``--plan``), leaving an
+    existing-config re-run byte-for-byte unchanged.
+    """
+    path = Path.home() / ".config" / "tj" / "config.toml"
+    if not path.exists():
+        return None
+    try:
+        from tokenjam.core.config import load_config as _lc
+        cfg = _lc(str(path))
+        pb = cfg.budgets.get(provider_key)
+        return pb.plan if pb else None
+    except Exception:
+        return None
+
+
+def _collect_combination_billing(
+    provider_label: str,
+    choices: list[tuple[str, str]],
+    ceiling_prompt: str,
+    plan_override: str | None,
+    budget: float | None,
+) -> tuple[str, float | None, float]:
+    """Collect one leg's billing answers up front for the combination flow.
+
+    Returns ``(plan, usd_ceiling, daily_budget)`` — the same three values a leg
+    resolves inline — so a multi-surface run can ask every billing question
+    before any leg's long-running backfill runs, then thread the answers back
+    into the leg (via ``plan_override`` / ``plan_usd_override`` / ``budget``) so
+    the leg re-asks nothing. Mirrors the legs' own logic exactly: ``--plan``
+    short-circuits the tier prompt, and the API spend-ceiling sub-prompt only
+    fires for the interactive ``api`` tier.
+    """
+    if plan_override:
+        plan = plan_override
+    else:
+        plan = _prompt_plan(provider_label, choices)
+    usd: float | None = None
+    if plan == "api" and not plan_override:
+        ceiling = click.prompt(
+            ceiling_prompt, type=float, default=0.0, show_default=False,
+        )
+        if ceiling > 0:
+            usd = ceiling
+    daily_budget = _prompt_daily_budget(budget, plan)
+    return plan, usd, daily_budget
+
+
 def _onboard_combination(
     ctx: click.Context,
     budget: float | None,
@@ -2130,6 +2202,35 @@ def _onboard_combination(
         ctx.exit(1)
         return
 
+    # --- Ask every billing question up front, before any long-running work ---
+    # The old shape ran each leg to completion in turn: the Claude leg asked its
+    # plan, then ran its (slow) backfill, and only THEN did the Codex leg ask
+    # its plan — so a combination run interleaved a question with minutes of
+    # ingest. We hoist each selected leg's billing (plan tier → API ceiling →
+    # daily budget) to the top, Claude first then Codex, then run the legs with
+    # the answers threaded in so neither leg re-prompts. Project name and
+    # backfill scope stay inside the Claude leg — they already run there before
+    # its backfill, which now precedes the (prompt-free) Codex leg, so no
+    # cross-leg interleaving remains: Claude billing → Codex billing → project →
+    # backfill scope → execution. A leg whose plan is already stored (an
+    # existing-config re-run, no --plan) keeps it without asking, exactly as the
+    # single-persona flow does — so we only hoist a leg's billing when the leg
+    # would actually prompt.
+    cc_plan, cc_usd, cc_budget = plan_override, None, budget
+    if uses_cc and (_global_provider_plan("anthropic") is None or plan_override):
+        cc_plan, cc_usd, cc_budget = _collect_combination_billing(
+            "Claude", _ANTHROPIC_PLAN_CHOICES,
+            "Monthly Anthropic API spend ceiling in USD (0 = no limit)",
+            plan_override, budget,
+        )
+    codex_plan, codex_usd, codex_budget = plan_override, None, budget
+    if uses_codex and (_global_provider_plan("openai") is None or plan_override):
+        codex_plan, codex_usd, codex_budget = _collect_combination_billing(
+            "OpenAI / Codex", _OPENAI_PLAN_CHOICES,
+            "Monthly OpenAI API spend ceiling in USD (0 = no limit)",
+            plan_override, budget,
+        )
+
     done: list[str] = []
 
     # --- Claude Code (full flow: config + statusline + auto-backfill) ---
@@ -2137,8 +2238,9 @@ def _onboard_combination(
         console.print()
         console.print("[bold]Setting up Claude Code…[/bold]")
         _onboard_claude_code(
-            ctx, budget, no_daemon, force, reconfigure=False,
-            plan_override=plan_override, project_override=project_override,
+            ctx, cc_budget, no_daemon, force, reconfigure=False,
+            plan_override=cc_plan, plan_usd_override=cc_usd,
+            project_override=project_override,
             verify=False, standalone=False,
             backfill_days=backfill_days, backfill_all=backfill_all,
         )
@@ -2149,8 +2251,9 @@ def _onboard_combination(
         console.print()
         console.print("[bold]Setting up Codex…[/bold]")
         _onboard_codex(
-            ctx, budget, no_daemon, force, reconfigure=False,
-            plan_override=plan_override, verify=False, standalone=False,
+            ctx, codex_budget, no_daemon, force, reconfigure=False,
+            plan_override=codex_plan, plan_usd_override=codex_usd,
+            verify=False, standalone=False,
         )
         # Run the on-disk Codex backfill exactly once here. Passing
         # standalone=False above suppressed the per-path onboarder's own backfill


### PR DESCRIPTION
## Problem

The combination onboard flow (bare `tj onboard` → "A combination of the above") ran each surface leg to completion in turn. The Claude Code leg asked its billing plan, ran its **history backfill** (potentially several minutes on a large `~/.claude` history), and only *then* did the Codex leg open with its own plan prompt.

Result — a founder running combination (Claude Code = yes, Codex = yes) saw:

```
Claude billing → project name → backfill scope → backfill RAN → (only now) Codex billing
```

A question stranded behind minutes of long-running work.

## Fix

Hoist each selected leg's billing questions (plan tier → API spend ceiling → daily budget) to the **top** of the combination flow — Claude first, then Codex — then run the legs with the collected answers threaded straight in, so neither leg re-prompts.

- The two legs already accept `plan_override`; a new `plan_usd_override` threads the pre-collected API spend ceiling, and the daily budget rides the existing `budget` param.
- Project name and backfill scope stay **inside** the Claude leg — they already run there *before* its backfill, which now precedes the prompt-free Codex leg — so no cross-leg interleaving remains.

A combination run now reads:

```
Claude billing → Codex billing → project → backfill scope → execution
```

## Behavior preserved

- **Existing-config re-runs**: a leg whose plan is already stored keeps it without re-asking (only a leg that *would* prompt gets hoisted), exactly as the single-persona flow does.
- **Single-persona flows** (`--claude-code` / `--codex`) and **flag-driven / non-interactive** runs are unchanged — the new leg param defaults to `None` and is only consulted when a plan override is present.

## Tests

Extended the combination prompt-order tests:

- `test_codex_billing_asked_before_claude_leg_runs` — pins the core cross-leg guarantee (Codex billing precedes the Claude leg + its backfill) via sentinels the stubbed legs print.
- `test_collected_answers_threaded_into_legs` — asserts plan tier / API ceiling / daily budget reach each leg via `plan_override` / `plan_usd_override` / `budget`.
- `test_existing_stored_plan_not_reprompted` — an existing-config re-run collects nothing up front (no stray prompt).
- `test_full_combined_order_with_real_claude_leg` — end-to-end CLI drive of the real Claude leg pinning the full order: billing → billing → project → backfill scope → execution.

Full unit suite (1799 passed, 1 skipped), the wider `unit + synthetic + agents + integration` set (2348 passed), `ruff`, and `mypy` all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
