### PR TITLE
Include cache-write tokens in optimize-path token totals

### DIFF
--- a/tests/unit/test_optimize.py
+++ b/tests/unit/test_optimize.py
@@ -100,6 +100,51 @@ def test_summarize_window_total_includes_cache_read_tokens(db):
     assert s.total_tokens == 1000 + 200 + 5000
 
 
+def test_summarize_window_total_includes_cache_write_tokens(db):
+    """Window header total must also include cache-CREATION tokens, not just
+    cache-read, so a cache-write-heavy window's reclaimable-share denominator
+    (cmd_optimize._reclaimable_share) isn't inflated."""
+    start = utcnow() - timedelta(days=2)
+    db.insert_span(make_llm_span(
+        model="claude-opus-4-7",
+        provider="anthropic",
+        input_tokens=1000,
+        output_tokens=200,
+        cache_tokens=500,
+        cache_write_tokens=8000,
+        cost_usd=0.030,
+        session_id="cache-write-heavy",
+        start_time=start,
+    ))
+    since = utcnow() - timedelta(days=30)
+    until = utcnow() + timedelta(hours=1)
+    s = summarize_window(db.conn, since, until)
+    assert s.total_tokens == 1000 + 200 + 500 + 8000
+
+
+def test_downgrade_window_total_tokens_includes_cache_write_tokens(db):
+    """window_total_tokens (the percent_of_tokens denominator) must include
+    cache-creation volume for every session in the window, candidate or not."""
+    _insert_small_opus_session(db, session_id="a")
+    db.insert_span(make_llm_span(
+        model="claude-sonnet-4-6",
+        provider="anthropic",
+        input_tokens=2000,
+        output_tokens=300,
+        cache_write_tokens=9000,
+        cost_usd=0.10,
+        session_id="cache-write-session",
+        start_time=utcnow() - timedelta(days=1),
+    ))
+    since = utcnow() - timedelta(days=30)
+    until = utcnow() + timedelta(hours=1)
+    finding = analyze_model_downgrade(
+        db.conn, since, until, agent_id=None, window_days=30.0,
+    )
+    assert finding is not None
+    assert finding.window_total_tokens == (1000 + 200) + (2000 + 300 + 9000)
+
+
 def test_downgrade_flags_small_opus_but_not_large(db):
     _insert_small_opus_session(db, session_id="a")
     _insert_large_opus_session(db, session_id="b")

--- a/tests/unit/test_optimize.py
+++ b/tests/unit/test_optimize.py
@@ -145,6 +145,36 @@ def test_downgrade_window_total_tokens_includes_cache_write_tokens(db):
     assert finding.window_total_tokens == (1000 + 200) + (2000 + 300 + 9000)
 
 
+def test_downgrade_percent_of_tokens_counts_cache_write_in_numerator(db):
+    """percent_of_tokens = candidate_tokens / window_total_tokens must measure
+    both sides on the same basis. When every session is a downgrade candidate
+    carrying cache-write tokens, the candidate share is ~100% — a numerator that
+    omitted cache-write would understate it against the (now cache-write-inclusive)
+    denominator."""
+    db.insert_span(make_llm_span(
+        model="claude-opus-4-7",
+        provider="anthropic",
+        input_tokens=1000,
+        output_tokens=200,
+        cache_tokens=500,
+        cache_write_tokens=8000,
+        cost_usd=0.030,
+        session_id="candidate-cache-write",
+        start_time=utcnow() - timedelta(days=2),
+    ))
+    since = utcnow() - timedelta(days=30)
+    until = utcnow() + timedelta(hours=1)
+    finding = analyze_model_downgrade(
+        db.conn, since, until, agent_id=None, window_days=30.0,
+    )
+    assert finding is not None
+    assert finding.candidate_sessions == 1
+    expected_tokens = 1000 + 200 + 500 + 8000
+    assert finding.candidate_tokens == expected_tokens
+    assert finding.window_total_tokens == expected_tokens
+    assert finding.percent_of_tokens == 100.0
+
+
 def test_downgrade_flags_small_opus_but_not_large(db):
     _insert_small_opus_session(db, session_id="a")
     _insert_large_opus_session(db, session_id="b")

--- a/tokenjam/core/optimize/analyzers/model_downgrade.py
+++ b/tokenjam/core/optimize/analyzers/model_downgrade.py
@@ -258,7 +258,10 @@ def analyze_model_downgrade(
         candidate_sessions += 1
         actual_cost += float(cost or 0.0)
         alt_cost += alt_unit
-        candidate_tokens += int(in_tok or 0) + int(out_tok or 0) + int(cache_tok or 0)
+        candidate_tokens += (
+            int(in_tok or 0) + int(out_tok or 0) + int(cache_tok or 0)
+            + int(cache_write_tok or 0)
+        )
         # This session's recoverable saving (clamped at 0 — a cheaper model
         # never costs more in our candidate set, but guard against pricing noise).
         per_session_savings.append(max(float(cost or 0.0) - alt_unit, 0.0))

--- a/tokenjam/core/optimize/analyzers/model_downgrade.py
+++ b/tokenjam/core/optimize/analyzers/model_downgrade.py
@@ -196,6 +196,7 @@ def analyze_model_downgrade(
         f"COALESCE(SUM(input_tokens),0)  AS input_tokens, "
         f"COALESCE(SUM(output_tokens),0) AS output_tokens, "
         f"COALESCE(SUM(cache_tokens),0)  AS cache_tokens, "
+        f"COALESCE(SUM(cache_write_tokens),0) AS cache_write_tokens, "
         f"COALESCE(SUM(cost_usd),0.0)    AS cost_usd "
         f"FROM spans WHERE {where} AND model IS NOT NULL "
         f"GROUP BY session_id",
@@ -229,10 +230,13 @@ def analyze_model_downgrade(
 
     for row in llm_rows:
         session_id, trace_id, _agent, start_time, end_time, provider, model, \
-            in_tok, out_tok, cache_tok, cost = row
+            in_tok, out_tok, cache_tok, cache_write_tok, cost = row
         # Accumulate window-wide token totals (used for subscription-mode
         # token-share rendering even when the row isn't a candidate).
-        window_total_tokens += int(in_tok or 0) + int(out_tok or 0) + int(cache_tok or 0)
+        window_total_tokens += (
+            int(in_tok or 0) + int(out_tok or 0) + int(cache_tok or 0)
+            + int(cache_write_tok or 0)
+        )
         if not provider or not model:
             continue
         alt = _lookup_downgrade(provider, model)

--- a/tokenjam/core/optimize/runner.py
+++ b/tokenjam/core/optimize/runner.py
@@ -62,7 +62,7 @@ def summarize_window(
     row = conn.execute(
         f"SELECT COUNT(*) AS spans, "
         f"COUNT(DISTINCT session_id) AS sessions, "
-        f"COALESCE(SUM(COALESCE(input_tokens,0) + COALESCE(output_tokens,0) + COALESCE(cache_tokens,0)), 0) AS tokens, "
+        f"COALESCE(SUM(COALESCE(input_tokens,0) + COALESCE(output_tokens,0) + COALESCE(cache_tokens,0) + COALESCE(cache_write_tokens,0)), 0) AS tokens, "
         f"COALESCE(SUM(cost_usd), 0.0) AS cost "
         f"FROM spans WHERE {where}",
         params,


### PR DESCRIPTION
## Problem

Two optimize-path token totals summed input + output + cache-read tokens
but silently omitted cache-write (cache-creation) tokens:

- `summarize_window` (`tokenjam/core/optimize/runner.py`) — its `total_tokens`
  feeds the reclaimable-share denominator used by every optimize analyzer's
  reclaimable-% figure.
- `analyze_model_downgrade` (`tokenjam/core/optimize/analyzers/model_downgrade.py`)
  — its `window_total_tokens` feeds the model-downgrade analyzer's
  candidate-token share.

For any window with meaningful cache-creation volume, both totals understated
the true token volume, which inflated the derived percentages.

This is the same class of bug as public issue #377, which PR #450 fixed for
the cost-comparison window path (`WindowTotals` / `get_window_cost_totals`).
That PR did not touch these two optimize-path call sites, so the gap
persisted there.

## Fix

Add `COALESCE(SUM(cache_write_tokens), 0)` to `summarize_window`'s token SQL
sum, and add `cache_write_tok` to `window_total_tokens`'s accumulation in
`analyze_model_downgrade`, matching the pattern PR #450 established for
`get_window_cost_totals`.

## Other sites noted (not fixed, out of scope for this change)

While verifying no other token-total site has the same gap, I found two more
that also omit cache-write tokens from a "total tokens" figure:

- `analyze_model_downgrade`'s `candidate_tokens` accumulation (same file,
  just below the fixed `window_total_tokens` line) — sums input+output+cache
  for candidate sessions only, still missing cache-write.
- `workflow_restructure.py`'s per-cluster `cluster_tokens` aggregate
  (`SUM(input_tokens + output_tokens + cache_tokens)`) — same gap pattern.

Flagging these for a follow-up rather than expanding this PR's scope.

## Test plan

- Added `test_summarize_window_total_includes_cache_write_tokens` and
  `test_downgrade_window_total_tokens_includes_cache_write_tokens` to
  `tests/unit/test_optimize.py`, asserting a cache-write-heavy window's
  totals include the cache-creation volume.
- `pytest tests/unit/ tests/synthetic/ tests/agents/ tests/integration/` —
  2432 passed, 1 pre-existing unrelated failure (an onboarding test that
  fails locally due to a real `~/.config/tj/config.toml` on this machine;
  reproduces identically on `main` with no changes applied), 2 skipped.
- `ruff check` clean on all changed files.