### PR TITLE
feat: accept OpenInference (llm.*) attributes in the OTLP parser

### DIFF
--- a/tests/unit/test_ingest_otlp.py
+++ b/tests/unit/test_ingest_otlp.py
@@ -10,7 +10,7 @@ import pytest
 from tokenjam.core.db import InMemoryBackend
 from tokenjam.core.ingest_adapters.otlp import ingest_otlp
 from tokenjam.otel.otlp_parsing import parse_otlp_span
-from tokenjam.otel.semconv import GenAIAttributes
+from tokenjam.otel.semconv import GenAIAttributes, OpenInferenceAttributes
 
 
 FIXTURE_PATH = Path(__file__).parent.parent / "fixtures" / "otlp_sample.json"
@@ -83,6 +83,67 @@ def test_parse_otlp_span_extracts_cache_read_and_write_tokens():
         ],
     }
     span = parse_otlp_span(raw, {})
+    assert span.cache_tokens == 1000
+    assert span.cache_write_tokens == 2000
+
+
+def test_parse_otlp_span_extracts_openinference_llm_span():
+    """An OpenInference-instrumented LLM span (llm.* only, no gen_ai.*) is parsed.
+
+    Agents instrumented with OpenInference (Arize's convention — LangChain,
+    LlamaIndex, CrewAI, etc.) emit `llm.*` attributes instead of `gen_ai.*`.
+    The shared OTLP parser must fall back to them so these spans land with
+    model/provider/tokens instead of silently zero-token.
+    """
+    raw = {
+        "name": "ChatOpenAI",
+        "attributes": [
+            {"key": OpenInferenceAttributes.SPAN_KIND, "value": {"stringValue": "LLM"}},
+            {"key": OpenInferenceAttributes.MODEL_NAME, "value": {"stringValue": "gpt-4o"}},
+            {"key": OpenInferenceAttributes.SYSTEM, "value": {"stringValue": "openai"}},
+            {"key": OpenInferenceAttributes.PROMPT_TOKENS, "value": {"intValue": "1200"}},
+            {"key": OpenInferenceAttributes.COMPLETION_TOKENS, "value": {"intValue": "250"}},
+            {"key": OpenInferenceAttributes.CACHE_READ_TOKENS, "value": {"intValue": "800"}},
+            {"key": OpenInferenceAttributes.CACHE_WRITE_TOKENS, "value": {"intValue": "300"}},
+        ],
+    }
+    span = parse_otlp_span(raw, {})
+    assert span.model == "gpt-4o"
+    assert span.provider == "openai"
+    assert span.billing_account == "openai"
+    assert span.input_tokens == 1200
+    assert span.output_tokens == 250
+    assert span.cache_tokens == 800
+    assert span.cache_write_tokens == 300
+
+
+def test_parse_otlp_span_genai_wins_over_openinference():
+    """When BOTH conventions are present on a span, gen_ai.* takes precedence."""
+    raw = {
+        "name": "ChatAnthropic",
+        "attributes": [
+            # gen_ai.* (preferred)
+            {"key": GenAIAttributes.REQUEST_MODEL, "value": {"stringValue": "claude-sonnet-4-6"}},
+            {"key": GenAIAttributes.PROVIDER_NAME, "value": {"stringValue": "anthropic"}},
+            {"key": GenAIAttributes.INPUT_TOKENS, "value": {"intValue": "1500"}},
+            {"key": GenAIAttributes.OUTPUT_TOKENS, "value": {"intValue": "320"}},
+            {"key": GenAIAttributes.CACHE_READ_TOKENS, "value": {"intValue": "1000"}},
+            {"key": GenAIAttributes.CACHE_CREATE_TOKENS, "value": {"intValue": "2000"}},
+            # OpenInference (fallback — must be ignored here)
+            {"key": OpenInferenceAttributes.MODEL_NAME, "value": {"stringValue": "gpt-4o"}},
+            {"key": OpenInferenceAttributes.SYSTEM, "value": {"stringValue": "openai"}},
+            {"key": OpenInferenceAttributes.PROMPT_TOKENS, "value": {"intValue": "1"}},
+            {"key": OpenInferenceAttributes.COMPLETION_TOKENS, "value": {"intValue": "2"}},
+            {"key": OpenInferenceAttributes.CACHE_READ_TOKENS, "value": {"intValue": "3"}},
+            {"key": OpenInferenceAttributes.CACHE_WRITE_TOKENS, "value": {"intValue": "4"}},
+        ],
+    }
+    span = parse_otlp_span(raw, {})
+    assert span.model == "claude-sonnet-4-6"
+    assert span.provider == "anthropic"
+    assert span.billing_account == "anthropic"
+    assert span.input_tokens == 1500
+    assert span.output_tokens == 320
     assert span.cache_tokens == 1000
     assert span.cache_write_tokens == 2000
 

--- a/tokenjam/otel/otlp_parsing.py
+++ b/tokenjam/otel/otlp_parsing.py
@@ -14,7 +14,12 @@ from datetime import datetime, timezone
 from typing import Any
 
 from tokenjam.core.models import NormalizedSpan, SpanKind, SpanStatus
-from tokenjam.otel.semconv import GenAIAttributes, ResourceAttributes, TjAttributes
+from tokenjam.otel.semconv import (
+    GenAIAttributes,
+    OpenInferenceAttributes,
+    ResourceAttributes,
+    TjAttributes,
+)
 from tokenjam.utils.ids import new_span_id
 
 
@@ -140,9 +145,33 @@ def parse_otlp_span(raw: dict, resource_attrs: dict[str, Any]) -> NormalizedSpan
     if not provider:
         provider = attrs.get("gen_ai.system") or None
 
+    # OpenInference fallback (Arize convention: LangChain, LlamaIndex, CrewAI,
+    # LangGraph, OpenAI Agents SDK, DSPy, ...). gen_ai.* wins when present; fall
+    # back to the `llm.*` attributes for agents instrumented with OpenInference.
+    if not provider:
+        provider = attrs.get(OpenInferenceAttributes.SYSTEM) or None
+
     # Extract tool_name from span names like "tool.Read", "tool.exec".
     if not tool_name and span_name.startswith("tool."):
         tool_name = span_name[5:]
+
+    model = attrs.get(GenAIAttributes.REQUEST_MODEL) or attrs.get(
+        OpenInferenceAttributes.MODEL_NAME
+    )
+    input_tokens = safe_int(attrs.get(GenAIAttributes.INPUT_TOKENS))
+    if input_tokens is None:
+        input_tokens = safe_int(attrs.get(OpenInferenceAttributes.PROMPT_TOKENS))
+    output_tokens = safe_int(attrs.get(GenAIAttributes.OUTPUT_TOKENS))
+    if output_tokens is None:
+        output_tokens = safe_int(attrs.get(OpenInferenceAttributes.COMPLETION_TOKENS))
+    cache_tokens = safe_int(attrs.get(GenAIAttributes.CACHE_READ_TOKENS))
+    if cache_tokens is None:
+        cache_tokens = safe_int(attrs.get(OpenInferenceAttributes.CACHE_READ_TOKENS))
+    cache_write_tokens = safe_int(attrs.get(GenAIAttributes.CACHE_CREATE_TOKENS))
+    if cache_write_tokens is None:
+        cache_write_tokens = safe_int(
+            attrs.get(OpenInferenceAttributes.CACHE_WRITE_TOKENS)
+        )
 
     return NormalizedSpan(
         span_id=raw.get("spanId", new_span_id()),
@@ -169,12 +198,12 @@ def parse_otlp_span(raw: dict, resource_attrs: dict[str, Any]) -> NormalizedSpan
         ],
         agent_id=agent_id,
         provider=provider,
-        model=attrs.get(GenAIAttributes.REQUEST_MODEL),
+        model=model,
         tool_name=tool_name,
-        input_tokens=safe_int(attrs.get(GenAIAttributes.INPUT_TOKENS)),
-        output_tokens=safe_int(attrs.get(GenAIAttributes.OUTPUT_TOKENS)),
-        cache_tokens=safe_int(attrs.get(GenAIAttributes.CACHE_READ_TOKENS)),
-        cache_write_tokens=safe_int(attrs.get(GenAIAttributes.CACHE_CREATE_TOKENS)),
+        input_tokens=input_tokens,
+        output_tokens=output_tokens,
+        cache_tokens=cache_tokens,
+        cache_write_tokens=cache_write_tokens,
         cost_usd=safe_float(attrs.get(TjAttributes.COST_USD)),
         request_type=attrs.get(GenAIAttributes.REQUEST_TYPE),
         conversation_id=attrs.get(GenAIAttributes.CONVERSATION_ID),

--- a/tokenjam/otel/otlp_parsing.py
+++ b/tokenjam/otel/otlp_parsing.py
@@ -155,9 +155,9 @@ def parse_otlp_span(raw: dict, resource_attrs: dict[str, Any]) -> NormalizedSpan
     if not tool_name and span_name.startswith("tool."):
         tool_name = span_name[5:]
 
-    model = attrs.get(GenAIAttributes.REQUEST_MODEL) or attrs.get(
-        OpenInferenceAttributes.MODEL_NAME
-    )
+    model = attrs.get(GenAIAttributes.REQUEST_MODEL)
+    if model is None:
+        model = attrs.get(OpenInferenceAttributes.MODEL_NAME)
     input_tokens = safe_int(attrs.get(GenAIAttributes.INPUT_TOKENS))
     if input_tokens is None:
         input_tokens = safe_int(attrs.get(OpenInferenceAttributes.PROMPT_TOKENS))

--- a/tokenjam/otel/semconv.py
+++ b/tokenjam/otel/semconv.py
@@ -56,6 +56,32 @@ class GenAIAttributes:
     SPAN_LLM_CALL     = "gen_ai.llm.call"
 
 
+class OpenInferenceAttributes:
+    """OpenInference (Arize) span attribute names.
+
+    Emitted by OpenInference instrumentors (LangChain, LlamaIndex, CrewAI,
+    LangGraph, OpenAI Agents SDK, DSPy, and 25+ frameworks) instead of the OTel
+    GenAI `gen_ai.*` convention. Read by `parse_otlp_span` as a fallback AFTER
+    the `gen_ai.*` reads, so gen_ai wins when both are present.
+    """
+    # Span-kind gate ("LLM" | "TOOL" | ...)
+    SPAN_KIND = "openinference.span.kind"
+
+    # LLM identity
+    MODEL_NAME = "llm.model_name"
+    SYSTEM     = "llm.system"
+
+    # Token usage
+    PROMPT_TOKENS       = "llm.token_count.prompt"
+    COMPLETION_TOKENS   = "llm.token_count.completion"
+    CACHE_READ_TOKENS   = "llm.token_count.prompt_details.cache_read"
+    CACHE_WRITE_TOKENS  = "llm.token_count.prompt_details.cache_write"
+
+    # Span-kind values
+    KIND_LLM  = "LLM"
+    KIND_TOOL = "TOOL"
+
+
 class ClaudeCodeEvents:
     """Event names and attributes from Claude Code's OTel log exporter."""
     # Event names (logRecord body values)


### PR DESCRIPTION
Our OTLP ingest only read the OTel GenAI semconv (`gen_ai.*`), so agents instrumented with **OpenInference** (Arize's convention — LangChain, LlamaIndex, CrewAI, LangGraph, OpenAI Agents SDK, DSPy, and 25+ frameworks) emitted `llm.*` attributes and landed with **zero tokens** — a silent onboarding failure. This teaches the shared parser to accept OpenInference as a fallback so any OTel-instrumented agent onboards, whichever convention it uses.

## Summary
- Add `OpenInferenceAttributes` to `tokenjam/otel/semconv.py` (pure constants, no internal imports).
- In `parse_otlp_span`, read OpenInference `llm.*` attributes as a **fallback after** the existing `gen_ai.*` reads — mirroring the file's existing `service.name`→agent_id and `gen_ai.system`→provider fallbacks. `llm.system` runs through the existing `provider_to_billing_account` mapping.
- Additive + backward-compatible: the `gen_ai.*` path is unchanged and every existing test passes byte-for-byte.

## Attribute mapping (gen_ai wins when both present)
| our field | OTel GenAI (preferred) | OpenInference fallback (added) |
|---|---|---|
| model | `gen_ai.request.model` | `llm.model_name` |
| provider | `gen_ai.provider.name` / `gen_ai.system` | `llm.system` |
| input_tokens | `gen_ai.usage.input_tokens` | `llm.token_count.prompt` |
| output_tokens | `gen_ai.usage.output_tokens` | `llm.token_count.completion` |
| cache_tokens (read) | `gen_ai.usage.cache_read_tokens` | `llm.token_count.prompt_details.cache_read` |
| cache_write_tokens | `gen_ai.usage.cache_creation_tokens` | `llm.token_count.prompt_details.cache_write` |

The `openinference.span.kind` key + `LLM`/`TOOL` values are captured as constants for future span-kind gating; extraction itself keys off attribute presence, same as the gen_ai path.

## Shared parser — Cloud inherits it
`tokenjam/otel/otlp_parsing.py` is the single OTLP-parsing home (Critical Rule 17), imported by both the live `POST /api/v1/spans` route and the `tj backfill otlp` adapter — and by **TokenJam Cloud**. So Cloud inherits OpenInference support for free with no separate change. This is deliberately OSS (observability-layer breadth, not a commercial feature).

## Tests / Verification
- `tests/unit/test_ingest_otlp.py`:
  - `test_parse_otlp_span_extracts_openinference_llm_span` — an `llm.*`-only span extracts model, provider→billing_account, and input/output/cache_read/cache_write tokens.
  - `test_parse_otlp_span_genai_wins_over_openinference` — a mixed span proves `gen_ai.*` precedence.
- Gates (touched files): `ruff check` clean, `mypy` clean.
- `pytest tests/unit/ tests/synthetic/ tests/integration/` — 2461 passed.

## What's NOT in this PR
- No behavior change to the `gen_ai.*` path.
- No span-kind gating logic (`openinference.span.kind` constants added but not yet used to route LLM vs TOOL) — extraction keys off attribute presence today, matching the existing parser.

🤖 Generated with [Claude Code](https://claude.com/claude-code)