### PR TITLE
Fix #345: honor TJ_CONFIG in pricing-override config discovery

### DIFF
--- a/tests/unit/test_pricing_override.py
+++ b/tests/unit/test_pricing_override.py
@@ -21,6 +21,7 @@ def _isolate_pricing(monkeypatch, tmp_path):
     empty dir so a project-local tj.toml/.tj/config.toml [pricing] section
     can't leak in either (config discovery walks the cwd)."""
     monkeypatch.delenv(pricing.USER_PRICING_ENV, raising=False)
+    monkeypatch.delenv("TJ_CONFIG", raising=False)
     monkeypatch.setenv("HOME", str(tmp_path))          # POSIX
     monkeypatch.setenv("USERPROFILE", str(tmp_path))   # Windows Path.home()
     monkeypatch.chdir(tmp_path)
@@ -284,6 +285,59 @@ def test_config_pricing_merges_with_user_file_and_wins(tmp_path, monkeypatch):
     # Each source's unique entries survive the merge.
     assert pricing.get_rates("unknown", "file-only-model").input_per_mtok == 2.0
     assert pricing.get_rates("unknown", "config-only-model").input_per_mtok == 3.0
+
+
+def test_config_pricing_section_tj_config_env(tmp_path, monkeypatch):
+    """TJ_CONFIG points at a config whose [pricing] overrides must take effect
+    (#345). Without env-aware discovery, the pricing loader walks only the
+    default search paths and silently drops the user's rate overrides."""
+    custom = tmp_path / "custom.toml"
+    _write(
+        custom,
+        'version = "1"\n'
+        "[pricing.models]\n"
+        '"claude-haiku-4-5" = { input_per_mtok = 0.11, output_per_mtok = 0.12 }\n',
+    )
+    monkeypatch.setenv("TJ_CONFIG", str(custom))
+    pricing.clear_pricing_cache()
+
+    rates = pricing.get_rates("unknown", "claude-haiku-4-5")
+    assert rates is not None
+    assert rates.input_per_mtok == 0.11
+    assert rates.output_per_mtok == 0.12
+
+
+def test_config_pricing_section_tj_config_wins_over_search_path(tmp_path, monkeypatch):
+    """TJ_CONFIG takes precedence over the default search paths, matching
+    load_config() resolution order (#345)."""
+    _write_main_config(
+        tmp_path,
+        '[pricing.models]\n"claude-haiku-4-5" = { input_per_mtok = 0.05, output_per_mtok = 0.06 }\n',
+    )
+    custom = tmp_path / "elsewhere.toml"
+    _write(
+        custom,
+        'version = "1"\n'
+        "[pricing.models]\n"
+        '"claude-haiku-4-5" = { input_per_mtok = 0.21, output_per_mtok = 0.22 }\n',
+    )
+    monkeypatch.setenv("TJ_CONFIG", str(custom))
+    pricing.clear_pricing_cache()
+
+    rates = pricing.get_rates("unknown", "claude-haiku-4-5")
+    assert rates is not None
+    assert rates.input_per_mtok == 0.21
+
+
+def test_config_pricing_section_tj_config_missing_degrades(tmp_path, monkeypatch):
+    """A TJ_CONFIG pointing at a nonexistent file degrades to packaged rates
+    instead of raising (#345)."""
+    monkeypatch.setenv("TJ_CONFIG", str(tmp_path / "nope.toml"))
+    pricing.clear_pricing_cache()
+
+    rates = pricing.get_rates("anthropic", "claude-haiku-4-5")
+    assert rates is not None
+    assert rates.input_per_mtok == 1.00
 
 
 # --- Packaged current-Anthropic-model coverage (issue #8) -------------------

--- a/tokenjam/core/pricing.py
+++ b/tokenjam/core/pricing.py
@@ -106,15 +106,18 @@ def _user_pricing_file() -> Path | None:
 def _config_pricing_section() -> dict | None:
     """Return the [pricing] section of the discovered main config, or None.
 
-    Read directly from the config file (not via a full TjConfig parse) so the
-    pricing loader stays light and free of the config dataclass tree. Any
-    error — no config file, unreadable, malformed — degrades silently to None;
-    config problems surface through the normal config-load path elsewhere.
+    Config discovery honors ``TJ_CONFIG`` the same way ``load_config`` does,
+    so the [pricing] section is read from the same file as the rest of the
+    app. Read directly from the config file (not via a full TjConfig parse)
+    so the pricing loader stays light and free of the config dataclass tree.
+    Any error — no config file, unreadable, malformed — degrades silently to
+    None; config problems surface through the normal config-load path
+    elsewhere.
     """
     from tokenjam.core.config import find_config_file
 
     try:
-        path = find_config_file()
+        path = find_config_file(os.environ.get("TJ_CONFIG"))
     except (FileNotFoundError, OSError):
         return None
     if path is None:


### PR DESCRIPTION
`_config_pricing_section()` called `find_config_file()` with no override, so pricing discovery only walked the default search paths and never read `TJ_CONFIG`, while `load_config()` resolves the env var first. With `TJ_CONFIG` pointing at a non-default config, the app loaded that file but the pricing loader resolved a different file (or none), silently dropping `[pricing]` rate overrides and computing costs from the wrong rate table.

## Summary
- Pass `os.environ.get("TJ_CONFIG")` into `find_config_file()` inside `_config_pricing_section()`, so the `[pricing]` section is read from the same file as the rest of the app.
- A `TJ_CONFIG` pointing at a missing file still degrades silently to packaged rates via the existing `FileNotFoundError` catch.

## Related issue
Closes #345

## Tests / Verification
- New regression tests in `tests/unit/test_pricing_override.py`: overrides take effect from a `TJ_CONFIG` file, `TJ_CONFIG` wins over search-path discovery, and a nonexistent `TJ_CONFIG` path degrades to packaged rates. Confirmed the new tests fail without the fix and pass with it.
- `pytest tests/unit/test_pricing_override.py -q` — 30 passed
- `pytest tests/unit/ -q` — 2001 passed, 1 skipped
- `pytest tests/synthetic/ tests/agents/ tests/integration/ -q` — 564 passed
- `ruff check tokenjam/core/pricing.py tests/unit/test_pricing_override.py` — clean
- `mypy tokenjam/core/pricing.py` — clean

## Checklist
- [x] Tests pass (`pytest tests/unit/ tests/synthetic/ tests/agents/ tests/integration/`)
- [x] Lint clean (`ruff check tokenjam/`)
- [x] Type check clean (`mypy tokenjam/`)
- [x] Contributor docs updated (not needed, no architecture change)
- [x] Test spans use `tests/factories.py` (not applicable, config-layer change)

@anilmurty ready for review.
