### PR TITLE
Extend read timeout for heavy computed serve endpoints

### DIFF
--- a/tests/integration/test_context_serve.py
+++ b/tests/integration/test_context_serve.py
@@ -125,7 +125,7 @@ def _apibackend_wired_to(app, monkeypatch) -> ApiBackend:
     api = ApiBackend("http://daemon")
     transport = httpx.ASGITransport(app=app)
 
-    def _sync_get(path, params=None):
+    def _sync_get(path, params=None, *, timeout=None):
         async def _call():
             async with httpx.AsyncClient(
                 transport=transport, base_url="http://daemon",

--- a/tests/integration/test_data_access_parity.py
+++ b/tests/integration/test_data_access_parity.py
@@ -75,7 +75,7 @@ def _serve_access(app, monkeypatch) -> ServeDataAccess:
     api = ApiBackend("http://daemon")
     transport = httpx.ASGITransport(app=app)
 
-    def _sync_get(path, params=None):
+    def _sync_get(path, params=None, *, timeout=None):
         async def _call():
             async with httpx.AsyncClient(
                 transport=transport, base_url="http://daemon",

--- a/tests/integration/test_quota_audit_serve.py
+++ b/tests/integration/test_quota_audit_serve.py
@@ -115,7 +115,7 @@ def _apibackend_wired_to(app, monkeypatch) -> ApiBackend:
     api = ApiBackend("http://daemon")
     transport = httpx.ASGITransport(app=app)
 
-    def _sync_get(path, params=None):
+    def _sync_get(path, params=None, *, timeout=None):
         async def _call():
             async with httpx.AsyncClient(
                 transport=transport, base_url="http://daemon",

--- a/tests/integration/test_tokenmaxx_serve.py
+++ b/tests/integration/test_tokenmaxx_serve.py
@@ -60,7 +60,7 @@ def _apibackend_wired_to(app, monkeypatch) -> ApiBackend:
     api = ApiBackend("http://daemon")
     transport = httpx.ASGITransport(app=app)
 
-    def _sync_get(path, params=None):
+    def _sync_get(path, params=None, *, timeout=None):
         async def _call():
             async with httpx.AsyncClient(
                 transport=transport, base_url="http://daemon",

--- a/tests/unit/test_api_backend_timeout.py
+++ b/tests/unit/test_api_backend_timeout.py
@@ -1,0 +1,79 @@
+"""The ApiBackend HTTP client keeps a tight blanket timeout for cheap shim
+reads but overrides it for the heavy *computed* endpoints.
+
+Regression for the onboarding-killer bug: with `tj serve` holding the DuckDB
+write lock, `tj quota-audit` routes through `GET /api/v1/quota-audit`, which the
+daemon computes in ~13s on a large history (3,424 sessions / 150k turns). Under
+the old blanket 10s client timeout that raised `httpx.ReadTimeout`, so the very
+next step onboarding advertises failed deterministically for exactly the
+large-history users tj most wants. The fix is a per-request read-timeout
+override on the heavy computed fetchers, keeping the 10s default for the cheap
+reads.
+
+We assert on the timeout httpx actually attaches to each outgoing request
+(`request.extensions["timeout"]`), so this pins the wire-level behavior, not an
+internal constant.
+"""
+from __future__ import annotations
+
+import httpx
+import pytest
+
+from tokenjam.core.api_backend import ApiBackend
+
+
+def _backend_recording_timeouts() -> tuple[ApiBackend, dict[str, float | None]]:
+    """An ApiBackend whose transport records the per-request *read* timeout.
+
+    Preserves the real client's blanket default timeout so the cheap-read path
+    is faithfully exercised; only the socket is swapped for a MockTransport.
+    """
+    read_timeouts: dict[str, float | None] = {}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        timeout = request.extensions.get("timeout") or {}
+        read_timeouts[request.url.path] = timeout.get("read")
+        return httpx.Response(200, json={})
+
+    api = ApiBackend("http://daemon")
+    # Rebuild the client with the SAME default timeout the constructor uses,
+    # over a MockTransport, so an un-overridden `_get` still sees the 10s ceiling.
+    api.client = httpx.Client(
+        base_url="http://daemon",
+        timeout=ApiBackend._DEFAULT_TIMEOUT,
+        transport=httpx.MockTransport(handler),
+    )
+    return api, read_timeouts
+
+
+@pytest.mark.parametrize(
+    "call, path",
+    [
+        (lambda api: api.fetch_opus_quota_audit(since="30d"), "/api/v1/quota-audit"),
+        (lambda api: api.fetch_context_diagnostic(since="30d"), "/api/v1/context"),
+        (lambda api: api.fetch_optimize_report(since="30d"), "/api/v1/optimize"),
+        (lambda api: api.fetch_reuse_clusters(since="30d"), "/api/v1/reuse/clusters"),
+        (lambda api: api.fetch_cost_compare(since="30d"), "/api/v1/cost/compare"),
+    ],
+)
+def test_heavy_endpoints_use_extended_read_timeout(call, path):
+    api, read_timeouts = _backend_recording_timeouts()
+    call(api)
+    # The heavy computed endpoint must ride the 60s override, not the 10s
+    # cheap-read ceiling — otherwise a >10s server-side compute ReadTimeouts.
+    assert read_timeouts[path] == ApiBackend._HEAVY_ENDPOINT_TIMEOUT
+    assert read_timeouts[path] > ApiBackend._DEFAULT_TIMEOUT
+    api.close()
+
+
+def test_cheap_reads_keep_the_tight_default_timeout():
+    from tokenjam.core.models import CostFilters, TraceFilters
+
+    api, read_timeouts = _backend_recording_timeouts()
+    api.get_traces(TraceFilters(limit=1, offset=0))
+    api.get_cost_summary(CostFilters())
+    # Cheap shim reads must NOT inherit the heavy override — a wedged daemon
+    # should still fail fast for these near-instant lookups.
+    assert read_timeouts["/api/v1/traces"] == ApiBackend._DEFAULT_TIMEOUT
+    assert read_timeouts["/api/v1/cost"] == ApiBackend._DEFAULT_TIMEOUT
+    api.close()

--- a/tokenjam/core/api_backend.py
+++ b/tokenjam/core/api_backend.py
@@ -59,15 +59,20 @@ class ApiBackend:
     ) -> dict:
         """GET `path` and return the parsed JSON body.
 
-        `timeout` overrides the client's blanket read timeout for a single
-        request — used by the heavy computed endpoints whose server-side
-        aggregation can outlast the cheap-read ceiling on large histories.
-        Cheap shim reads pass nothing and keep the tight default.
+        `timeout` extends only the READ leg for a single request — used by the
+        heavy computed endpoints whose server-side aggregation can outlast the
+        cheap-read ceiling on large histories. Connect/write/pool keep the
+        tight default (a bare float would widen all four dimensions). Cheap
+        shim reads pass nothing and keep the tight default throughout.
         """
         if timeout is None:
             resp = self.client.get(path, params=params)
         else:
-            resp = self.client.get(path, params=params, timeout=timeout)
+            resp = self.client.get(
+                path,
+                params=params,
+                timeout=httpx.Timeout(self._DEFAULT_TIMEOUT, read=timeout),
+            )
         resp.raise_for_status()
         return resp.json()
 

--- a/tokenjam/core/api_backend.py
+++ b/tokenjam/core/api_backend.py
@@ -30,15 +30,44 @@ from tokenjam.utils.time_parse import utcnow
 class ApiBackend:
     """Read-only backend that queries tj serve instead of DuckDB."""
 
+    #: Blanket read timeout for the cheap shim reads (traces/cost/status/…).
+    #: These are near-instant DB lookups the daemon serves in well under a
+    #: second, so a tight ceiling keeps a wedged daemon from hanging the CLI.
+    _DEFAULT_TIMEOUT = 10
+
+    #: Read timeout for the heavy *computed* endpoints (quota-audit, context).
+    #: These re-aggregate a user's whole history server-side, so on a large DB
+    #: they can legitimately take longer than the cheap-read ceiling — e.g. a
+    #: 3,424-session / 150k-turn history computes the Opus quota audit in ~13s.
+    #: Under the blanket 10s ceiling that raised ReadTimeout and the very next
+    #: step onboarding advertises (`tj quota-audit`) failed deterministically
+    #: for exactly the large-history users tj most wants. A generous override
+    #: absorbs that compute while still bounding a genuinely stuck daemon.
+    _HEAVY_ENDPOINT_TIMEOUT = 60
+
     def __init__(self, base_url: str, api_key: str | None = None) -> None:
         self.base_url = base_url.rstrip("/")
         headers: dict[str, str] = {}
         if api_key:
             headers["Authorization"] = f"Bearer {api_key}"
-        self.client = httpx.Client(base_url=self.base_url, headers=headers, timeout=10)
+        self.client = httpx.Client(
+            base_url=self.base_url, headers=headers, timeout=self._DEFAULT_TIMEOUT
+        )
 
-    def _get(self, path: str, params: dict | None = None) -> dict:
-        resp = self.client.get(path, params=params)
+    def _get(
+        self, path: str, params: dict | None = None, *, timeout: float | None = None
+    ) -> dict:
+        """GET `path` and return the parsed JSON body.
+
+        `timeout` overrides the client's blanket read timeout for a single
+        request — used by the heavy computed endpoints whose server-side
+        aggregation can outlast the cheap-read ceiling on large histories.
+        Cheap shim reads pass nothing and keep the tight default.
+        """
+        if timeout is None:
+            resp = self.client.get(path, params=params)
+        else:
+            resp = self.client.get(path, params=params, timeout=timeout)
         resp.raise_for_status()
         return resp.json()
 
@@ -284,7 +313,9 @@ class ApiBackend:
         }
         if agent_id:
             params["agent_id"] = agent_id
-        return self._get("/api/v1/cost/compare", params)
+        return self._get(
+            "/api/v1/cost/compare", params, timeout=self._HEAVY_ENDPOINT_TIMEOUT
+        )
 
     def fetch_optimize_report(
         self,
@@ -315,7 +346,9 @@ class ApiBackend:
             params["budget_provider"] = budget_provider
         if budget_usd is not None:
             params["budget_usd"] = budget_usd
-        return self._get("/api/v1/optimize", params)
+        return self._get(
+            "/api/v1/optimize", params, timeout=self._HEAVY_ENDPOINT_TIMEOUT
+        )
 
     def fetch_reuse_clusters(
         self,
@@ -335,7 +368,9 @@ class ApiBackend:
         params: dict[str, Any] = {"since": since}
         if agent_id:
             params["agent_id"] = agent_id
-        return self._get("/api/v1/reuse/clusters", params)
+        return self._get(
+            "/api/v1/reuse/clusters", params, timeout=self._HEAVY_ENDPOINT_TIMEOUT
+        )
 
     #: `/sessions` page size for `find_last_substantial_session`. The floor is
     #: usually 1 tool call, so the newest row almost always qualifies — this
@@ -404,7 +439,9 @@ class ApiBackend:
         params: dict[str, Any] = {"since": since}
         if agent_id:
             params["agent_id"] = agent_id
-        return self._get("/api/v1/context", params)
+        return self._get(
+            "/api/v1/context", params, timeout=self._HEAVY_ENDPOINT_TIMEOUT
+        )
 
     def fetch_opus_quota_audit(
         self,
@@ -426,7 +463,9 @@ class ApiBackend:
         params: dict[str, Any] = {"since": since}
         if agent_id:
             params["agent_id"] = agent_id
-        return self._get("/api/v1/quota-audit", params)
+        return self._get(
+            "/api/v1/quota-audit", params, timeout=self._HEAVY_ENDPOINT_TIMEOUT
+        )
 
     def close(self) -> None:
         self.client.close()


### PR DESCRIPTION
## Problem

When `tj serve` is running it holds the DuckDB write lock, so CLI commands route their queries through the daemon's REST API via `ApiBackend`. That client had a **blanket 10s read timeout** — fine for the cheap shim reads (traces/cost/status/alerts), but too tight for the *computed* endpoints that re-aggregate a user's whole history server-side.

On a large history (e.g. 3,424 sessions / 150k turns, 30d window) the daemon computes `GET /api/v1/quota-audit` in ~13s. Under the 10s ceiling that raised `httpx.ReadTimeout`, so `tj quota-audit` failed **deterministically** against a running daemon — and the bigger the history, the more certain the failure. The cheap `/api/v1/context` (0.6s) and other reads completed fine under the same daemon.

## Fix

Add a per-request **read-timeout override (60s)** on the heavy computed fetchers — `quota-audit`, `context`, `optimize`, `reuse/clusters`, `cost/compare` — while keeping the tight **10s default** for the cheap reads so a genuinely wedged daemon still fails fast.

`ApiBackend._get` gains an optional `timeout` kwarg that overrides the client's blanket timeout for a single request.
The heavy fetchers pass `timeout=_HEAVY_ENDPOINT_TIMEOUT` (60s); cheap reads pass nothing and keep `_DEFAULT_TIMEOUT` (10s).

## Validation

Real-socket before/after run against an HTTP server whose `quota-audit` handler sleeps 12s (mimicking the >10s server-side compute):

| Path | Behavior |
|------|----------|
| Blanket 10s (old) `_get("/api/v1/quota-audit")` | `ReadTimeout at 10.0s` — reproduces the bug |
| Fixed `fetch_opus_quota_audit` (60s override) | `OK in 12.0s` — completes |
| Cheap read `get_traces` on a slow path | `ReadTimeout at 10.0s` — tight ceiling preserved |

New regression test `tests/unit/test_api_backend_timeout.py` asserts the wire-level timeout httpx attaches to each request: heavy endpoints get 60s, cheap reads keep 10s.
Existing serve-integration test doubles updated to match the new `_get` signature.
`ruff` + `mypy` clean; full unit + integration suites green (one unrelated pre-existing env-artifact failure in `test_onboard_path_branch`).

🤖 shipped by [shiploop](https://github.com/anshss/shiploop)