### PR TITLE
Surface potholes and drive first-fix-enable at the end of onboarding

### DIFF
--- a/tests/unit/test_onboard_pothole_activation.py
+++ b/tests/unit/test_onboard_pothole_activation.py
@@ -1,0 +1,190 @@
+"""Onboarding tail: pothole surfacing + first-fix-enable CTA (#179).
+
+Exercises ``_run_pothole_first_fix`` directly (mirrors the direct-call +
+capsys pattern in ``test_onboard_first_run.py``'s nudge tests) rather than
+driving the full onboard wizard — the apply/enable/revert mechanics
+themselves are already covered by ``test_pothole_apply.py``; this file only
+tests onboarding's orchestration: what gets shown, when the enable ask fires,
+and that enforcement is never armed without an explicit confirm.
+"""
+from __future__ import annotations
+
+import pytest
+
+from tokenjam.cli import cmd_onboard
+from tokenjam.core.optimize import pothole_apply
+from tokenjam.core.optimize.analyzers.pothole import (
+    PotholeCluster,
+    PotholeExample,
+    PotholeFinding,
+)
+
+
+def _cluster(**overrides) -> PotholeCluster:
+    base = dict(
+        signature="cwd_confusion", family_key="cwd_confusion",
+        title="cwd / relative-path confusion", sessions=12, occurrences=324,
+        repos=["demo"], rung=3, scope="project",
+        proposed_fix="PostToolUseFailure hook: inject the real cwd on failure.",
+        examples=[
+            PotholeExample(session_id="s1", repo="demo", ts=None, snippet="no such file"),
+        ],
+        estimated_recoverable_tokens=486_000,
+        suggested_target="/tmp/does-not-matter/.claude/hooks/cwd-confusion.py",
+    )
+    base.update(overrides)
+    return PotholeCluster(**base)
+
+
+def _finding(clusters, **overrides) -> PotholeFinding:
+    base = dict(
+        clusters=clusters, sessions_scanned=42,
+        estimated_recoverable_tokens=sum(c.estimated_recoverable_tokens for c in clusters) or None,
+    )
+    base.update(overrides)
+    return PotholeFinding(**base)
+
+
+@pytest.fixture
+def _no_op_apply(monkeypatch):
+    """Fail loudly if a test that shouldn't reach apply/enable does anyway."""
+    def _boom(*a, **k):
+        raise AssertionError("apply_pothole_fix should not have been called")
+
+    monkeypatch.setattr(pothole_apply, "apply_pothole_fix", _boom)
+    monkeypatch.setattr(pothole_apply, "enable_enforcement", _boom)
+
+
+def test_thin_history_shows_watching_note_and_never_applies(monkeypatch, capsys, _no_op_apply):
+    import tokenjam.core.optimize.analyzers.pothole as pothole_mod
+
+    monkeypatch.setattr(pothole_mod, "compute_pothole_finding", lambda **k: _finding([]))
+    cmd_onboard._run_pothole_first_fix(object(), port=7391, want_daemon=True)
+    out = capsys.readouterr().out
+    assert "still watching" in out
+    assert "The mistakes your agent keeps making" not in out
+
+
+def test_no_hook_quality_candidate_routes_to_review_later(monkeypatch, capsys, _no_op_apply):
+    import tokenjam.core.optimize.analyzers.pothole as pothole_mod
+
+    low_confidence = _cluster(rung=1, family_key="edit_before_read", title="Edit before Read")
+    distilled = _cluster(
+        rung=3, family_key="distilled:some-slug", title="a distilled guess",
+    )
+    monkeypatch.setattr(
+        pothole_mod, "compute_pothole_finding",
+        lambda **k: _finding([low_confidence, distilled]),
+    )
+    monkeypatch.setattr(cmd_onboard, "_is_interactive", lambda: True)
+    cmd_onboard._run_pothole_first_fix(object(), port=7391, want_daemon=True)
+    out = capsys.readouterr().out
+    assert "The mistakes your agent keeps making" in out
+    assert "No day-1 hook-quality fix yet" in out
+    assert "Enable this fix now" not in out
+
+
+def test_non_interactive_shows_cta_but_never_prompts(monkeypatch, capsys, _no_op_apply):
+    import tokenjam.core.optimize.analyzers.pothole as pothole_mod
+
+    monkeypatch.setattr(pothole_mod, "compute_pothole_finding", lambda **k: _finding([_cluster()]))
+    monkeypatch.setattr(cmd_onboard, "_is_interactive", lambda: False)
+    cmd_onboard._run_pothole_first_fix(object(), port=7391, want_daemon=True)
+    out = capsys.readouterr().out
+    assert "cwd / relative-path confusion" in out
+    assert "324" in out  # occurrences shown in the shock-stat list
+    assert "Re-run `tj onboard --claude-code`" in out
+    assert "Enable this fix now" not in out
+
+
+def test_interactive_decline_skips_apply(monkeypatch, capsys, _no_op_apply):
+    import tokenjam.core.optimize.analyzers.pothole as pothole_mod
+
+    monkeypatch.setattr(pothole_mod, "compute_pothole_finding", lambda **k: _finding([_cluster()]))
+    monkeypatch.setattr(cmd_onboard, "_is_interactive", lambda: True)
+    monkeypatch.setattr(cmd_onboard.click, "confirm", lambda *a, **k: False)
+    cmd_onboard._run_pothole_first_fix(object(), port=7391, want_daemon=True)
+    out = capsys.readouterr().out
+    assert "Your #1 fix:" in out
+    assert "Skipped" in out
+
+
+def test_interactive_confirm_applies_and_enables_with_explicit_confirm(
+    monkeypatch, capsys,
+):
+    import tokenjam.core.optimize.analyzers.pothole as pothole_mod
+
+    cluster = _cluster()
+    monkeypatch.setattr(pothole_mod, "compute_pothole_finding", lambda **k: _finding([cluster]))
+    monkeypatch.setattr(cmd_onboard, "_is_interactive", lambda: True)
+    monkeypatch.setattr(cmd_onboard.click, "confirm", lambda *a, **k: True)
+
+    calls = {}
+
+    def _fake_apply(config, cluster_dict, *, target_path, scope, go, force):
+        calls["apply"] = {
+            "target_path": target_path, "scope": scope, "go": go, "force": force,
+        }
+        return {"dry_run": False, "record": {"id": "fix123"}}
+
+    def _fake_enable(config, fix_id, *, confirm):
+        calls["enable"] = {"fix_id": fix_id, "confirm": confirm}
+
+    monkeypatch.setattr(pothole_apply, "apply_pothole_fix", _fake_apply)
+    monkeypatch.setattr(pothole_apply, "enable_enforcement", _fake_enable)
+
+    cmd_onboard._run_pothole_first_fix(object(), port=7391, want_daemon=True)
+    out = capsys.readouterr().out
+
+    # Evidence + the hook explainer print before the (mocked) confirm ask.
+    assert "Evidence" in out
+    assert "s1" in out  # repro session id from the example
+    assert "What enabling does" in out
+    assert out.index("Evidence") < out.index("What enabling does")
+
+    # Applied with go=True and no silent force; enabled only via explicit confirm=True.
+    assert calls["apply"]["go"] is True
+    assert calls["apply"]["force"] is False
+    assert calls["apply"]["target_path"] == cluster.suggested_target
+    assert calls["enable"]["fix_id"] == "fix123"
+    assert calls["enable"]["confirm"] is True
+
+    assert "Enabled: cwd / relative-path confusion" in out
+    assert "One-click revert" in out
+    assert "#/review" in out
+
+
+def test_apply_refused_never_silently_forces(monkeypatch, capsys):
+    import tokenjam.core.optimize.analyzers.pothole as pothole_mod
+
+    cluster = _cluster()
+    monkeypatch.setattr(pothole_mod, "compute_pothole_finding", lambda **k: _finding([cluster]))
+    monkeypatch.setattr(cmd_onboard, "_is_interactive", lambda: True)
+    monkeypatch.setattr(cmd_onboard.click, "confirm", lambda *a, **k: True)
+
+    def _refuse(*a, **k):
+        raise pothole_apply.PotholeApplyRefused("an active session was seen")
+
+    monkeypatch.setattr(pothole_apply, "apply_pothole_fix", _refuse)
+    called_enable = []
+    monkeypatch.setattr(
+        pothole_apply, "enable_enforcement",
+        lambda *a, **k: called_enable.append((a, k)),
+    )
+
+    cmd_onboard._run_pothole_first_fix(object(), port=7391, want_daemon=True)
+    out = capsys.readouterr().out
+    assert "Could not enable yet" in out
+    assert "an active session was seen" in out
+    assert not called_enable
+
+
+def test_no_daemon_points_at_tj_serve_first(monkeypatch, capsys, _no_op_apply):
+    import tokenjam.core.optimize.analyzers.pothole as pothole_mod
+
+    low_confidence = _cluster(rung=1, family_key="edit_before_read")
+    monkeypatch.setattr(pothole_mod, "compute_pothole_finding", lambda **k: _finding([low_confidence]))
+    monkeypatch.setattr(cmd_onboard, "_is_interactive", lambda: True)
+    cmd_onboard._run_pothole_first_fix(object(), port=7391, want_daemon=False)
+    out = capsys.readouterr().out
+    assert "run `tj serve`" in out

--- a/tokenjam/cli/cmd_onboard.py
+++ b/tokenjam/cli/cmd_onboard.py
@@ -966,6 +966,175 @@ def _try_backfill_codex(config) -> tuple[str | None, bool, int]:
     return msg, True, total
 
 
+def _lens_review_url(port: int, *, want_daemon: bool) -> str:
+    """One-click-revert pointer for the pothole activation tail below — the
+    Lens Review inbox (`#/review`, the Improve lens's home) already renders a
+    single-click Revert next to every applied fix, so onboarding never needs
+    its own revert UI. When the daemon isn't running yet (``--no-daemon``),
+    say so instead of printing a URL that won't answer."""
+    if want_daemon:
+        return f"http://127.0.0.1:{port}/#/review"
+    return f"run `tj serve`, then open http://127.0.0.1:{port}/#/review"
+
+
+def _run_pothole_first_fix(config: object, *, port: int, want_daemon: bool) -> None:
+    """Onboarding tail (#179): the backfill's payoff is a fix, not just a
+    chart. Scans the freshly-backfilled Claude Code history for recurring
+    potholes (``core.optimize.analyzers.pothole``) and, for a high-confidence
+    hook-quality finding, drives the user through approve+enable of their
+    first fix — human-gated at every step, never auto-armed.
+
+    Thin history (the detector found no recurring cluster — it needs
+    ``MIN_RECURRING_SESSIONS`` repeats of the same failure before it will
+    ever propose anything) gets a "still watching" note instead of a fix CTA.
+    Non-interactive runs (CI, a piped ``tj onboard``) only ever print the
+    summary — the enable ask requires a human at a terminal to confirm.
+
+    Never raises: any failure here is best-effort and must not sink the rest
+    of onboarding, which has already written config/statusline/daemon state
+    by the time this runs.
+    """
+    from dataclasses import asdict
+
+    from tokenjam.core.backfill import CLAUDE_CODE_PROJECTS_ROOT
+    from tokenjam.core.optimize import pothole_apply
+    from tokenjam.core.optimize.analyzers.pothole import compute_pothole_finding
+
+    console.print()
+    console.print("[dim]Scanning your history for recurring mistakes…[/dim]")
+    try:
+        # projects_root=CLAUDE_CODE_PROJECTS_ROOT: scan the exact directory
+        # the backfill above just read, not `compute_pothole_finding`'s own
+        # default (a module-level constant baked in at import time from
+        # ``Path.home()`` — it won't follow a test's ``Path.home`` patch the
+        # way this already-monkeypatchable module attribute does).
+        #
+        # distill_enabled=False: onboarding stays fast and dependency-free —
+        # the LLM-distill pass shells out to a real `claude` CLI per residual
+        # cluster (slow, and not guaranteed to be configured yet at this
+        # point in setup). Every distilled cluster is hardcoded to rung 1
+        # anyway (never enforcement-eligible), so it can never be the day-1
+        # candidate below — the daemon's periodic background recompute
+        # (`tj serve`'s pothole job) already runs the full distill-enabled
+        # scan and will surface those in the Lens Review inbox on its own
+        # schedule.
+        finding = compute_pothole_finding(
+            projects_root=CLAUDE_CODE_PROJECTS_ROOT, distill_enabled=False,
+        )
+    except Exception:
+        return
+
+    if not finding.clusters:
+        console.print(
+            "[bold]Recurring mistakes:[/bold] still watching — check back "
+            "after a few more sessions."
+        )
+        return
+
+    console.print()
+    console.print(
+        f"[bold]The mistakes your agent keeps making[/bold]  "
+        f"[dim]({finding.sessions_scanned} sessions scanned)[/dim]"
+    )
+    for cluster in finding.clusters[:5]:
+        distilled = (
+            " [dim](distilled — needs a closer look)[/dim]"
+            if (cluster.family_key or "").startswith("distilled:") else ""
+        )
+        console.print(
+            f"  [yellow]{cluster.occurrences:>4}x[/yellow]  {cluster.title}"
+            f"{distilled}  [dim]· {cluster.sessions} sessions · "
+            f"rung {cluster.rung}[/dim]"
+        )
+    total_tokens = finding.estimated_recoverable_tokens or 0
+    if total_tokens:
+        console.print(
+            f"  [dim]~{total_tokens:,} estimated recoverable tokens across "
+            f"{len(finding.clusters)} pattern"
+            f"{'s' if len(finding.clusters) != 1 else ''} — {finding.caveat}[/dim]"
+        )
+    lens_hint = _lens_review_url(port, want_daemon=want_daemon)
+
+    # High-confidence, hook-quality only (Hard constraint #2): rung 3-5 is the
+    # intervention ladder's enforcement tier (ENFORCEMENT_RUNGS), and every
+    # distilled (LLM-guessed) cluster is hardcoded to rung 1 by the detector
+    # itself — so filtering on rung already excludes distilled clusters. The
+    # explicit family_key check stays as defense-in-depth against a future
+    # detector change quietly handing a distilled cluster a higher rung. A
+    # cluster with no resolved write target can't be applied non-interactively
+    # (it would need a human to pick one), so it's excluded too.
+    candidate = next(
+        (
+            c for c in finding.clusters
+            if c.rung in pothole_apply.ENFORCEMENT_RUNGS
+            and not (c.family_key or "").startswith("distilled:")
+            and c.suggested_target
+        ),
+        None,
+    )
+    if candidate is None:
+        console.print()
+        console.print(
+            f"[dim]No day-1 hook-quality fix yet — review the rest anytime "
+            f"in the Lens Review inbox ({lens_hint}).[/dim]"
+        )
+        return
+
+    if not _is_interactive():
+        console.print()
+        console.print(
+            f"[dim]Re-run `tj onboard --claude-code` from a terminal, or "
+            f"open the Lens Review inbox ({lens_hint}), to approve + enable "
+            f"your first fix.[/dim]"
+        )
+        return
+
+    console.print()
+    console.print(f"[bold]Your #1 fix:[/bold] {candidate.title}")
+    console.print(
+        f"  [dim]Evidence — {candidate.occurrences} occurrences across "
+        f"{candidate.sessions} sessions:[/dim]"
+    )
+    for ex in candidate.examples[:3]:
+        console.print(f"    [dim]· session {ex.session_id} ({ex.repo}): {ex.snippet}[/dim]")
+    console.print(f"  Proposed fix: {candidate.proposed_fix}")
+    console.print(
+        "  [dim]What enabling does: Claude Code calls tj automatically right "
+        "after a matching tool failure. It never blocks or edits your code — "
+        "it only injects a short recovery note into context. The hook ships "
+        "disabled and stays that way unless you confirm below; you can "
+        "disable or revert it at any time.[/dim]"
+    )
+    if not click.confirm("  Enable this fix now?", default=False):
+        console.print(
+            f"[dim]  Skipped — enable anytime from the Lens Review inbox "
+            f"({lens_hint}) or by re-running tj onboard.[/dim]"
+        )
+        return
+
+    try:
+        result = pothole_apply.apply_pothole_fix(
+            config, asdict(candidate),
+            target_path=candidate.suggested_target, scope=candidate.scope,
+            go=True, force=False,
+        )
+        fix_id = result["record"]["id"]
+        pothole_apply.enable_enforcement(config, fix_id, confirm=True)
+    except pothole_apply.PotholeApplyRefused as exc:
+        console.print(f"[yellow]  Could not enable yet: {exc}[/yellow]")
+        console.print(f"[dim]  Retry from the Lens Review inbox ({lens_hint}).[/dim]")
+        return
+
+    console.print(
+        f"[green]✓[/green] Enabled: {candidate.title} "
+        f"[dim](wired at {candidate.suggested_target})[/dim]"
+    )
+    console.print(
+        f"  [dim]One-click revert any time: open {lens_hint} and click "
+        f"Revert next to this fix (fix id {fix_id}).[/dim]"
+    )
+
+
 def _print_setup_complete_home(
     *, sessions_backfilled: int = 0, has_data: bool = False,
     days: int | None = None,
@@ -1946,6 +2115,8 @@ def _onboard_claude_code(
     # already ran above. On the combination path this is deferred to
     # `_onboard_combination` so the banner prints exactly once (#432).
     if standalone:
+        if backfill_has_data:
+            _run_pothole_first_fix(config, port=port, want_daemon=want_daemon)
         _print_setup_complete_home(
             sessions_backfilled=backfill_sessions_total,
             has_data=backfill_has_data,


### PR DESCRIPTION
Onboarding already backfills a user's Claude Code history and stops at "observability is set up." The payoff of that backfill — this repo's cross-session pothole detector — only ever showed up in the separately-discovered Lens Review inbox, never in onboarding itself. This re-sequences the onboarding tail so the backfill's payoff is a fix, not just a chart.

## Summary
After the existing Claude Code backfill, scan for recurring potholes and print "the mistakes your agent keeps making" — occurrences, sessions, rung, and an estimated-recoverable-tokens total (the shareable shock-stat).
Thin history (no recurring cluster yet) gets a "still watching — check back after a few more sessions" note instead of a fix CTA.
For a user with a high-confidence, hook-quality finding, drive an interactive approve+enable of their first fix: show evidence (repro sessions + estimated tokens wasted) and a plain-language "what enabling does" explainer, *then* ask.
Enforcement is armed only after that explicit confirm — never automatically — and a one-click revert (the Review inbox) is surfaced right next to the confirmation.
Non-interactive runs (CI, a piped `tj onboard`) print the same summary but never prompt.

## Day-1 candidate selection
Only clusters at an enforcement rung (3-5 — hook/wrapper/config) are offered for day-1 enable. Every LLM-distilled cluster (as opposed to the detector's hardcoded, regex-matched families) is rung 1 by construction, so this filter already excludes them; the code also checks the `distilled:` family-key prefix explicitly as defense-in-depth. A cluster with no resolved write target is skipped too, since onboarding has no UI for picking one.

The scan itself runs with the LLM-distill pass disabled (`distill_enabled=False`) — that pass shells out to a real `claude` CLI per residual cluster, which is slow and an unneeded dependency this early in setup, and a distilled cluster could never be the day-1 candidate anyway. The daemon's existing periodic background recompute still runs the full distill-enabled scan for the Review inbox.

## Tests / Verification
Added `tests/unit/test_onboard_pothole_activation.py` (7 tests): thin-history branch, no-qualifying-candidate branch, non-interactive gating, interactive decline, interactive confirm → apply + enable with an explicit `confirm=True`, an apply refusal (e.g. an active session) never silently forcing, and the no-daemon revert-hint wording.
`pytest tests/unit/ -q -k "onboard or pothole"`: 363 passed (1 pre-existing, already-tracked, environment-dependent failure unrelated to this change: `test_bare_onboard_sdk_choice_falls_through_to_generic`, which false-negatives on any dev host that already has a real `~/.config/tj/config.toml`).
`ruff check` / `mypy` clean on the changed file.
Live-verified against a real, full local Claude Code history (thousands of real sessions, copied into an isolated sandbox `HOME`): the detector surfaced the same recurring families a prior manual investigation had found (cwd/relative-path confusion, edit-before-read, blocked sleep-chains, etc.), the non-interactive path correctly skipped the enable prompt and printed the review-later pointer, and — using the real detected cluster data with an explicit sandboxed write target — apply → enable → refuse-without-confirm → revert all ran for real: the hook file was written and git-committed, `settings.json` was untouched until enable, `enable_enforcement(confirm=False)` correctly refused, and revert both unwired the hook from `settings.json` and deleted the freshly-created file.

## What's NOT in this PR
The combination onboarding path (multiple agent types in one run) and the Codex-only path don't get this tail yet — scoped to the primary Claude Code path per the brief; a follow-up can extend it if wanted.
`tj optimize pothole`'s plain-text CLI renderer still shows the generic "No candidates" summary instead of the cluster list — a separate, already-known gap in the CLI view (independent of this onboarding-tail change).

🤖 shipped by [shiploop](https://github.com/anshss/shiploop)