### PR TITLE
fix(helicone): handle NDJSON inputs correctly

### DIFF
--- a/tests/unit/test_ingest_helicone.py
+++ b/tests/unit/test_ingest_helicone.py
@@ -260,3 +260,30 @@ def test_record_to_span_cache_write_absent_leaves_field_none():
     span = _record_to_span(record)
     assert span is not None
     assert span.cache_write_tokens is None
+
+
+def test_ingest_handles_ndjson(db, tmp_path):
+    """NDJSON format (line-by-line JSON objects) is accepted."""
+    record1 = {
+        "request": {
+            "id": "req-ndjson-1",
+            "created_at": "2026-04-01T10:00:00Z",
+            "model": "claude-haiku-4-5",
+            "provider": "ANTHROPIC",
+            "prompt_tokens": 200,
+        },
+    }
+    record2 = {
+        "request": {
+            "id": "req-ndjson-2",
+            "created_at": "2026-04-01T10:00:01Z",
+            "model": "claude-haiku-4-5",
+            "provider": "ANTHROPIC",
+            "prompt_tokens": 300,
+        },
+    }
+    path = tmp_path / "dump.ndjson"
+    path.write_text(json.dumps(record1) + "\n" + json.dumps(record2) + "\n")
+    result = ingest_helicone(db, source_file=str(path))
+    assert result["records_read"] == 2
+    assert result["spans_written"] == 2

--- a/tests/unit/test_ingest_helicone.py
+++ b/tests/unit/test_ingest_helicone.py
@@ -287,3 +287,13 @@ def test_ingest_handles_ndjson(db, tmp_path):
     result = ingest_helicone(db, source_file=str(path))
     assert result["records_read"] == 2
     assert result["spans_written"] == 2
+
+
+def test_ingest_malformed_ndjson_raises_valueerror(db, tmp_path):
+    """A malformed line in an NDJSON file raises a descriptive ValueError."""
+    path = tmp_path / "malformed.ndjson"
+    path.write_text('{"request": {"id": "1"}}\n{bad json}\n')
+    with pytest.raises(ValueError) as exc:
+        ingest_helicone(db, source_file=str(path))
+    assert "Failed to parse NDJSON in" in str(exc.value)
+    assert "at line 2" in str(exc.value)

--- a/tokenjam/core/ingest_adapters/helicone.py
+++ b/tokenjam/core/ingest_adapters/helicone.py
@@ -250,11 +250,14 @@ def _load_file(path: Path) -> Any:
     except json.JSONDecodeError:
         pass
     records: list[Any] = []
-    for line in text.splitlines():
+    for i, line in enumerate(text.splitlines(), start=1):
         line = line.strip()
         if not line:
             continue
-        records.append(json.loads(line))
+        try:
+            records.append(json.loads(line))
+        except json.JSONDecodeError as e:
+            raise ValueError(f"Failed to parse NDJSON in {path} at line {i}") from e
     return records
 
 

--- a/tokenjam/core/ingest_adapters/helicone.py
+++ b/tokenjam/core/ingest_adapters/helicone.py
@@ -245,19 +245,17 @@ def _load_file(path: Path) -> Any:
     text = path.read_text().strip()
     if not text:
         return []
-    if text[0] == "{" and "\n{" in text and not text.startswith("{\""):
-        try:
-            return json.loads(text)
-        except json.JSONDecodeError:
-            pass
-        records: list[Any] = []
-        for line in text.splitlines():
-            line = line.strip()
-            if not line:
-                continue
-            records.append(json.loads(line))
-        return records
-    return json.loads(text)
+    try:
+        return json.loads(text)
+    except json.JSONDecodeError:
+        pass
+    records: list[Any] = []
+    for line in text.splitlines():
+        line = line.strip()
+        if not line:
+            continue
+        records.append(json.loads(line))
+    return records
 
 
 def _fetch_url(url: str, api_key: str | None, since: datetime | None) -> Any:


### PR DESCRIPTION
## Summary

This PR resolves an issue where the Helicone ingest adapter (`_load_file`) would crash with a `JSONDecodeError` when attempting to load valid NDJSON input. The previous logic used an incorrect string-matching
heuristic that effectively bypassed the NDJSON parsing block.

### Changes:
- **`helicone.py`**: Refactored the `_load_file` detection logic. Instead of relying on `text.startswith()`, the code now attempts a standard `try...except json.JSONDecodeError` on the entire file first, seamlessly
falling back to a line-by-line parser for NDJSON inputs.
- **`test_ingest_helicone.py`**: Added `test_ingest_handles_ndjson` to ensure line-by-line JSON payload formats are successfully parsed and routed correctly.

## Related issue

Closes #351

## Checklist

- [x] Tests pass (`pytest tests/unit/ tests/synthetic/ tests/agents/ tests/integration/`)
- [x] Lint clean (`ruff check tokenjam/`)
- [x] Type check clean (`mypy tokenjam/`)
- [x] CLAUDE.md updated (if architecture changed)
- [x] Test spans use `tests/factories.py` (not raw `NormalizedSpan`)
- [x] Requested `@anilmurty` as reviewer (or @-mentioned him above)

@anilmurty please review