### PR TITLE
Print a repair hint instead of a raw traceback for a dangling editable install

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -72,8 +72,8 @@ mcp       = []
 bloat     = ["llmlingua>=0.2"]
 
 [project.scripts]
-tj = "tokenjam.cli.main:cli"
-tokenjam = "tokenjam.cli.main:cli"
+tj = "tokenjam.cli.entrypoint:main"
+tokenjam = "tokenjam.cli.entrypoint:main"
 
 [tool.pytest.ini_options]
 testpaths = ["tests/unit", "tests/synthetic", "tests/agents", "tests/integration"]
@@ -88,8 +88,15 @@ packages = ["tokenjam"]
 # — `incidents/` is outside the `tokenjam/` package, so it is never wheeled on
 # its own. cmd_demo._discover_scenarios() resolves this packaged path first, with
 # a repo-root fallback for the dev tree.
+#
+# `entrypoint.py` is force-included too (even though it already lives inside
+# `tokenjam/`) so it is physically copied into site-packages rather than only
+# resolved through an editable install's `.pth` redirect. That is what lets it
+# still run — and print a repair hint — after the editable source checkout
+# has been deleted; see the module docstring for the full story.
 [tool.hatch.build.targets.wheel.force-include]
 "incidents" = "tokenjam/incidents"
+"tokenjam/cli/entrypoint.py" = "tokenjam/cli/entrypoint.py"
 
 [tool.ruff]
 line-length = 100

--- a/tests/unit/test_cli_entrypoint.py
+++ b/tests/unit/test_cli_entrypoint.py
@@ -1,0 +1,104 @@
+"""Tests for the `tj` / `tokenjam` console-script entrypoint.
+
+Covers the dangling-editable-install case: an editable install whose source
+checkout (e.g. a git worktree) has been deleted degrades `tokenjam` to an
+empty PEP 420 namespace package (`tokenjam.__file__ is None`, no real `cli`
+subpackage on any contributing path), so every real submodule import raises
+ModuleNotFoundError. The entrypoint must detect that specific condition and
+print a one-line repair hint instead of letting a bare traceback surface.
+"""
+from __future__ import annotations
+
+import sys
+import types
+
+import pytest
+
+from tokenjam.cli import entrypoint
+
+
+def _namespace_module(path: str) -> types.ModuleType:
+    """Build a fake module object shaped like a broken PEP 420 namespace
+    package: no __file__, __path__ pointing at the given directory."""
+    module = types.ModuleType("tokenjam")
+    module.__file__ = None
+    module.__path__ = [path]
+    return module
+
+
+def test_dangling_editable_install_true_when_source_gone(tmp_path, monkeypatch):
+    # tmp_path has no `cli/main.py` - simulates the deleted-worktree case.
+    monkeypatch.setitem(sys.modules, "tokenjam", _namespace_module(str(tmp_path)))
+
+    assert entrypoint._dangling_editable_install() is True
+
+
+def test_dangling_editable_install_false_when_cli_package_present(tmp_path, monkeypatch):
+    # A namespace package whose path DOES still hold a real cli/main.py is
+    # not the dangling-install case (defensive: don't misfire on a benign
+    # namespace-package layout).
+    cli_dir = tmp_path / "cli"
+    cli_dir.mkdir()
+    (cli_dir / "main.py").write_text("")
+    monkeypatch.setitem(sys.modules, "tokenjam", _namespace_module(str(tmp_path)))
+
+    assert entrypoint._dangling_editable_install() is False
+
+
+def test_dangling_editable_install_false_for_real_module(monkeypatch):
+    real_module = types.ModuleType("tokenjam")
+    real_module.__file__ = "/some/real/install/tokenjam/__init__.py"
+    monkeypatch.setitem(sys.modules, "tokenjam", real_module)
+
+    assert entrypoint._dangling_editable_install() is False
+
+
+def test_dangling_editable_install_never_raises_when_tokenjam_missing(monkeypatch):
+    monkeypatch.delitem(sys.modules, "tokenjam", raising=False)
+
+    def _boom(name, *args, **kwargs):
+        raise ModuleNotFoundError("No module named 'tokenjam'")
+
+    monkeypatch.setattr("builtins.__import__", _boom)
+
+    assert entrypoint._dangling_editable_install() is False
+
+
+def test_main_prints_repair_hint_and_exits_1_on_dangling_install(monkeypatch, capsys):
+    def _fail_load_cli():
+        raise ModuleNotFoundError("No module named 'tokenjam.cli'")
+
+    monkeypatch.setattr(entrypoint, "_load_cli", _fail_load_cli)
+    monkeypatch.setattr(entrypoint, "_dangling_editable_install", lambda: True)
+
+    with pytest.raises(SystemExit) as exc_info:
+        entrypoint.main()
+
+    assert exc_info.value.code == 1
+    captured = capsys.readouterr()
+    assert "no longer exists" in captured.err
+    assert "pipx reinstall tokenjam" in captured.err
+    assert "Traceback" not in captured.err
+
+
+def test_main_reraises_unrelated_module_not_found_error(monkeypatch):
+    # A ModuleNotFoundError from some OTHER cause (e.g. a genuinely missing
+    # dependency) must not be swallowed as if it were the dangling-install
+    # case - only the specific namespace-package signal should be caught.
+    def _fail_load_cli():
+        raise ModuleNotFoundError("No module named 'some_unrelated_dependency'")
+
+    monkeypatch.setattr(entrypoint, "_load_cli", _fail_load_cli)
+    monkeypatch.setattr(entrypoint, "_dangling_editable_install", lambda: False)
+
+    with pytest.raises(ModuleNotFoundError, match="some_unrelated_dependency"):
+        entrypoint.main()
+
+
+def test_main_runs_cli_normally_when_import_succeeds(monkeypatch):
+    monkeypatch.setattr(entrypoint, "_load_cli", lambda: (lambda: 0))
+
+    with pytest.raises(SystemExit) as exc_info:
+        entrypoint.main()
+
+    assert exc_info.value.code == 0

--- a/tokenjam/cli/entrypoint.py
+++ b/tokenjam/cli/entrypoint.py
@@ -1,0 +1,77 @@
+"""Console-script entrypoint for `tj` / `tokenjam`.
+
+Why this file exists separately from `tokenjam.cli.main`: it is force-included
+into the wheel (see `[tool.hatch.build.targets.wheel.force-include]` in
+`pyproject.toml`), so it is physically copied into site-packages even for an
+editable install. That matters because an editable install of `tokenjam`
+otherwise resolves every submodule (including `tokenjam.cli.main`) through a
+`.pth` entry that just points back at the dev checkout — if that checkout
+(e.g. a git worktree) is later deleted, `tokenjam` degrades to an empty PEP
+420 namespace package and every real submodule import raises
+`ModuleNotFoundError`, with nothing left on disk to run a guard from.
+
+This module is the one piece of code guaranteed to still be on disk in that
+situation, so it is the only place that can catch the failure and print an
+actionable hint instead of letting a bare traceback reach the user.
+"""
+from __future__ import annotations
+
+import os
+import sys
+
+_DANGLING_EDITABLE_HINT = (
+    "tj's install points at a source path that no longer exists. "
+    "Reinstall with `pipx reinstall tokenjam` or `pip install -e <checkout>`."
+)
+
+
+def _dangling_editable_install() -> bool:
+    """Best-effort detection of a broken editable install.
+
+    Must never raise: any failure here just means "not detected" so the
+    caller falls back to re-raising the original ModuleNotFoundError.
+    """
+    try:
+        import tokenjam
+
+        if getattr(tokenjam, "__file__", None) is not None:
+            # Resolved as a normal module (not a namespace package) - a real
+            # install, nothing dangling.
+            return False
+
+        # `__file__ is None` means `tokenjam` only resolved as a PEP 420
+        # namespace package. That alone isn't proof the editable source is
+        # gone (a namespace package is also valid packaging), so also check
+        # whether any contributing path actually holds the real `cli`
+        # subpackage on disk.
+        paths = list(getattr(tokenjam, "__path__", None) or [])
+        return not any(_has_real_cli_package(path) for path in paths)
+    except Exception:
+        return False
+
+
+def _has_real_cli_package(path: str) -> bool:
+    try:
+        return os.path.isfile(os.path.join(path, "cli", "main.py"))
+    except Exception:
+        return False
+
+
+def _load_cli():
+    """Import the real CLI. Split out so tests can simulate the failure
+    without needing an actual broken editable install on disk."""
+    from tokenjam.cli.main import cli
+
+    return cli
+
+
+def main() -> None:
+    """Entry point registered as the `tj` / `tokenjam` console scripts."""
+    try:
+        cli = _load_cli()
+    except ModuleNotFoundError:
+        if _dangling_editable_install():
+            sys.stderr.write(_DANGLING_EDITABLE_HINT + "\n")
+            raise SystemExit(1)
+        raise
+    raise SystemExit(cli())


### PR DESCRIPTION
## Problem

If \`tokenjam\` is installed with \`pip install -e .\` (or via a tool that does this under the hood) and the source checkout it points at is later removed (e.g. a deleted git worktree), the \`tj\`/\`tokenjam\` CLI degrades: \`tokenjam\` resolves as an empty Python namespace package (no \`__file__\`, no real \`cli\` subpackage on disk), so every subcommand dies with a bare traceback:

\`\`\`
Traceback (most recent call last):
  File ".../bin/tj", line 5, in <module>
    from tokenjam.cli.main import cli
ModuleNotFoundError: No module named 'tokenjam.cli'
\`\`\`

Nothing in that traceback tells the user the actual cause (a dangling editable install) or how to fix it.

## Fix

- Added \`tokenjam/cli/entrypoint.py\`, a small module registered as the \`tj\`/\`tokenjam\` console scripts. It tries the real import; on \`ModuleNotFoundError\` it checks specifically for the namespace-package signature (\`tokenjam.__file__ is None\` and no contributing path holds a real \`cli/main.py\`) and prints a one-line hint instead of letting the traceback through:

  > \`tj's install points at a source path that no longer exists. Reinstall with \`pipx reinstall tokenjam\` or \`pip install -e <checkout>\`.\`

  Any other \`ModuleNotFoundError\` (e.g. a genuinely missing dependency) still propagates normally — this only catches the specific dangling-editable case.
- The tricky part: the console-script stub that pip generates does a hard, unguarded top-level import of whatever module the entry point names. If that target module lives entirely inside the vanished editable source tree, there's nothing left on disk to run a guard from. So \`entrypoint.py\` is also added to \`[tool.hatch.build.targets.wheel.force-include]\`, which makes hatchling physically copy it into site-packages even for an editable install (the same mechanism already used to ship the \`incidents/\` demo data) — so it's guaranteed to still be present and importable even after the rest of the source is deleted.

## Test plan

- Added \`tests/unit/test_cli_entrypoint.py\`: unit tests simulating the namespace-package condition via fake module objects (dangling case detected, benign namespace package with real \`cli/main.py\` not misdetected, real install not misdetected, detector never raises), plus tests for \`main()\`'s hint/exit-1 path, its re-raise of unrelated \`ModuleNotFoundError\`s, and its normal success path.
- Manually verified end-to-end outside the test suite: built a real editable install in a scratch venv, confirmed \`tokenjam/cli/entrypoint.py\` is physically present in site-packages, ran \`tj --version\` (works), deleted the source checkout, ran \`tj --version\` again — now prints the one-line hint and exits 1 instead of a traceback (confirmed for another subcommand too).
- \`make test\`: 2436 passed, 2 skipped, 1 pre-existing unrelated failure (\`test_bare_onboard_sdk_choice_falls_through_to_generic\`, fails identically on a clean checkout of this branch before my changes — caused by a real \`~/.config/tj/config.toml\` on the test machine leaking into an isolated-filesystem test, unrelated to this change).
- \`ruff check\` and \`mypy\` clean on the new/changed files.