### PR TITLE
Fix Langfuse ingest adapter crash on NDJSON inputs and bare-lists

### DIFF
--- a/tests/unit/test_ingest_langfuse.py
+++ b/tests/unit/test_ingest_langfuse.py
@@ -232,3 +232,32 @@ def test_observation_to_span_cache_write_absent_leaves_field_none():
     span = _observation_to_span(obs)
     assert span is not None
     assert span.cache_write_tokens is None
+
+
+def test_ingest_ndjson_input(db, tmp_path):
+    """NDJSON files (whether compact or with double-quote starters) are parsed successfully."""
+    ndjson_content = (
+        '{"id": "obs-1", "traceId": "trace-1", "type": "GENERATION", '
+        '"startTime": "2026-04-01T10:00:00.000Z", "endTime": "2026-04-01T10:00:01.500Z", '
+        '"model": "claude-sonnet-4-6", "usage": {"input": 1000, "output": 200}}\n'
+        '{"id": "obs-2", "traceId": "trace-1", "type": "GENERATION", '
+        '"startTime": "2026-04-01T10:00:02.000Z", "endTime": "2026-04-01T10:00:03.500Z", '
+        '"model": "claude-sonnet-4-6", "usage": {"input": 1000, "output": 200}}\n'
+    )
+    path = tmp_path / "dump.ndjson"
+    path.write_text(ndjson_content)
+    result = ingest_langfuse(db, source_file=str(path))
+    assert result["observations_read"] == 2
+    assert result["spans_written"] == 2
+
+
+def test_ingest_malformed_ndjson_raises_valueerror(db, tmp_path):
+    """A malformed line in an NDJSON file raises a descriptive ValueError."""
+    path = tmp_path / "malformed.ndjson"
+    path.write_text(
+        '{"id": "obs-1", "traceId": "trace-1", "type": "GENERATION", "startTime": "2026-04-01T10:00:00.000Z"}\n{bad json}\n'
+    )
+    with pytest.raises(ValueError) as exc:
+        ingest_langfuse(db, source_file=str(path))
+    assert "Failed to parse NDJSON in" in str(exc.value)
+    assert "at line 2" in str(exc.value)

--- a/tokenjam/core/ingest_adapters/langfuse.py
+++ b/tokenjam/core/ingest_adapters/langfuse.py
@@ -202,25 +202,23 @@ def _iter_observations(payload: Any) -> Iterable[dict[str, Any]]:
 
 def _load_file(path: Path) -> Any:
     """Load a JSON file. Accepts a bare list, a {data: [...]} envelope, or NDJSON."""
-    text = path.read_text()
-    text = text.strip()
+    text = path.read_text().strip()
     if not text:
         return []
-    # NDJSON heuristic: looks like multiple JSON objects on separate lines.
-    if text[0] == "{" and "\n{" in text and not text.startswith("{\""):
-        # Could be NDJSON or a multi-line object. Try parsing whole-file first.
+    try:
+        return json.loads(text)
+    except json.JSONDecodeError:
+        pass
+    records: list[Any] = []
+    for i, line in enumerate(text.splitlines(), start=1):
+        line = line.strip()
+        if not line:
+            continue
         try:
-            return json.loads(text)
-        except json.JSONDecodeError:
-            pass
-        records: list[Any] = []
-        for line in text.splitlines():
-            line = line.strip()
-            if not line:
-                continue
             records.append(json.loads(line))
-        return records
-    return json.loads(text)
+        except json.JSONDecodeError as e:
+            raise ValueError(f"Failed to parse NDJSON in {path} at line {i}") from e
+    return records
 
 
 def _fetch_url(url: str, api_key: str | None, since: datetime | None) -> Any:


### PR DESCRIPTION
## Summary

This PR resolves a crash in the Langfuse ingest adapter when parsing NDJSON inputs. Specifically, it ports the fallback line-by-line NDJSON parsing logic from the Helicone adapter to Langfuse's `_load_file`.

### Changes:
- **NDJSON Fallback Parsing**: Refactored `_load_file` to fall back to line-by-line parsing upon encountering a `JSONDecodeError`, raising a descriptive `ValueError` with line numbers on malformed inputs.
- **Unit Tests**: Added tests verifying line-by-line NDJSON extraction and descriptive parsing tracebacks.

## Related issue

Closes #352

## Checklist

- [x] Tests pass (`pytest tests/unit/ tests/synthetic/ tests/agents/ tests/integration/`)
- [x] Lint clean (`ruff check tokenjam/`)
- [x] Type check clean (`mypy tokenjam/`)
- [x] CLAUDE.md updated (if architecture changed)
- [x] Test spans use `tests/factories.py` (not raw `NormalizedSpan`)
- [x] Requested `@anilmurty` as reviewer (or @-mentioned him above)

@anilmurty  please review