### PR TITLE
Bump version to 0.6.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "tokenjam"
-version = "0.5.4"
+version = "0.6.0"
 description = "TokenJam — local-first OTel-native observability for Autonomous AI agents"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/sdk-ts/package.json
+++ b/sdk-ts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tokenjam/sdk",
-  "version": "0.5.4",
+  "version": "0.6.0",
   "description": "TypeScript SDK for TokenJam — local-first observability for AI agents",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",


### PR DESCRIPTION
Release cut: bumps `pyproject.toml` and `sdk-ts/package.json` to 0.6.0 in lockstep (the npm wrapper derives its version from the release tag at publish time).

Feature release — highlights since v0.5.4: quota-weighted quickstart headline + live statusline preview, one-paste `npx tokenjam onboard` with ephemeral-runner guard, path-branched onboarding with `--verify`/`tj ping`, bounded + progress-surfaced backfill (30-day fast path), plan-tier-gated budget prompt, `tj backfill codex`, uninstall integrity (`--purge`, wrapper/zshrc cleanup), gzip OTLP ingest fix, wrapper 24h refresh.

After merge: `gh release create v0.6.0 --generate-notes` fires the PyPI + npm publish workflows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)