### PR TITLE
Quantify recoverable tokens for over-powered subagents in optimize ranking

### DIFF
--- a/tests/unit/test_optimize_subagent.py
+++ b/tests/unit/test_optimize_subagent.py
@@ -3,6 +3,8 @@ from __future__ import annotations
 
 from datetime import timedelta
 
+import pytest
+
 from tokenjam.core.db import InMemoryBackend
 from tokenjam.core.optimize.analyzers.subagent_rightsizing import run as run_subagent
 from tokenjam.core.optimize.runner import report_from_dict, report_to_dict
@@ -94,6 +96,93 @@ def test_flags_over_powered_fable_subagent():
         assert a.sub_agent_id == "fableA"
         assert a.model == "claude-fable-5"
         assert "over_powered" in a.flags
+    finally:
+        db.close()
+
+
+def test_over_powered_subagent_carries_quantified_estimate():
+    """An over_powered subagent must fill estimated_recoverable_* with the
+    model-swap delta (premium cost − cheaper same-family cost over the same
+    tokens), so it can compete for a ranked slot (#101)."""
+    db = InMemoryBackend()
+    try:
+        ctx, now = _ctx(db, window_cost_usd=1.0)
+        # Opus subagent, big context, tiny output -> over_powered (+over_provisioned).
+        db.insert_span(make_llm_span(
+            model="claude-opus-4-8", provider="anthropic",
+            input_tokens=80_000, output_tokens=100,
+            cost_usd=0.60, session_id="s1", sub_agent_id="agentA", start_time=now,
+        ))
+        run_subagent(ctx)
+        f = ctx.report.findings["subagent"]
+
+        # Cheaper same-family model for opus is haiku. Priced over the SAME tokens:
+        #   input  80_000 @ $1.00/Mtok  = 0.08
+        #   output    100 @ $5.00/Mtok  = 0.0005
+        # alt_cost = 0.0805; delta = 0.60 − 0.0805 = 0.5195.
+        assert f.estimated_recoverable_usd == pytest.approx(0.5195, abs=1e-6)
+        # Recoverable tokens = the quota sitting in the priced over_powered rows.
+        assert f.estimated_recoverable_tokens == 80_100
+        assert f.estimate_confidence == "heuristic"
+        assert "review" in f.estimate_basis.lower()
+    finally:
+        db.close()
+
+
+def test_over_provisioned_only_subagent_has_no_estimate():
+    """A subagent flagged only over_provisioned (a NON-premium model handed a
+    large context) contributes nothing to the estimate — its recoverable is a
+    prompt-size cut we don't size — so the finding stays unranked (estimate
+    None), honestly, rather than inventing a number (#101)."""
+    db = InMemoryBackend()
+    try:
+        ctx, now = _ctx(db, window_cost_usd=1.0)
+        # Sonnet (not premium): big context, tiny output -> over_provisioned only.
+        db.insert_span(make_llm_span(
+            model="claude-sonnet-4-6", provider="anthropic",
+            input_tokens=80_000, output_tokens=100,
+            cost_usd=0.30, session_id="s1", sub_agent_id="agentS", start_time=now,
+        ))
+        run_subagent(ctx)
+        f = ctx.report.findings["subagent"]
+
+        assert f.flagged[0].flags == ["over_provisioned"]
+        assert f.estimated_recoverable_usd is None
+        assert f.estimated_recoverable_tokens is None
+    finally:
+        db.close()
+
+
+def test_over_powered_estimate_ranks_in_numbered_slot():
+    """A CC-heavy window with significant over_powered subagent spend must earn a
+    numbered (major) slot in the ranked report, not fall to the unranked tail —
+    the exact regression #101 fixes."""
+    from tokenjam.cli.cmd_optimize import (
+        DE_MINIMIS_SHARE,
+        _rank_findings,
+        _reclaimable_share,
+    )
+
+    db = InMemoryBackend()
+    try:
+        ctx, now = _ctx(db, window_cost_usd=2.0)
+        # The window's token total (drives the reclaimable-share ranking).
+        ctx.report.window.total_tokens = 200_000
+        db.insert_span(make_llm_span(
+            model="claude-opus-4-8", provider="anthropic",
+            input_tokens=80_000, output_tokens=100,
+            cost_usd=0.60, session_id="s1", sub_agent_id="agentA", start_time=now,
+        ))
+        run_subagent(ctx)
+        f = ctx.report.findings["subagent"]
+
+        share = _reclaimable_share(f, ctx.report.window.total_tokens)
+        assert share is not None                      # now quantified, not unranked
+        assert share >= DE_MINIMIS_SHARE              # 80_100 / 200_000 = 0.40 -> major
+
+        ranked = _rank_findings(ctx.report, requested=None)
+        major = [name for name, s in ranked if s is not None and s >= DE_MINIMIS_SHARE]
+        assert "subagent" in major
     finally:
         db.close()
 

--- a/tokenjam/cli/cmd_optimize.py
+++ b/tokenjam/cli/cmd_optimize.py
@@ -1462,8 +1462,8 @@ def _render_subagent(
     # this finding its ranked slot. Dollars for api-billed users; the token quota
     # otherwise (same category discipline as the peer analyzers). Honest
     # "estimated recoverable" framing only; the caveat below still governs.
-    if finding.estimated_recoverable_tokens:
-        if pricing_mode == "api" and finding.estimated_recoverable_usd:
+    if finding.estimated_recoverable_tokens is not None:
+        if pricing_mode == "api" and finding.estimated_recoverable_usd is not None:
             recov = format_cost(finding.estimated_recoverable_usd)
         else:
             recov = f"{format_tokens(finding.estimated_recoverable_tokens)} tokens"

--- a/tokenjam/cli/cmd_optimize.py
+++ b/tokenjam/cli/cmd_optimize.py
@@ -1458,6 +1458,20 @@ def _render_subagent(
             )
             console.print(f"           [yellow]→[/yellow] {', '.join(r.flags)}")
 
+    # Quantified estimate (#101): the over_powered model-swap delta — what earns
+    # this finding its ranked slot. Dollars for api-billed users; the token quota
+    # otherwise (same category discipline as the peer analyzers). Honest
+    # "estimated recoverable" framing only; the caveat below still governs.
+    if finding.estimated_recoverable_tokens:
+        if pricing_mode == "api" and finding.estimated_recoverable_usd:
+            recov = format_cost(finding.estimated_recoverable_usd)
+        else:
+            recov = f"{format_tokens(finding.estimated_recoverable_tokens)} tokens"
+        console.print(
+            f"     • [green]~{recov}[/green] estimated recoverable "
+            f"[dim](over_powered subagents at their cheaper same-family model)[/dim]"
+        )
+
     console.print(f"     [yellow]![/yellow] [italic]{finding.caveat}[/italic]")
 
 

--- a/tokenjam/core/optimize/analyzers/subagent_rightsizing.py
+++ b/tokenjam/core/optimize/analyzers/subagent_rightsizing.py
@@ -31,8 +31,10 @@ from dataclasses import dataclass, field
 from typing import Any
 
 from tokenjam.core.model_tiers import is_premium_tier
+from tokenjam.core.optimize.analyzers.model_downgrade import lookup_downgrade
 from tokenjam.core.optimize.registry import register
 from tokenjam.core.optimize.types import AnalyzerContext
+from tokenjam.core.pricing import get_rates
 
 # "Produced little": total output tokens below this look like a small task.
 SMALL_OUTPUT_TOKENS = 2_000
@@ -58,12 +60,18 @@ SUBAGENT_HONESTY_CAVEAT = (
     "subagents before changing how you dispatch them or which model they use."
 )
 
-# estimate_basis for the savings contract (#111). Candidate-only in v1 — we
-# surface the spend concentrated in flagged subagents, not a guaranteed saving.
+# estimate_basis for the savings contract (#111). The quantified estimate is
+# the token-cost delta of routing each over_powered subagent (premium model,
+# little output) to its cheaper same-family model over the SAME tokens — a
+# model-swap counterfactual with no token-count change and no quality claim.
+# over_provisioned is deliberately excluded: its recoverable is a prompt-size
+# reduction we can't size honestly, so it never inflates this number.
 SUBAGENT_ESTIMATE_BASIS = (
-    "spend concentrated in structurally-flagged subagents (premium model with "
-    "little output, or large context with little output); review before "
-    "re-dispatching — no guaranteed saving"
+    "over_powered subagents priced at their cheaper same-family model over the "
+    "same tokens — a model-swap delta, structural fit only, no quality "
+    "validation; review before re-dispatching. over_provisioned spend is "
+    "flagged but not counted here (its recoverable prompt-size cut isn't "
+    "quantifiable). No guaranteed saving."
 )
 
 
@@ -80,6 +88,9 @@ class SubagentRow:
     cache_tokens:       int
     cache_write_tokens: int
     cost_usd:           float
+    # Provider is captured so the over_powered estimate can price the cheaper
+    # same-family alternative; defaulted for round-trip of pre-provider payloads.
+    provider:           str = "unknown"
     flags:              list[str] = field(default_factory=list)
 
 
@@ -136,6 +147,7 @@ def _compute_rows(conn, since, until, agent_id: str | None) -> list[SubagentRow]
     rows = conn.execute(
         f"SELECT session_id, sub_agent_id, "
         f"arg_max(model, COALESCE(input_tokens, 0) + COALESCE(output_tokens, 0)) AS model, "
+        f"arg_max(provider, COALESCE(input_tokens, 0) + COALESCE(output_tokens, 0)) AS provider, "
         f"COUNT(*) FILTER (WHERE name = 'gen_ai.llm.call') AS llm_calls, "
         f"COUNT(*) FILTER (WHERE tool_name IS NOT NULL) AS tool_calls, "
         f"COALESCE(SUM(input_tokens), 0) AS in_tok, "
@@ -150,7 +162,7 @@ def _compute_rows(conn, since, until, agent_id: str | None) -> list[SubagentRow]
     ).fetchall()
 
     result: list[SubagentRow] = []
-    for (sid, said, model, llm_calls, tool_calls,
+    for (sid, said, model, provider, llm_calls, tool_calls,
          in_tok, out_tok, cache_tok, cache_w_tok, cost) in rows:
         in_tok = int(in_tok or 0)
         out_tok = int(out_tok or 0)
@@ -158,6 +170,7 @@ def _compute_rows(conn, since, until, agent_id: str | None) -> list[SubagentRow]
         cache_w_tok = int(cache_w_tok or 0)
         cost = float(cost or 0.0)
         model = str(model or "unknown")
+        provider = str(provider or "unknown")
         flags = _flags_for(
             model=model, output_tokens=out_tok, tool_calls=int(tool_calls or 0),
             input_tokens=in_tok, cache_tokens=cache_tok, cost_usd=cost,
@@ -173,9 +186,66 @@ def _compute_rows(conn, since, until, agent_id: str | None) -> list[SubagentRow]
             cache_tokens=cache_tok,
             cache_write_tokens=cache_w_tok,
             cost_usd=round(cost, 8),
+            provider=provider,
             flags=flags,
         ))
     return result
+
+
+def _alt_cost_for_row(r: SubagentRow, alt_model: str) -> float | None:
+    """Cost of ``r``'s exact token mix priced at ``alt_model``, or ``None`` when
+    the alternative has no pricing data. Prices EVERY token class the original
+    was billed for (input + output + cache read + cache write) so the delta
+    reflects only the rate difference — never an artificial saving from dropping
+    a token class the cheaper model would still be charged for."""
+    rates = get_rates(r.provider, alt_model)
+    if rates is None:
+        return None
+    return (
+        r.input_tokens / 1_000_000 * rates.input_per_mtok
+        + r.output_tokens / 1_000_000 * rates.output_per_mtok
+        + r.cache_tokens / 1_000_000 * rates.cache_read_per_mtok
+        + r.cache_write_tokens / 1_000_000 * rates.cache_write_per_mtok
+    )
+
+
+def _over_powered_recoverable(rows: list[SubagentRow]) -> tuple[float, int]:
+    """Conservative recoverable estimate over the over_powered subagents.
+
+    For each subagent flagged ``over_powered`` (a premium-tier model that did
+    little work), price its same-family cheaper alternative over the identical
+    token mix and take the POSITIVE cost delta — a pure model-swap
+    counterfactual, no token-count change and no quality claim. A subagent with
+    no cheaper alternative or no pricing data contributes nothing (we refuse to
+    invent a number). ``over_provisioned`` is intentionally excluded: reducing an
+    over-large prompt is a real saving but not one we can size honestly here.
+
+    Returns ``(recoverable_usd, recoverable_tokens)`` where the token figure is
+    the quota (input + output + cache) sitting in the priced over_powered
+    subagents — the share that routing to a cheaper model frees against a plan
+    cap, mirroring the model-downgrade analyzer's token framing so the Overview
+    tiles and the ranked-report share stay comparable.
+    """
+    recoverable_usd = 0.0
+    recoverable_tokens = 0
+    for r in rows:
+        if "over_powered" not in r.flags:
+            continue
+        alt = lookup_downgrade(r.provider, r.model)
+        if not alt:
+            continue
+        alt_cost = _alt_cost_for_row(r, alt)
+        if alt_cost is None:
+            continue
+        delta = r.cost_usd - alt_cost
+        if delta <= 0:
+            continue
+        recoverable_usd += delta
+        recoverable_tokens += (
+            r.input_tokens + r.output_tokens
+            + r.cache_tokens + r.cache_write_tokens
+        )
+    return recoverable_usd, recoverable_tokens
 
 
 @register("subagent")
@@ -195,6 +265,16 @@ def run(ctx: AnalyzerContext) -> None:
         (r for r in rows if r.flags), key=lambda r: r.cost_usd, reverse=True
     )
 
+    # Quantified recoverable estimate (#101 / savings contract #111): the
+    # model-swap delta over the over_powered subagents. Computed over ALL flagged
+    # rows (not just the TOP_N rendered) so the ranked-report share reflects the
+    # full window. None when nothing over_powered had a priced cheaper
+    # alternative — the finding then renders unranked (honest empty estimate),
+    # exactly like it did before it could quantify anything.
+    recoverable_usd, recoverable_tokens = _over_powered_recoverable(flagged)
+    est_usd = round(recoverable_usd, 8) if recoverable_tokens > 0 else None
+    est_tokens = recoverable_tokens if recoverable_tokens > 0 else None
+
     ctx.report.findings["subagent"] = SubagentRightsizingFinding(
         sessions_with_subagents=len({r.session_id for r in rows}),
         total_subagents=len(rows),
@@ -205,4 +285,6 @@ def run(ctx: AnalyzerContext) -> None:
         flagged_cost_usd=round(sum(r.cost_usd for r in flagged), 8),
         rows=rows[:TOP_N],
         flagged=flagged[:TOP_N],
+        estimated_recoverable_usd=est_usd,
+        estimated_recoverable_tokens=est_tokens,
     )


### PR DESCRIPTION
## Problem

The subagent right-sizing analyzer flags `over_powered` / `over_provisioned` subagent spawns — one of the most actionable findings for Claude Code users — but never filled `estimated_recoverable_usd` / `estimated_recoverable_tokens`. The ranked `tj optimize` report orders findings by `estimated_recoverable_tokens / window total`, so a finding with no estimate renders unranked. The subagent analyzer was therefore **structurally locked out of the numbered slots** no matter how much flagged spend it found.

## Fix

Derive a conservative recoverable estimate for `over_powered` subagents: the token-cost delta of routing each to its cheaper same-family model (reusing `lookup_downgrade` + the pricing tables) over the **identical token mix**. It's a pure model-swap counterfactual — no token-count change, no quality claim — consistent with the analyzer's honesty discipline:

`over_provisioned` is deliberately **excluded** — its recoverable is a prompt-size reduction we can't size honestly, so it never inflates the number.
A subagent with no cheaper alternative or no pricing data contributes **nothing** rather than inventing a figure.
When nothing `over_powered` has a priced alternative, the estimate stays `None` and the finding renders unranked (honest empty state), exactly as before.
`estimate_basis` / `estimate_confidence` carry the honest framing; the CLI renders an "estimated recoverable" line and the existing caveat still governs.

Per-subagent `provider` is now captured so the cheaper model can be priced; it round-trips through the report (de)serialization.

The finding now competes for a numbered slot on its own merits. On a CC-heavy dataset with significant flagged subagent spend it lands in slot ①.

## Tests

`test_over_powered_subagent_carries_quantified_estimate` — the model-swap delta math.
`test_over_provisioned_only_subagent_has_no_estimate` — the exclusion stays honest (estimate `None`).
`test_over_powered_estimate_ranks_in_numbered_slot` — the finding earns a numbered (major) slot.

All existing optimize unit tests pass (106); the full unit + synthetic suites are green except one pre-existing, unrelated onboarding test that reads a real local config.

🤖 shipped by [shiploop](https://github.com/anshss/shiploop)