### PR TITLE
Release 0.5.7: fix SDK provenance metadata + align npm README to onboard-first

### DIFF
--- a/npm-wrapper/README.md
+++ b/npm-wrapper/README.md
@@ -21,9 +21,7 @@ npx tokenjam
 
 Bare `npx tokenjam` reads the session logs you already have (Claude Code today; more sources land in the full CLI) and prints a 15-second, read-only report: quota composition (what share of your tokens went to re-reading history and context vs. net-new work) plus a session timeline. Nothing is installed, nothing is kept.
 
-<div align="center">
-<img src="https://raw.githubusercontent.com/Metabuilder-Labs/tokenjam/main/docs/assets/tj-quickstart-hero.png" alt="Sample npx tokenjam output: quota composition (95.9% re-reading context, 4.1% net-new work) and a session timeline table" width="620">
-</div>
+For the full setup, run `npx tokenjam onboard`: it wires up live capture, all six analyzers, the Lens dashboard, and the zero-token statusline in one command.
 
 ## Commands
 
@@ -31,7 +29,7 @@ All arguments pass straight through to the Python CLI, so any `tj` subcommand an
 
 | Command | What it does |
 |---|---|
-| `npx tokenjam` / `npx tokenjam quickstart` | Zero-install first run: quota composition and a session timeline from your existing session logs. |
+| `npx tokenjam` | Zero-install first run: quota composition and a session timeline from your existing session logs. |
 | `npx tokenjam context` | Where your quota goes: re-read vs. net-new share, recurring inclusions, `/compact` candidates. |
 | `npx tokenjam optimize` | Cost-saving candidates: model downsizing, cache opportunities, prompt trimming, workflow reuse, subagent right-sizing. |
 | `npx tokenjam onboard` | Guided setup: writes a config, generates an ingest secret, and optionally installs the background daemon for live capture. |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "tokenjam"
-version = "0.5.6"
+version = "0.5.7"
 description = "TokenJam — local-first OTel-native observability for Autonomous AI agents"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/sdk-ts/package.json
+++ b/sdk-ts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tokenjam/sdk",
-  "version": "0.5.6",
+  "version": "0.5.7",
   "description": "TypeScript SDK for TokenJam — local-first observability for AI agents",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
@@ -18,6 +18,11 @@
     "llm"
   ],
   "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/Metabuilder-Labs/tokenjam.git",
+    "directory": "sdk-ts"
+  },
   "devDependencies": {
     "@types/node": "^25.5.0",
     "typescript": "^5.4"


### PR DESCRIPTION
## Summary

- **SDK provenance fix (`sdk-ts/package.json`)**: adds a `repository` field (matching the pattern already used in `npm-wrapper/package.json`, with `directory: "sdk-ts"`). The v0.5.6 `publish-npm` SDK job 422'd on npm's OIDC trusted-publishing provenance check because `repository.url` was empty; this field is required for provenance attestation to validate.
- **npm page alignment (`npm-wrapper/README.md`)**: npmjs.com/package/tokenjam renders this file directly. Updated it to match the main README's current "Get started" positioning:
  - Removed the quickstart hero screenshot (`docs/assets/tj-quickstart-hero.png`), replaced with a one-line pointer to `npx tokenjam onboard` as the full-setup entry point (wires up live capture, all six analyzers, Lens, and the zero-token statusline).
  - Removed the `npx tokenjam quickstart` alias from the command table row (kept bare `npx tokenjam` as the zero-install/read-only report entry, unchanged wording otherwise).
  - No more mentions of "quickstart" anywhere on the page; badges, thin-launcher explanation, and runner requirements sections are untouched.
- **Version bump**: `pyproject.toml` and `sdk-ts/package.json` 0.5.6 → 0.5.7 (lockstep). `npm-wrapper/package.json` version is untouched; CI derives it from the release tag.

After merge, cutting v0.5.7 republishes all packages via OIDC trusted publishing (the SDK now with valid provenance metadata) and refreshes the npm page copy.

## Test plan

- [x] `python3 -c "import json; json.load(open('sdk-ts/package.json'))"` — valid JSON
- [x] `grep -c quickstart npm-wrapper/README.md` → 0
- [x] `grep -c tj-quickstart-hero npm-wrapper/README.md` → 0
- [x] `pyproject.toml` and `sdk-ts/package.json` both read `0.5.7`
- [ ] CI green on this PR
- [ ] Post-merge: cut `v0.5.7` tag, verify OIDC publish succeeds for the SDK package (no more 422)