### PR TITLE
Release 0.5.6

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "tokenjam"
-version = "0.5.5"
+version = "0.5.6"
 description = "TokenJam — local-first OTel-native observability for Autonomous AI agents"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/sdk-ts/package.json
+++ b/sdk-ts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tokenjam/sdk",
-  "version": "0.5.5",
+  "version": "0.5.6",
   "description": "TypeScript SDK for TokenJam — local-first observability for AI agents",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",


### PR DESCRIPTION
Patch release: version bump only, containing the onboarding-reliability batch already merged to main via #463 (which bundled #461 and #462).

## What's in this release

- **Heavy-endpoint serve timeout**: `quota-audit` and `context` — computed endpoints that aggregate a user's whole history over a running daemon — now get a 60s read timeout instead of the blanket 10s client timeout. Fixes a deterministic `ReadTimeout` on the very first post-onboarding step for users with large histories.
- **PATH-shadow guard in onboarding**: onboarding now verifies what bare `tj` actually resolves to after install, warns when nothing resolves or an older install shadows the freshly installed CLI, and applies a best-effort fix. The zshrc PATH block writer now refuses to write a non-absolute directory.
- **Durable daemon entrypoint**: the launchd/systemd daemon entrypoint no longer captures uv's ephemeral archive-cache path, so `uv cache prune` can no longer silently kill the daemon or pin it to a stale version.

## Version bump

- `pyproject.toml`: 0.5.5 → 0.5.6
- `sdk-ts/package.json`: 0.5.5 → 0.5.6

(Mirrors the 0.5.5 release cut — the npm wrapper derives its version from the release tag at publish time, no manual bump needed there.)

## Checks

- `make lint`: clean
- `make typecheck`: clean (191 source files)
- `make test`: 2425 passed, 2 skipped, 1 known pre-existing failure (`test_bare_onboard_sdk_choice_falls_through_to_generic` — fails identically on main when a real `~/.config/tj/config.toml` exists on the machine; passes on clean CI runners)

🤖 Generated with [Claude Code](https://claude.com/claude-code)