### PR TITLE
fix: scope tj stop/reset to the invoking install's daemon

### DIFF
--- a/tests/unit/test_cmd_stop.py
+++ b/tests/unit/test_cmd_stop.py
@@ -21,8 +21,7 @@ class TestStopSweepsForegroundProcesses:
         monkeypatch.setattr("tokenjam.cli.cmd_stop.Path.home", lambda: tmp_path)
 
         # First call: launchctl unload (returncode=0). Subsequent calls:
-        # _find_serve_pid uses subprocess too — but it's gated behind
-        # _find_serve_pid which we'll patch separately.
+        # _find_serve_pid is patched separately below (PID-file lookup).
         run_mock = MagicMock(return_value=MagicMock(returncode=0))
         kill_mock = MagicMock()
         # _find_serve_pid returns a PID once, then None to break the loop.
@@ -30,7 +29,8 @@ class TestStopSweepsForegroundProcesses:
 
         with patch("tokenjam.cli.cmd_stop.subprocess.run", run_mock), \
              patch("tokenjam.cli.cmd_stop.os.kill", kill_mock), \
-             patch("tokenjam.cli.cmd_stop._find_serve_pid", find_pid_mock):
+             patch("tokenjam.cli.cmd_stop._find_serve_pid", find_pid_mock), \
+             patch("tokenjam.cli.cmd_stop._wait_for_exit", return_value=True):
             result = CliRunner().invoke(cmd_stop, [], obj={})
 
         assert result.exit_code == 0, result.output
@@ -42,20 +42,21 @@ class TestStopSweepsForegroundProcesses:
 
     def test_does_not_loop_on_slow_shutdown(self, tmp_path, monkeypatch):
         """SIGTERM is async — if the target process hasn't exited before the
-        next pgrep, the sweep must NOT re-signal the same PID. Otherwise a
+        next lookup, the sweep must NOT re-signal the same PID. Otherwise a
         slow shutdown handler can make `tj stop` hang forever."""
         monkeypatch.setattr("tokenjam.cli.cmd_stop.Path.home", lambda: tmp_path)
         kill_mock = MagicMock()
-        # pgrep keeps returning the same PID — simulates a process whose
-        # SIGTERM handler hasn't completed yet.
+        # The PID-file lookup keeps finding the same PID — simulates a
+        # process whose SIGTERM handler hasn't completed yet.
         find_pid_mock = MagicMock(side_effect=[12345] * 50)
 
         with patch("tokenjam.cli.cmd_stop.os.kill", kill_mock), \
-             patch("tokenjam.cli.cmd_stop._find_serve_pid", find_pid_mock):
+             patch("tokenjam.cli.cmd_stop._find_serve_pid", find_pid_mock), \
+             patch("tokenjam.cli.cmd_stop._wait_for_exit", return_value=True):
             result = CliRunner().invoke(cmd_stop, [], obj={})
 
         assert result.exit_code == 0
-        # SIGTERM sent exactly once even though pgrep saw the PID 50 times.
+        # SIGTERM sent exactly once even though the lookup saw the PID 50 times.
         assert kill_mock.call_count == 1
         kill_mock.assert_called_once_with(12345, 15)
 
@@ -66,3 +67,94 @@ class TestStopSweepsForegroundProcesses:
             result = CliRunner().invoke(cmd_stop, [], obj={})
         assert result.exit_code == 0
         assert "not running" in result.output
+
+
+class TestStopVerifiesTermination:
+    """`tj stop` must not claim success for a process that's still alive.
+    It has to observe the exit (escalating to SIGKILL once) before it does."""
+
+    def test_escalates_to_sigkill_when_sigterm_does_not_land(self, tmp_path, monkeypatch):
+        monkeypatch.setattr("tokenjam.cli.cmd_stop.Path.home", lambda: tmp_path)
+        kill_mock = MagicMock()
+        find_pid_mock = MagicMock(side_effect=[12345, None])
+        # SIGTERM's wait fails (still alive); SIGKILL's wait succeeds.
+        wait_mock = MagicMock(side_effect=[False, True])
+
+        with patch("tokenjam.cli.cmd_stop.os.kill", kill_mock), \
+             patch("tokenjam.cli.cmd_stop._find_serve_pid", find_pid_mock), \
+             patch("tokenjam.cli.cmd_stop._wait_for_exit", wait_mock):
+            result = CliRunner().invoke(cmd_stop, [], obj={})
+
+        assert result.exit_code == 0, result.output
+        assert kill_mock.call_count == 2
+        kill_mock.assert_any_call(12345, 15)  # SIGTERM
+        kill_mock.assert_any_call(12345, 9)   # SIGKILL
+        assert "PID 12345 (SIGKILL)" in result.output
+        assert "tj serve stopped" in result.output
+
+    def test_reports_failure_honestly_when_process_survives_sigkill(
+        self, tmp_path, monkeypatch,
+    ):
+        """A process that resists even SIGKILL (e.g. stuck in uninterruptible
+        I/O) must never be reported as stopped."""
+        monkeypatch.setattr("tokenjam.cli.cmd_stop.Path.home", lambda: tmp_path)
+        kill_mock = MagicMock()
+        find_pid_mock = MagicMock(side_effect=[12345, None])
+        wait_mock = MagicMock(return_value=False)  # never confirmed dead
+
+        with patch("tokenjam.cli.cmd_stop.os.kill", kill_mock), \
+             patch("tokenjam.cli.cmd_stop._find_serve_pid", find_pid_mock), \
+             patch("tokenjam.cli.cmd_stop._wait_for_exit", wait_mock):
+            result = CliRunner().invoke(cmd_stop, [], obj={})
+
+        assert result.exit_code == 0
+        assert "tj serve did not stop" in result.output
+        assert "PID 12345" in result.output
+        assert "tj serve stopped" not in result.output
+
+    def test_stop_tj_serve_returns_false_when_termination_unconfirmed(
+        self, tmp_path, monkeypatch,
+    ):
+        from tokenjam.cli.cmd_stop import stop_tj_serve
+
+        monkeypatch.setattr("tokenjam.cli.cmd_stop.Path.home", lambda: tmp_path)
+        find_pid_mock = MagicMock(side_effect=[12345, None])
+
+        with patch("tokenjam.cli.cmd_stop.os.kill", MagicMock()), \
+             patch("tokenjam.cli.cmd_stop._find_serve_pid", find_pid_mock), \
+             patch("tokenjam.cli.cmd_stop._wait_for_exit", return_value=False):
+            stopped, stopped_via = stop_tj_serve(quiet=True)
+
+        assert stopped is False
+        assert stopped_via == []
+
+
+class TestWaitForExit:
+    """Direct tests of the polling primitive, with fake sleep/monotonic so
+    nothing here waits real time."""
+
+    def test_returns_true_as_soon_as_pid_is_gone(self):
+        from tokenjam.cli.cmd_stop import _wait_for_exit
+
+        alive_calls = MagicMock(side_effect=[True, True, False])
+        sleep_mock = MagicMock()
+        with patch("tokenjam.cli.cmd_stop._pid_alive", alive_calls):
+            result = _wait_for_exit(
+                12345, timeout_s=5.0, sleep=sleep_mock, monotonic=MagicMock(return_value=0.0),
+            )
+
+        assert result is True
+        assert sleep_mock.call_count == 2
+
+    def test_returns_false_once_timeout_elapses(self):
+        from tokenjam.cli.cmd_stop import _wait_for_exit
+
+        # Always alive; monotonic jumps straight past the timeout on the
+        # second read, so this returns immediately without a real loop.
+        monotonic_mock = MagicMock(side_effect=[0.0, 10.0])
+        with patch("tokenjam.cli.cmd_stop._pid_alive", return_value=True):
+            result = _wait_for_exit(
+                12345, timeout_s=1.0, sleep=MagicMock(), monotonic=monotonic_mock,
+            )
+
+        assert result is False

--- a/tests/unit/test_cmd_stop_scoping.py
+++ b/tests/unit/test_cmd_stop_scoping.py
@@ -1,0 +1,150 @@
+"""`tj stop` must only ever touch the `tj serve` daemon started under THIS
+install's $HOME -- never another install/worktree's daemon that happens to
+be running on the same machine.
+
+The old `_find_serve_pid()` was a bare `pgrep -f "tokenjam\\.serve|tj
+serve|uv run tj serve"` with no scoping at all: any process on the machine
+whose command line matched that pattern got SIGTERM'd, regardless of which
+install started it. `TestCrossInstallIsolation` below spawns a REAL,
+detached child process (not a mock) with a command line that matches the
+old pattern, so a regression back to machine-wide pgrep gets caught for
+real, not just in a mock's argument list.
+"""
+from __future__ import annotations
+
+import json
+import os
+import signal
+import subprocess
+import sys
+from pathlib import Path
+
+from tokenjam.cli.cmd_stop import stop_tj_serve
+from tokenjam.core.server_state import find_own_serve_pid
+
+
+def _spawn_orphan_serve() -> int:
+    """Spawn a real, detached process -- reparented off of the test process
+    the moment the wrapping shell exits, exactly like a real orphaned `tj
+    serve` foreground process, so nothing here is responsible for reaping
+    it (avoids the zombie-stays-"alive"-to-os.kill artifact of a direct
+    subprocess.Popen child).
+
+    Its command line contains the literal tokens "tj" "serve", so a bare
+    `pgrep -f "tj serve"` still matches it the same way it would match a
+    real `tj serve` invocation.
+    """
+    result = subprocess.run(
+        [
+            "/bin/sh", "-c",
+            f"{sys.executable} -c 'import time; time.sleep(30)' tj serve "
+            "</dev/null >/dev/null 2>&1 & echo $!",
+        ],
+        capture_output=True, text=True, check=True,
+    )
+    return int(result.stdout.strip())
+
+
+def _is_alive(pid: int) -> bool:
+    try:
+        os.kill(pid, 0)
+    except ProcessLookupError:
+        return False
+    return True
+
+
+def _cleanup(pid: int) -> None:
+    try:
+        os.kill(pid, signal.SIGKILL)
+    except ProcessLookupError:
+        pass
+
+
+def _write_state(home: Path, pid: int, port: int = 7391) -> None:
+    state_path = home / ".local" / "share" / "tj" / "server.state"
+    state_path.parent.mkdir(parents=True, exist_ok=True)
+    state_path.write_text(json.dumps({
+        "config_path": str(home / ".config" / "tj" / "config.toml"),
+        "port": port,
+        "pid": pid,
+    }))
+
+
+class TestCrossInstallIsolation:
+    def test_stop_from_other_install_does_not_kill_this_install_daemon(
+        self, tmp_path, monkeypatch,
+    ):
+        home_a = tmp_path / "home-a"
+        home_b = tmp_path / "home-b"
+        home_a.mkdir()
+        home_b.mkdir()
+
+        pid_a = _spawn_orphan_serve()
+        try:
+            _write_state(home_a, pid_a)
+            # Install B has no server.state -- nothing running there.
+
+            monkeypatch.setattr("tokenjam.cli.cmd_stop.Path.home", lambda: home_b)
+            stopped, stopped_via = stop_tj_serve(quiet=True)
+
+            assert stopped is False
+            assert stopped_via == []
+            assert _is_alive(pid_a), (
+                "tj stop from install B signaled install A's daemon -- "
+                "this is the cross-install kill bug."
+            )
+        finally:
+            _cleanup(pid_a)
+
+    def test_stop_from_same_install_stops_its_own_daemon(self, tmp_path, monkeypatch):
+        home_a = tmp_path / "home-a"
+        home_a.mkdir()
+
+        pid_a = _spawn_orphan_serve()
+        try:
+            _write_state(home_a, pid_a)
+            monkeypatch.setattr("tokenjam.cli.cmd_stop.Path.home", lambda: home_a)
+
+            stopped, stopped_via = stop_tj_serve(quiet=True)
+
+            assert stopped is True
+            assert any(str(pid_a) in entry for entry in stopped_via)
+            assert not _is_alive(pid_a)
+        finally:
+            _cleanup(pid_a)
+
+
+class TestStaleStateFile:
+    def test_dead_pid_in_state_file_is_treated_as_not_running(self, tmp_path, monkeypatch):
+        home = tmp_path / "home"
+        home.mkdir()
+        # A PID that (almost certainly) doesn't exist: spawn+wait, then reuse
+        # its now-dead PID.
+        dead = subprocess.Popen([sys.executable, "-c", "pass"])
+        dead.wait(timeout=5)
+
+        _write_state(home, dead.pid)
+        monkeypatch.setattr("tokenjam.cli.cmd_stop.Path.home", lambda: home)
+
+        stopped, stopped_via = stop_tj_serve(quiet=True)
+
+        assert stopped is False
+        assert stopped_via == []
+
+    def test_find_own_serve_pid_none_when_state_file_missing(self, tmp_path, monkeypatch):
+        monkeypatch.setattr(
+            "tokenjam.core.server_state.Path.home", lambda: tmp_path / "no-state-here",
+        )
+        assert find_own_serve_pid() is None
+
+
+class TestNoDaemonRunning:
+    def test_reports_not_running_with_no_state_file_and_no_plist(self, tmp_path, monkeypatch):
+        home = tmp_path / "home"
+        home.mkdir()
+        monkeypatch.setattr("tokenjam.cli.cmd_stop.Path.home", lambda: home)
+
+        stopped, stopped_via = stop_tj_serve(quiet=True)
+
+        assert stopped is False
+        assert stopped_via == []

--- a/tokenjam/cli/cmd_serve.py
+++ b/tokenjam/cli/cmd_serve.py
@@ -2,9 +2,9 @@ from __future__ import annotations
 
 import click
 from contextlib import asynccontextmanager
-from pathlib import Path
 from typing import AsyncIterator
 
+from tokenjam.core.server_state import server_state_path
 from tokenjam.utils.formatting import console
 
 
@@ -56,7 +56,7 @@ def cmd_serve(ctx: click.Context, host: str | None, port: int | None,
     # Same reasoning for `scheduler.start()`: don't fire off a background
     # thread for a server that's about to exit with EADDRINUSE.
     import json as _json
-    _state_path = Path.home() / ".local" / "share" / "tj" / "server.state"
+    _state_path = server_state_path()
 
     # Optional enforcement-plane proxy (#219) — a second in-process listener on
     # config.proxy.port, started/stopped with the server's lifespan. Suggest

--- a/tokenjam/cli/cmd_stop.py
+++ b/tokenjam/cli/cmd_stop.py
@@ -21,6 +21,14 @@ _TERM_WAIT_S = 2.0
 _KILL_WAIT_S = 1.0
 _POLL_INTERVAL_S = 0.05
 
+# Before anything's been found+signaled, a single miss from `_find_serve_pid`
+# can just be racing a just-spawned child's execve (it hasn't written its
+# state file / become visible yet) rather than "nothing running". Retry a
+# bounded few times before concluding that. Once something HAS been found,
+# a miss means discovery is genuinely done -- see the loop below.
+_DISCOVERY_MAX_MISSES = 5
+_DISCOVERY_RETRY_S = 0.1
+
 
 def stop_tj_serve(*, quiet: bool = False) -> tuple[bool, list[str]]:
     """Stop tj serve (launchd/systemd + orphan foreground processes).
@@ -59,9 +67,18 @@ def stop_tj_serve(*, quiet: bool = False) -> tuple[bool, list[str]]:
     # This also catches a launchd/systemd-managed daemon that's slow to exit,
     # since it writes the same state file regardless of how it was launched.
     signaled: set[int] = set()
+    misses = 0
     for _ in range(20):
         pid = _find_serve_pid()
-        if not pid or pid in signaled:
+        if not pid:
+            if signaled:
+                break
+            misses += 1
+            if misses >= _DISCOVERY_MAX_MISSES:
+                break
+            time.sleep(_DISCOVERY_RETRY_S)
+            continue
+        if pid in signaled:
             break
         try:
             os.kill(pid, signal.SIGTERM)

--- a/tokenjam/cli/cmd_stop.py
+++ b/tokenjam/cli/cmd_stop.py
@@ -3,24 +3,38 @@ from __future__ import annotations
 import os
 import signal
 import subprocess
+import time
 from pathlib import Path
+from typing import Callable
 
 import click
 
+from tokenjam.core.server_state import find_own_serve_pid
 from tokenjam.utils.formatting import console
+
+# How long to wait for a signaled PID to actually exit before concluding the
+# signal didn't land. SIGTERM gets the longer window (graceful shutdown --
+# flushing the pipeline, closing DuckDB); SIGKILL is immediate at the kernel
+# level, so a short window is just there to observe the exit, not to wait on
+# any handler.
+_TERM_WAIT_S = 2.0
+_KILL_WAIT_S = 1.0
+_POLL_INTERVAL_S = 0.05
 
 
 def stop_tj_serve(*, quiet: bool = False) -> tuple[bool, list[str]]:
     """Stop tj serve (launchd/systemd + orphan foreground processes).
 
     Callable from onboard/backfill without requiring ``tj`` on PATH.
-    Returns ``(stopped, stopped_via)`` where *stopped* is True when anything
-    was stopped.
+    Returns ``(stopped, stopped_via)`` where *stopped* is True only once
+    every process this call signaled has been confirmed to have exited --
+    never on a signal simply having been sent.
     """
     plist_path = Path.home() / "Library/LaunchAgents/com.tokenjam.serve.plist"
     systemd_path = Path.home() / ".config/systemd/user/tokenjam.service"
 
     stopped_via: list[str] = []
+    failed_via: list[str] = []
 
     # Try launchd first (macOS).
     if plist_path.exists():
@@ -40,7 +54,10 @@ def stop_tj_serve(*, quiet: bool = False) -> tuple[bool, list[str]]:
         if result.returncode == 0:
             stopped_via.append("systemd service stopped")
 
-    # Sweep orphan foreground `uv run tj serve` / `tj serve` processes.
+    # Sweep the `tj serve` daemon belonging to THIS install (see
+    # _find_serve_pid -- PID-file scoped to $HOME, not a machine-wide pgrep).
+    # This also catches a launchd/systemd-managed daemon that's slow to exit,
+    # since it writes the same state file regardless of how it was launched.
     signaled: set[int] = set()
     for _ in range(20):
         pid = _find_serve_pid()
@@ -51,16 +68,38 @@ def stop_tj_serve(*, quiet: bool = False) -> tuple[bool, list[str]]:
         except ProcessLookupError:
             break
         signaled.add(pid)
-        stopped_via.append(f"PID {pid}")
+
+        if _wait_for_exit(pid, timeout_s=_TERM_WAIT_S):
+            stopped_via.append(f"PID {pid}")
+            continue
+
+        # SIGTERM didn't land in time -- escalate rather than silently
+        # reporting success for a process that's still alive.
+        try:
+            os.kill(pid, signal.SIGKILL)
+        except ProcessLookupError:
+            stopped_via.append(f"PID {pid}")
+            continue
+
+        if _wait_for_exit(pid, timeout_s=_KILL_WAIT_S):
+            stopped_via.append(f"PID {pid} (SIGKILL)")
+        else:
+            failed_via.append(f"PID {pid}")
 
     if not quiet:
+        if failed_via:
+            console.print(
+                f"[red]tj serve did not stop.[/red] Still running: "
+                f"{', '.join(failed_via)}"
+            )
         if stopped_via:
             console.print(
                 f"[green]tj serve stopped.[/green] ({', '.join(stopped_via)})"
             )
-        else:
+        elif not failed_via:
             console.print("[dim]tj serve is not running.[/dim]")
-    return bool(stopped_via), stopped_via
+
+    return (bool(stopped_via) and not failed_via), stopped_via
 
 
 @click.command("stop")
@@ -71,18 +110,46 @@ def cmd_stop(ctx: click.Context) -> None:
 
 
 def _find_serve_pid() -> int | None:
-    """Find the PID of a running `tj serve`. process."""
+    """Find the PID of the `tj serve` daemon started under THIS install
+    (i.e. this invocation's $HOME) -- see `tokenjam.core.server_state`.
+
+    A thin wrapper (rather than calling `find_own_serve_pid()` directly from
+    `stop_tj_serve`) so tests can patch discovery independently of the
+    signal-and-verify logic above.
+    """
+    return find_own_serve_pid()
+
+
+def _pid_alive(pid: int) -> bool:
+    """`os.kill(pid, 0)` sends no signal -- it only checks the PID exists.
+    A thin, separately-patchable wrapper so tests can simulate exit timing
+    without mocking every `os.kill` call (including the SIGTERM/SIGKILL
+    sends above) into a no-op."""
     try:
-        result = subprocess.run(
-            ["pgrep", "-f", "tokenjam\\.serve|tj serve|uv run tj serve"],
-            capture_output=True, text=True,
-        )
-        if result.returncode == 0:
-            for line in result.stdout.strip().splitlines():
-                pid = int(line.strip())
-                # Don't return our own PID
-                if pid != os.getpid():
-                    return pid
-    except (FileNotFoundError, ValueError):
-        pass
-    return None
+        os.kill(pid, 0)
+    except ProcessLookupError:
+        return False
+    return True
+
+
+def _wait_for_exit(
+    pid: int,
+    *,
+    timeout_s: float,
+    interval_s: float = _POLL_INTERVAL_S,
+    sleep: Callable[[float], None] = time.sleep,
+    monotonic: Callable[[], float] = time.monotonic,
+) -> bool:
+    """Poll until `pid` exits or `timeout_s` elapses.
+
+    Returns True once the process is confirmed gone, False if it's still
+    alive when we give up. `sleep`/`monotonic` are injectable so tests never
+    wait real seconds.
+    """
+    start = monotonic()
+    while True:
+        if not _pid_alive(pid):
+            return True
+        if monotonic() - start >= timeout_s:
+            return False
+        sleep(interval_s)

--- a/tokenjam/core/server_state.py
+++ b/tokenjam/core/server_state.py
@@ -1,0 +1,101 @@
+"""The `tj serve` PID file: `~/.local/share/tj/server.state`.
+
+Written by `tj serve` (see `cmd_serve.py`) after uvicorn binds the port, so
+other subcommands can find the daemon's config regardless of CWD. `tj stop`
+(and, through it, `tj reset` / `tj uninstall`) reads it to locate the daemon
+belonging to THIS install -- instead of a bare `pgrep -f`, which matches
+every `tj serve` process on the machine, including ones started by a
+different install/worktree with a different $HOME.
+
+`Path.home()` is what actually scopes this: it resolves through the
+invoking process's $HOME, so two installs with different $HOME never see
+each other's state file, and never see each other's daemon.
+"""
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+from dataclasses import dataclass
+from pathlib import Path
+
+
+def server_state_path() -> Path:
+    return Path.home() / ".local" / "share" / "tj" / "server.state"
+
+
+@dataclass(frozen=True)
+class ServerState:
+    pid: int
+    port: int | None
+    config_path: str | None
+
+
+def read_server_state(path: Path | None = None) -> ServerState | None:
+    """Read + parse the state file. Returns None if it's missing or
+    malformed -- a corrupt/partial write (e.g. a crash mid-write) just means
+    "nothing found", never a crash here."""
+    state_path = path if path is not None else server_state_path()
+    try:
+        raw = state_path.read_text()
+    except OSError:
+        return None
+    try:
+        data = json.loads(raw)
+        pid = int(data["pid"])
+    except (json.JSONDecodeError, KeyError, TypeError, ValueError):
+        return None
+    return ServerState(pid=pid, port=data.get("port"), config_path=data.get("config_path"))
+
+
+def is_pid_alive(pid: int) -> bool:
+    """`os.kill(pid, 0)` sends no signal -- it only checks the PID exists."""
+    try:
+        os.kill(pid, 0)
+    except ProcessLookupError:
+        return False
+    except PermissionError:
+        # Owned by someone else, but it exists.
+        return True
+    return True
+
+
+def is_serve_process(pid: int) -> bool:
+    """`pid`'s command line still looks like a `tj serve` process.
+
+    Guards against PID reuse: a stale state file's PID may since have been
+    recycled by an unrelated process, and we must never signal that.
+    """
+    try:
+        result = subprocess.run(
+            ["ps", "-p", str(pid), "-o", "command="],
+            capture_output=True, text=True,
+        )
+    except FileNotFoundError:
+        # No `ps` on this platform -- fail open on identity (liveness above
+        # is still checked) rather than refuse to ever stop anything.
+        return True
+    if result.returncode != 0:
+        return False
+    cmdline = result.stdout.strip()
+    return any(marker in cmdline for marker in ("tokenjam.serve", "tj serve", "uv run tj serve"))
+
+
+def find_own_serve_pid() -> int | None:
+    """The PID of the `tj serve` daemon belonging to THIS install, or None.
+
+    Validates the PID is alive AND still looks like a `tj serve` process
+    before returning it -- so a stale state file (process already dead, or
+    its PID recycled by something else) is handled as "nothing running"
+    rather than a false positive.
+    """
+    state = read_server_state()
+    if state is None:
+        return None
+    if state.pid == os.getpid():
+        return None
+    if not is_pid_alive(state.pid):
+        return None
+    if not is_serve_process(state.pid):
+        return None
+    return state.pid

--- a/tokenjam/core/server_state.py
+++ b/tokenjam/core/server_state.py
@@ -66,9 +66,24 @@ def is_serve_process(pid: int) -> bool:
     Guards against PID reuse: a stale state file's PID may since have been
     recycled by an unrelated process, and we must never signal that.
     """
+    proc_cmdline = Path(f"/proc/{pid}/cmdline")
+    if proc_cmdline.exists():
+        # Prefer /proc on Linux: it's the exact, NUL-separated argv, never
+        # truncated by a display width. GNU `ps`'s COMMAND column truncates
+        # long lines -- a long interpreter path (e.g. a hostedtoolcache
+        # Python) can push "tj serve" past the cut, a real miss on Linux CI.
+        try:
+            raw = proc_cmdline.read_bytes()
+        except OSError:
+            return False
+        cmdline = " ".join(part for part in raw.decode(errors="replace").split("\0") if part)
+        return _looks_like_serve(cmdline)
+
     try:
+        # `-ww`: unlimited width, so this fallback (macOS/BSD, no /proc)
+        # can't be truncated the same way the bare form was.
         result = subprocess.run(
-            ["ps", "-p", str(pid), "-o", "command="],
+            ["ps", "-ww", "-p", str(pid), "-o", "command="],
             capture_output=True, text=True,
         )
     except FileNotFoundError:
@@ -77,7 +92,10 @@ def is_serve_process(pid: int) -> bool:
         return True
     if result.returncode != 0:
         return False
-    cmdline = result.stdout.strip()
+    return _looks_like_serve(result.stdout.strip())
+
+
+def _looks_like_serve(cmdline: str) -> bool:
     return any(marker in cmdline for marker in ("tokenjam.serve", "tj serve", "uv run tj serve"))
 
 


### PR DESCRIPTION
> **Stack slice of #482.** One of 12 concern-scoped PRs split out of #482. Its base is the previous slice, so the diff above shows only this slice's changes.
>
> **Do not merge this PR directly.** The complete change lands in one merge via the anchor PR #482, which contains every commit in this stack and is green. CI on a mid-stack slice may be red: slices are ordered by concern rather than by dependency, so a branch can reference code that lands in a later slice. That is an artifact of the ordering, not a defect in this diff.

Scopes `tj stop` (and `reset`/`uninstall` through it) to the daemon started by **this** install, via a PID/state file resolved from `Path.home()`, instead of a bare `pgrep -f` that would match every `tj serve` on the machine.

Also hardens process detection for Linux: reads `/proc/<pid>/cmdline` when available (never truncated) and falls back to `ps -ww` elsewhere, fixing a GNU `ps` COMMAND-column truncation miss, plus a bounded retry that tolerates the just-spawned child's `execve` race.
