### PR TITLE
[feature] Add verbosity analyzer (#478)

### DIFF
--- a/docs/optimize/verbosity.md
+++ b/docs/optimize/verbosity.md
@@ -1,0 +1,96 @@
+# Verbosity
+
+Product name: **Verbosity**. Internal/CLI name: `verbosity`.
+
+```bash
+tj optimize verbosity
+```
+
+The other analyzers target **input** and model choice. Verbosity is the one
+that looks at **output** — sessions burning tokens on answers that run long for
+the work they did. It flags a session only when its output is a clear outlier
+against sessions doing the *same shape* of work, then surfaces a brevity remedy
+for you to measure.
+
+## The weakest-grounded analyzer — treated that way
+
+Output length is not waste. A terse answer can drop information the task needed,
+and "too verbose" is task-dependent — so verbosity's recoverable figure is the
+least defensible of any analyzer. Two consequences are baked in:
+
+- The baseline is the **per-`(tool, arg-shape)` median** — the only signal
+  grounded in like-for-like tasks. A high output:input ratio is carried as a
+  descriptive field only; it never flags a session on its own (a legitimately
+  long answer to a short prompt is not waste).
+- The recoverable figure is a **soft upper bound**, and `--validate` (measuring
+  a brevity constraint on your own calls) is load-bearing, not optional, before
+  anyone claims a dollar saving.
+
+## What it flags
+
+Sessions are grouped into cohorts by their task-shape signature — the
+`(tool_name, arg_shape)` sequence, the same signature the [Script](script.md)
+analyzer uses. For each cohort:
+
+| Step | Rule |
+|---|---|
+| Cohort must be real | At least `MIN_COHORT_SESSIONS` (5) sessions share the signature, else its median is noise and the cohort is skipped. |
+| Baseline | The cohort's **median** output tokens. |
+| Flag | A session whose output exceeds `HIGH_VERBOSITY_MULTIPLE` (2.0×) the cohort median. |
+
+Thresholds live as module constants in
+`tokenjam/core/optimize/analyzers/output_verbosity.py`
+(`MIN_COHORT_SESSIONS`, `HIGH_VERBOSITY_MULTIPLE`, `MAX_EXAMPLES`).
+
+It reads aggregate token counts and the tool-call shape — no prompt/completion
+content capture required.
+
+## Output
+
+The finding reports, for the window:
+
+- `total_candidates` — the true number of flagged sessions
+- `candidates` — the top `MAX_EXAMPLES` (5) by over-baseline output; when more
+  were flagged the CLI shows "showing top 5 of N" so the headline never
+  under-reports
+- per candidate: `output_tokens`, `baseline_output_tokens` (the cohort median),
+  `over_baseline_tokens`, `over_baseline_multiple`, and the descriptive-only
+  `output_input_ratio`
+- `suggested_max_tokens` — the cohort baseline, an advisory `max_tokens` cap to
+  review (never applied)
+- `sessions_examined` / `cohorts_examined`
+
+Rendering follows the same plan-tier-aware convention as the rest of
+`tj optimize`: `api` plans see the dollar figure, subscription/local/unknown
+plans see the over-baseline token figure instead.
+
+## Estimate basis / confidence
+
+`estimated_recoverable_tokens` is the over-baseline output summed across flagged
+sessions; `estimated_recoverable_usd` prices it at **output** rates.
+`estimate_confidence` is `"heuristic"` and `estimate_basis` reads:
+
+> output tokens above the per-task-shape median, priced at output rates — a
+> SOFT upper bound, not a measured saving: a brevity constraint can be
+> net-negative once its own overhead is counted, so measure before claiming
+
+`confidence` on the finding is `structural` (Rule 14). The mandatory caveat,
+surfaced in every render mode:
+
+> Predicted high-verbosity output — review before constraining a response.
+> Output length is not waste: a terse answer can drop information the task
+> needed. This is a candidate to look at, never a claim you are wasting tokens.
+> Measure a brevity constraint before applying it.
+
+## Remedy — surfaced, not applied
+
+The finding carries a terse system-prompt snippet and a suggested `max_tokens`
+cap (the cohort baseline). Both are advisory strings — you apply them and
+measure the result. Enforcing a brevity policy fleet-wide is a Cloud concern,
+not something the OSS analyzer does.
+
+## See also
+
+- [Trim](trim.md) — the input-side counterpart: low-significance tokens in captured prompts
+- [Downsize](downsize.md) — cheaper-model candidates by session shape
+- [Script](script.md) — the same `(tool_name, arg_shape)` signature, used to find deterministic workflows

--- a/tests/unit/test_optimize_verbosity.py
+++ b/tests/unit/test_optimize_verbosity.py
@@ -18,6 +18,7 @@ from tokenjam.core.db import InMemoryBackend
 from tokenjam.core.optimize import ANALYZER_REGISTRY, build_report
 from tokenjam.core.optimize.analyzers.output_verbosity import (
     HIGH_VERBOSITY_MULTIPLE,
+    MAX_EXAMPLES,
     MIN_COHORT_SESSIONS,
     VERBOSITY_HONESTY_CAVEAT,
     VerbosityFinding,
@@ -237,3 +238,28 @@ def test_cli_renders_candidate_without_error(db):
     # Should not raise for any pricing mode.
     for mode in ("api", "subscription", "local", "unknown"):
         _render_verbosity(finding, pricing_mode=mode, marker="①")
+
+
+def test_truncates_display_candidates_but_reports_true_total(db):
+    """More than MAX_EXAMPLES flagged sessions: `candidates` is capped for
+    display, but `total_candidates` carries the real count so the renderer can
+    say "top 5 of N" instead of silently under-reporting — and it survives the
+    report_to_dict/report_from_dict round-trip (the serve path). (Greptile #479)"""
+    # 10 baseline sessions at 100 output tokens (median stays ~100) …
+    for i in range(10):
+        _seed_session(db, f"low-{i}", output_tokens=100, i=i)
+    # … plus MAX_EXAMPLES + 1 verbose sessions well above 2× the median.
+    n_high = MAX_EXAMPLES + 1
+    for i in range(n_high):
+        _seed_session(db, f"hi-{i}", output_tokens=1000, i=20 + i)
+
+    report = build_report(
+        db=db, config=_config(), since=SINCE, until=UNTIL, findings=["verbosity"],
+    )
+    finding = report.findings["verbosity"]
+    assert len(finding.candidates) == MAX_EXAMPLES      # display cap
+    assert finding.total_candidates == n_high           # true flagged count
+
+    restored = report_from_dict(report_to_dict(report)).findings["verbosity"]
+    assert restored.total_candidates == n_high
+    assert len(restored.candidates) == MAX_EXAMPLES

--- a/tests/unit/test_optimize_verbosity.py
+++ b/tests/unit/test_optimize_verbosity.py
@@ -1,0 +1,239 @@
+"""Verbosity analyzer (#478) — the output-side lever.
+
+Covers detection against the per-task-shape median baseline (the preferred,
+most-defensible signal), the recoverable-savings contract (output above the
+baseline priced at output rates), the honest candidate framing (Rule 14), and a
+clean report_to_dict/report_from_dict round-trip.
+
+All spans go through tests/factories (Critical Rule 8).
+"""
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+
+import pytest
+
+from tokenjam.core.config import CaptureConfig, TjConfig
+from tokenjam.core.db import InMemoryBackend
+from tokenjam.core.optimize import ANALYZER_REGISTRY, build_report
+from tokenjam.core.optimize.analyzers.output_verbosity import (
+    HIGH_VERBOSITY_MULTIPLE,
+    MIN_COHORT_SESSIONS,
+    VERBOSITY_HONESTY_CAVEAT,
+    VerbosityFinding,
+)
+from tokenjam.core.optimize.runner import report_from_dict, report_to_dict
+from tokenjam.otel.semconv import GenAIAttributes
+from tests.factories import make_llm_span, make_session, make_tool_span
+
+
+@pytest.fixture
+def db():
+    backend = InMemoryBackend()
+    yield backend
+    backend.close()
+
+
+SINCE = datetime(2026, 5, 1, tzinfo=timezone.utc)
+UNTIL = datetime(2026, 5, 30, tzinfo=timezone.utc)
+BASE = datetime(2026, 5, 10, tzinfo=timezone.utc)
+
+
+def _config(tool_inputs: bool = True) -> TjConfig:
+    return TjConfig(version="1", capture=CaptureConfig(tool_inputs=tool_inputs))
+
+
+def _seed_session(db, sid, *, output_tokens, input_tokens=1000, i=0,
+                  tool_input=None, model="claude-haiku-4-5"):
+    """One session: an LLM span carrying the output tokens + a tool span that
+    defines the task shape."""
+    sess = make_session(session_id=sid, plan_tier="api", duration_seconds=30.0)
+    db.upsert_session(sess)
+    llm = make_llm_span(
+        model=model, input_tokens=input_tokens, output_tokens=output_tokens,
+    )
+    llm.session_id = sid
+    llm.start_time = BASE + timedelta(minutes=i)
+    db.insert_span(llm)
+    tool = make_tool_span(tool_name="bash")
+    tool.session_id = sid
+    tool.start_time = BASE + timedelta(minutes=i, seconds=1)
+    tool.attributes = {GenAIAttributes.TOOL_INPUT: tool_input or {"command": "git pull"}}
+    db.insert_span(tool)
+
+
+def _run(db, config=None, agent_id=None):
+    report = build_report(
+        db=db, config=config or _config(), since=SINCE, until=UNTIL,
+        agent_id=agent_id, findings=["verbosity"],
+    )
+    return report.findings["verbosity"]
+
+
+# -- Registration --
+
+def test_self_registers():
+    assert "verbosity" in ANALYZER_REGISTRY
+
+
+# -- Detection --
+
+def test_flags_output_above_task_shape_median(db):
+    """A cohort of like-shaped sessions with one blatant output outlier flags
+    that outlier against the cohort median."""
+    # 5 baseline sessions at 200 output tokens each (median = 200) …
+    for i in range(MIN_COHORT_SESSIONS):
+        _seed_session(db, f"base-{i}", output_tokens=200, i=i)
+    # … plus one verbose outlier well above HIGH_VERBOSITY_MULTIPLE × median.
+    over = int(200 * HIGH_VERBOSITY_MULTIPLE) + 1000
+    _seed_session(db, "verbose", output_tokens=over, i=50)
+
+    finding = _run(db)
+    assert isinstance(finding, VerbosityFinding)
+    ids = {c.session_id for c in finding.candidates}
+    assert "verbose" in ids
+    # None of the baseline sessions should be flagged.
+    assert not (ids & {f"base-{i}" for i in range(MIN_COHORT_SESSIONS)})
+
+    c = next(c for c in finding.candidates if c.session_id == "verbose")
+    assert c.baseline_output_tokens == 200
+    assert c.over_baseline_tokens == over - 200
+    assert c.over_baseline_multiple >= HIGH_VERBOSITY_MULTIPLE
+
+
+def test_no_flag_when_output_near_median(db):
+    """A cohort where every session is close to the median flags nothing —
+    output length is not waste, only clear outliers are candidates."""
+    for i in range(MIN_COHORT_SESSIONS + 3):
+        _seed_session(db, f"even-{i}", output_tokens=200 + i, i=i)
+    finding = _run(db)
+    assert finding.candidates == []
+    # The cohort still had a usable median.
+    assert finding.cohorts_examined == 1
+
+
+def test_cohort_below_min_size_is_not_a_baseline(db):
+    """Below MIN_COHORT_SESSIONS the median is noise — no cohort, no flag even
+    with a huge output."""
+    _seed_session(db, "solo-a", output_tokens=200, i=0)
+    _seed_session(db, "solo-b", output_tokens=100000, i=1)
+    finding = _run(db)
+    assert finding.cohorts_examined == 0
+    assert finding.candidates == []
+
+
+def test_output_input_ratio_is_descriptive_not_the_flag(db):
+    """A huge output:input ratio alone does NOT flag a session when its output
+    is in line with its cohort median — the ratio is the weakest signal."""
+    # Every session has a tiny input (10) and identical output (500): ratio 50×,
+    # but no output outlier, so nothing is flagged.
+    for i in range(MIN_COHORT_SESSIONS + 1):
+        _seed_session(db, f"hi-ratio-{i}", output_tokens=500, input_tokens=10, i=i)
+    finding = _run(db)
+    assert finding.candidates == []
+
+
+# -- Recoverable-savings contract (#111) --
+
+def test_recoverable_is_output_above_baseline_at_output_rates(db):
+    """estimated_recoverable_usd = over-baseline output priced at OUTPUT rates."""
+    from tokenjam.core.pricing import get_rates
+
+    for i in range(MIN_COHORT_SESSIONS):
+        _seed_session(db, f"b-{i}", output_tokens=200, i=i, model="claude-haiku-4-5")
+    over = 5000
+    _seed_session(db, "big", output_tokens=200 + over, i=50, model="claude-haiku-4-5")
+
+    finding = _run(db)
+    assert finding.estimated_recoverable_tokens == over
+    rates = get_rates("anthropic", "claude-haiku-4-5")
+    assert rates is not None
+    expected = round((over / 1_000_000) * rates.output_per_mtok, 6)
+    assert finding.estimated_recoverable_usd == pytest.approx(expected)
+    assert finding.estimate_confidence == "heuristic"
+    assert finding.estimate_basis  # non-empty basis surfaced
+
+
+def test_empty_window_contributes_no_recoverable(db):
+    """A dead telemetry window yields a finding with no recoverable figure."""
+    finding = _run(db)
+    assert finding.estimated_recoverable_usd is None
+    assert finding.estimated_recoverable_tokens is None
+    assert finding.candidates == []
+
+
+# -- Honest framing (Rule 14) --
+
+def test_caveat_is_conservative_candidate_framing(db):
+    """The mandatory caveat frames output as a review candidate, never waste."""
+    finding = VerbosityFinding()
+    assert finding.caveat == VERBOSITY_HONESTY_CAVEAT
+    lowered = VERBOSITY_HONESTY_CAVEAT.lower()
+    assert "review" in lowered
+    assert "candidate" in lowered
+    assert "not waste" in lowered
+    # Never asserts wasted spend.
+    assert "you are wasting" not in lowered or "never a claim" in lowered
+
+
+def test_surfaces_remedy_but_does_not_apply(db):
+    """A brevity remedy (snippet + suggested max_tokens) is surfaced, not applied."""
+    for i in range(MIN_COHORT_SESSIONS):
+        _seed_session(db, f"r-{i}", output_tokens=300, i=i)
+    _seed_session(db, "loud", output_tokens=3000, i=50)
+    finding = _run(db)
+    assert finding.remedy_snippet
+    assert "concise" in finding.remedy_snippet.lower()
+    assert finding.suggested_max_tokens == 300  # the cohort median baseline
+
+
+# -- Round-trip --
+
+def test_report_round_trips(db):
+    for i in range(MIN_COHORT_SESSIONS):
+        _seed_session(db, f"rt-{i}", output_tokens=250, i=i)
+    _seed_session(db, "rt-loud", output_tokens=9000, i=50)
+
+    report = build_report(db=db, config=_config(), since=SINCE, until=UNTIL,
+                          findings=["verbosity"])
+    d = report_to_dict(report)
+    restored = report_from_dict(d)
+    orig = report.findings["verbosity"]
+    back = restored.findings["verbosity"]
+    assert back.estimated_recoverable_tokens == orig.estimated_recoverable_tokens
+    assert back.estimated_recoverable_usd == orig.estimated_recoverable_usd
+    assert back.suggested_max_tokens == orig.suggested_max_tokens
+    assert len(back.candidates) == len(orig.candidates)
+    assert back.candidates[0].session_id == orig.candidates[0].session_id
+    assert back.candidates[0].task_shape == orig.candidates[0].task_shape
+    assert back.caveat == orig.caveat
+
+
+# -- CLI wiring (self-registration reaches the renderer + Click choices) --
+
+def test_in_click_choices_and_renderer():
+    """verbosity appears in the positional Click choices (auto-derived from the
+    registry) and has a human-readable renderer — no edits to cmd_optimize's
+    dispatch needed beyond registration wiring."""
+    from tokenjam.cli.cmd_optimize import _FINDING_RENDERERS, cmd_optimize
+
+    findings_param = next(
+        p for p in cmd_optimize.params if getattr(p, "name", None) == "findings"
+    )
+    assert "verbosity" in findings_param.type.choices
+    assert "verbosity" in _FINDING_RENDERERS
+
+
+def test_cli_renders_candidate_without_error(db):
+    """The finding renders through the CLI dispatch path (regression guard: a
+    finding in the registry but missing from _FINDING_RENDERERS would KeyError)."""
+    from tokenjam.cli.cmd_optimize import _render_verbosity
+
+    for i in range(MIN_COHORT_SESSIONS):
+        _seed_session(db, f"cli-{i}", output_tokens=300, i=i)
+    _seed_session(db, "cli-loud", output_tokens=8000, i=50)
+    finding = _run(db)
+    assert finding.candidates
+    # Should not raise for any pricing mode.
+    for mode in ("api", "subscription", "local", "unknown"):
+        _render_verbosity(finding, pricing_mode=mode, marker="①")

--- a/tokenjam/cli/cmd_optimize.py
+++ b/tokenjam/cli/cmd_optimize.py
@@ -1316,10 +1316,13 @@ def _render_verbosity(
             )
         return
 
+    shown = len(finding.candidates)
+    total = finding.total_candidates or shown
+    more = f" [dim](showing top {shown} of {total})[/dim]" if total > shown else ""
     console.print(
-        f"     • [bold]{len(finding.candidates)}[/bold] high-verbosity "
-        f"candidate{'s' if len(finding.candidates) != 1 else ''} "
-        f"[dim](output well above the per-task-shape median)[/dim]"
+        f"     • [bold]{total}[/bold] high-verbosity "
+        f"candidate{'s' if total != 1 else ''} "
+        f"[dim](output well above the per-task-shape median)[/dim]{more}"
     )
     for c in finding.candidates:
         # Recoverable framing: dollars only for api-billed users; otherwise the

--- a/tokenjam/cli/cmd_optimize.py
+++ b/tokenjam/cli/cmd_optimize.py
@@ -316,6 +316,7 @@ _MINOR_FINDING_LABELS = {
     "reuse":           "Reuse",
     "trim":            "Prompt bloat",
     "subagent":        "Subagent right-sizing",
+    "verbosity":       "Verbosity",
 }
 
 
@@ -1293,6 +1294,61 @@ def _render_subagent(
     console.print(f"     [yellow]![/yellow] [italic]{finding.caveat}[/italic]")
 
 
+def _render_verbosity(
+    finding, *, pricing_mode: str = "api", marker: str = "",
+) -> None:
+    """
+    Render the verbosity finding — sessions whose OUTPUT tokens run high vs
+    the per-task-shape median (the like-for-like baseline). The least-grounded
+    analyzer: candidate framing only, recoverable shown as a soft estimate.
+    """
+    console.print(_finding_header(marker, "Verbosity:"))
+    if not finding.candidates:
+        if finding.sessions_examined == 0:
+            console.print("     [dim]No LLM spans in this window.[/dim]")
+        else:
+            console.print(
+                f"     [dim]Examined {finding.sessions_examined} session"
+                f"{'s' if finding.sessions_examined != 1 else ''} across "
+                f"{finding.cohorts_examined} task-shape cohort"
+                f"{'s' if finding.cohorts_examined != 1 else ''}; no session's "
+                f"output ran high enough vs its cohort median to flag.[/dim]"
+            )
+        return
+
+    console.print(
+        f"     • [bold]{len(finding.candidates)}[/bold] high-verbosity "
+        f"candidate{'s' if len(finding.candidates) != 1 else ''} "
+        f"[dim](output well above the per-task-shape median)[/dim]"
+    )
+    for c in finding.candidates:
+        # Recoverable framing: dollars only for api-billed users; otherwise the
+        # over-baseline token figure (the same category discipline as peers).
+        if pricing_mode == "api" and c.recoverable_usd:
+            recov = f"~{format_cost(c.recoverable_usd)} at output rates"
+        else:
+            recov = f"~{format_tokens(c.over_baseline_tokens)} output tokens"
+        ratio = (
+            f", {c.output_input_ratio}× input"
+            if c.output_input_ratio is not None else ""
+        )
+        console.print(
+            f"       [dim]{c.session_id}[/dim]  "
+            f"[bold]{format_tokens(c.output_tokens)}[/bold] out "
+            f"[dim](vs {format_tokens(c.baseline_output_tokens)} median, "
+            f"{c.over_baseline_multiple}×{ratio})[/dim] → {recov} above baseline"
+        )
+    if finding.suggested_max_tokens:
+        console.print(
+            f"     [dim]Remedy to review (not applied): add a terse "
+            f"system-prompt line and/or a max_tokens cap near "
+            f"~{format_tokens(finding.suggested_max_tokens)}, then measure with "
+            f"[bold]tj optimize --validate[/bold].[/dim]"
+        )
+    if finding.caveat:
+        console.print(f"     [yellow]![/yellow] [italic]{finding.caveat}[/italic]")
+
+
 # Dispatch table — analyzer registration name → renderer.
 _FINDING_RENDERERS = {
     "cache":       _render_cache_efficacy,
@@ -1301,4 +1357,5 @@ _FINDING_RENDERERS = {
     "reuse":        _render_reuse,
     "trim":         _render_prompt_bloat,
     "subagent":     _render_subagent,
+    "verbosity":    _render_verbosity,
 }

--- a/tokenjam/core/optimize/analyzers/output_verbosity.py
+++ b/tokenjam/core/optimize/analyzers/output_verbosity.py
@@ -123,6 +123,10 @@ class VerbosityFinding:
     """
 
     candidates: list[VerbosityCandidate] = field(default_factory=list)
+    # Pre-truncation flagged count. `candidates` is capped at MAX_EXAMPLES for
+    # display, but the recoverable totals accumulate over every flagged session —
+    # so the renderer reports this, not len(candidates), as the headline count.
+    total_candidates: int = 0
     sessions_examined: int = 0
     cohorts_examined: int = 0       # task-shape cohorts with a usable median
     # Surfaced remedy (not applied): a terse system-prompt snippet + a suggested
@@ -280,7 +284,7 @@ def run(ctx: AnalyzerContext) -> None:
         for m in members:
             if m.output_tokens <= threshold:
                 continue
-            over = int(m.output_tokens - median)
+            over = int(round(m.output_tokens - median))
             if over <= 0:
                 continue
             rates = get_rates(m.provider or "", m.model)
@@ -318,6 +322,7 @@ def run(ctx: AnalyzerContext) -> None:
 
     # Largest over-baseline output first — the most worthwhile to review.
     candidates.sort(key=lambda c: c.over_baseline_tokens, reverse=True)
+    finding.total_candidates = len(candidates)
     finding.candidates = candidates[:MAX_EXAMPLES]
     finding.estimated_recoverable_tokens = total_recoverable_tokens
     finding.estimated_recoverable_usd = (

--- a/tokenjam/core/optimize/analyzers/output_verbosity.py
+++ b/tokenjam/core/optimize/analyzers/output_verbosity.py
@@ -1,0 +1,331 @@
+"""
+Verbosity analyzer — the output-side lever the other analyzers miss.
+
+Every other analyzer targets the INPUT side (prompt size, model choice,
+caching, repeated shapes). None looks at OUTPUT tokens. An agent that
+generates verbose prose burns output tokens — often the pricier per-token
+side — and that spend is invisible today. This analyzer surfaces
+`(agent, model)` cohorts / sessions whose output runs high relative to a
+like-for-like baseline, as REVIEW CANDIDATES only.
+
+Honesty discipline (registry: verbosity — this is the *least-grounded*
+analyzer, and it is framed that way):
+
+  Unlike `trim`, which removes provably-redundant INPUT, output length is
+  NOT waste — a terse answer can drop information the task needed, and
+  "wasteful output" is task-dependent. So verbosity's recoverable estimate
+  is inherently softer than the input-side analyzers. Every user-visible
+  string says "predicted high-verbosity output — review before constraining
+  a response", never "you're wasting X".
+
+Detection baseline (v1 — tune on real data), strongest signal first:
+
+  1. PREFERRED — per-`(tool, arg-shape)` / task-shape MEDIAN. A session's
+     task shape is the ordered tuple of its `(tool_name, arg_shape)` tool
+     calls (the same signature the `script` analyzer builds). Output tokens
+     are compared against the median for the SAME task shape — the only
+     signal grounded in like-for-like tasks. A session is a candidate when
+     its output exceeds `HIGH_VERBOSITY_MULTIPLE` × its cohort median.
+  2. output:input ratio — the WEAKEST signal, deliberately NOT the lead: a
+     legitimately long answer to a short prompt is not waste. Carried only
+     as a secondary descriptive field on each candidate, never as the flag.
+
+Recoverable (softer than peers, per the issue framing): output tokens ABOVE
+the cohort median, priced at OUTPUT rates. It is surfaced as an estimate
+under an explicit "predicted / review before constraining" caveat — a
+measured number (via `tj optimize --validate`, #477) is the honest one for
+this lever, and the estimate_basis says so.
+
+Remedy is SURFACED, not applied (issue #478 out-of-scope): recommend an
+output-brevity constraint — a terse system-prompt snippet and/or a
+`max_tokens` cap — for the user to apply and then MEASURE.
+"""
+from __future__ import annotations
+
+import json
+import statistics
+from dataclasses import dataclass, field
+from typing import Any
+
+from tokenjam.core.optimize.analyzers.workflow_restructure import _arg_signature
+from tokenjam.core.optimize.registry import register
+from tokenjam.core.optimize.types import AnalyzerContext
+from tokenjam.core.pricing import get_rates
+from tokenjam.otel.semconv import GenAIAttributes
+
+# A task-shape cohort needs at least this many sessions before its median is a
+# meaningful baseline. Below this, "the median" is one or two sessions and any
+# multiple is noise — the least-grounded analyzer must be conservative about
+# what it calls a baseline at all.
+MIN_COHORT_SESSIONS = 5
+
+# A session is a high-verbosity candidate when its output tokens exceed this
+# multiple of the cohort median. Deliberately well above 1.0 — output length is
+# not waste, so we only flag the clear outliers, not everything above the middle.
+HIGH_VERBOSITY_MULTIPLE = 2.0
+
+# Cap on surfaced example candidates (largest over-baseline output first).
+MAX_EXAMPLES = 5
+
+# Mandatory caveat (Rule 14), carried as the dataclass default like every other
+# recoverable finding's caveat so no surface can drop it. States the ONE thing
+# that makes this the least-grounded analyzer: output length is not waste.
+VERBOSITY_HONESTY_CAVEAT = (
+    "Predicted high-verbosity output — review before constraining a response. "
+    "Output length is not waste: a terse answer can drop information the task "
+    "needed. This is a candidate to look at, never a claim you are wasting "
+    "tokens. Measure a brevity constraint before applying it."
+)
+
+# The `estimate_basis` surfaced behind the "estimated recoverable" tag. Names
+# the softer basis explicitly and points at measurement (#477).
+VERBOSITY_ESTIMATE_BASIS = (
+    "output tokens above the per-task-shape median, priced at output rates — a "
+    "SOFT upper bound, not a measured saving: a brevity constraint can be "
+    "net-negative once its own overhead is counted, so measure before claiming"
+)
+
+# Surfaced remedy (not applied). A terse system-prompt snippet the user can add,
+# paired with a max_tokens cap suggestion computed per candidate cohort.
+VERBOSITY_REMEDY_SNIPPET = (
+    "Be concise. Answer in the fewest words that fully address the request; "
+    "omit restatement, preamble, and filler. Prefer lists over prose."
+)
+
+
+@dataclass
+class VerbosityCandidate:
+    """One session whose output runs high vs its task-shape cohort median."""
+
+    session_id: str
+    agent_id: str | None
+    model: str
+    task_shape: list[dict]          # [{"tool": "...", "args": [...]}], may be []
+    cohort_sessions: int            # how many sessions share this task shape
+    output_tokens: int              # this session's output tokens
+    baseline_output_tokens: int     # the cohort median
+    over_baseline_tokens: int       # output_tokens - baseline (>= 0)
+    over_baseline_multiple: float   # output_tokens / baseline
+    # WEAKEST signal, descriptive only — never the flag. A long answer to a
+    # short prompt is not waste, so we surface the ratio but don't gate on it.
+    output_input_ratio: float | None
+    recoverable_usd: float | None   # over_baseline priced at output rates (None: no rates)
+
+
+@dataclass
+class VerbosityFinding:
+    """High output-token spend candidates, on the #111 recoverable contract.
+
+    Framed more conservatively than peer analyzers (issue #478): the recoverable
+    figure is a soft upper bound under the "review before constraining" caveat,
+    and the preferred baseline is the per-task-shape median (the most defensible
+    signal), not the output:input ratio (the weakest).
+    """
+
+    candidates: list[VerbosityCandidate] = field(default_factory=list)
+    sessions_examined: int = 0
+    cohorts_examined: int = 0       # task-shape cohorts with a usable median
+    # Surfaced remedy (not applied): a terse system-prompt snippet + a suggested
+    # max_tokens cap (the cohort baseline, the point most candidates already
+    # sit under). Advisory strings only — the user applies + measures.
+    remedy_snippet: str = VERBOSITY_REMEDY_SNIPPET
+    suggested_max_tokens: int | None = None
+    confidence: str = "structural"
+    caveat: str = VERBOSITY_HONESTY_CAVEAT
+    # Recoverable-savings contract (#111). See types.DowngradeFinding for field
+    # semantics. None when no candidate cleared the threshold.
+    estimated_recoverable_usd: float | None = None
+    estimated_recoverable_tokens: int | None = None
+    estimate_basis: str = ""
+    estimate_confidence: str = "heuristic"
+
+
+def _extract_tool_input(attrs: Any) -> Any:
+    """Pull gen_ai.tool.input from a span's attributes JSON. None when absent."""
+    if isinstance(attrs, str):
+        try:
+            attrs = json.loads(attrs)
+        except Exception:
+            return None
+    if not isinstance(attrs, dict):
+        return None
+    return attrs.get(GenAIAttributes.TOOL_INPUT)
+
+
+def _signature_repr(signature: tuple[tuple[str, tuple[str, ...]], ...]) -> list[dict]:
+    """Human-readable task-shape signature, mirroring workflow_restructure."""
+    out: list[dict] = []
+    for tool_name, arg_sig in signature:
+        entry: dict[str, Any] = {"tool": tool_name}
+        if arg_sig:
+            entry["args"] = list(arg_sig)
+        out.append(entry)
+    return out
+
+
+@register("verbosity")
+def run(ctx: AnalyzerContext) -> None:
+    """Attach a VerbosityFinding to ctx.report.findings["verbosity"].
+
+    Groups sessions by their task shape (ordered `(tool, arg-shape)` tuple),
+    computes the per-cohort output-token median, and flags the sessions whose
+    output exceeds the median by a wide multiple — the like-for-like baseline
+    the issue calls the most defensible signal.
+    """
+    capture = getattr(ctx.config, "capture", None)
+    has_tool_inputs = bool(capture and getattr(capture, "tool_inputs", False))
+
+    finding = VerbosityFinding(estimate_basis=VERBOSITY_ESTIMATE_BASIS)
+
+    # No calls in the window → nothing to attach a per-call figure to (mirrors
+    # the empty-window contract every recoverable finding honours, #211).
+    if ctx.summary.total_tokens == 0:
+        ctx.report.findings["verbosity"] = finding
+        return
+
+    clauses = [
+        "start_time >= $1", "start_time < $2", "session_id IS NOT NULL",
+    ]
+    params: list[Any] = [ctx.since, ctx.until]
+    if ctx.agent_id:
+        clauses.append(f"agent_id = ${len(params) + 1}")
+        params.append(ctx.agent_id)
+    where = " AND ".join(clauses)
+
+    # LLM spans: output tokens per session (task shape carries no model on tool
+    # spans, so MODE(model) is the session's dominant model for pricing).
+    llm_rows = ctx.conn.execute(
+        f"SELECT session_id, "
+        f"FIRST(agent_id) AS agent_id, "
+        f"MIN(provider) AS provider, "
+        f"MODE(model) AS model, "
+        f"COALESCE(SUM(output_tokens), 0) AS output_tokens, "
+        f"COALESCE(SUM(input_tokens), 0) AS input_tokens "
+        f"FROM spans WHERE {where} AND model IS NOT NULL "
+        f"GROUP BY session_id",
+        params,
+    ).fetchall()
+
+    if not llm_rows:
+        ctx.report.findings["verbosity"] = finding
+        return
+
+    # Tool spans per session, ordered, to reconstruct the task-shape signature.
+    tool_rows = ctx.conn.execute(
+        f"SELECT session_id, tool_name, attributes "
+        f"FROM spans WHERE {where} AND tool_name IS NOT NULL "
+        f"ORDER BY session_id, start_time",
+        params,
+    ).fetchall()
+    session_signatures: dict[str, list[tuple[str, tuple[str, ...]]]] = {}
+    for session_id, tool_name, attrs in tool_rows:
+        seq = session_signatures.setdefault(str(session_id), [])
+        tool_input = _extract_tool_input(attrs) if has_tool_inputs else None
+        arg_sig = _arg_signature(tool_input) if has_tool_inputs else ()
+        seq.append((str(tool_name), arg_sig))
+
+    # Per-session facts, keyed by the task-shape signature cohort.
+    @dataclass
+    class _Session:
+        session_id: str
+        agent_id: str | None
+        provider: str | None
+        model: str
+        output_tokens: int
+        input_tokens: int
+        signature: tuple[tuple[str, tuple[str, ...]], ...]
+
+    sessions: list[_Session] = []
+    for row in llm_rows:
+        session_id, agent_id, provider, model, out_tok, in_tok = row
+        if not model:
+            continue
+        sig = tuple(session_signatures.get(str(session_id), []))
+        sessions.append(_Session(
+            session_id=str(session_id),
+            agent_id=str(agent_id) if agent_id else None,
+            provider=str(provider) if provider else None,
+            model=str(model),
+            output_tokens=int(out_tok or 0),
+            input_tokens=int(in_tok or 0),
+            signature=sig,
+        ))
+
+    finding.sessions_examined = len(sessions)
+    if not sessions:
+        ctx.report.findings["verbosity"] = finding
+        return
+
+    cohorts: dict[tuple, list[_Session]] = {}
+    for s in sessions:
+        cohorts.setdefault(s.signature, []).append(s)
+
+    candidates: list[VerbosityCandidate] = []
+    total_recoverable_tokens = 0
+    total_recoverable_usd = 0.0
+    have_any_usd = False
+    baselines: list[int] = []
+    cohorts_examined = 0
+
+    for signature, members in cohorts.items():
+        if len(members) < MIN_COHORT_SESSIONS:
+            continue
+        outputs = [m.output_tokens for m in members]
+        median = statistics.median(outputs)
+        if median <= 0:
+            continue
+        cohorts_examined += 1
+        baselines.append(int(round(median)))
+        threshold = median * HIGH_VERBOSITY_MULTIPLE
+        for m in members:
+            if m.output_tokens <= threshold:
+                continue
+            over = int(m.output_tokens - median)
+            if over <= 0:
+                continue
+            rates = get_rates(m.provider or "", m.model)
+            recoverable_usd: float | None = None
+            if rates is not None:
+                recoverable_usd = round(
+                    (over / 1_000_000) * rates.output_per_mtok, 6
+                )
+                total_recoverable_usd += recoverable_usd
+                have_any_usd = True
+            total_recoverable_tokens += over
+            candidates.append(VerbosityCandidate(
+                session_id=m.session_id,
+                agent_id=m.agent_id,
+                model=m.model,
+                task_shape=_signature_repr(signature),
+                cohort_sessions=len(members),
+                output_tokens=m.output_tokens,
+                baseline_output_tokens=int(round(median)),
+                over_baseline_tokens=over,
+                over_baseline_multiple=round(m.output_tokens / median, 2),
+                # Weakest signal, descriptive only.
+                output_input_ratio=(
+                    round(m.output_tokens / m.input_tokens, 2)
+                    if m.input_tokens > 0 else None
+                ),
+                recoverable_usd=recoverable_usd,
+            ))
+
+    finding.cohorts_examined = cohorts_examined
+
+    if not candidates:
+        ctx.report.findings["verbosity"] = finding
+        return
+
+    # Largest over-baseline output first — the most worthwhile to review.
+    candidates.sort(key=lambda c: c.over_baseline_tokens, reverse=True)
+    finding.candidates = candidates[:MAX_EXAMPLES]
+    finding.estimated_recoverable_tokens = total_recoverable_tokens
+    finding.estimated_recoverable_usd = (
+        round(total_recoverable_usd, 6) if have_any_usd else None
+    )
+    # Suggested max_tokens cap = the median cohort baseline (the point most
+    # sessions already sit under). Advisory only — the remedy the user MEASURES.
+    if baselines:
+        finding.suggested_max_tokens = int(round(statistics.median(baselines)))
+
+    ctx.report.findings["verbosity"] = finding

--- a/tokenjam/core/optimize/runner.py
+++ b/tokenjam/core/optimize/runner.py
@@ -464,6 +464,7 @@ def _build_finding_constructors() -> dict:
         cands = [VerbosityCandidate(**c) for c in d.get("candidates") or []]
         return VerbosityFinding(
             candidates=cands,
+            total_candidates=int(d.get("total_candidates", 0)),
             sessions_examined=int(d.get("sessions_examined", 0)),
             cohorts_examined=int(d.get("cohorts_examined", 0)),
             remedy_snippet=d.get("remedy_snippet", ""),

--- a/tokenjam/core/optimize/runner.py
+++ b/tokenjam/core/optimize/runner.py
@@ -37,6 +37,7 @@ ANALYZER_ORDER: list[str] = [
     "trim",
     "subagent",
     "summarize",
+    "verbosity",
 ]
 
 THIN_DATA_DAYS = 7
@@ -338,6 +339,11 @@ def _build_finding_constructors() -> dict:
         SummarizeCandidate,
         SummarizeFinding,
     )
+    from tokenjam.core.optimize.analyzers.output_verbosity import (
+        VERBOSITY_HONESTY_CAVEAT,
+        VerbosityCandidate,
+        VerbosityFinding,
+    )
     from tokenjam.core.optimize.types import ReuseCluster, ReuseFinding
 
     def _cache_efficacy(d: dict) -> CacheEfficacyFinding:
@@ -454,6 +460,22 @@ def _build_finding_constructors() -> dict:
             avg_reduction_pct=d.get("avg_reduction_pct"),
         )
 
+    def _verbosity(d: dict) -> VerbosityFinding:
+        cands = [VerbosityCandidate(**c) for c in d.get("candidates") or []]
+        return VerbosityFinding(
+            candidates=cands,
+            sessions_examined=int(d.get("sessions_examined", 0)),
+            cohorts_examined=int(d.get("cohorts_examined", 0)),
+            remedy_snippet=d.get("remedy_snippet", ""),
+            suggested_max_tokens=d.get("suggested_max_tokens"),
+            confidence=d.get("confidence", "structural"),
+            caveat=d.get("caveat", VERBOSITY_HONESTY_CAVEAT),
+            estimated_recoverable_usd=d.get("estimated_recoverable_usd"),
+            estimated_recoverable_tokens=d.get("estimated_recoverable_tokens"),
+            estimate_basis=d.get("estimate_basis", ""),
+            estimate_confidence=d.get("estimate_confidence", "heuristic"),
+        )
+
     return {
         "cache": _cache_efficacy,
         "cache-recommend": _cache_recommend,
@@ -462,6 +484,7 @@ def _build_finding_constructors() -> dict:
         "trim": _prompt_bloat,
         "subagent": _subagent,
         "summarize": _summarize,
+        "verbosity": _verbosity,
     }
 
 


### PR DESCRIPTION
Adds the output-side cost lever the existing analyzers miss. Every current analyzer targets the INPUT side (prompt size, model choice, caching, repeated shapes); none looks at OUTPUT tokens, so verbose generation burns output tokens (the pricier per-token side) invisibly.

## Summary
- New self-registering `@register("verbosity")` analyzer (`tokenjam/core/optimize/analyzers/output_verbosity.py`).
- Detection leads with the most defensible signal: the per-`(tool, arg-shape)` task-shape **median** of output tokens. A session is a candidate only when its output exceeds `HIGH_VERBOSITY_MULTIPLE` (2.0×) its like-for-like cohort median, and only for cohorts of at least `MIN_COHORT_SESSIONS` (5).
- The output:input ratio is carried as a **weak, descriptive-only** field — never the flag (a long answer to a short prompt is not waste).
- Carries the #111 recoverable-savings contract: `estimated_recoverable_usd` = output above the cohort median priced at OUTPUT rates, `estimated_recoverable_tokens`, `estimate_basis`, `estimate_confidence="heuristic"`. Round-trips through `report_to_dict` / `report_from_dict`.
- Human-readable renderer + `--json`. Self-registers, so `cmd_optimize`'s positional choices auto-derive (no edits to its dispatch beyond the renderer/label wiring every wave-2 finding needs).

## Design rule honored (least-grounded analyzer)
Output length is not waste the way provably-redundant input is (`trim`), so verbosity is framed the softest of any analyzer:
- Framing is candidate-only: "predicted high-verbosity output — review before constraining a response." Never "you're wasting X" — the mandatory `VERBOSITY_HONESTY_CAVEAT` says output length is not waste and is carried as a dataclass default so no surface can drop it (Rule 14).
- The recoverable figure is an explicit **soft upper bound**; `estimate_basis` states a brevity constraint can be net-negative once its overhead is counted and points at measurement (`--validate`, #477) as the honest number.

## Remedy (surfaced, not applied)
Recommends an output-brevity constraint — a terse system-prompt snippet (`remedy_snippet`) plus a suggested `max_tokens` cap (the cohort median baseline) — for the user to apply and then **measure**. Nothing is written or applied.

## Detection heuristic + baseline (chosen)
- **Baseline:** per-task-shape median output tokens, where a session's task shape is the ordered `(tool_name, arg_shape)` tuple of its tool calls (the same signature the `script` analyzer builds).
- **Flag:** `session output_tokens > 2.0 × cohort median`, cohorts of ≥5 sessions only.
- **Recoverable:** `(output_tokens − cohort median)` per candidate, priced at that session's dominant model's output rate.

## Tests / Verification
- `tests/unit/test_optimize_verbosity.py` (12 tests, all via `tests/factories.py` per Rule 8): median-baseline detection, no-flag-when-near-median, sub-cohort-size guard, ratio-is-descriptive-not-the-flag, the recoverable contract (output-above-baseline at output rates), empty-window contributes nothing, honest-caveat framing, remedy surfaced not applied, `report_to_dict`/`report_from_dict` round-trip, Click-choice + renderer wiring, and CLI render across all four pricing modes.
- `ruff check tokenjam/` — clean. `mypy tokenjam/` — clean (194 files). `pytest tests/unit tests/synthetic` — 2056 passed; integration optimize/mcp/cli — 136 passed.

## What's NOT in this PR (deliberately deferred)
- Actually applying the terse constraint (out of scope per #478 — a remedy the user or the enforcement plane applies).
- The measured-savings path via `tj optimize --validate` (#477) — verbosity findings feed straight into it; until then the $ figure is an explicit soft estimate.
- A Lens Optimize-tab renderer for verbosity (the CLI + `--json` + registry-driven Overview waste band pick it up; no UI JS was added).

Closes #478

🤖 Generated with [Claude Code](https://claude.com/claude-code)