### PR TITLE
feat(sdk): record_outcome helper — emit gen_ai outcome events for Cloud ROI

### DIFF
--- a/docs/python-sdk.md
+++ b/docs/python-sdk.md
@@ -74,6 +74,36 @@ record_tool_call(
 )
 ```
 
+## Record an outcome
+
+Attach a business outcome to a workflow in one line instead of hand-POSTing an
+OTLP event. `record_outcome` emits the emerging gen_ai outcome event (OTel
+semconv issue #2665) alongside your spans:
+
+```python
+from tokenjam.sdk import record_outcome
+
+# Inside an active @watch() / AgentSession, the session is inherited:
+record_outcome("ticket_resolved", success=True, value_usd=25.00)
+
+# Or attach to a workflow / session you name yourself:
+record_outcome(
+    "lead_qualified",
+    workflow_id="onboarding-run-42",
+    success=True,
+    value_usd=500.00,
+)
+```
+
+At least one of `workflow_id` / `session_id` is required (an active session
+satisfies it). `value_usd` is **optional and self-reported** — a value you
+declare, which TokenJam does not measure or verify.
+
+**ROI is a TokenJam Cloud feature.** The OSS SDK only *emits* the outcome event
+(and the local stack ingests it as a normal span). Turning declared value ÷
+measured cost into an ROI figure happens in TokenJam Cloud — there is no local
+ROI compute.
+
 ## Examples
 
 The [`examples/`](../examples/) directory has runnable agents for every integration. See [`examples/README.md`](../examples/README.md) for the full list.

--- a/docs/typescript-sdk.md
+++ b/docs/typescript-sdk.md
@@ -62,6 +62,29 @@ new SpanBuilder("invoke_agent")
   .build();
 ```
 
+## Record an outcome
+
+Attach a business outcome to a workflow in one call instead of hand-building an
+OTLP event. `recordOutcome` emits the emerging gen_ai outcome event (OTel
+semconv issue #2665):
+
+```ts
+await client.recordOutcome({
+  outcomeType: "ticket_resolved",
+  sessionId: "sess-9",
+  success: true,
+  valueUsd: 25.0, // optional, self-reported
+});
+```
+
+At least one of `workflowId` / `sessionId` is required. `valueUsd` is
+**optional and self-reported** — a value you declare, which TokenJam does not
+measure or verify.
+
+**ROI is a TokenJam Cloud feature.** The SDK only *emits* the outcome event;
+turning declared value ÷ measured cost into an ROI figure happens in TokenJam
+Cloud. There is no local ROI compute.
+
 ## Errors and retries
 
 The client buffers up to 1000 spans if `tj serve` is unreachable, retries with exponential backoff (3 attempts, 2s base delay), and drops the buffer on process exit.

--- a/examples/README.md
+++ b/examples/README.md
@@ -77,6 +77,7 @@ These examples demonstrate what makes tj unique: real-time alerting and behavior
 | [`sensitive_actions_demo.py`](alerts_and_drift/sensitive_actions_demo.py) | None | Fires alerts when agent calls sensitive tools |
 | [`budget_breach_demo.py`](alerts_and_drift/budget_breach_demo.py) | None | Exceeds budget limits, shows cost alerts |
 | [`drift_demo.py`](alerts_and_drift/drift_demo.py) | None | Builds baseline, then triggers drift detection |
+| [`record_outcome_demo.py`](alerts_and_drift/record_outcome_demo.py) | None | Attaches a business outcome (+ self-reported value) to a workflow via `record_outcome()` |
 
 These examples include the required `tj.toml` config snippets as comments at the top of each file. Copy the relevant config to your `tj.toml` before running.
 

--- a/examples/alerts_and_drift/record_outcome_demo.py
+++ b/examples/alerts_and_drift/record_outcome_demo.py
@@ -1,0 +1,59 @@
+"""
+Record an Outcome Demo
+
+Runs a small "support agent" session (a couple of LLM + tool calls) and then
+attaches a business OUTCOME to it with `record_outcome()` — one line instead of
+hand-POSTing an OTLP event.
+
+No API keys required — uses simulated instrumentation.
+
+What record_outcome does: it emits the emerging gen_ai outcome event (OTel
+semconv issue #2665) as a span alongside your telemetry. TokenJam Cloud's ROI
+backend turns declared value ÷ measured cost into an ROI figure. The OSS SDK
+here only EMITS the event — there is no local ROI compute.
+
+Honesty note: `value_usd` is OPTIONAL and SELF-REPORTED. It is a value YOU
+declare for the outcome; TokenJam does not measure or verify it.
+"""
+from __future__ import annotations
+
+from tokenjam.sdk import record_outcome
+from tokenjam.sdk.agent import AgentSession, record_llm_call, record_tool_call
+from tokenjam.utils.ids import new_uuid
+
+
+def run_support_session() -> None:
+    """A tiny support workflow that resolves a ticket, then records the outcome."""
+    with AgentSession(agent_id="support-agent", conversation_id=new_uuid()):
+        record_llm_call(
+            model="claude-haiku-4-5",
+            provider="anthropic",
+            input_tokens=350,
+            output_tokens=120,
+        )
+        record_tool_call(
+            tool_name="lookup_order",
+            tool_input={"order_id": "A-1001"},
+            tool_output={"status": "shipped"},
+        )
+        record_llm_call(
+            model="claude-haiku-4-5",
+            provider="anthropic",
+            input_tokens=180,
+            output_tokens=90,
+        )
+
+        # Attach the business outcome. Inside an active AgentSession the session
+        # is inherited automatically — no need to pass workflow_id/session_id.
+        record_outcome(
+            "ticket_resolved",
+            success=True,
+            value_usd=25.00,  # self-reported: what resolving this ticket is worth
+        )
+
+
+if __name__ == "__main__":
+    run_support_session()
+    print("Recorded a 'ticket_resolved' outcome for the support-agent session.")
+    print("Inspect the spans with:  tj traces --since 1h")
+    print("ROI compute is a TokenJam Cloud feature — the SDK only emits the event.")

--- a/sdk-ts/README.md
+++ b/sdk-ts/README.md
@@ -71,6 +71,33 @@ new TjClient(options: TjClientOptions)
 | `client.send(span)` | Buffer a span; auto-flushes when `batchSize` is reached. |
 | `client.flush()` | Immediately send all buffered spans. Returns `IngestResult | null`. |
 | `client.shutdown()` | Flush remaining spans and stop the timer. Call before process exit. |
+| `client.recordOutcome(options)` | Emit a gen_ai outcome event attaching a business outcome to a workflow. |
+
+### Record an outcome
+
+Attach a business outcome to a workflow in one call — the emerging gen_ai
+outcome event (OTel semconv issue #2665) TokenJam Cloud's ROI backend ingests.
+
+```typescript
+await client.recordOutcome({
+  outcomeType: "ticket_resolved", // required marker
+  sessionId: "sess-9",            // at least one of sessionId / workflowId
+  success: true,
+  valueUsd: 25.0,                 // optional, self-reported
+});
+```
+
+| Option | Type | Description |
+|---|---|---|
+| `outcomeType` | `string` | Required. Caller-defined label (e.g. `"ticket_resolved"`). The marker attribute. |
+| `workflowId` | `string` | Explicit workflow key. At least one of `workflowId` / `sessionId` is required. |
+| `sessionId` | `string` | Session (or root session of a fan-out) the outcome belongs to. |
+| `success` | `boolean` | Whether the outcome was achieved. Defaults to `true`. |
+| `valueUsd` | `number` | **Optional, self-reported** business value. TokenJam does not measure or verify it. |
+| `agentId` | `string` | Emitting agent id. |
+| `attributes` | `Record<string, unknown>` | Extra attributes attached verbatim. |
+
+**ROI compute is a TokenJam Cloud feature.** The SDK only emits the event.
 
 ## SpanBuilder
 

--- a/sdk-ts/examples/record-outcome.ts
+++ b/sdk-ts/examples/record-outcome.ts
@@ -1,0 +1,56 @@
+/**
+ * Record an outcome (TypeScript) — attach a business outcome to a workflow in
+ * one call with `client.recordOutcome(...)` instead of hand-building an OTLP
+ * outcome event.
+ *
+ * Requires `tj serve` running (the TS SDK sends over HTTP):
+ *
+ *     tj serve &
+ *     npx tsx sdk-ts/examples/record-outcome.ts   # or compile with tsc
+ *
+ * Honesty note: `valueUsd` is OPTIONAL and SELF-REPORTED. It is a value YOU
+ * declare for the outcome; TokenJam does not measure or verify it. ROI compute
+ * (declared value ÷ measured cost) is a TokenJam Cloud feature — this SDK only
+ * EMITS the outcome event.
+ */
+import { TjClient, SpanBuilder } from "@tokenjam/sdk";
+
+async function main(): Promise<void> {
+  const client = new TjClient({
+    ingestSecret: process.env.TJ_INGEST_SECRET ?? "your-ingest-secret",
+    serviceName: "support-agent",
+  }).start();
+
+  const sessionId = "sess-" + Math.random().toString(36).slice(2, 10);
+
+  // A tiny support workflow: one LLM call attributed to the session.
+  await client.send(
+    new SpanBuilder("gen_ai.llm.call")
+      .agentId("support-agent")
+      .provider("anthropic")
+      .model("claude-haiku-4-5")
+      .inputTokens(350)
+      .outputTokens(120)
+      .attribute("session.id", sessionId)
+      .durationMs(900)
+      .build()
+  );
+
+  // Attach the business outcome to that session's workflow.
+  await client.recordOutcome({
+    outcomeType: "ticket_resolved",
+    sessionId,
+    success: true,
+    valueUsd: 25.0, // self-reported: what resolving this ticket is worth
+    agentId: "support-agent",
+  });
+
+  await client.shutdown();
+  console.log(`Recorded a 'ticket_resolved' outcome for ${sessionId}.`);
+  console.log("ROI compute is a TokenJam Cloud feature — the SDK only emits the event.");
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/sdk-ts/package.json
+++ b/sdk-ts/package.json
@@ -6,7 +6,7 @@
   "types": "dist/index.d.ts",
   "scripts": {
     "build": "tsc",
-    "test": "node --test dist/client.test.js dist/span-builder.test.js dist/semconv.test.js",
+    "test": "node --test dist/client.test.js dist/record-outcome.test.js dist/span-builder.test.js dist/semconv.test.js",
     "pretest": "tsc",
     "lint": "tsc --noEmit"
   },

--- a/sdk-ts/src/client.ts
+++ b/sdk-ts/src/client.ts
@@ -2,9 +2,42 @@
  * TjClient — sends spans to the TokenJam REST API.
  * Communicates via HTTP POST to /api/v1/spans in OTLP JSON format.
  */
-import { GenAIAttributes } from "./semconv.js";
+import { GenAIAttributes, TjAttributes } from "./semconv.js";
+import { SpanBuilder } from "./span-builder.js";
 import type { IngestResult, OtlpSpan, OtlpValue, Span, SpanBatch } from "./types.js";
 import { SpanKind, SpanStatus } from "./types.js";
+
+export interface RecordOutcomeOptions {
+  /**
+   * The kind of outcome, a caller-defined label
+   * (e.g. "ticket_resolved", "lead_qualified", "pr_merged"). Required — this is
+   * the marker attribute; without it the event is not recognised downstream.
+   */
+  outcomeType: string;
+  /**
+   * An explicit workflow key to attach the outcome to. Optional if sessionId is
+   * given. At least one of workflowId / sessionId is required.
+   */
+  workflowId?: string;
+  /**
+   * The session (or root session of a fan-out) the outcome belongs to. At least
+   * one of workflowId / sessionId is required.
+   */
+  sessionId?: string;
+  /** Whether the outcome was achieved (execution succeeded). Defaults to true. */
+  success?: boolean;
+  /**
+   * An OPTIONAL, SELF-REPORTED business value for the outcome in USD. A value
+   * YOU declare — TokenJam does not measure or verify it. Negative values are
+   * treated as undeclared. ROI compute (declared value / measured cost) is a
+   * TokenJam Cloud feature; the SDK only emits the event.
+   */
+  valueUsd?: number;
+  /** The emitting agent id (stamped as gen_ai.agent.id). */
+  agentId?: string;
+  /** Extra attributes attached verbatim to the event. */
+  attributes?: Record<string, unknown>;
+}
 
 export interface TjClientOptions {
   /** Base URL of the TokenJam server (default: http://127.0.0.1:7391) */
@@ -130,6 +163,58 @@ export class TjClient {
     if (this.buffer.length >= this.batchSize) {
       await this.flush();
     }
+  }
+
+  /**
+   * Emit a gen_ai outcome event attaching a business outcome to a workflow.
+   *
+   * A thin wrapper that builds and sends one outcome span carrying the emerging
+   * gen_ai outcome-event attributes (OTel semconv issue #2665) that TokenJam
+   * Cloud's ROI ingest keys off — one call instead of hand-POSTing OTLP JSON.
+   * The span is buffered like any other (auto-flushes at batchSize).
+   *
+   * ROI compute is a TokenJam Cloud feature; the SDK only emits the event.
+   * `valueUsd` is self-reported — TokenJam does not measure or verify it.
+   *
+   * @throws if outcomeType is empty, or neither workflowId nor sessionId is set.
+   */
+  async recordOutcome(options: RecordOutcomeOptions): Promise<void> {
+    if (!options.outcomeType) {
+      throw new Error("recordOutcome requires a non-empty outcomeType");
+    }
+    if (!options.workflowId && !options.sessionId) {
+      throw new Error(
+        "recordOutcome requires at least one of workflowId or sessionId"
+      );
+    }
+
+    const builder = new SpanBuilder(GenAIAttributes.SPAN_OUTCOME)
+      .kind(SpanKind.CLIENT)
+      // The marker attrs the Cloud ROI ingest keys off, plus the stock
+      // event.name so the event can also ride the OTLP event path.
+      .attribute(GenAIAttributes.EVENT_NAME, GenAIAttributes.OUTCOME_EVENT_NAME)
+      .attribute(GenAIAttributes.OUTCOME_TYPE, options.outcomeType)
+      .attribute(GenAIAttributes.OUTCOME_SUCCESS, options.success ?? true);
+
+    if (options.workflowId) {
+      builder.attribute(TjAttributes.WORKFLOW_ID, options.workflowId);
+    }
+    if (options.sessionId) {
+      // session.id is the key the canonical OTLP parser reads (not the
+      // SpanBuilder.sessionId() gen_ai.session.id form).
+      builder.attribute(TjAttributes.SESSION_ID, options.sessionId);
+    }
+    if (options.agentId) {
+      builder.agentId(options.agentId);
+    }
+    if (options.valueUsd != null) {
+      builder.attribute(GenAIAttributes.OUTCOME_VALUE_USD, options.valueUsd);
+    }
+    for (const [key, value] of Object.entries(options.attributes ?? {})) {
+      builder.attribute(key, value);
+    }
+
+    await this.send(builder.build());
   }
 
   /**

--- a/sdk-ts/src/index.ts
+++ b/sdk-ts/src/index.ts
@@ -1,4 +1,8 @@
-export { TjClient, type TjClientOptions } from "./client.js";
+export {
+  TjClient,
+  type TjClientOptions,
+  type RecordOutcomeOptions,
+} from "./client.js";
 export { type Span, type SpanBatch, type IngestResult, SpanKind, SpanStatus } from "./types.js";
 export { SpanBuilder } from "./span-builder.js";
 export { GenAIAttributes, TjAttributes, ClaudeCodeEvents } from "./semconv.js";

--- a/sdk-ts/src/record-outcome.test.ts
+++ b/sdk-ts/src/record-outcome.test.ts
@@ -1,0 +1,175 @@
+import { describe, it, beforeEach, afterEach } from "node:test";
+import assert from "node:assert/strict";
+import { createServer, type IncomingMessage, type ServerResponse } from "node:http";
+import { TjClient } from "./client.js";
+import { GenAIAttributes, TjAttributes } from "./semconv.js";
+
+/**
+ * Tests for TjClient.recordOutcome — asserts the emitted outcome span carries
+ * the exact attribute names/shape TokenJam Cloud's ROI ingest keys off
+ * (roi.is_outcome_event / write_outcome_from_span), and that argument
+ * validation mirrors the Cloud OutcomeIn validator.
+ */
+function createMockServer(): {
+  server: ReturnType<typeof createServer>;
+  port: () => number;
+  requests: Array<{ body: string }>;
+  start: () => Promise<void>;
+  stop: () => Promise<void>;
+} {
+  const requests: Array<{ body: string }> = [];
+  const server = createServer((req: IncomingMessage, res: ServerResponse) => {
+    let body = "";
+    req.on("data", (chunk: Buffer) => {
+      body += chunk.toString();
+    });
+    req.on("end", () => {
+      requests.push({ body });
+      res.writeHead(200, { "Content-Type": "application/json" });
+      res.end(JSON.stringify({ ingested: 1, rejected: 0, rejections: [] }));
+    });
+  });
+
+  return {
+    server,
+    port: () => {
+      const addr = server.address();
+      if (addr && typeof addr === "object") return addr.port;
+      throw new Error("Server not started");
+    },
+    requests,
+    async start() {
+      await new Promise<void>((resolve) => {
+        server.listen(0, "127.0.0.1", resolve);
+      });
+    },
+    async stop() {
+      await new Promise<void>((resolve, reject) => {
+        server.close((err) => (err ? reject(err) : resolve()));
+      });
+    },
+  };
+}
+
+/** Extract the first span's attribute map from a captured OTLP request body. */
+function attrMapOf(body: string): Map<string, unknown> {
+  const parsed = JSON.parse(body);
+  const span = parsed.resourceSpans[0].scopeSpans[0].spans[0];
+  return new Map(
+    span.attributes.map((a: { key: string; value: Record<string, unknown> }) => [
+      a.key,
+      a.value,
+    ])
+  );
+}
+
+function spanNameOf(body: string): string {
+  return JSON.parse(body).resourceSpans[0].scopeSpans[0].spans[0].name;
+}
+
+describe("TjClient.recordOutcome", () => {
+  let mock: ReturnType<typeof createMockServer>;
+
+  beforeEach(async () => {
+    mock = createMockServer();
+    await mock.start();
+  });
+
+  afterEach(async () => {
+    await mock.stop();
+  });
+
+  function newClient() {
+    return new TjClient({
+      baseUrl: `http://127.0.0.1:${mock.port()}`,
+      ingestSecret: "secret",
+      batchSize: 1,
+    });
+  }
+
+  it("emits an outcome span with the Cloud marker attributes", async () => {
+    await newClient().recordOutcome({
+      outcomeType: "ticket_resolved",
+      workflowId: "wf-123",
+    });
+
+    assert.equal(mock.requests.length, 1);
+    const body = mock.requests[0].body;
+    assert.equal(spanNameOf(body), GenAIAttributes.SPAN_OUTCOME);
+
+    const attrs = attrMapOf(body);
+    assert.deepEqual(attrs.get(GenAIAttributes.EVENT_NAME), {
+      stringValue: GenAIAttributes.OUTCOME_EVENT_NAME,
+    });
+    assert.deepEqual(attrs.get(GenAIAttributes.OUTCOME_TYPE), {
+      stringValue: "ticket_resolved",
+    });
+    assert.deepEqual(attrs.get(GenAIAttributes.OUTCOME_SUCCESS), {
+      boolValue: true,
+    });
+    assert.deepEqual(attrs.get(TjAttributes.WORKFLOW_ID), {
+      stringValue: "wf-123",
+    });
+    // No value declared -> value_usd attribute absent (never fabricated).
+    assert.equal(attrs.has(GenAIAttributes.OUTCOME_VALUE_USD), false);
+  });
+
+  it("uses canonical attribute name strings matching the Cloud roi.py", () => {
+    assert.equal(GenAIAttributes.OUTCOME_EVENT_NAME, "gen_ai.outcome");
+    assert.equal(GenAIAttributes.EVENT_NAME, "event.name");
+    assert.equal(GenAIAttributes.OUTCOME_TYPE, "gen_ai.outcome.type");
+    assert.equal(GenAIAttributes.OUTCOME_SUCCESS, "gen_ai.outcome.success");
+    assert.equal(GenAIAttributes.OUTCOME_VALUE_USD, "gen_ai.outcome.value_usd");
+    assert.equal(TjAttributes.WORKFLOW_ID, "tokenjam.workflow_id");
+    assert.equal(TjAttributes.SESSION_ID, "session.id");
+  });
+
+  it("stamps session.id and self-reported value_usd", async () => {
+    await newClient().recordOutcome({
+      outcomeType: "lead_qualified",
+      sessionId: "sess-9",
+      valueUsd: 42.5,
+      agentId: "sales-bot",
+    });
+
+    const attrs = attrMapOf(mock.requests[0].body);
+    assert.deepEqual(attrs.get(TjAttributes.SESSION_ID), { stringValue: "sess-9" });
+    assert.deepEqual(attrs.get(GenAIAttributes.OUTCOME_VALUE_USD), {
+      doubleValue: 42.5,
+    });
+    assert.deepEqual(attrs.get(GenAIAttributes.AGENT_ID), {
+      stringValue: "sales-bot",
+    });
+  });
+
+  it("carries success=false and extra attributes", async () => {
+    await newClient().recordOutcome({
+      outcomeType: "checkout",
+      workflowId: "wf-1",
+      success: false,
+      attributes: { customer_tier: "enterprise" },
+    });
+
+    const attrs = attrMapOf(mock.requests[0].body);
+    assert.deepEqual(attrs.get(GenAIAttributes.OUTCOME_SUCCESS), {
+      boolValue: false,
+    });
+    assert.deepEqual(attrs.get("customer_tier"), { stringValue: "enterprise" });
+  });
+
+  it("rejects an empty outcomeType", async () => {
+    await assert.rejects(
+      () => newClient().recordOutcome({ outcomeType: "", workflowId: "wf-1" }),
+      /outcomeType/
+    );
+    assert.equal(mock.requests.length, 0);
+  });
+
+  it("rejects when neither workflowId nor sessionId is given", async () => {
+    await assert.rejects(
+      () => newClient().recordOutcome({ outcomeType: "ticket_resolved" }),
+      /workflowId or sessionId/
+    );
+    assert.equal(mock.requests.length, 0);
+  });
+});

--- a/sdk-ts/src/semconv.ts
+++ b/sdk-ts/src/semconv.ts
@@ -24,12 +24,26 @@ export const GenAIAttributes = {
   SPAN_CREATE_AGENT: "create_agent",
   SPAN_TOOL_CALL: "gen_ai.tool.call",
   SPAN_LLM_CALL: "gen_ai.llm.call",
+
+  // Outcome / feedback event (emerging gen_ai outcome-event semconv, OTel
+  // semconv issue #2665). recordOutcome() emits a span carrying these; the
+  // outcome-type attribute is the marker TokenJam Cloud's ROI ingest keys off.
+  SPAN_OUTCOME: "gen_ai.outcome",
+  OUTCOME_EVENT_NAME: "gen_ai.outcome",
+  EVENT_NAME: "event.name",
+  OUTCOME_TYPE: "gen_ai.outcome.type",
+  OUTCOME_SUCCESS: "gen_ai.outcome.success",
+  OUTCOME_VALUE_USD: "gen_ai.outcome.value_usd",
 } as const;
 
 export const TjAttributes = {
   COST_USD: "tokenjam.cost_usd",
   ALERT_TYPE: "tokenjam.alert.type",
   ALERT_SEVERITY: "tokenjam.alert.severity",
+  // session.id is the key the canonical OTLP parser reads for a span's session.
+  SESSION_ID: "session.id",
+  // Explicit workflow key for an outcome event (see recordOutcome).
+  WORKFLOW_ID: "tokenjam.workflow_id",
   SANDBOX_EVENT: "tokenjam.sandbox.event",
   EGRESS_HOST: "tokenjam.sandbox.egress_host",
   EGRESS_PORT: "tokenjam.sandbox.egress_port",

--- a/tests/agents/test_record_outcome.py
+++ b/tests/agents/test_record_outcome.py
@@ -1,0 +1,176 @@
+"""
+Tests for the record_outcome SDK helper.
+
+record_outcome emits one OTel span carrying the emerging gen_ai outcome-event
+attributes (OTel semconv issue #2665) that TokenJam Cloud's ROI ingest keys off
+(roi.is_outcome_event / write_outcome_from_span). These tests assert the span
+carries the exact attribute names/shape the Cloud parses, and that argument
+validation mirrors the Cloud OutcomeIn validator (at least one of
+workflow_id / session_id required).
+
+Uses a single module-level TracerProvider with a collecting exporter, mirroring
+tests/agents/test_mock_scenarios.py (Critical Rule 11).
+"""
+from __future__ import annotations
+
+import threading
+from typing import Sequence
+
+import pytest
+from opentelemetry import trace
+from opentelemetry.sdk.trace import ReadableSpan, TracerProvider
+from opentelemetry.sdk.trace.export import (
+    SimpleSpanProcessor,
+    SpanExporter,
+    SpanExportResult,
+)
+
+from tokenjam.otel.semconv import GenAIAttributes, TjAttributes
+from tokenjam.sdk.agent import AgentSession, record_outcome
+
+
+class _CollectingExporter(SpanExporter):
+    """In-memory span exporter that collects finished spans for assertions."""
+
+    def __init__(self) -> None:
+        self._spans: list[ReadableSpan] = []
+        self._lock = threading.Lock()
+
+    def export(self, spans: Sequence[ReadableSpan]) -> SpanExportResult:
+        with self._lock:
+            self._spans.extend(spans)
+        return SpanExportResult.SUCCESS
+
+    def shutdown(self) -> None:
+        pass
+
+    def get_finished_spans(self) -> list[ReadableSpan]:
+        with self._lock:
+            return list(self._spans)
+
+    def clear(self) -> None:
+        with self._lock:
+            self._spans.clear()
+
+
+# Module-level setup: set the tracer provider once (Critical Rule 11).
+_exporter = _CollectingExporter()
+_provider = TracerProvider()
+_provider.add_span_processor(SimpleSpanProcessor(_exporter))
+trace.set_tracer_provider(_provider)
+
+import tokenjam.sdk.agent as _agent_mod  # noqa: E402
+
+
+@pytest.fixture(autouse=True)
+def otel_exporter():
+    # Bind the SDK's tracer to OUR provider instance (not the global) for the
+    # duration of each test, so spans land in our collecting exporter even when
+    # another module won set_tracer_provider first (set-once — Critical Rule 11).
+    # Restore afterwards so we don't leak our exporter into other test modules.
+    original = _agent_mod._tracer
+    _agent_mod._tracer = _provider.get_tracer("tokenjam.sdk")
+    _exporter.clear()
+    try:
+        yield _exporter
+    finally:
+        _agent_mod._tracer = original
+
+
+def _outcome_spans(exporter: _CollectingExporter) -> list[ReadableSpan]:
+    return [
+        s for s in exporter.get_finished_spans()
+        if s.name == GenAIAttributes.SPAN_OUTCOME
+    ]
+
+
+# ── Marker attributes the Cloud ROI ingest recognises ───────────────────────
+
+def test_record_outcome_emits_marker_attributes(otel_exporter):
+    record_outcome("ticket_resolved", workflow_id="wf-123")
+
+    spans = _outcome_spans(otel_exporter)
+    assert len(spans) == 1
+    attrs = spans[0].attributes
+
+    # event.name + the outcome-type marker (roi.is_outcome_event keys off these)
+    assert attrs[GenAIAttributes.EVENT_NAME] == GenAIAttributes.OUTCOME_EVENT_NAME
+    assert attrs[GenAIAttributes.OUTCOME_TYPE] == "ticket_resolved"
+    # success defaults to True
+    assert attrs[GenAIAttributes.OUTCOME_SUCCESS] is True
+    # explicit workflow key rides tokenjam.workflow_id
+    assert attrs[TjAttributes.WORKFLOW_ID] == "wf-123"
+    # no value declared -> value_usd attribute absent (never fabricated)
+    assert GenAIAttributes.OUTCOME_VALUE_USD not in attrs
+
+
+def test_record_outcome_uses_canonical_attribute_names():
+    """The attribute STRINGS must match what the Cloud roi.py constants expect."""
+    assert GenAIAttributes.OUTCOME_EVENT_NAME == "gen_ai.outcome"
+    assert GenAIAttributes.EVENT_NAME == "event.name"
+    assert GenAIAttributes.OUTCOME_TYPE == "gen_ai.outcome.type"
+    assert GenAIAttributes.OUTCOME_SUCCESS == "gen_ai.outcome.success"
+    assert GenAIAttributes.OUTCOME_VALUE_USD == "gen_ai.outcome.value_usd"
+    assert TjAttributes.WORKFLOW_ID == "tokenjam.workflow_id"
+    # session_id rides "session.id" — the key the canonical OTLP parser reads.
+    assert TjAttributes.SESSION_ID == "session.id"
+
+
+# ── value_usd (self-reported) ───────────────────────────────────────────────
+
+def test_record_outcome_declared_value(otel_exporter):
+    record_outcome(
+        "lead_qualified", session_id="sess-9", value_usd=42.5, success=True
+    )
+    attrs = _outcome_spans(otel_exporter)[0].attributes
+    assert attrs[GenAIAttributes.OUTCOME_VALUE_USD] == 42.5
+    assert attrs[TjAttributes.SESSION_ID] == "sess-9"
+
+
+def test_record_outcome_failure_success_false(otel_exporter):
+    record_outcome("checkout", workflow_id="wf-1", success=False)
+    attrs = _outcome_spans(otel_exporter)[0].attributes
+    assert attrs[GenAIAttributes.OUTCOME_SUCCESS] is False
+
+
+def test_record_outcome_extra_attributes(otel_exporter):
+    record_outcome(
+        "ticket_resolved",
+        workflow_id="wf-1",
+        attributes={"customer_tier": "enterprise"},
+    )
+    attrs = _outcome_spans(otel_exporter)[0].attributes
+    assert attrs["customer_tier"] == "enterprise"
+
+
+# ── Session inheritance from the active @watch()/AgentSession span ──────────
+
+def test_record_outcome_inherits_active_session(otel_exporter):
+    with AgentSession(agent_id="support-bot") as session:
+        # No explicit session_id/workflow_id — inherited from the active span.
+        record_outcome("ticket_resolved")
+
+    attrs = _outcome_spans(otel_exporter)[0].attributes
+    # The active session's conversation_id is stamped as session.id.
+    assert attrs[TjAttributes.SESSION_ID] == session.conversation_id
+    assert attrs[GenAIAttributes.AGENT_ID] == "support-bot"
+
+
+# ── Argument validation (mirrors the Cloud OutcomeIn validator) ─────────────
+
+def test_record_outcome_requires_outcome_type():
+    with pytest.raises(ValueError, match="outcome_type"):
+        record_outcome("", workflow_id="wf-1")
+
+
+def test_record_outcome_requires_workflow_or_session():
+    # No active session, no workflow_id, no session_id -> reject.
+    with pytest.raises(ValueError, match="workflow_id or session_id"):
+        record_outcome("ticket_resolved")
+
+
+def test_record_outcome_rejected_emits_no_span(otel_exporter):
+    with pytest.raises(ValueError):
+        record_outcome("ticket_resolved")
+    # A rejected call must not leak a half-built outcome span.
+    assert _outcome_spans(otel_exporter) == []

--- a/tokenjam/otel/semconv.py
+++ b/tokenjam/otel/semconv.py
@@ -55,6 +55,20 @@ class GenAIAttributes:
     SPAN_TOOL_CALL    = "gen_ai.tool.call"
     SPAN_LLM_CALL     = "gen_ai.llm.call"
 
+    # Outcome / feedback event (emerging gen_ai outcome-event semconv, OTel
+    # semconv issue #2665). `record_outcome()` emits a span carrying these so a
+    # business outcome (+ an optional self-reported $ value) can be attached to a
+    # workflow. The standard event NAME is OUTCOME_EVENT_NAME; the outcome TYPE
+    # attribute is the marker TokenJam Cloud's ROI ingest keys off
+    # (roi.is_outcome_event). ROI compute is a Cloud feature — the OSS SDK only
+    # EMITS the event; the local stack ingests it as a normal span (no local ROI).
+    SPAN_OUTCOME       = "gen_ai.outcome"
+    OUTCOME_EVENT_NAME = "gen_ai.outcome"
+    EVENT_NAME         = "event.name"
+    OUTCOME_TYPE       = "gen_ai.outcome.type"
+    OUTCOME_SUCCESS    = "gen_ai.outcome.success"
+    OUTCOME_VALUE_USD  = "gen_ai.outcome.value_usd"
+
 
 class OpenInferenceAttributes:
     """OpenInference (Arize) span attribute names.
@@ -229,6 +243,11 @@ class TjAttributes:
     # the dashboard can group a run's member sessions and render a parent tree.
     RUN_ID            = "tokenjam.run_id"
     PARENT_SESSION_ID = "tokenjam.parent_session_id"
+    # Explicit workflow key for an outcome event (`record_outcome`). When set, it
+    # overrides the session-root walk on the Cloud ROI side (roi.write_outcome
+    # keys the outcome to this id when no session_id is given). Lets a caller
+    # attach an outcome to a workflow it names itself rather than by session.
+    WORKFLOW_ID       = "tokenjam.workflow_id"
     # Privacy-safe hash of a tool call's arguments, computed at ingest BEFORE the
     # raw `gen_ai.tool.input` is stripped per capture config. Lets retry-loop
     # detection tell an identical repeated call from normal repeated tool use

--- a/tokenjam/sdk/__init__.py
+++ b/tokenjam/sdk/__init__.py
@@ -1,4 +1,10 @@
-from tokenjam.sdk.agent import watch, AgentSession, record_llm_call, record_tool_call
+from tokenjam.sdk.agent import (
+    watch,
+    AgentSession,
+    record_llm_call,
+    record_tool_call,
+    record_outcome,
+)
 from tokenjam.sdk.client import TokenJamClient
 from tokenjam.sdk.integrations.anthropic import patch_anthropic
 from tokenjam.sdk.integrations.openai import patch_openai
@@ -15,6 +21,7 @@ from tokenjam.sdk.integrations.nemoclaw import watch_nemoclaw
 
 __all__ = [
     "watch", "AgentSession", "record_llm_call", "record_tool_call",
+    "record_outcome",
     "TokenJamClient",
     "patch_anthropic", "patch_openai", "patch_gemini", "patch_bedrock",
     "patch_langchain", "patch_langgraph", "patch_crewai", "patch_autogen",

--- a/tokenjam/sdk/agent.py
+++ b/tokenjam/sdk/agent.py
@@ -1,6 +1,7 @@
 """
 SDK entry points: @watch() decorator, AgentSession context manager,
-and manual span recording functions (record_llm_call, record_tool_call).
+and manual span recording functions (record_llm_call, record_tool_call,
+record_outcome).
 
 IMPORTANT: @watch() alone tracks session start/end only. Individual LLM call
 spans require patch_anthropic(), patch_openai(), or equivalent provider patches.
@@ -10,11 +11,11 @@ from __future__ import annotations
 import functools
 import logging
 from contextlib import AbstractContextManager
-from typing import Callable, TYPE_CHECKING
+from typing import Any, Callable, TYPE_CHECKING
 
 from opentelemetry import trace
 
-from tokenjam.otel.semconv import GenAIAttributes
+from tokenjam.otel.semconv import GenAIAttributes, TjAttributes
 from tokenjam.utils.ids import new_uuid
 
 if TYPE_CHECKING:
@@ -204,4 +205,96 @@ def record_tool_call(
             end_ns = start_ns + int(duration_ms * 1_000_000)
             span.end(end_time=end_ns)
             return
+    span.end()
+
+
+def record_outcome(
+    outcome_type: str,
+    *,
+    workflow_id: str | None = None,
+    session_id: str | None = None,
+    success: bool = True,
+    value_usd: float | None = None,
+    attributes: dict[str, Any] | None = None,
+) -> None:
+    """Emit a gen_ai outcome event attaching a business outcome to a workflow.
+
+    This is a thin wrapper that emits one OTel span carrying the emerging
+    gen_ai outcome-event attributes (OTel semconv issue #2665). It sits
+    alongside record_llm_call / record_tool_call as a manual-instrumentation
+    primitive — one line instead of hand-POSTing OTLP JSON.
+
+    Args:
+        outcome_type: the kind of outcome, a caller-defined label
+            (e.g. "ticket_resolved", "lead_qualified", "pr_merged"). This is the
+            marker attribute; without it the event is not recognised downstream.
+        workflow_id: an explicit workflow key to attach the outcome to. Optional
+            if session_id is given (the outcome is then keyed to the session's
+            workflow). At least one of workflow_id / session_id is required.
+        session_id: the session (or root session of a fan-out) the outcome
+            belongs to. If omitted, the active @watch()/AgentSession span's
+            session/conversation is inherited where available.
+        success: whether the outcome was achieved (execution succeeded). Defaults
+            to True.
+        value_usd: an OPTIONAL, SELF-REPORTED business value for the outcome in
+            USD. This is a value YOU declare — TokenJam does not measure or
+            verify it. Negative values are treated as undeclared. ROI compute
+            (declared value ÷ measured cost) is a TokenJam Cloud feature; the OSS
+            SDK only emits the event.
+        attributes: extra attributes to attach verbatim to the event.
+
+    Raises:
+        ValueError: if outcome_type is empty, or neither workflow_id nor
+            session_id is provided (mirrors the Cloud OutcomeIn validator).
+    """
+    if not outcome_type:
+        raise ValueError("record_outcome requires a non-empty outcome_type")
+
+    from tokenjam.sdk.bootstrap import ensure_initialised
+    ensure_initialised()
+
+    # Resolve session/agent inheritance from the active span BEFORE starting our
+    # own span, so a validation failure emits no half-built outcome span.
+    parent_span = trace.get_current_span()
+    inherited_agent = None
+    inherited_conv = None
+    inherited_session: str | None = None
+    if parent_span and parent_span.is_recording():
+        inherited_agent = parent_span.attributes.get(GenAIAttributes.AGENT_ID)
+        inherited_conv = parent_span.attributes.get(GenAIAttributes.CONVERSATION_ID)
+        # Inherit the active session key. @watch()/AgentSession stamps its stable
+        # id as the conversation id (session continuity keys off it); a raw span
+        # may instead carry an explicit session.id. Prefer the explicit one.
+        explicit = parent_span.attributes.get(TjAttributes.SESSION_ID)
+        inherited_session = explicit if explicit is not None else inherited_conv
+
+    resolved_session = session_id or inherited_session
+    if not workflow_id and not resolved_session:
+        raise ValueError(
+            "record_outcome requires at least one of workflow_id or session_id "
+            "(an active @watch()/AgentSession session also satisfies this)"
+        )
+
+    span = _tracer.start_span(GenAIAttributes.SPAN_OUTCOME)
+    if inherited_agent:
+        span.set_attribute(GenAIAttributes.AGENT_ID, inherited_agent)
+    if inherited_conv:
+        span.set_attribute(GenAIAttributes.CONVERSATION_ID, inherited_conv)
+
+    # The marker attribute the Cloud ROI ingest keys off (roi.is_outcome_event),
+    # plus the stock OTel event.name so it can also ride the event path.
+    span.set_attribute(GenAIAttributes.EVENT_NAME, GenAIAttributes.OUTCOME_EVENT_NAME)
+    span.set_attribute(GenAIAttributes.OUTCOME_TYPE, outcome_type)
+    span.set_attribute(GenAIAttributes.OUTCOME_SUCCESS, bool(success))
+    if workflow_id:
+        span.set_attribute(TjAttributes.WORKFLOW_ID, workflow_id)
+    if resolved_session:
+        span.set_attribute(TjAttributes.SESSION_ID, resolved_session)
+    if value_usd is not None:
+        span.set_attribute(GenAIAttributes.OUTCOME_VALUE_USD, float(value_usd))
+    if attributes:
+        for key, value in attributes.items():
+            span.set_attribute(key, value)
+
+    span.set_status(trace.Status(trace.StatusCode.OK))
     span.end()


### PR DESCRIPTION
Adds a thin SDK primitive — `record_outcome` (Python) / `TjClient.recordOutcome` (TypeScript) — that emits the emerging gen_ai outcome/feedback event so a user can attach a business outcome (+ an optional self-reported $ value) to a workflow in one line instead of hand-POSTing OTLP JSON. This is the adoption unlock for TokenJam Cloud's ROI backend (Phase B): the OSS SDK emits the event; Cloud turns it into ROI.

## Summary
- **Python:** `tokenjam.sdk.record_outcome(outcome_type, *, workflow_id=None, session_id=None, success=True, value_usd=None, attributes=None)` in `tokenjam/sdk/agent.py`, exported from `tokenjam.sdk`. Sits alongside `record_llm_call` / `record_tool_call`; bootstraps via `ensure_initialised()` (Critical Rule 12) and emits one OTel span.
- **TypeScript:** `TjClient.recordOutcome({ outcomeType, workflowId?, sessionId?, success?, valueUsd?, agentId?, attributes? })` in `sdk-ts/src/client.ts` — mirrors the API, emits the same OTLP event over HTTP.
- Outcome-event semconv constants added to `tokenjam/otel/semconv.py` and mirrored in `sdk-ts/src/semconv.ts` (Critical Rule 10).
- Docs (`docs/python-sdk.md`, `docs/typescript-sdk.md`, `sdk-ts/README.md`) + one runnable example per language.

## Cloud schema it targets (cross-repo)
TokenJam Cloud recognises an outcome event via `is_outcome_event(attrs)` and writes it through `write_outcome_from_span` (`api/app/roi.py`, PR #109). Both repos share the OSS `tokenjam.otel.otlp_parsing.parse_otlp_span` for attribute extraction, so the emitted event carries exactly what Cloud parses:

| Attribute | Value |
|---|---|
| `event.name` | `gen_ai.outcome` (stock OTel event-path marker) |
| `gen_ai.outcome.type` | the required marker `is_outcome_event` keys off |
| `gen_ai.outcome.success` | bool |
| `gen_ai.outcome.value_usd` | float (omitted when undeclared) |
| `tokenjam.workflow_id` | explicit workflow key |
| `session.id` | the session key the shared OTLP parser reads (`TjAttributes.SESSION_ID`) |

Argument validation mirrors Cloud's `OutcomeIn`: `outcome_type` required, and at least one of `workflow_id` / `session_id` (an active `@watch()`/`AgentSession` session satisfies it via inheritance).

## Honesty (Rule 14)
`value_usd` is **customer-declared / self-reported** — documented as such in every surface (docstrings, both example files, both docs pages, README). Nothing fabricates a value; a negative value is treated as undeclared (matching Cloud's `_coerce_value_usd`). Docs state plainly that ROI compute is a Cloud feature and there is no local OSS ROI compute.

## Tests / Verification
- **Python:** `tests/agents/test_record_outcome.py` (9 tests) — asserts the exact marker attributes/strings, `session.id` + self-reported `value_usd`, `success=false`, extra attributes, active-session inheritance, and both validation rejections (empty type; neither workflow nor session). Uses the module-level collecting-exporter pattern (Critical Rule 11) with the SDK tracer bound to the test's own provider and restored on teardown so it can't leak into sibling modules.
- **TypeScript:** `sdk-ts/src/record-outcome.test.ts` (6 tests, wired into the `test` script) — asserts the emitted OTLP body's attribute shape, canonical name strings, and both rejections.
- Full local runs green: `pytest tests/unit/ tests/synthetic/ tests/agents/` (2143 passed), `pytest tests/integration/` (429 passed), `cd sdk-ts && npm test` (27 passed). `ruff check tokenjam/` and `mypy` clean for touched files.

## What's NOT in this PR (deliberately out of scope)
- **No local OSS outcome ingest / local ROI compute.** Emit-only is the core job; local ROI is deliberately Cloud-only (roi-feature-spec decision #4). The local stack ingests the outcome as an ordinary span.
- **No `loop.py` integration.** The brief allowed a tiny tie-in to the annotation primitive if natural, but `loop.py` is a DB-backed, human-verdict, local-first surface with a different shape; wiring the emit path into it would be over-building for no adoption benefit. Left as a clean, standalone emit primitive.
- **No version bump** (worker convention).

🤖 Generated with [Claude Code](https://claude.com/claude-code)