### PR TITLE
Launch-readiness bundle: statusline attribution, cache-write token totals, daemon binary resolution, dangling-install hint

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -72,8 +72,8 @@ mcp       = []
 bloat     = ["llmlingua>=0.2"]
 
 [project.scripts]
-tj = "tokenjam.cli.main:cli"
-tokenjam = "tokenjam.cli.main:cli"
+tj = "tokenjam.cli.entrypoint:main"
+tokenjam = "tokenjam.cli.entrypoint:main"
 
 [tool.pytest.ini_options]
 testpaths = ["tests/unit", "tests/synthetic", "tests/agents", "tests/integration"]
@@ -88,8 +88,15 @@ packages = ["tokenjam"]
 # — `incidents/` is outside the `tokenjam/` package, so it is never wheeled on
 # its own. cmd_demo._discover_scenarios() resolves this packaged path first, with
 # a repo-root fallback for the dev tree.
+#
+# `entrypoint.py` is force-included too (even though it already lives inside
+# `tokenjam/`) so it is physically copied into site-packages rather than only
+# resolved through an editable install's `.pth` redirect. That is what lets it
+# still run — and print a repair hint — after the editable source checkout
+# has been deleted; see the module docstring for the full story.
 [tool.hatch.build.targets.wheel.force-include]
 "incidents" = "tokenjam/incidents"
+"tokenjam/cli/entrypoint.py" = "tokenjam/cli/entrypoint.py"
 
 [tool.ruff]
 line-length = 100

--- a/tests/unit/test_attribution_cache.py
+++ b/tests/unit/test_attribution_cache.py
@@ -1,0 +1,158 @@
+"""Unit tests for the statusline's cheap on-disk attribution cache.
+
+`refresh_attribution_cache` is the write side (called by `ingest_claude_code`
+after a backfill); `read_attribution_cache` is the read side the statusline
+uses. Both take an explicit `path` so no test ever touches the real
+`~/.local/share/tj/attribution_cache.json`.
+"""
+from __future__ import annotations
+
+import json
+from datetime import timedelta
+
+import pytest
+
+from tokenjam.core.attribution_cache import (
+    read_attribution_cache,
+    refresh_attribution_cache,
+    write_attribution_cache,
+)
+from tokenjam.core.config import CaptureConfig
+from tokenjam.core.db import InMemoryBackend
+from tokenjam.otel.semconv import GenAIAttributes
+from tokenjam.utils.time_parse import utcnow
+from tests.factories import make_llm_span, make_session, make_tool_span
+
+BASE = utcnow() - timedelta(hours=1)
+
+
+@pytest.fixture
+def db():
+    backend = InMemoryBackend()
+    yield backend
+    backend.close()
+
+
+def _seed_recurring_file_read(db, path: str = "CLAUDE.md") -> None:
+    """Three sessions all Read-ing the same file — a recurring inclusion.
+
+    Each session also needs at least one LLM-call span:
+    `compute_context_diagnostic` only computes recurring inclusions once
+    `load_turn_compositions` finds turns (a tool-only DB has none).
+    """
+    for i, sid in enumerate(("sess-a", "sess-b", "sess-c")):
+        db.upsert_session(make_session(session_id=sid, plan_tier="max_5x"))
+        llm = make_llm_span(
+            model="claude-sonnet-4-5", input_tokens=100, output_tokens=50,
+            cache_tokens=100, cost_usd=0.01, session_id=sid,
+        )
+        llm.start_time = BASE + timedelta(seconds=i)
+        db.insert_span(llm)
+        tool = make_tool_span(tool_name="Read")
+        tool.session_id = sid
+        tool.start_time = BASE + timedelta(seconds=i, milliseconds=500)
+        tool.attributes = {GenAIAttributes.TOOL_INPUT: {"file_path": path}}
+        db.insert_span(tool)
+
+
+# --- read/write round trip --------------------------------------------------
+
+
+def test_write_then_read_round_trips(tmp_path):
+    path = tmp_path / "cache.json"
+    write_attribution_cache("CLAUDE.md", 14, 3, path=path)
+    cached = read_attribution_cache(path=path)
+    assert cached["top_label"] == "CLAUDE.md"
+    assert cached["occurrences"] == 14
+    assert cached["sessions"] == 3
+
+
+def test_read_missing_file_returns_none(tmp_path):
+    assert read_attribution_cache(path=tmp_path / "missing.json") is None
+
+
+def test_read_corrupt_json_returns_none(tmp_path):
+    path = tmp_path / "cache.json"
+    path.write_text("{not json")
+    assert read_attribution_cache(path=path) is None
+
+
+def test_read_non_dict_json_returns_none(tmp_path):
+    path = tmp_path / "cache.json"
+    path.write_text(json.dumps([1, 2, 3]))
+    assert read_attribution_cache(path=path) is None
+
+
+def test_read_missing_fields_returns_none(tmp_path):
+    path = tmp_path / "cache.json"
+    path.write_text(json.dumps({"computed_at": utcnow().isoformat()}))
+    assert read_attribution_cache(path=path) is None
+
+
+def test_read_stale_entry_returns_none(tmp_path):
+    path = tmp_path / "cache.json"
+    stale = utcnow() - timedelta(days=30)
+    path.write_text(json.dumps({
+        "top_label": "CLAUDE.md", "occurrences": 5, "sessions": 2,
+        "computed_at": stale.isoformat(),
+    }))
+    assert read_attribution_cache(path=path, max_age_seconds=7 * 24 * 60 * 60) is None
+
+
+def test_read_fresh_entry_within_max_age_returns_data(tmp_path):
+    path = tmp_path / "cache.json"
+    recent = utcnow() - timedelta(hours=1)
+    path.write_text(json.dumps({
+        "top_label": "CLAUDE.md", "occurrences": 5, "sessions": 2,
+        "computed_at": recent.isoformat(),
+    }))
+    cached = read_attribution_cache(path=path, max_age_seconds=7 * 24 * 60 * 60)
+    assert cached is not None
+    assert cached["top_label"] == "CLAUDE.md"
+
+
+# --- refresh_attribution_cache (the ingest-time write) ----------------------
+
+
+def test_refresh_writes_top_driver_when_capture_on(db, tmp_path):
+    _seed_recurring_file_read(db, path="CLAUDE.md")
+    cache_path = tmp_path / "cache.json"
+    refresh_attribution_cache(
+        db.conn, CaptureConfig(tool_inputs=True), path=cache_path
+    )
+    cached = read_attribution_cache(path=cache_path)
+    assert cached is not None
+    assert cached["top_label"] == "CLAUDE.md"
+    assert cached["occurrences"] == 3
+    assert cached["sessions"] == 3
+
+
+def test_refresh_no_op_when_capture_off(db, tmp_path):
+    _seed_recurring_file_read(db, path="CLAUDE.md")
+    cache_path = tmp_path / "cache.json"
+    refresh_attribution_cache(db.conn, CaptureConfig(), path=cache_path)
+    assert not cache_path.exists()
+
+
+def test_refresh_no_op_when_no_recurring_inclusions(db, tmp_path):
+    # A single Read in one session never clears RECURRING_MIN_SESSIONS.
+    db.upsert_session(make_session(session_id="sess-a", plan_tier="max_5x"))
+    tool = make_tool_span(tool_name="Read")
+    tool.session_id = "sess-a"
+    tool.start_time = BASE
+    tool.attributes = {GenAIAttributes.TOOL_INPUT: {"file_path": "CLAUDE.md"}}
+    db.insert_span(tool)
+
+    cache_path = tmp_path / "cache.json"
+    refresh_attribution_cache(
+        db.conn, CaptureConfig(tool_inputs=True), path=cache_path
+    )
+    assert not cache_path.exists()
+
+
+def test_refresh_never_raises_on_bad_connection(tmp_path):
+    cache_path = tmp_path / "cache.json"
+    refresh_attribution_cache(
+        object(), CaptureConfig(tool_inputs=True), path=cache_path
+    )
+    assert not cache_path.exists()

--- a/tests/unit/test_attribution_cache.py
+++ b/tests/unit/test_attribution_cache.py
@@ -13,6 +13,7 @@ from datetime import timedelta
 import pytest
 
 from tokenjam.core.attribution_cache import (
+    format_driver_label,
     read_attribution_cache,
     refresh_attribution_cache,
     write_attribution_cache,
@@ -89,6 +90,26 @@ def test_read_missing_fields_returns_none(tmp_path):
     assert read_attribution_cache(path=path) is None
 
 
+def test_read_missing_computed_at_expires(tmp_path):
+    # A complete entry with NO computed_at can't be proven fresh, so it must
+    # expire (return None) rather than show a stale driver forever.
+    path = tmp_path / "cache.json"
+    path.write_text(json.dumps({
+        "top_label": "CLAUDE.md", "occurrences": 14, "sessions": 3,
+    }))
+    assert read_attribution_cache(path=path) is None
+
+
+def test_read_unparseable_computed_at_expires(tmp_path):
+    # A non-string / unparseable timestamp is treated the same as aged-out.
+    path = tmp_path / "cache.json"
+    path.write_text(json.dumps({
+        "top_label": "CLAUDE.md", "occurrences": 14, "sessions": 3,
+        "computed_at": "not-a-timestamp",
+    }))
+    assert read_attribution_cache(path=path) is None
+
+
 def test_read_stale_entry_returns_none(tmp_path):
     path = tmp_path / "cache.json"
     stale = utcnow() - timedelta(days=30)
@@ -156,3 +177,26 @@ def test_refresh_never_raises_on_bad_connection(tmp_path):
         object(), CaptureConfig(tool_inputs=True), path=cache_path
     )
     assert not cache_path.exists()
+
+
+# --- format_driver_label (the single display reader) ------------------------
+
+
+def test_format_driver_label_formats_label_and_count(tmp_path):
+    path = tmp_path / "cache.json"
+    write_attribution_cache("CLAUDE.md", 14, 3, path=path)
+    assert format_driver_label(path=path) == "CLAUDE.md ×14"
+
+
+def test_format_driver_label_none_when_no_cache(tmp_path):
+    assert format_driver_label(path=tmp_path / "missing.json") is None
+
+
+def test_format_driver_label_none_when_stale(tmp_path):
+    path = tmp_path / "cache.json"
+    stale = utcnow() - timedelta(days=30)
+    path.write_text(json.dumps({
+        "top_label": "CLAUDE.md", "occurrences": 5, "sessions": 2,
+        "computed_at": stale.isoformat(),
+    }))
+    assert format_driver_label(path=path) is None

--- a/tests/unit/test_cli_entrypoint.py
+++ b/tests/unit/test_cli_entrypoint.py
@@ -1,0 +1,104 @@
+"""Tests for the `tj` / `tokenjam` console-script entrypoint.
+
+Covers the dangling-editable-install case: an editable install whose source
+checkout (e.g. a git worktree) has been deleted degrades `tokenjam` to an
+empty PEP 420 namespace package (`tokenjam.__file__ is None`, no real `cli`
+subpackage on any contributing path), so every real submodule import raises
+ModuleNotFoundError. The entrypoint must detect that specific condition and
+print a one-line repair hint instead of letting a bare traceback surface.
+"""
+from __future__ import annotations
+
+import sys
+import types
+
+import pytest
+
+from tokenjam.cli import entrypoint
+
+
+def _namespace_module(path: str) -> types.ModuleType:
+    """Build a fake module object shaped like a broken PEP 420 namespace
+    package: no __file__, __path__ pointing at the given directory."""
+    module = types.ModuleType("tokenjam")
+    module.__file__ = None
+    module.__path__ = [path]
+    return module
+
+
+def test_dangling_editable_install_true_when_source_gone(tmp_path, monkeypatch):
+    # tmp_path has no `cli/main.py` - simulates the deleted-worktree case.
+    monkeypatch.setitem(sys.modules, "tokenjam", _namespace_module(str(tmp_path)))
+
+    assert entrypoint._dangling_editable_install() is True
+
+
+def test_dangling_editable_install_false_when_cli_package_present(tmp_path, monkeypatch):
+    # A namespace package whose path DOES still hold a real cli/main.py is
+    # not the dangling-install case (defensive: don't misfire on a benign
+    # namespace-package layout).
+    cli_dir = tmp_path / "cli"
+    cli_dir.mkdir()
+    (cli_dir / "main.py").write_text("")
+    monkeypatch.setitem(sys.modules, "tokenjam", _namespace_module(str(tmp_path)))
+
+    assert entrypoint._dangling_editable_install() is False
+
+
+def test_dangling_editable_install_false_for_real_module(monkeypatch):
+    real_module = types.ModuleType("tokenjam")
+    real_module.__file__ = "/some/real/install/tokenjam/__init__.py"
+    monkeypatch.setitem(sys.modules, "tokenjam", real_module)
+
+    assert entrypoint._dangling_editable_install() is False
+
+
+def test_dangling_editable_install_never_raises_when_tokenjam_missing(monkeypatch):
+    monkeypatch.delitem(sys.modules, "tokenjam", raising=False)
+
+    def _boom(name, *args, **kwargs):
+        raise ModuleNotFoundError("No module named 'tokenjam'")
+
+    monkeypatch.setattr("builtins.__import__", _boom)
+
+    assert entrypoint._dangling_editable_install() is False
+
+
+def test_main_prints_repair_hint_and_exits_1_on_dangling_install(monkeypatch, capsys):
+    def _fail_load_cli():
+        raise ModuleNotFoundError("No module named 'tokenjam.cli'")
+
+    monkeypatch.setattr(entrypoint, "_load_cli", _fail_load_cli)
+    monkeypatch.setattr(entrypoint, "_dangling_editable_install", lambda: True)
+
+    with pytest.raises(SystemExit) as exc_info:
+        entrypoint.main()
+
+    assert exc_info.value.code == 1
+    captured = capsys.readouterr()
+    assert "no longer exists" in captured.err
+    assert "pipx reinstall tokenjam" in captured.err
+    assert "Traceback" not in captured.err
+
+
+def test_main_reraises_unrelated_module_not_found_error(monkeypatch):
+    # A ModuleNotFoundError from some OTHER cause (e.g. a genuinely missing
+    # dependency) must not be swallowed as if it were the dangling-install
+    # case - only the specific namespace-package signal should be caught.
+    def _fail_load_cli():
+        raise ModuleNotFoundError("No module named 'some_unrelated_dependency'")
+
+    monkeypatch.setattr(entrypoint, "_load_cli", _fail_load_cli)
+    monkeypatch.setattr(entrypoint, "_dangling_editable_install", lambda: False)
+
+    with pytest.raises(ModuleNotFoundError, match="some_unrelated_dependency"):
+        entrypoint.main()
+
+
+def test_main_runs_cli_normally_when_import_succeeds(monkeypatch):
+    monkeypatch.setattr(entrypoint, "_load_cli", lambda: (lambda: 0))
+
+    with pytest.raises(SystemExit) as exc_info:
+        entrypoint.main()
+
+    assert exc_info.value.code == 0

--- a/tests/unit/test_cmd_resume_brief.py
+++ b/tests/unit/test_cmd_resume_brief.py
@@ -79,3 +79,37 @@ def test_no_flags_raises_usage_error(runner, tmp_path):
     result = _invoke(runner, _config(tmp_path), ["resume-brief"], stdin="")
     assert result.exit_code != 0
     assert "Provide --session" in result.output or "Usage" in result.output
+
+
+# --- top-driver hint (neutral informational wording) ------------------------
+
+
+def test_top_driver_hint_neutral_wording(tmp_path, monkeypatch):
+    """The hint reads as neutral context, not a "TOP RE-READ DRIVER" alert.
+
+    The resume-brief hook can't compute the live re-read share, so a low-share
+    user must not see an alarm — only a plain informational line.
+    """
+    from tokenjam.cli.cmd_resume_brief import _top_driver_hint
+    from tokenjam.core.attribution_cache import write_attribution_cache
+
+    cache_path = tmp_path / "attribution_cache.json"
+    monkeypatch.setattr(
+        "tokenjam.core.attribution_cache._cache_path", lambda: cache_path
+    )
+    write_attribution_cache("CLAUDE.md", 14, 3, path=cache_path)
+
+    hint = _top_driver_hint()
+    assert "Most re-read context (last 30d): CLAUDE.md ×14" in hint
+    assert "TOP RE-READ DRIVER" not in hint  # not an alert
+    assert "—" not in hint  # house style: no em dashes in user-facing copy
+
+
+def test_top_driver_hint_empty_when_no_cache(tmp_path, monkeypatch):
+    from tokenjam.cli.cmd_resume_brief import _top_driver_hint
+
+    monkeypatch.setattr(
+        "tokenjam.core.attribution_cache._cache_path",
+        lambda: tmp_path / "missing.json",
+    )
+    assert _top_driver_hint() == ""

--- a/tests/unit/test_onboard_daemon.py
+++ b/tests/unit/test_onboard_daemon.py
@@ -97,11 +97,35 @@ class TestTjBinaryResolution:
     matches inside `/python3`). The unit is written pointing at a binary that
     doesn't exist; `launchctl load` still returns 0, so onboarding reports
     success while `tj serve` never launches.
+
+    Also regression for a PATH-shadow bug: `_resolve_tj_binary` used to
+    prefer `shutil.which("tj")` over the interpreter sibling, so an
+    older/other `tj` earlier on PATH at the moment `tj onboard` installs the
+    daemon got permanently baked into the launchd/systemd unit — surviving
+    even after the shadowing PATH entry was later removed. It must now
+    prefer the PATH-independent sibling next to the running interpreter,
+    the same priority `_current_tj_binary` uses.
     """
 
-    def test_prefers_tj_on_path(self, monkeypatch):
+    def test_prefers_interpreter_sibling_over_a_shadowing_path_tj(self, monkeypatch, tmp_path):
+        """A `tj` earlier on PATH must never win over the sibling next to the
+        interpreter that onboard is actually running as — that's the whole
+        PATH-shadow bug this resolves."""
         from tokenjam.cli.cmd_onboard import _resolve_tj_binary
-        monkeypatch.setattr("tokenjam.cli.cmd_onboard.shutil.which", lambda _: "/usr/local/bin/tj")
+        sibling = tmp_path / "tj"
+        sibling.write_text("#!/bin/sh\n")
+        monkeypatch.setattr("tokenjam.cli.cmd_onboard.sys.executable", str(tmp_path / "python3"))
+        monkeypatch.setattr(
+            "tokenjam.cli.cmd_onboard.shutil.which", lambda _: "/usr/local/bin/tj",
+        )
+        assert _resolve_tj_binary() == str(sibling)
+
+    def test_falls_back_to_which_when_no_sibling_exists(self, monkeypatch, tmp_path):
+        from tokenjam.cli.cmd_onboard import _resolve_tj_binary
+        monkeypatch.setattr("tokenjam.cli.cmd_onboard.sys.executable", str(tmp_path / "python3"))
+        monkeypatch.setattr(
+            "tokenjam.cli.cmd_onboard.shutil.which", lambda _: "/usr/local/bin/tj",
+        )
         assert _resolve_tj_binary() == "/usr/local/bin/tj"
 
     def test_fallback_python3_resolves_to_sibling_tj(self, monkeypatch):
@@ -169,8 +193,11 @@ class TestDaemonSurvivesUvCachePrune:
     working (and self-updates) after a prune.
     """
 
-    def test_program_args_prefers_direct_tj_when_not_ephemeral(self, monkeypatch):
+    def test_program_args_prefers_direct_tj_when_not_ephemeral(self, monkeypatch, tmp_path):
         from tokenjam.cli.cmd_onboard import _daemon_program_args
+        # No real sibling `tj` next to this fake interpreter path, so
+        # resolution falls back to the (non-ephemeral) `which` result.
+        monkeypatch.setattr("tokenjam.cli.cmd_onboard.sys.executable", str(tmp_path / "python3"))
         monkeypatch.setattr(
             "tokenjam.cli.cmd_onboard.shutil.which",
             lambda b: "/usr/local/bin/tj" if b == "tj" else None,

--- a/tests/unit/test_onboard_hygiene.py
+++ b/tests/unit/test_onboard_hygiene.py
@@ -26,8 +26,12 @@ def test_capture_block_has_all_four_toggles(tmp_path):
     # #15: onboard previously omitted tool_inputs (CLAUDE.md documents four).
     res, cfg = _run(tmp_path)
     assert res.exit_code == 0, res.output
-    for key in ("prompts", "completions", "tool_inputs", "tool_outputs"):
+    for key in ("prompts", "completions", "tool_outputs"):
         assert f"{key} = false" in cfg, f"[capture] missing {key}"
+    # tool_inputs defaults ON: it only captures file paths / search queries
+    # (not message or tool-output content), which is what lets the recurring-
+    # inclusion attribution (statusline / `tj context`) work out of the box.
+    assert "tool_inputs = true" in cfg, "[capture] tool_inputs should default on"
 
 
 def test_no_stale_openclawwatch_url(tmp_path):

--- a/tests/unit/test_onboard_path_resolution.py
+++ b/tests/unit/test_onboard_path_resolution.py
@@ -45,6 +45,47 @@ def test_current_tj_binary_falls_back_to_bare_when_nothing_resolves(monkeypatch,
     assert cmd_onboard._current_tj_binary() == "tj"
 
 
+# --- _resolve_tj_binary: daemon-install must share the same PATH-shadow ------
+# --- immunity as _current_tj_binary, without going through it directly ------
+#
+# `_resolve_tj_binary` feeds `_install_launchd`/`_install_systemd`, which bake
+# its result into a plist/unit file that persists indefinitely. It used to
+# prefer `shutil.which("tj")` first, so an older/other `tj` shadowing the
+# real one on PATH at the moment `tj onboard` installs the daemon got
+# permanently pinned into the daemon's ProgramArguments — surviving even
+# after the shadowing PATH entry was later removed. It must resolve the same
+# way `_current_tj_binary` does (sibling first), but its last-resort
+# fallback intentionally returns the *constructed* sibling path rather than
+# a bare `"tj"`, so `_daemon_program_args`'s ephemeral uv/pipx-cache
+# detection still has a real path shape to inspect.
+
+
+def test_resolve_tj_binary_prefers_interpreter_sibling_over_a_shadowing_path_tj(monkeypatch, tmp_path):
+    sibling = tmp_path / "tj"
+    sibling.write_text("#!/bin/sh\n")
+    monkeypatch.setattr(cmd_onboard.sys, "executable", str(tmp_path / "python3"))
+    # Even if PATH resolves to a different (shadowing) tj, the sibling wins.
+    monkeypatch.setattr(cmd_onboard.shutil, "which", lambda _b: "/usr/bin/tj")
+    assert cmd_onboard._resolve_tj_binary() == str(sibling)
+
+
+def test_resolve_tj_binary_falls_back_to_which_when_no_sibling(monkeypatch, tmp_path):
+    monkeypatch.setattr(cmd_onboard.sys, "executable", str(tmp_path / "python3"))
+    monkeypatch.setattr(cmd_onboard.shutil, "which", lambda _b: "/usr/bin/tj")
+    assert cmd_onboard._resolve_tj_binary() == "/usr/bin/tj"
+
+
+def test_resolve_tj_binary_falls_back_to_constructed_sibling_when_nothing_resolves(monkeypatch, tmp_path):
+    """Unlike `_current_tj_binary`, the final fallback is the constructed
+    sibling path, NOT a bare `"tj"` — `_daemon_program_args` needs a path
+    shape (e.g. containing `/uv/` or `/pipx/`) to detect an ephemeral cache
+    install and route the daemon through a durable uvx/pipx shim instead."""
+    sibling = tmp_path / "tj"
+    monkeypatch.setattr(cmd_onboard.sys, "executable", str(tmp_path / "python3"))
+    monkeypatch.setattr(cmd_onboard.shutil, "which", lambda _b: None)
+    assert cmd_onboard._resolve_tj_binary() == str(sibling)
+
+
 # --- _probe_tj_path_resolution: the three states -----------------------------
 
 

--- a/tests/unit/test_optimize.py
+++ b/tests/unit/test_optimize.py
@@ -100,6 +100,51 @@ def test_summarize_window_total_includes_cache_read_tokens(db):
     assert s.total_tokens == 1000 + 200 + 5000
 
 
+def test_summarize_window_total_includes_cache_write_tokens(db):
+    """Window header total must also include cache-CREATION tokens, not just
+    cache-read, so a cache-write-heavy window's reclaimable-share denominator
+    (cmd_optimize._reclaimable_share) isn't inflated."""
+    start = utcnow() - timedelta(days=2)
+    db.insert_span(make_llm_span(
+        model="claude-opus-4-7",
+        provider="anthropic",
+        input_tokens=1000,
+        output_tokens=200,
+        cache_tokens=500,
+        cache_write_tokens=8000,
+        cost_usd=0.030,
+        session_id="cache-write-heavy",
+        start_time=start,
+    ))
+    since = utcnow() - timedelta(days=30)
+    until = utcnow() + timedelta(hours=1)
+    s = summarize_window(db.conn, since, until)
+    assert s.total_tokens == 1000 + 200 + 500 + 8000
+
+
+def test_downgrade_window_total_tokens_includes_cache_write_tokens(db):
+    """window_total_tokens (the percent_of_tokens denominator) must include
+    cache-creation volume for every session in the window, candidate or not."""
+    _insert_small_opus_session(db, session_id="a")
+    db.insert_span(make_llm_span(
+        model="claude-sonnet-4-6",
+        provider="anthropic",
+        input_tokens=2000,
+        output_tokens=300,
+        cache_write_tokens=9000,
+        cost_usd=0.10,
+        session_id="cache-write-session",
+        start_time=utcnow() - timedelta(days=1),
+    ))
+    since = utcnow() - timedelta(days=30)
+    until = utcnow() + timedelta(hours=1)
+    finding = analyze_model_downgrade(
+        db.conn, since, until, agent_id=None, window_days=30.0,
+    )
+    assert finding is not None
+    assert finding.window_total_tokens == (1000 + 200) + (2000 + 300 + 9000)
+
+
 def test_downgrade_flags_small_opus_but_not_large(db):
     _insert_small_opus_session(db, session_id="a")
     _insert_large_opus_session(db, session_id="b")

--- a/tests/unit/test_optimize.py
+++ b/tests/unit/test_optimize.py
@@ -145,6 +145,36 @@ def test_downgrade_window_total_tokens_includes_cache_write_tokens(db):
     assert finding.window_total_tokens == (1000 + 200) + (2000 + 300 + 9000)
 
 
+def test_downgrade_percent_of_tokens_counts_cache_write_in_numerator(db):
+    """percent_of_tokens = candidate_tokens / window_total_tokens must measure
+    both sides on the same basis. When every session is a downgrade candidate
+    carrying cache-write tokens, the candidate share is ~100% — a numerator that
+    omitted cache-write would understate it against the (now cache-write-inclusive)
+    denominator."""
+    db.insert_span(make_llm_span(
+        model="claude-opus-4-7",
+        provider="anthropic",
+        input_tokens=1000,
+        output_tokens=200,
+        cache_tokens=500,
+        cache_write_tokens=8000,
+        cost_usd=0.030,
+        session_id="candidate-cache-write",
+        start_time=utcnow() - timedelta(days=2),
+    ))
+    since = utcnow() - timedelta(days=30)
+    until = utcnow() + timedelta(hours=1)
+    finding = analyze_model_downgrade(
+        db.conn, since, until, agent_id=None, window_days=30.0,
+    )
+    assert finding is not None
+    assert finding.candidate_sessions == 1
+    expected_tokens = 1000 + 200 + 500 + 8000
+    assert finding.candidate_tokens == expected_tokens
+    assert finding.window_total_tokens == expected_tokens
+    assert finding.percent_of_tokens == 100.0
+
+
 def test_downgrade_flags_small_opus_but_not_large(db):
     _insert_small_opus_session(db, session_id="a")
     _insert_large_opus_session(db, session_id="b")

--- a/tests/unit/test_statusline.py
+++ b/tests/unit/test_statusline.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 
 import json
 
+import pytest
 from click.testing import CliRunner
 
 from tests.factories import (
@@ -23,6 +24,18 @@ from tokenjam.cli.cmd_statusline import (
     render_line,
     session_shares,
 )
+
+
+@pytest.fixture(autouse=True)
+def _isolate_attribution_cache(tmp_path, monkeypatch):
+    # Every test in this module resolves the attribution cache to an (empty,
+    # unless a test writes to it) tmp path — never the real
+    # ~/.local/share/tj/attribution_cache.json — so results are deterministic
+    # regardless of what's actually been backfilled on the host machine.
+    monkeypatch.setattr(
+        "tokenjam.core.attribution_cache._cache_path",
+        lambda: tmp_path / "attribution_cache.json",
+    )
 
 
 def _run(payload) -> str:
@@ -134,6 +147,45 @@ def test_warn_boundary_is_inclusive(tmp_path):
     # Exactly at the warn threshold should already nudge.
     line = _line_for_reread(tmp_path, REREAD_WARN)
     assert "/compact" in line
+
+
+# --- top re-read driver (cached attribution) ---------------------------------
+
+
+def test_top_driver_shown_past_warn_when_cached(tmp_path):
+    from tokenjam.core.attribution_cache import write_attribution_cache
+
+    cache_path = tmp_path / "attribution_cache.json"
+    write_attribution_cache("CLAUDE.md", 14, 3, path=cache_path)
+    line = _line_for_reread(tmp_path, REREAD_WARN + 1)
+    assert "CLAUDE.md ×14" in line
+
+
+def test_top_driver_absent_below_warn_even_when_cached(tmp_path):
+    from tokenjam.core.attribution_cache import write_attribution_cache
+
+    cache_path = tmp_path / "attribution_cache.json"
+    write_attribution_cache("CLAUDE.md", 14, 3, path=cache_path)
+    line = _line_for_reread(tmp_path, REREAD_WARN - 5)
+    assert "CLAUDE.md" not in line
+
+
+def test_top_driver_absent_when_no_cache_file(tmp_path):
+    line = _line_for_reread(tmp_path, REREAD_CRIT + 1)
+    assert "×" not in line
+
+
+def test_format_status_line_appends_top_driver_when_passed():
+    line = format_status_line("Opus 4.8", 1000, 90.0, "CLAUDE.md ×14")
+    assert "re-read 90% (CLAUDE.md ×14)" in line
+
+
+def test_format_status_line_unchanged_when_top_driver_omitted():
+    # Existing 3-arg callers (quickstart's preview, existing tests) render
+    # byte-for-byte the same with the new parameter defaulted to None.
+    assert format_status_line("Opus 4.8", 1000, 90.0) == format_status_line(
+        "Opus 4.8", 1000, 90.0, None
+    )
 
 
 def test_line_reports_model_and_tokens(tmp_path):

--- a/tokenjam/cli/cmd_onboard.py
+++ b/tokenjam/cli/cmd_onboard.py
@@ -583,7 +583,12 @@ ingest_secret = "{ingest_secret}"
 [capture]
 prompts = false
 completions = false
-tool_inputs = false
+# tool_inputs captures Read/Grep/Glob file paths + search queries (not their
+# content) so `tj context` / the statusline can name files or searches you
+# keep re-reading across sessions. prompts/tool_outputs stay off by default
+# since those would persist actual message/tool-output text; turn them on for
+# deeper analysis.
+tool_inputs = true
 tool_outputs = false
 
 [storage]

--- a/tokenjam/cli/cmd_onboard.py
+++ b/tokenjam/cli/cmd_onboard.py
@@ -3174,15 +3174,29 @@ def _install_daemon(config_path: str) -> str | None:
 def _resolve_tj_binary() -> str:
     """Resolve the absolute path to the ``tj`` executable for daemon units.
 
-    Prefer the copy on PATH. When ``tj`` isn't on PATH (e.g. a venv whose bin
-    dir isn't exported), fall back to the sibling ``tj`` next to the running
-    interpreter — derived by path, not string substitution. The old
+    Prefer the sibling ``tj`` next to the running interpreter — derived by
+    path, not string substitution — the same PATH-independent priority
+    ``_current_tj_binary`` uses: it's fixed at process start and reflects the
+    binary onboard is actually running as, so it can't be shadowed by an
+    older/other ``tj`` earlier on PATH at the moment onboard installs the
+    daemon. Without this, a PATH shadow at install time permanently pins the
+    launchd/systemd unit to the wrong binary — surviving even after the
+    shadowing PATH entry is later removed.
+
+    Falls back to ``shutil.which("tj")`` only when no sibling exists (e.g. a
+    venv whose bin dir isn't exported), and as a last resort to the
+    constructed sibling path anyway — NOT a bare ``"tj"`` — so
+    ``_daemon_program_args``'s ephemeral-cache detection (uv/pipx cache
+    paths) still has a real path shape to inspect. The old
     ``sys.executable.replace("/python", "/tj")`` rewrote a ``python3``-named
     interpreter to a nonexistent ``tj3`` (``/python`` matches inside
     ``/python3``), so launchd/systemd pointed at a binary that doesn't exist
     while ``launchctl load`` still returned 0 (#340).
     """
-    return shutil.which("tj") or str(Path(sys.executable).with_name("tj"))
+    sibling = Path(sys.executable).with_name("tj")
+    if sibling.exists():
+        return str(sibling)
+    return shutil.which("tj") or str(sibling)
 
 
 def _daemon_program_args(config_path: str) -> list[str] | None:

--- a/tokenjam/cli/cmd_resume_brief.py
+++ b/tokenjam/cli/cmd_resume_brief.py
@@ -229,21 +229,20 @@ def cmd_resume_brief(
 
 
 def _top_driver_hint() -> str:
-    """An optional trailing "top re-read driver" line, or "" when none cached.
+    """An optional trailing informational line naming the most re-read source.
 
     Reads the same on-disk artifact the statusline reads (``tj backfill`` /
-    ``tj onboard`` write it) — no DB access from this hook path. Fail-safe:
+    ``tj onboard`` write it), via the shared ``format_driver_label`` reader, so
+    no DB access happens on this hook path. Worded as NEUTRAL context, not a
+    warning: the resume-brief hook can't compute the live re-read share, so it
+    must not read as an alert for a user whose current share is low. Fail-safe:
     any error or missing cache degrades to "".
     """
     try:
-        from tokenjam.core.attribution_cache import read_attribution_cache
-        cached = read_attribution_cache()
+        from tokenjam.core.attribution_cache import format_driver_label
+        label = format_driver_label()
     except Exception:  # noqa: BLE001 - a brief must never break a session
         return ""
-    if not cached:
+    if not label:
         return ""
-    label = cached.get("top_label")
-    occurrences = cached.get("occurrences")
-    if not label or not occurrences:
-        return ""
-    return f"\n\nTOP RE-READ DRIVER\n  {label} re-read ×{occurrences} — see `tj context`."
+    return f"\n\nMost re-read context (last 30d): {label}. See `tj context`."

--- a/tokenjam/cli/cmd_resume_brief.py
+++ b/tokenjam/cli/cmd_resume_brief.py
@@ -223,6 +223,27 @@ def cmd_resume_brief(
         return
 
     if brief:
-        click.echo(brief)
+        click.echo(brief + _top_driver_hint())
     elif verbose:
         click.echo("resume-brief: nothing to brief (no method captured)", err=True)
+
+
+def _top_driver_hint() -> str:
+    """An optional trailing "top re-read driver" line, or "" when none cached.
+
+    Reads the same on-disk artifact the statusline reads (``tj backfill`` /
+    ``tj onboard`` write it) — no DB access from this hook path. Fail-safe:
+    any error or missing cache degrades to "".
+    """
+    try:
+        from tokenjam.core.attribution_cache import read_attribution_cache
+        cached = read_attribution_cache()
+    except Exception:  # noqa: BLE001 - a brief must never break a session
+        return ""
+    if not cached:
+        return ""
+    label = cached.get("top_label")
+    occurrences = cached.get("occurrences")
+    if not label or not occurrences:
+        return ""
+    return f"\n\nTOP RE-READ DRIVER\n  {label} re-read ×{occurrences} — see `tj context`."

--- a/tokenjam/cli/cmd_statusline.py
+++ b/tokenjam/cli/cmd_statusline.py
@@ -130,23 +130,13 @@ def format_status_line(
 def _top_driver_label() -> str | None:
     """The cached top recurring-inclusion driver as a "<label> ×<count>" string.
 
-    Reads the tiny on-disk artifact ``tj backfill`` (and ``tj onboard``, which
-    calls the same ingest path) writes — never a DuckDB query from this
-    zero-token surface. Fail-safe: any error or missing/stale cache degrades
-    to ``None``, which callers render as no suffix at all.
+    Thin wrapper over ``attribution_cache.format_driver_label`` — the single
+    reader of the cache's JSON schema, shared with the resume-brief — so this
+    zero-token surface never issues a DuckDB query. Fail-safe: any error or a
+    missing/stale cache degrades to ``None`` (rendered as no suffix at all).
     """
-    try:
-        from tokenjam.core.attribution_cache import read_attribution_cache
-        cached = read_attribution_cache()
-    except Exception:
-        return None
-    if not cached:
-        return None
-    label = cached.get("top_label")
-    occurrences = cached.get("occurrences")
-    if not label or not occurrences:
-        return None
-    return f"{label} ×{occurrences}"
+    from tokenjam.core.attribution_cache import format_driver_label
+    return format_driver_label()
 
 
 def render_line(data: dict) -> str:

--- a/tokenjam/cli/cmd_statusline.py
+++ b/tokenjam/cli/cmd_statusline.py
@@ -95,7 +95,10 @@ def _badge_and_nudge(reread_pct: float) -> tuple[str, str | None]:
 
 
 def format_status_line(
-    model_name: str, total: int | None, reread_pct: float | None
+    model_name: str,
+    total: int | None,
+    reread_pct: float | None,
+    top_driver: str | None = None,
 ) -> str:
     """Build the statusline string from already-resolved figures.
 
@@ -105,15 +108,45 @@ def format_status_line(
     IDENTICAL text for identical inputs and the preview can never drift from
     the real product. ``total``/``reread_pct`` of ``None`` degrades to the
     model-only segment (mirrors "no transcript" / "unreadable transcript").
+
+    ``top_driver`` is an optional pre-formatted "<label> ×<count>" suffix
+    (e.g. ``"CLAUDE.md ×14"``) naming the top recurring-inclusion source, not
+    just its raw percentage. Defaults to ``None`` — every existing caller that
+    doesn't pass it renders byte-for-byte unchanged.
     """
     parts = [f"◆ {model_name}"]  # ◆ model
     if total is not None and reread_pct is not None:
         parts.append(f"{format_tokens(total)} tok")
         badge, nudge = _badge_and_nudge(reread_pct)
-        parts.append(f"{badge} re-read {reread_pct:.0f}%")
+        reread_part = f"{badge} re-read {reread_pct:.0f}%"
+        if top_driver:
+            reread_part += f" ({top_driver})"
+        parts.append(reread_part)
         if nudge:
             parts.append(nudge)
     return "  ".join(parts)
+
+
+def _top_driver_label() -> str | None:
+    """The cached top recurring-inclusion driver as a "<label> ×<count>" string.
+
+    Reads the tiny on-disk artifact ``tj backfill`` (and ``tj onboard``, which
+    calls the same ingest path) writes — never a DuckDB query from this
+    zero-token surface. Fail-safe: any error or missing/stale cache degrades
+    to ``None``, which callers render as no suffix at all.
+    """
+    try:
+        from tokenjam.core.attribution_cache import read_attribution_cache
+        cached = read_attribution_cache()
+    except Exception:
+        return None
+    if not cached:
+        return None
+    label = cached.get("top_label")
+    occurrences = cached.get("occurrences")
+    if not label or not occurrences:
+        return None
+    return f"{label} ×{occurrences}"
 
 
 def render_line(data: dict) -> str:
@@ -121,7 +154,9 @@ def render_line(data: dict) -> str:
 
     Always returns at least the model segment; appends token count, the re-read
     badge, and the compaction nudge only when a transcript is found and readable.
-    Never raises — a transcript read failure degrades to the model-only line.
+    Past the WARN threshold, also names the top cached re-read driver (e.g.
+    ``"CLAUDE.md ×14"``) when one is available, so the nudge isn't just a bare
+    percentage. Never raises — any failure degrades to the model-only line.
     """
     model_name = _model_name(data)
     path = find_transcript(data)
@@ -131,7 +166,8 @@ def render_line(data: dict) -> str:
         total, reread_pct = session_shares(path)
     except Exception:
         return format_status_line(model_name, None, None)
-    return format_status_line(model_name, total, reread_pct)
+    top_driver = _top_driver_label() if reread_pct >= REREAD_WARN else None
+    return format_status_line(model_name, total, reread_pct, top_driver)
 
 
 @click.command("statusline")

--- a/tokenjam/cli/entrypoint.py
+++ b/tokenjam/cli/entrypoint.py
@@ -1,0 +1,77 @@
+"""Console-script entrypoint for `tj` / `tokenjam`.
+
+Why this file exists separately from `tokenjam.cli.main`: it is force-included
+into the wheel (see `[tool.hatch.build.targets.wheel.force-include]` in
+`pyproject.toml`), so it is physically copied into site-packages even for an
+editable install. That matters because an editable install of `tokenjam`
+otherwise resolves every submodule (including `tokenjam.cli.main`) through a
+`.pth` entry that just points back at the dev checkout — if that checkout
+(e.g. a git worktree) is later deleted, `tokenjam` degrades to an empty PEP
+420 namespace package and every real submodule import raises
+`ModuleNotFoundError`, with nothing left on disk to run a guard from.
+
+This module is the one piece of code guaranteed to still be on disk in that
+situation, so it is the only place that can catch the failure and print an
+actionable hint instead of letting a bare traceback reach the user.
+"""
+from __future__ import annotations
+
+import os
+import sys
+
+_DANGLING_EDITABLE_HINT = (
+    "tj's install points at a source path that no longer exists. "
+    "Reinstall with `pipx reinstall tokenjam` or `pip install -e <checkout>`."
+)
+
+
+def _dangling_editable_install() -> bool:
+    """Best-effort detection of a broken editable install.
+
+    Must never raise: any failure here just means "not detected" so the
+    caller falls back to re-raising the original ModuleNotFoundError.
+    """
+    try:
+        import tokenjam
+
+        if getattr(tokenjam, "__file__", None) is not None:
+            # Resolved as a normal module (not a namespace package) - a real
+            # install, nothing dangling.
+            return False
+
+        # `__file__ is None` means `tokenjam` only resolved as a PEP 420
+        # namespace package. That alone isn't proof the editable source is
+        # gone (a namespace package is also valid packaging), so also check
+        # whether any contributing path actually holds the real `cli`
+        # subpackage on disk.
+        paths = list(getattr(tokenjam, "__path__", None) or [])
+        return not any(_has_real_cli_package(path) for path in paths)
+    except Exception:
+        return False
+
+
+def _has_real_cli_package(path: str) -> bool:
+    try:
+        return os.path.isfile(os.path.join(path, "cli", "main.py"))
+    except Exception:
+        return False
+
+
+def _load_cli():
+    """Import the real CLI. Split out so tests can simulate the failure
+    without needing an actual broken editable install on disk."""
+    from tokenjam.cli.main import cli
+
+    return cli
+
+
+def main() -> None:
+    """Entry point registered as the `tj` / `tokenjam` console scripts."""
+    try:
+        cli = _load_cli()
+    except ModuleNotFoundError:
+        if _dangling_editable_install():
+            sys.stderr.write(_DANGLING_EDITABLE_HINT + "\n")
+            raise SystemExit(1)
+        raise
+    raise SystemExit(cli())

--- a/tokenjam/core/attribution_cache.py
+++ b/tokenjam/core/attribution_cache.py
@@ -71,14 +71,42 @@ def read_attribution_cache(
         occurrences = data.get("occurrences")
         if not label or not occurrences:
             return None
+        # A timestamp-less or unparseable entry must EXPIRE, not be trusted
+        # forever: without a usable ``computed_at`` we can't prove it's fresh,
+        # so a stale driver would otherwise show indefinitely. Treat missing /
+        # non-string / unparseable timestamps the same as aged-out.
         computed_at = data.get("computed_at")
-        if isinstance(computed_at, str):
-            age = _age_seconds(computed_at)
-            if age is not None and age > max_age_seconds:
-                return None
+        if not isinstance(computed_at, str):
+            return None
+        age = _age_seconds(computed_at)
+        if age is None or age > max_age_seconds:
+            return None
         return data
     except Exception:  # noqa: BLE001 - fail-safe read for the statusline hook
         return None
+
+
+def format_driver_label(*, path: Path | None = None) -> str | None:
+    """The cached top driver formatted as ``"<label> ×<count>"``, or ``None``.
+
+    The single source of truth for reading + validating + formatting the cache
+    for display — both the statusline (``cli/cmd_statusline``) and the
+    resume-brief (``cli/cmd_resume_brief``) call this, so the cache's JSON
+    schema has ONE reader and the two surfaces can't drift on field names or
+    formatting. Fail-safe: any error or a missing / stale / malformed cache
+    degrades to ``None``, which callers render as no suffix at all.
+    """
+    try:
+        cached = read_attribution_cache(path=path)
+    except Exception:  # noqa: BLE001 - a display helper must never raise
+        return None
+    if not cached:
+        return None
+    label = cached.get("top_label")
+    occurrences = cached.get("occurrences")
+    if not label or not occurrences:
+        return None
+    return f"{label} ×{occurrences}"
 
 
 def _age_seconds(computed_at: str) -> float | None:

--- a/tokenjam/core/attribution_cache.py
+++ b/tokenjam/core/attribution_cache.py
@@ -1,0 +1,144 @@
+"""Cheap on-disk hand-off of the top recurring-inclusion driver.
+
+``tj context`` (``core/context_diagnostic``) already knows WHICH file, search,
+prompt, or tool output is re-included most often across sessions — but
+answering that needs a live DuckDB connection plus the capture-gated attribute
+data. The statusline (``cli/cmd_statusline``) is the opposite: zero-token,
+pure-stdlib, invoked after every turn, and must never open the DB or do
+anything slower than a linear transcript scan.
+
+``tj backfill claude-code`` (and `tj onboard`, which calls the same
+``ingest_claude_code`` function directly) already holds that connection and
+the ``[capture]`` flags, so it is the one process that computes the window's
+top driver and hands it off here as a tiny JSON file. The statusline does a
+plain stat+read of that file — no query, no live computation.
+"""
+from __future__ import annotations
+
+import json
+from datetime import timedelta
+from pathlib import Path
+from typing import Any
+
+# Window the cached driver is computed over on each refresh.
+ATTRIBUTION_WINDOW_DAYS = 30
+
+# A cached driver older than this is presumed stale enough that the statusline
+# should fall back to the plain badge rather than show it as current.
+MAX_CACHE_AGE_SECONDS = 7 * 24 * 60 * 60
+
+
+def _cache_path() -> Path:
+    """Resolved lazily (not at import) so tests can patch ``Path.home``."""
+    return Path.home() / ".local" / "share" / "tj" / "attribution_cache.json"
+
+
+def write_attribution_cache(
+    label: str, occurrences: int, sessions: int, *, path: Path | None = None
+) -> None:
+    """Persist the top recurring-inclusion driver. Best-effort; never raises."""
+    from tokenjam.utils.time_parse import utcnow
+
+    target = path or _cache_path()
+    try:
+        target.parent.mkdir(parents=True, exist_ok=True)
+        target.write_text(json.dumps({
+            "top_label": label,
+            "occurrences": occurrences,
+            "sessions": sessions,
+            "computed_at": utcnow().isoformat(),
+        }))
+    except Exception:  # noqa: BLE001 - a cache write must never break ingest
+        pass
+
+
+def read_attribution_cache(
+    *, path: Path | None = None, max_age_seconds: int = MAX_CACHE_AGE_SECONDS
+) -> dict[str, Any] | None:
+    """Read the cached top driver, or ``None`` if missing/stale/corrupt.
+
+    Fail-safe for the statusline hook: any error (missing file, malformed
+    JSON, an aged-out entry) degrades to ``None`` rather than raising.
+    """
+    target = path or _cache_path()
+    try:
+        if not target.is_file():
+            return None
+        data = json.loads(target.read_text())
+        if not isinstance(data, dict):
+            return None
+        label = data.get("top_label")
+        occurrences = data.get("occurrences")
+        if not label or not occurrences:
+            return None
+        computed_at = data.get("computed_at")
+        if isinstance(computed_at, str):
+            age = _age_seconds(computed_at)
+            if age is not None and age > max_age_seconds:
+                return None
+        return data
+    except Exception:  # noqa: BLE001 - fail-safe read for the statusline hook
+        return None
+
+
+def _age_seconds(computed_at: str) -> float | None:
+    try:
+        from datetime import datetime
+
+        from tokenjam.utils.time_parse import utcnow
+
+        ts = datetime.fromisoformat(computed_at)
+        now = utcnow()
+        if ts.tzinfo is None:
+            ts = ts.replace(tzinfo=now.tzinfo)
+        return (now - ts).total_seconds()
+    except Exception:  # noqa: BLE001
+        return None
+
+
+def refresh_attribution_cache(
+    conn: Any, capture: Any, *, path: Path | None = None
+) -> None:
+    """Compute the window's top recurring-inclusion driver and cache it.
+
+    Called by ``ingest_claude_code`` after a backfill (the same path
+    ``tj onboard`` uses), the one process that already holds a live DuckDB
+    connection and the ``[capture]`` flags. Best-effort: any failure (empty
+    window, capture off, query error) leaves any existing cache file
+    untouched rather than raising or clobbering it with an empty result.
+    """
+    try:
+        from tokenjam.core.context_diagnostic import compute_context_diagnostic
+        from tokenjam.utils.time_parse import utcnow
+
+        tool_inputs = bool(getattr(capture, "tool_inputs", False))
+        prompts = bool(getattr(capture, "prompts", False))
+        tool_outputs = bool(getattr(capture, "tool_outputs", False))
+        if not (tool_inputs or prompts or tool_outputs):
+            return
+
+        until = utcnow()
+        since = until - timedelta(days=ATTRIBUTION_WINDOW_DAYS)
+        diag = compute_context_diagnostic(
+            conn, since, until,
+            tool_inputs_captured=tool_inputs,
+            prompts_captured=prompts,
+            tool_outputs_captured=tool_outputs,
+        )
+        if not diag.recurring:
+            return
+        top = diag.recurring[0]
+        write_attribution_cache(
+            _short_label(top), top.occurrences, top.sessions, path=path
+        )
+    except Exception:  # noqa: BLE001 - must never break the ingest it follows
+        pass
+
+
+def _short_label(inclusion: Any) -> str:
+    """A terse display label for a recurring inclusion (basename for files)."""
+    from tokenjam.core.context_diagnostic import INCLUSION_FILE_READ
+
+    if inclusion.inclusion_type == INCLUSION_FILE_READ:
+        return Path(inclusion.target).name or inclusion.target
+    return inclusion.label[:40]

--- a/tokenjam/core/backfill.py
+++ b/tokenjam/core/backfill.py
@@ -835,6 +835,16 @@ def ingest_claude_code(
     # `max_sessions` means there may be older sessions on disk we skipped.
     if max_sessions is not None and result.sessions_seen >= max_sessions:
         result.limit_reached = True
+
+    # Refresh the statusline's cheap top-driver cache — best-effort, never
+    # blocks or fails the ingest. The statusline is DB-free and can't compute
+    # recurring-inclusion attribution itself; this backfill path already holds
+    # the connection + capture flags, so it hands the result off as a small
+    # on-disk artifact the statusline can stat+read.
+    if conn is not None:
+        from tokenjam.core.attribution_cache import refresh_attribution_cache
+        refresh_attribution_cache(conn, capture)
+
     return result
 
 

--- a/tokenjam/core/optimize/analyzers/model_downgrade.py
+++ b/tokenjam/core/optimize/analyzers/model_downgrade.py
@@ -258,7 +258,10 @@ def analyze_model_downgrade(
         candidate_sessions += 1
         actual_cost += float(cost or 0.0)
         alt_cost += alt_unit
-        candidate_tokens += int(in_tok or 0) + int(out_tok or 0) + int(cache_tok or 0)
+        candidate_tokens += (
+            int(in_tok or 0) + int(out_tok or 0) + int(cache_tok or 0)
+            + int(cache_write_tok or 0)
+        )
         # This session's recoverable saving (clamped at 0 — a cheaper model
         # never costs more in our candidate set, but guard against pricing noise).
         per_session_savings.append(max(float(cost or 0.0) - alt_unit, 0.0))

--- a/tokenjam/core/optimize/analyzers/model_downgrade.py
+++ b/tokenjam/core/optimize/analyzers/model_downgrade.py
@@ -196,6 +196,7 @@ def analyze_model_downgrade(
         f"COALESCE(SUM(input_tokens),0)  AS input_tokens, "
         f"COALESCE(SUM(output_tokens),0) AS output_tokens, "
         f"COALESCE(SUM(cache_tokens),0)  AS cache_tokens, "
+        f"COALESCE(SUM(cache_write_tokens),0) AS cache_write_tokens, "
         f"COALESCE(SUM(cost_usd),0.0)    AS cost_usd "
         f"FROM spans WHERE {where} AND model IS NOT NULL "
         f"GROUP BY session_id",
@@ -229,10 +230,13 @@ def analyze_model_downgrade(
 
     for row in llm_rows:
         session_id, trace_id, _agent, start_time, end_time, provider, model, \
-            in_tok, out_tok, cache_tok, cost = row
+            in_tok, out_tok, cache_tok, cache_write_tok, cost = row
         # Accumulate window-wide token totals (used for subscription-mode
         # token-share rendering even when the row isn't a candidate).
-        window_total_tokens += int(in_tok or 0) + int(out_tok or 0) + int(cache_tok or 0)
+        window_total_tokens += (
+            int(in_tok or 0) + int(out_tok or 0) + int(cache_tok or 0)
+            + int(cache_write_tok or 0)
+        )
         if not provider or not model:
             continue
         alt = _lookup_downgrade(provider, model)

--- a/tokenjam/core/optimize/runner.py
+++ b/tokenjam/core/optimize/runner.py
@@ -62,7 +62,7 @@ def summarize_window(
     row = conn.execute(
         f"SELECT COUNT(*) AS spans, "
         f"COUNT(DISTINCT session_id) AS sessions, "
-        f"COALESCE(SUM(COALESCE(input_tokens,0) + COALESCE(output_tokens,0) + COALESCE(cache_tokens,0)), 0) AS tokens, "
+        f"COALESCE(SUM(COALESCE(input_tokens,0) + COALESCE(output_tokens,0) + COALESCE(cache_tokens,0) + COALESCE(cache_write_tokens,0)), 0) AS tokens, "
         f"COALESCE(SUM(cost_usd), 0.0) AS cost "
         f"FROM spans WHERE {where}",
         params,


### PR DESCRIPTION
## Launch-readiness bundle

Bundles four independently-reviewed, individually-green fixes into a single merge. Each component below is its own PR and stays open; GitHub auto-marks them MERGED when this anchor lands, so every change keeps its own review thread and diff.

### Components

- **Statusline top re-read driver + capture default** (this PR, #471) — the statusline now names the #1 re-read source inline (e.g. `re-read 88% (CLAUDE.md ×14)`) instead of a bare percentage, backed by a fail-safe on-disk attribution cache refreshed during backfill/onboard (zero DB query, zero tokens in the hook). `[capture] tool_inputs` defaults on so attribution works out of the box (file paths + search queries only; prompt/output text capture stays off). Includes review fixes: timestamp-less cache entries now expire, the resume-brief line reads as neutral context rather than a warning, and cache read/format logic is a single shared helper.
- **Cache-write tokens in optimize totals** (#468) — `summarize_window` and the `model_downgrade` analyzer now include `cache_write_tokens` in their token totals (both the `window_total_tokens` denominator and the `candidate_tokens` numerator), so reclaimable-share and `percent_of_tokens` no longer understate cache-heavy windows. Mirrors the earlier public fix (#377 / #450).
- **Daemon binary resolution** (#469) — `_resolve_tj_binary()` now prefers the interpreter-sibling `tj` over a PATH lookup, so `tj onboard` can't permanently pin the launchd/systemd unit to a shadowing/stale `tj` present on PATH at install time.
- **Dangling editable-install hint** (#470) — a thin force-included entrypoint catches the namespace-package `ModuleNotFoundError` that occurs when a `pip install -e` source checkout has been removed, and prints a one-line reinstall hint instead of a raw traceback.

### Merge notes

All three siblings merged into this branch with zero conflicts. Only `tokenjam/cli/cmd_onboard.py` is touched by two components (the capture-default flip here and `_resolve_tj_binary` in #469) — different functions, auto-merged cleanly and verified to coexist.

### Union verification (combined tree)

- `make test`: 2466 passed, 2 skipped, 1 failed — the one failure is a pre-existing host-config collision (`~/.config/tj/config.toml` on the dev machine), unrelated to this batch and reproducing on a clean checkout.
- `make lint`: pass · `make typecheck`: pass (193 source files).
