### PR TITLE
Silence stderr and fix malformed OTEL export in claude() shell wrapper

### DIFF
--- a/tests/unit/test_onboard_path_resolution.py
+++ b/tests/unit/test_onboard_path_resolution.py
@@ -13,7 +13,10 @@ explicitly since PATH reordering isn't something onboard should do silently.
 """
 from __future__ import annotations
 
+import shutil
 import subprocess
+
+import pytest
 
 from tokenjam.cli import cmd_onboard
 
@@ -212,3 +215,82 @@ def test_wrapper_block_handles_path_with_spaces(monkeypatch):
     monkeypatch.setattr(cmd_onboard, "_current_tj_binary", lambda: "/Users/a b/.local/bin/tj")
     block = cmd_onboard._claude_wrapper_block()
     assert '"/Users/a b/.local/bin/tj"' in block
+
+
+# --- _claude_wrapper_block: stderr silenced, no-leading-comma fallback ------
+#
+# A stale/shadowed/half-uninstalled `tj` must never flash a traceback into
+# every `claude` launch, and a failed or empty `otel-resource-attrs` lookup
+# must never produce a malformed `,service.instance.id=...` value.
+
+
+def test_wrapper_block_silences_otel_attrs_stderr(monkeypatch):
+    monkeypatch.setattr(cmd_onboard, "_current_tj_binary", lambda: "/home/x/.local/bin/tj")
+    block = cmd_onboard._claude_wrapper_block()
+    assert '"/home/x/.local/bin/tj" otel-resource-attrs 2>/dev/null' in block
+    # The capture must be failure-tolerant (never aborts the wrapper / lets a
+    # nonzero tj exit status propagate into the claude launch).
+    assert '_tj_attrs="$("/home/x/.local/bin/tj" otel-resource-attrs 2>/dev/null)" || _tj_attrs=""' in block
+
+
+def test_wrapper_block_falls_back_without_leading_comma(monkeypatch):
+    monkeypatch.setattr(cmd_onboard, "_current_tj_binary", lambda: "/home/x/.local/bin/tj")
+    block = cmd_onboard._claude_wrapper_block()
+    # Old (buggy) shape: a single export directly concatenating the raw
+    # command substitution, which produces a leading comma when it's empty.
+    assert '),service.instance.id=$_tj_inst"' not in block
+    # New shape: branch on whether the lookup produced anything.
+    assert 'export OTEL_RESOURCE_ATTRIBUTES="$_tj_attrs,service.instance.id=$_tj_inst"' in block
+    assert 'export OTEL_RESOURCE_ATTRIBUTES="service.instance.id=$_tj_inst"' in block
+
+
+def test_wrapper_block_survives_broken_tj_end_to_end(tmp_path, monkeypatch):
+    """Empirical: source the generated block in a real zsh with a
+    deliberately broken `tj` first on PATH and confirm `claude` launches
+    with zero extra output and a well-formed OTEL_RESOURCE_ATTRIBUTES."""
+    import os
+    import stat
+
+    zsh = shutil.which("zsh")
+    if zsh is None:
+        pytest.skip("zsh not available")
+
+    bin_dir = tmp_path / "bin"
+    bin_dir.mkdir()
+
+    def _make_executable(path, content):
+        path.write_text(content)
+        path.chmod(path.stat().st_mode | stat.S_IEXEC | stat.S_IXGRP | stat.S_IXOTH)
+
+    broken_tj = bin_dir / "tj"
+    _make_executable(
+        broken_tj,
+        "#!/bin/sh\n"
+        "echo 'Traceback (most recent call last):' >&2\n"
+        "echo 'ModuleNotFoundError: no module named tokenjam' >&2\n"
+        "exit 1\n",
+    )
+    fake_claude = bin_dir / "claude"
+    _make_executable(fake_claude, "#!/bin/sh\necho claude-ran\n")
+
+    monkeypatch.setattr(cmd_onboard, "_current_tj_binary", lambda: str(broken_tj))
+    block = cmd_onboard._claude_wrapper_block()
+
+    script = tmp_path / "rc.zsh"
+    script.write_text(block + "\nclaude\necho \"ATTRS=$OTEL_RESOURCE_ATTRIBUTES\"\n")
+
+    env = dict(os.environ)
+    env["PATH"] = f"{bin_dir}:{env['PATH']}"
+
+    result = subprocess.run(
+        [zsh, str(script)], capture_output=True, text=True, env=env, timeout=10,
+    )
+
+    assert result.stderr == ""  # the broken tj's traceback must never leak
+    assert "Traceback" not in result.stdout
+    assert "claude-ran" in result.stdout
+
+    [attrs_line] = [line for line in result.stdout.splitlines() if line.startswith("ATTRS=")]
+    attrs = attrs_line[len("ATTRS="):]
+    assert not attrs.startswith(",")
+    assert attrs == "service.instance.id=unknown"

--- a/tokenjam/cli/cmd_onboard.py
+++ b/tokenjam/cli/cmd_onboard.py
@@ -2949,7 +2949,19 @@ def _claude_wrapper_block() -> str:
     earlier on that terminal's PATH, or fail outright if `tj`'s directory
     isn't on PATH at all.
 
-    Written portably so it works in both zsh and bash.
+    Every ``tj`` invocation here is stderr-silenced (``2>/dev/null``) and
+    failure-tolerant: a stale/shadowed/half-uninstalled ``tj`` ahead on PATH
+    must never flash a traceback into an interactive ``claude`` launch, and a
+    failed or empty ``otel-resource-attrs`` lookup falls back to just
+    ``service.instance.id=...`` rather than a malformed value with a leading
+    comma.
+
+    Written portably so it works in both zsh and bash. Re-running
+    ``_install_claude_wrapper`` always regenerates this block fresh and
+    replaces the prior one in place (matched by ``_WRAPPER_MARKER`` ..
+    ``_WRAPPER_END_MARKER``, content-agnostic) — so a content-only fix like
+    this one reaches existing users automatically on their next ``tj
+    onboard``, with no marker version bump needed.
     """
     tj_bin = _current_tj_binary()
     return (
@@ -2976,7 +2988,16 @@ def _claude_wrapper_block() -> str:
         f"    esac\n"
         f"  fi\n"
         f'  [ -z "$_tj_inst" ] && _tj_inst="unknown"\n'
-        f'  export OTEL_RESOURCE_ATTRIBUTES="$("{tj_bin}" otel-resource-attrs),service.instance.id=$_tj_inst"\n'
+        f"  # Silence stderr and tolerate failure: a stale/shadowed tj on PATH\n"
+        f"  # must never leak a traceback into every claude launch, and an empty\n"
+        f"  # or failing lookup must not produce a malformed leading-comma value.\n"
+        f'  local _tj_attrs\n'
+        f'  _tj_attrs="$("{tj_bin}" otel-resource-attrs 2>/dev/null)" || _tj_attrs=""\n'
+        f'  if [ -n "$_tj_attrs" ]; then\n'
+        f'    export OTEL_RESOURCE_ATTRIBUTES="$_tj_attrs,service.instance.id=$_tj_inst"\n'
+        f"  else\n"
+        f'    export OTEL_RESOURCE_ATTRIBUTES="service.instance.id=$_tj_inst"\n'
+        f"  fi\n"
         f"  # Report this terminal's session closed on exit/interrupt so the\n"
         f"  # dashboard archives its tile. Idempotent — double-fire is harmless.\n"
         f"  trap '\"{tj_bin}\" session-end --instance \"$_tj_inst\" >/dev/null 2>&1 || true' INT TERM HUP\n"


### PR DESCRIPTION
## Summary

The generated `claude()` shell wrapper (written to `~/.zshrc`/`~/.bashrc` during onboarding) captured `tj otel-resource-attrs` output via command substitution but only captured stdout — stderr from a failing `tj` (e.g. a stale or shadowed install earlier on PATH) printed straight to the terminal, flashing a traceback before Claude Code took over. On failure, the export still ran with an empty substitution, producing a malformed value with a leading comma (`,service.instance.id=...`) instead of falling back cleanly.

Every `tj otel-resource-attrs` invocation in the wrapper is now stderr-silenced (`2>/dev/null`) and failure-tolerant (`|| _tj_attrs=""`).
The export now branches: joined value when the lookup succeeded and produced output, `service.instance.id=...` alone otherwise — no more leading comma.
No marker-version bump needed: the wrapper block is fully regenerated and replaced in place on every `tj onboard` re-run, so existing users get the fix automatically on their next onboard.

## Test plan
[x] New unit tests pin the stderr redirection and the no-leading-comma fallback in the generated block (`test_wrapper_block_silences_otel_attrs_stderr`, `test_wrapper_block_falls_back_without_leading_comma`)
[x] New end-to-end test sources the generated block in a real `zsh` with a deliberately broken `tj` first on PATH and asserts zero stderr output and a well-formed `OTEL_RESOURCE_ATTRIBUTES` (`test_wrapper_block_survives_broken_tj_end_to_end`)
[x] `pytest tests/unit/` — full suite green (one pre-existing, unrelated failure from local machine state)
[x] `ruff check` / `mypy` clean on changed files
[x] Manually reproduced the exact scenario: broken `tj` first on PATH, sourced the generated wrapper, ran `claude --as demo` — zero extra stdout/stderr output, `OTEL_RESOURCE_ATTRIBUTES=service.instance.id=demo`

🤖 shipped by [shiploop](https://github.com/anshss/shiploop)