### PR TITLE
Fix: /cost/compare 500s when tj serve runs as a proxy daemon

### DIFF
--- a/tests/integration/test_cost_compare_serve.py
+++ b/tests/integration/test_cost_compare_serve.py
@@ -1,0 +1,160 @@
+"""A second `tj serve` that lost the DuckDB write-lock race runs as a thin
+proxy: its ``app.state.db`` is an ``ApiBackend`` pointing at the primary daemon,
+not a ``DuckDBBackend``. ``GET /api/v1/cost/compare`` used to call
+``compute_cost_diff(db, ...)`` unconditionally, which reaches for
+``db.get_window_cost_totals`` / ``db.get_cost_delta_by_group`` — methods only the
+direct DuckDB backend has. Under the proxy that raised
+``AttributeError: 'ApiBackend' object has no attribute 'get_window_cost_totals'``
+→ a 500.
+
+The route now detects the proxy case and forwards the whole comparison to the
+primary daemon (which owns the direct connection) via
+``ApiBackend.fetch_cost_compare``, returning the same schema a direct hit does.
+"""
+from __future__ import annotations
+
+import asyncio
+from datetime import timedelta
+
+import httpx
+import pytest
+
+from tokenjam.api.app import create_app
+from tokenjam.core.api_backend import ApiBackend
+from tokenjam.core.config import ApiAuthConfig, ApiConfig, StorageConfig, TjConfig
+from tokenjam.core.db import DuckDBBackend
+from tokenjam.core.ingest import IngestPipeline
+from tokenjam.utils.time_parse import utcnow
+from tests.factories import make_llm_span, make_session
+
+_COMPARE_URL = "/api/v1/cost/compare?since=7d&compare=previous"
+# The DuckDBBackend methods compute_cost_diff needs but the proxy shim lacks.
+_PROXY_ONLY_MISSING = "get_window_cost_totals"
+
+
+def _config() -> TjConfig:
+    # Auth off so the route's require_api_key passes without a bearer header;
+    # the proxy scenario itself is independent of auth.
+    return TjConfig(
+        version="1",
+        api=ApiConfig(auth=ApiAuthConfig(enabled=False)),
+    )
+
+
+def _seed(db) -> None:
+    """LLM spans in both the current (7d) and previous (7-14d) windows so the
+    comparison has real numbers on each side of the diff."""
+    now = utcnow()
+    db.upsert_session(make_session(agent_id="a", session_id="cur"))
+    db.upsert_session(make_session(agent_id="a", session_id="prev"))
+    db.insert_span(make_llm_span(
+        session_id="cur", agent_id="a", start_time=now - timedelta(days=1),
+        input_tokens=1000, output_tokens=300, cost_usd=2.0,
+    ))
+    db.insert_span(make_llm_span(
+        session_id="prev", agent_id="a", start_time=now - timedelta(days=10),
+        input_tokens=800, output_tokens=200, cost_usd=1.0,
+    ))
+
+
+def _proxy_apibackend(primary_app, monkeypatch) -> ApiBackend:
+    """An ApiBackend whose sync ``_get`` is bridged into the primary daemon's
+    in-process ASGI app — exactly the object a second `tj serve` puts in
+    ``app.state.db`` when the first daemon holds the write lock."""
+    api = ApiBackend("http://primary")
+    transport = httpx.ASGITransport(app=primary_app)
+
+    def _sync_get(path, params=None, *, timeout=None):
+        async def _call():
+            async with httpx.AsyncClient(
+                transport=transport, base_url="http://primary",
+            ) as c:
+                r = await c.get(path, params=params)
+                r.raise_for_status()
+                return r.json()
+
+        return asyncio.run(_call())
+
+    monkeypatch.setattr(api, "_get", _sync_get)
+    return api
+
+
+def test_apibackend_lacks_direct_compare_methods():
+    """Guards the premise: the proxy shim genuinely can't compute the diff
+    locally, so the route MUST forward rather than call compute_cost_diff."""
+    assert not hasattr(ApiBackend, _PROXY_ONLY_MISSING)
+    assert not hasattr(ApiBackend, "get_cost_delta_by_group")
+    # …but it CAN forward the whole comparison to the primary.
+    assert hasattr(ApiBackend, "fetch_cost_compare")
+
+
+@pytest.mark.asyncio
+async def test_cost_compare_forwards_through_proxy(tmp_path, monkeypatch):
+    """Hitting /cost/compare on the proxy daemon returns the real diff (200 +
+    full schema), not the old AttributeError 500."""
+    primary_db = DuckDBBackend(StorageConfig(path=str(tmp_path / "primary.duckdb")))
+    config = _config()
+    _seed(primary_db)
+    primary_app = create_app(
+        config=config, db=primary_db,
+        ingest_pipeline=IngestPipeline(db=primary_db, config=config),
+    )
+
+    api = _proxy_apibackend(primary_app, monkeypatch)
+    # The proxy daemon's state.db is the ApiBackend — no direct connection.
+    assert getattr(api, "conn", None) is None
+
+    proxy_app = create_app(
+        config=config, db=api,
+        ingest_pipeline=IngestPipeline(db=primary_db, config=config),
+    )
+    assert isinstance(proxy_app.state.db, ApiBackend)
+
+    transport = httpx.ASGITransport(app=proxy_app)
+    async with httpx.AsyncClient(transport=transport, base_url="http://proxy") as c:
+        resp = await c.get(_COMPARE_URL)
+
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    # Full CostDiff schema forwarded verbatim from the primary.
+    for key in (
+        "current", "previous", "cost_delta_usd", "cost_delta_pct",
+        "tokens_delta", "by_agent", "by_model", "framing",
+    ):
+        assert key in body, f"missing {key!r} in forwarded response"
+    # Real numbers from the seeded windows (current $2 vs previous $1).
+    assert body["current"]["total_cost_usd"] == pytest.approx(2.0)
+    assert body["previous"]["total_cost_usd"] == pytest.approx(1.0)
+    assert body["cost_delta_usd"] == pytest.approx(1.0)
+
+    primary_db.close()
+
+
+@pytest.mark.asyncio
+async def test_cost_compare_proxy_degrades_on_upstream_failure(tmp_path, monkeypatch):
+    """If the primary daemon is unreachable, the proxy returns a clean 502 —
+    not a raw proxy traceback."""
+    config = _config()
+    # An ApiBackend whose forward always fails at the transport layer.
+    api = ApiBackend("http://primary")
+
+    def _boom(path, params=None, *, timeout=None):
+        raise httpx.ConnectError("primary daemon down")
+
+    monkeypatch.setattr(api, "_get", _boom)
+
+    # A throwaway real db just to satisfy create_app / the pipeline; the route
+    # never touches it because state.db is the ApiBackend.
+    throwaway = DuckDBBackend(StorageConfig(path=str(tmp_path / "throwaway.duckdb")))
+    proxy_app = create_app(
+        config=config, db=api,
+        ingest_pipeline=IngestPipeline(db=throwaway, config=config),
+    )
+
+    transport = httpx.ASGITransport(app=proxy_app)
+    async with httpx.AsyncClient(transport=transport, base_url="http://proxy") as c:
+        resp = await c.get(_COMPARE_URL)
+
+    assert resp.status_code == 502, resp.text
+    assert "Upstream tj serve unavailable" in resp.json()["detail"]
+    throwaway.close()

--- a/tokenjam/api/routes/cost_compare.py
+++ b/tokenjam/api/routes/cost_compare.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 
 from typing import Any
 
+import httpx
 from fastapi import APIRouter, Depends, HTTPException, Query, Request
 
 from tokenjam.api.deps import require_api_key
@@ -18,6 +19,19 @@ from tokenjam.core.framing import WindowSummary, compute_framing, plan_tier_mix
 from tokenjam.utils.time_parse import parse_since, utcnow
 
 router = APIRouter()
+
+
+def _upstream_detail(exc: httpx.HTTPStatusError) -> str:
+    """Best-effort extraction of the primary daemon's own error detail so a
+    forwarded 4xx (e.g. an invalid ``--compare``) reads the same as a direct
+    hit rather than a generic proxy failure."""
+    try:
+        body = exc.response.json()
+    except Exception:
+        return str(exc)
+    if isinstance(body, dict) and body.get("detail"):
+        return str(body["detail"])
+    return str(exc)
 
 
 @router.get("/cost/compare", dependencies=[Depends(require_api_key)])
@@ -35,6 +49,33 @@ def get_cost_compare(
     db = request.app.state.db
     if db is None:
         raise HTTPException(status_code=503, detail="Server db not initialised.")
+
+    # A second `tj serve` that lost the DuckDB write-lock race runs as a thin
+    # proxy: its `state.db` is an ApiBackend pointing at the primary daemon, and
+    # ApiBackend has no `get_window_cost_totals` / `get_cost_delta_by_group` (the
+    # DuckDBBackend methods compute_cost_diff calls). Computing here would raise
+    # AttributeError → a 500. Instead forward the whole comparison to the primary
+    # daemon, which owns the direct connection and whose /cost/compare returns
+    # this exact schema — the same fetch_cost_compare path the CLI uses when the
+    # daemon holds the lock (#68 §12). Degrade to a clean status on an upstream
+    # failure rather than surfacing a raw proxy error.
+    from tokenjam.core.api_backend import ApiBackend
+
+    if isinstance(db, ApiBackend):
+        try:
+            return db.fetch_cost_compare(
+                since=since, compare=compare, agent_id=agent_id, top_n=top_n,
+            )
+        except httpx.HTTPStatusError as exc:
+            raise HTTPException(
+                status_code=exc.response.status_code,
+                detail=_upstream_detail(exc),
+            ) from exc
+        except httpx.HTTPError as exc:
+            raise HTTPException(
+                status_code=502,
+                detail=f"Upstream tj serve unavailable for /cost/compare: {exc}",
+            ) from exc
 
     try:
         since_dt = parse_since(since)


### PR DESCRIPTION
When two `tj serve` instances race for the DuckDB write lock, the loser falls back to a thin proxy shim whose `state.db` is an `ApiBackend` pointing at the primary daemon, not a direct `DuckDBBackend`. Hitting `/cost/compare` on that proxy 500'd.

## Summary
- `GET /api/v1/cost/compare` no longer 500s when the serving process is the proxy shim.
- Added a regression test that reproduces the proxy scenario end-to-end.

## Root cause + fix
`compute_cost_diff(db, ...)` was called unconditionally, and it reaches for `db.get_window_cost_totals` / `db.get_cost_delta_by_group` — methods only `DuckDBBackend` implements. `ApiBackend` (the shim a losing `tj serve` process installs as `state.db`) has neither, so the call raised `AttributeError: 'ApiBackend' object has no attribute 'get_window_cost_totals'`, which FastAPI surfaced as a 500 to any client (CLI `--compare` flag or the Lens UI) hitting the comparison endpoint on the losing daemon.

The route now detects the `ApiBackend` proxy case up front and forwards the whole comparison to the primary daemon via `ApiBackend.fetch_cost_compare` (already implemented, unused by this route until now), which returns the identical `CostDiff` schema a direct hit produces. Upstream failures degrade cleanly: an `httpx.HTTPStatusError` re-raises with the primary's own status code + `detail` (so a bad `--compare` value reads the same on both daemons), and a transport-level failure returns a plain 502 rather than a raw proxy traceback.

## Tests / Verification
- `tests/integration/test_cost_compare_serve.py` (new): asserts the premise (`ApiBackend` genuinely lacks the direct-compute methods but does expose `fetch_cost_compare`), exercises the full proxy → primary forward over a real ASGI transport bridge (200 + correct numbers), and covers the upstream-unavailable degrade path (502).
- Full local run: `pytest tests/unit/ tests/synthetic/ tests/agents/ tests/integration/` → 2509 passed, 1 skipped (skip unrelated to this change).
- `ruff check` and `mypy` clean on both touched files.

## What's NOT in this PR
- No changes to `ApiBackend.fetch_cost_compare` itself — it already existed and already matched the schema; this PR only wires the route to use it in the proxy case.

🤖 Generated with [Claude Code](https://claude.com/claude-code)