### PR TITLE
Bump version to 0.5.5

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "tokenjam"
-version = "0.5.4"
+version = "0.5.5"
 description = "TokenJam — local-first OTel-native observability for Autonomous AI agents"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/sdk-ts/package.json
+++ b/sdk-ts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tokenjam/sdk",
-  "version": "0.5.4",
+  "version": "0.5.5",
   "description": "TypeScript SDK for TokenJam — local-first observability for AI agents",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",


### PR DESCRIPTION
Release cut: bumps `pyproject.toml` and `sdk-ts/package.json` to 0.5.5 in lockstep (the npm wrapper derives its version from the release tag at publish time).

Supersedes #459 — same content at 0.5.5 while the 0.6.0-vs-0.5.5 call is decided; if the decision lands on 0.6.0 before release, a follow-up bump replaces this.

After merge: `gh release create v0.5.5 --generate-notes` fires the PyPI + npm publish workflows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)