### PR TITLE
fix(onboard): daemon install resolves tj via interpreter sibling, not PATH

### DIFF
--- a/tests/unit/test_onboard_daemon.py
+++ b/tests/unit/test_onboard_daemon.py
@@ -97,11 +97,35 @@ class TestTjBinaryResolution:
     matches inside `/python3`). The unit is written pointing at a binary that
     doesn't exist; `launchctl load` still returns 0, so onboarding reports
     success while `tj serve` never launches.
+
+    Also regression for a PATH-shadow bug: `_resolve_tj_binary` used to
+    prefer `shutil.which("tj")` over the interpreter sibling, so an
+    older/other `tj` earlier on PATH at the moment `tj onboard` installs the
+    daemon got permanently baked into the launchd/systemd unit — surviving
+    even after the shadowing PATH entry was later removed. It must now
+    prefer the PATH-independent sibling next to the running interpreter,
+    the same priority `_current_tj_binary` uses.
     """
 
-    def test_prefers_tj_on_path(self, monkeypatch):
+    def test_prefers_interpreter_sibling_over_a_shadowing_path_tj(self, monkeypatch, tmp_path):
+        """A `tj` earlier on PATH must never win over the sibling next to the
+        interpreter that onboard is actually running as — that's the whole
+        PATH-shadow bug this resolves."""
         from tokenjam.cli.cmd_onboard import _resolve_tj_binary
-        monkeypatch.setattr("tokenjam.cli.cmd_onboard.shutil.which", lambda _: "/usr/local/bin/tj")
+        sibling = tmp_path / "tj"
+        sibling.write_text("#!/bin/sh\n")
+        monkeypatch.setattr("tokenjam.cli.cmd_onboard.sys.executable", str(tmp_path / "python3"))
+        monkeypatch.setattr(
+            "tokenjam.cli.cmd_onboard.shutil.which", lambda _: "/usr/local/bin/tj",
+        )
+        assert _resolve_tj_binary() == str(sibling)
+
+    def test_falls_back_to_which_when_no_sibling_exists(self, monkeypatch, tmp_path):
+        from tokenjam.cli.cmd_onboard import _resolve_tj_binary
+        monkeypatch.setattr("tokenjam.cli.cmd_onboard.sys.executable", str(tmp_path / "python3"))
+        monkeypatch.setattr(
+            "tokenjam.cli.cmd_onboard.shutil.which", lambda _: "/usr/local/bin/tj",
+        )
         assert _resolve_tj_binary() == "/usr/local/bin/tj"
 
     def test_fallback_python3_resolves_to_sibling_tj(self, monkeypatch):
@@ -169,8 +193,11 @@ class TestDaemonSurvivesUvCachePrune:
     working (and self-updates) after a prune.
     """
 
-    def test_program_args_prefers_direct_tj_when_not_ephemeral(self, monkeypatch):
+    def test_program_args_prefers_direct_tj_when_not_ephemeral(self, monkeypatch, tmp_path):
         from tokenjam.cli.cmd_onboard import _daemon_program_args
+        # No real sibling `tj` next to this fake interpreter path, so
+        # resolution falls back to the (non-ephemeral) `which` result.
+        monkeypatch.setattr("tokenjam.cli.cmd_onboard.sys.executable", str(tmp_path / "python3"))
         monkeypatch.setattr(
             "tokenjam.cli.cmd_onboard.shutil.which",
             lambda b: "/usr/local/bin/tj" if b == "tj" else None,

--- a/tests/unit/test_onboard_path_resolution.py
+++ b/tests/unit/test_onboard_path_resolution.py
@@ -45,6 +45,47 @@ def test_current_tj_binary_falls_back_to_bare_when_nothing_resolves(monkeypatch,
     assert cmd_onboard._current_tj_binary() == "tj"
 
 
+# --- _resolve_tj_binary: daemon-install must share the same PATH-shadow ------
+# --- immunity as _current_tj_binary, without going through it directly ------
+#
+# `_resolve_tj_binary` feeds `_install_launchd`/`_install_systemd`, which bake
+# its result into a plist/unit file that persists indefinitely. It used to
+# prefer `shutil.which("tj")` first, so an older/other `tj` shadowing the
+# real one on PATH at the moment `tj onboard` installs the daemon got
+# permanently pinned into the daemon's ProgramArguments — surviving even
+# after the shadowing PATH entry was later removed. It must resolve the same
+# way `_current_tj_binary` does (sibling first), but its last-resort
+# fallback intentionally returns the *constructed* sibling path rather than
+# a bare `"tj"`, so `_daemon_program_args`'s ephemeral uv/pipx-cache
+# detection still has a real path shape to inspect.
+
+
+def test_resolve_tj_binary_prefers_interpreter_sibling_over_a_shadowing_path_tj(monkeypatch, tmp_path):
+    sibling = tmp_path / "tj"
+    sibling.write_text("#!/bin/sh\n")
+    monkeypatch.setattr(cmd_onboard.sys, "executable", str(tmp_path / "python3"))
+    # Even if PATH resolves to a different (shadowing) tj, the sibling wins.
+    monkeypatch.setattr(cmd_onboard.shutil, "which", lambda _b: "/usr/bin/tj")
+    assert cmd_onboard._resolve_tj_binary() == str(sibling)
+
+
+def test_resolve_tj_binary_falls_back_to_which_when_no_sibling(monkeypatch, tmp_path):
+    monkeypatch.setattr(cmd_onboard.sys, "executable", str(tmp_path / "python3"))
+    monkeypatch.setattr(cmd_onboard.shutil, "which", lambda _b: "/usr/bin/tj")
+    assert cmd_onboard._resolve_tj_binary() == "/usr/bin/tj"
+
+
+def test_resolve_tj_binary_falls_back_to_constructed_sibling_when_nothing_resolves(monkeypatch, tmp_path):
+    """Unlike `_current_tj_binary`, the final fallback is the constructed
+    sibling path, NOT a bare `"tj"` — `_daemon_program_args` needs a path
+    shape (e.g. containing `/uv/` or `/pipx/`) to detect an ephemeral cache
+    install and route the daemon through a durable uvx/pipx shim instead."""
+    sibling = tmp_path / "tj"
+    monkeypatch.setattr(cmd_onboard.sys, "executable", str(tmp_path / "python3"))
+    monkeypatch.setattr(cmd_onboard.shutil, "which", lambda _b: None)
+    assert cmd_onboard._resolve_tj_binary() == str(sibling)
+
+
 # --- _probe_tj_path_resolution: the three states -----------------------------
 
 

--- a/tokenjam/cli/cmd_onboard.py
+++ b/tokenjam/cli/cmd_onboard.py
@@ -3174,15 +3174,29 @@ def _install_daemon(config_path: str) -> str | None:
 def _resolve_tj_binary() -> str:
     """Resolve the absolute path to the ``tj`` executable for daemon units.
 
-    Prefer the copy on PATH. When ``tj`` isn't on PATH (e.g. a venv whose bin
-    dir isn't exported), fall back to the sibling ``tj`` next to the running
-    interpreter — derived by path, not string substitution. The old
+    Prefer the sibling ``tj`` next to the running interpreter — derived by
+    path, not string substitution — the same PATH-independent priority
+    ``_current_tj_binary`` uses: it's fixed at process start and reflects the
+    binary onboard is actually running as, so it can't be shadowed by an
+    older/other ``tj`` earlier on PATH at the moment onboard installs the
+    daemon. Without this, a PATH shadow at install time permanently pins the
+    launchd/systemd unit to the wrong binary — surviving even after the
+    shadowing PATH entry is later removed.
+
+    Falls back to ``shutil.which("tj")`` only when no sibling exists (e.g. a
+    venv whose bin dir isn't exported), and as a last resort to the
+    constructed sibling path anyway — NOT a bare ``"tj"`` — so
+    ``_daemon_program_args``'s ephemeral-cache detection (uv/pipx cache
+    paths) still has a real path shape to inspect. The old
     ``sys.executable.replace("/python", "/tj")`` rewrote a ``python3``-named
     interpreter to a nonexistent ``tj3`` (``/python`` matches inside
     ``/python3``), so launchd/systemd pointed at a binary that doesn't exist
     while ``launchctl load`` still returned 0 (#340).
     """
-    return shutil.which("tj") or str(Path(sys.executable).with_name("tj"))
+    sibling = Path(sys.executable).with_name("tj")
+    if sibling.exists():
+        return str(sibling)
+    return shutil.which("tj") or str(sibling)
 
 
 def _daemon_program_args(config_path: str) -> list[str] | None:


### PR DESCRIPTION
## Problem

The background-daemon installer (\`_install_launchd\`/\`_install_systemd\`) resolves the \`tj\` binary to bake into the daemon's ProgramArguments via \`_resolve_tj_binary()\`, which used to prefer \`shutil.which("tj")\` first, falling back to the interpreter sibling only if PATH resolution failed.

If an older/other \`tj\` happened to be earlier on PATH at the exact moment \`tj onboard\` installed the daemon (a real-world PATH-shadow scenario — confirmed elsewhere in this codebase for a VS Code integrated terminal ordering a stale pip \`tj\` ahead of a freshly-installed uv-tool shim), the daemon unit got permanently pinned to the wrong absolute binary in its plist/unit file. The daemon then silently runs a stale \`tj serve\` indefinitely — surviving even after the shadowing PATH entry is later removed, since the plist/unit already has the wrong path baked in.

## Fix

Flip \`_resolve_tj_binary()\`'s priority to match \`_current_tj_binary()\` (used elsewhere for the same PATH-shadow problem): prefer the PATH-independent sibling next to the running interpreter (\`sys.executable\`'s directory), falling back to \`shutil.which("tj")\` only when no sibling exists.

The final fallback intentionally still returns the *constructed* sibling path rather than a bare \`"tj"\` (unlike \`_current_tj_binary\`'s last resort) — \`_daemon_program_args\`'s ephemeral uv/pipx-cache detection needs a real path shape (containing \`/uv/\` or \`/pipx/\`) to route the daemon through a durable uvx/pipx shim instead of a cache path that \`uv cache prune\` could delete.

## Test plan

- Added regression tests in \`tests/unit/test_onboard_path_resolution.py\` mirroring the existing \`_current_tj_binary\` coverage (prefers sibling over a shadowing PATH tj; falls back to \`which\` when no sibling; falls back to the constructed sibling path, not bare \`tj\`, when nothing resolves).
- Updated two tests in \`tests/unit/test_onboard_daemon.py\` whose fixtures had been implicitly relying on the old which-first ordering (one ran against the real dev venv, where the sibling \`tj\` actually exists, so it silently depended on \`which\` losing).
- \`make test\`: 2433 passed, 2 skipped, 1 pre-existing failure unrelated to this change (\`test_bare_onboard_sdk_choice_falls_through_to_generic\` — fails identically on unmodified \`main\`; an isolation bug that hits the real \`~/.config/tj/config.toml\` on this machine).
- \`make lint\` / \`make typecheck\`: clean.