### PR TITLE
refactor: extract shared token-accounting, clustering and transcript-cache helpers

### DIFF
--- a/tests/integration/test_cost_charts.py
+++ b/tests/integration/test_cost_charts.py
@@ -196,3 +196,38 @@ async def test_components_empty_window_is_safe():
     assert d["total_cost_usd"] == 0
     assert d["recoverable"] == []
     assert "framing" in d
+
+
+@pytest.mark.asyncio
+async def test_components_never_invokes_the_full_corpus_relearn_scan(monkeypatch):
+    """`/cost/components` must not run `relearn`: its own docstring says HTTP
+    callers MUST cache it, not compute it per-request (it's a full-corpus,
+    tens-of-seconds scan), and its `RelearnFinding` never carries
+    `estimated_recoverable_usd` — so it contributes nothing to this
+    endpoint's output either way. Tracks invocation via a flag rather than
+    raising, since the route wraps `build_report` in a broad
+    try/except and would otherwise silently swallow an assertion."""
+    from tokenjam.core.optimize.registry import ANALYZER_REGISTRY
+
+    called = {"relearn": False}
+    real_relearn = ANALYZER_REGISTRY["relearn"]
+
+    def _tracking_relearn(ctx):
+        called["relearn"] = True
+        return real_relearn(ctx)
+
+    monkeypatch.setitem(ANALYZER_REGISTRY, "relearn", _tracking_relearn)
+
+    db = InMemoryBackend()
+    cfg = TjConfig(version="1")
+    _seed_downsize_and_cache(db)
+    transport = httpx.ASGITransport(app=_app(db, cfg))
+    async with httpx.AsyncClient(transport=transport, base_url="http://t") as c:
+        resp = await c.get("/api/v1/cost/components?since=30d")
+
+    assert resp.status_code == 200
+    assert called["relearn"] is False
+    # The other analyzers (downsize, cache/reuse via _seed_downsize_and_cache)
+    # still ran and still surface — this isn't a blanket "findings broken".
+    d = resp.json()
+    assert d["recoverable"], "excluding relearn must not silence every other analyzer"

--- a/tests/token_aggregate_guard.py
+++ b/tests/token_aggregate_guard.py
@@ -1,0 +1,95 @@
+"""Reusable guard: a token aggregate must sum ALL FOUR token types.
+
+A span bills across four buckets: ``input_tokens``, ``output_tokens``,
+``cache_tokens`` (cache reads) and ``cache_write_tokens`` (cache creation).
+Writing an aggregate that adds up some of them and forgets ``cache_write_
+tokens`` under-reports the most expensive bucket, and that exact omission has
+shipped three separate times in this package. Reviews keep missing it because
+the broken form looks complete: ``SUM(input_tokens + output_tokens +
+cache_tokens)`` reads like it covers everything.
+
+Use this from any test that owns a new aggregate::
+
+    from tests.token_aggregate_guard import assert_module_token_sums_are_complete
+    from tokenjam.core.optimize.analyzers import my_new_analyzer
+
+    def test_my_analyzer_sums_all_four_token_types():
+        assert_module_token_sums_are_complete(my_new_analyzer)
+
+Rule enforced: any single ``SUM(...)`` expression that adds up TWO OR MORE
+token columns must contain all four. A deliberate single-bucket sum
+(``SUM(cache_tokens)`` for a cache-read ratio, say) is untouched, because it
+isn't summing token types together in the first place.
+"""
+from __future__ import annotations
+
+import inspect
+import re
+from types import ModuleType
+
+TOKEN_COLUMNS = frozenset(
+    {"input_tokens", "output_tokens", "cache_tokens", "cache_write_tokens"}
+)
+
+_SUM_START = re.compile(r"\bSUM\s*\(", re.IGNORECASE)
+
+
+def _sum_expressions(sql: str) -> list[str]:
+    """Every ``SUM(...)`` body in ``sql``, paren-balanced so a nested
+    ``COALESCE(...)`` inside the sum is captured whole."""
+    bodies: list[str] = []
+    for match in _SUM_START.finditer(sql):
+        depth = 1
+        start = match.end()
+        for i in range(start, len(sql)):
+            if sql[i] == "(":
+                depth += 1
+            elif sql[i] == ")":
+                depth -= 1
+                if depth == 0:
+                    bodies.append(sql[start:i])
+                    break
+    return bodies
+
+
+def _columns_in(expression: str) -> set[str]:
+    """The token columns named in one SUM body. ``cache_tokens`` is matched on
+    a word boundary so it never swallows ``cache_write_tokens``."""
+    found = set()
+    for column in TOKEN_COLUMNS:
+        if re.search(rf"\b{column}\b", expression):
+            found.add(column)
+    return found
+
+
+def find_incomplete_token_sums(sql: str) -> list[tuple[str, set[str]]]:
+    """Every mixed token sum in ``sql`` that is missing a bucket, as
+    ``(expression, missing columns)``. Empty list means the text is clean."""
+    offenders = []
+    for body in _sum_expressions(sql):
+        columns = _columns_in(body)
+        if len(columns) >= 2 and columns != TOKEN_COLUMNS:
+            offenders.append((body.strip(), TOKEN_COLUMNS - columns))
+    return offenders
+
+
+def assert_sql_token_sums_are_complete(sql: str, *, context: str = "sql") -> None:
+    """Fail when ``sql`` contains a mixed token sum missing a bucket."""
+    offenders = find_incomplete_token_sums(sql)
+    assert not offenders, (
+        f"{context}: token aggregate is missing a token type. "
+        + "; ".join(
+            f"SUM({expr}) omits {', '.join(sorted(missing))}" for expr, missing in offenders
+        )
+    )
+
+
+def assert_module_token_sums_are_complete(module: ModuleType) -> None:
+    """Fail when any mixed token sum in ``module``'s source misses a bucket.
+
+    Reads the module's own source, so it covers every query the module builds,
+    including ones assembled at runtime from f-strings.
+    """
+    assert_sql_token_sums_are_complete(
+        inspect.getsource(module), context=module.__name__,
+    )

--- a/tests/unit/test_cost_accounting_guards.py
+++ b/tests/unit/test_cost_accounting_guards.py
@@ -1,0 +1,249 @@
+"""Accounting guards for the cost surfaces.
+
+Two failure modes that both quietly corrupt a dollar figure:
+
+  1. The same LLM call reaching the store twice (one ingest path observes it
+     live, another backfills it from the transcript), so a row-level sum prices
+     it twice. Every figure a cost card prints has to be summed over CALLS.
+  2. An aggregate that adds up token types and forgets ``cache_write_tokens``,
+     which under-reports the most expensive bucket.
+
+Scope note, so these tests are read for what they prove: the fixture spans
+below stamp each observation with the identity of the call it describes. That
+is what the accounting layer keys on, and it is the contract the ingest paths
+have to meet; making them agree on that stamp is separate work on its own
+track. These tests pin the CONSUMING side: given identically-identified
+observations, a cost figure is summed per call, in either arrival order, and a
+span carrying no identity still counts as its own call.
+
+Fully isolated: an ``InMemoryBackend`` DB, no config or transcript reads.
+"""
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+
+import pytest
+
+from tokenjam.core.db import InMemoryBackend
+from tokenjam.core.optimize import accounting, cost_verify
+from tokenjam.core.optimize import runner as runner_mod
+from tokenjam.core.optimize.analyzers import (
+    budget_projection,
+    cache_efficacy,
+    model_downgrade,
+    output_verbosity,
+    prompt_bloat,
+    subagent_rightsizing,
+    workflow_restructure,
+)
+from tests.factories import make_llm_span
+from tests.token_aggregate_guard import (
+    TOKEN_COLUMNS,
+    assert_module_token_sums_are_complete,
+    assert_sql_token_sums_are_complete,
+    find_incomplete_token_sums,
+)
+
+NOW = datetime(2026, 7, 20, 12, 0, tzinfo=timezone.utc)
+WINDOW_START = NOW - timedelta(days=2)
+
+#: One fixture session: three assistant turns, each a distinct API call.
+_CALLS = (
+    ("msg_aaa", 12_000, 900, 4_000, 2_000),
+    ("msg_bbb", 9_000, 400, 6_500, 0),
+    ("msg_ccc", 15_000, 1_200, 1_000, 3_500),
+)
+
+
+@pytest.fixture
+def db():
+    backend = InMemoryBackend()
+    yield backend
+    backend.close()
+
+
+def _span(call, *, source: str, offset_ms: int):
+    """One observation of one call.
+
+    ``source`` distinguishes the two ingest paths: they mint different
+    ``span_id``s for the same call and land milliseconds apart, which is
+    exactly why span_id-keyed dedup does not catch the overlap. Both stamp the
+    call's identity, which is what the accounting layer keys on.
+    """
+    call_id, input_tokens, output_tokens, cache_read, cache_write = call
+    return make_llm_span(
+        agent_id="svc-a", session_id="sess-1", model="claude-sonnet-5",
+        provider="anthropic",
+        input_tokens=input_tokens, output_tokens=output_tokens,
+        cache_tokens=cache_read, cache_write_tokens=cache_write,
+        span_id=f"{source}-{call_id}",
+        start_time=WINDOW_START + timedelta(milliseconds=offset_ms),
+        extra_attributes={"tj.call_id": call_id, "source": source},
+    )
+
+
+def _live_hook_spans():
+    return [_span(c, source="live", offset_ms=i * 1000) for i, c in enumerate(_CALLS)]
+
+
+def _backfill_spans():
+    # ~17ms after the live observation of the same call, per the shape observed
+    # on real doubled sessions.
+    return [_span(c, source="backfill.claude_code", offset_ms=i * 1000 + 17)
+            for i, c in enumerate(_CALLS)]
+
+
+def _priced_window(conn) -> float:
+    """The dollars the cost surfaces would report for the fixture window."""
+    rows = cost_verify._rows_for(conn, WINDOW_START - timedelta(days=1), NOW, "svc-a")
+    return cost_verify._priced_usd(rows)
+
+
+def _load(db, spans):
+    for span in spans:
+        db.insert_span(span)
+
+
+# --- H1: call-identity-deduped accounting -------------------------------------
+
+def test_ingest_order_does_not_change_the_dollar_figure(db):
+    """Live hook first, then backfill."""
+    _load(db, _live_hook_spans())
+    live_then_backfill_before = _priced_window(db.conn)
+    _load(db, _backfill_spans())
+    live_then_backfill = _priced_window(db.conn)
+
+    other = InMemoryBackend()
+    try:
+        _load(other, _backfill_spans())
+        backfill_first = _priced_window(other.conn)
+        _load(other, _live_hook_spans())
+        backfill_then_live = _priced_window(other.conn)
+    finally:
+        other.close()
+
+    # Both orders agree, and neither order changed the figure by observing the
+    # same calls a second time.
+    assert live_then_backfill == pytest.approx(backfill_then_live)
+    assert live_then_backfill == pytest.approx(live_then_backfill_before)
+    assert backfill_first == pytest.approx(backfill_then_live)
+
+
+def test_a_double_ingested_session_is_priced_once(db):
+    """The single-count claim, stated directly: a session observed by both
+    ingest paths costs the same as the same session observed by one."""
+    single = InMemoryBackend()
+    try:
+        _load(single, _live_hook_spans())
+        expected = _priced_window(single.conn)
+    finally:
+        single.close()
+
+    _load(db, _live_hook_spans())
+    _load(db, _backfill_spans())
+
+    assert _priced_window(db.conn) == pytest.approx(expected)
+    assert expected > 0.0        # the fixture actually costs something
+
+
+def test_distinct_calls_are_never_collapsed(db):
+    """The dedup keys on call identity, not on the token counts: two real
+    calls that happen to bill identically must both be counted."""
+    twin = ("msg_ddd", 12_000, 900, 4_000, 2_000)   # same numbers as msg_aaa
+    _load(db, _live_hook_spans())
+    _load(db, [_span(twin, source="live", offset_ms=9_000)])
+
+    single_only = InMemoryBackend()
+    try:
+        _load(single_only, _live_hook_spans())
+        base = _priced_window(single_only.conn)
+    finally:
+        single_only.close()
+
+    assert _priced_window(db.conn) > base
+
+
+def test_spans_without_a_call_id_keep_their_row_identity(db):
+    """No call id stamped means today's behaviour, unchanged: each row is its
+    own call. The dedup must never silently merge them."""
+    for i, call in enumerate(_CALLS):
+        db.insert_span(make_llm_span(
+            agent_id="svc-a", session_id="sess-1", model="claude-sonnet-5",
+            input_tokens=call[1], output_tokens=call[2],
+            cache_tokens=call[3], cache_write_tokens=call[4],
+            start_time=WINDOW_START + timedelta(milliseconds=i * 1000),
+        ))
+    rows = cost_verify._rows_for(db.conn, WINDOW_START - timedelta(days=1), NOW, "svc-a")
+    assert len(rows) == len(_CALLS)
+
+
+def test_call_identity_prefers_the_stamped_id_over_the_span_id():
+    stamped = accounting.call_identity(
+        "span-1", "sess-1", {"tj.call_id": "msg_aaa"},
+    )
+    other_row_same_call = accounting.call_identity(
+        "span-2", "sess-1", '{"tj.call_id": "msg_aaa"}',   # attributes as JSON text
+    )
+    assert stamped == other_row_same_call
+
+
+def test_call_identity_falls_back_to_the_span_id():
+    assert accounting.call_identity("span-1", "sess-1", None) != \
+        accounting.call_identity("span-2", "sess-1", None)
+
+
+def test_call_identity_separates_sessions():
+    assert accounting.call_identity("span-1", "sess-1", {"tj.call_id": "m"}) != \
+        accounting.call_identity("span-1", "sess-2", {"tj.call_id": "m"})
+
+
+def test_dedupe_keeps_the_last_observation():
+    rows = [("k1", 1), ("k2", 2), ("k1", 99)]
+    assert accounting.dedupe_by_call_identity(rows) == [("k1", 99), ("k2", 2)]
+
+
+# --- H2: every token aggregate sums all four types ----------------------------
+
+#: Every module that builds a token aggregate. Add yours here when you add an
+#: aggregate; that is the whole wiring cost of the guard.
+_AGGREGATE_MODULES = [
+    accounting, cost_verify, runner_mod,
+    budget_projection, cache_efficacy, model_downgrade, output_verbosity,
+    prompt_bloat, subagent_rightsizing, workflow_restructure,
+]
+
+
+@pytest.mark.parametrize(
+    "module", _AGGREGATE_MODULES, ids=lambda m: m.__name__.rsplit(".", 1)[-1],
+)
+def test_module_token_aggregates_sum_all_four_token_types(module):
+    assert_module_token_sums_are_complete(module)
+
+
+def test_the_canonical_sum_names_every_token_type():
+    sql = accounting.four_type_token_sum_sql(alias="tokens")
+    for column in TOKEN_COLUMNS:
+        assert column in sql
+    assert_sql_token_sums_are_complete(sql, context="four_type_token_sum_sql")
+
+
+def test_four_type_total_counts_both_cache_buckets():
+    row = {"input_tokens": 1, "output_tokens": 2, "cache_tokens": 4, "cache_write_tokens": 8}
+    assert accounting.four_type_token_total(row) == 15
+
+
+def test_the_guard_catches_the_bug_shape_that_shipped_three_times():
+    """The regression this whole helper exists for: a sum that looks complete
+    and silently drops the cache-write bucket."""
+    offenders = find_incomplete_token_sums(
+        "SELECT SUM(input_tokens + output_tokens + cache_tokens) FROM spans"
+    )
+    assert offenders and offenders[0][1] == {"cache_write_tokens"}
+
+
+def test_the_guard_allows_a_deliberate_single_bucket_sum():
+    """A cache-read ratio legitimately sums one bucket on its own; the guard
+    must not force a meaningless fourth term into it."""
+    assert find_incomplete_token_sums(
+        "SELECT COALESCE(SUM(cache_tokens), 0) AS cache_tok FROM spans"
+    ) == []

--- a/tests/unit/test_deadweight.py
+++ b/tests/unit/test_deadweight.py
@@ -1,0 +1,679 @@
+"""Unit tests for the MCP dead-weight + context-tax analyzer
+(core/optimize/analyzers/deadweight.py).
+
+Mirrors test_relearn.py's fixture style — hand-written Claude Code on-disk
+JSONL records under a tmp_path projects root, no I/O beyond that. The global
+``~/.claude.json`` path is resolved lazily inside ``_global_config_path``, so
+patching ``HOME`` (via monkeypatch, same as tests/conftest.py's autouse
+``_tj_isolated_home`` fixture) is enough to keep every test off the real
+developer machine — no test here ever touches the real home.
+"""
+from __future__ import annotations
+
+import json
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+from tokenjam.core.optimize.analyzers.deadweight import (
+    DEFERRED_SCHEMA_TAX_TOKENS,
+    FULL_SCHEMA_TAX_TOKENS,
+    MIN_SESSIONS_DEADWEIGHT,
+    compute_deadweight_finding,
+    enumerate_configured_servers,
+    run as run_deadweight,
+)
+
+_NOW = datetime.now(timezone.utc)
+_SINCE = _NOW - timedelta(days=7)
+_UNTIL = _NOW + timedelta(days=1)
+
+
+# --- Fixture builders (mirrors test_relearn.py) ----------------------------
+
+def _user_prompt(text: str, cwd: str | None = None) -> dict:
+    record = {"type": "user", "message": {"role": "user", "content": text}}
+    if cwd:
+        record["cwd"] = cwd
+    return record
+
+
+def _assistant(text: str | None, tools: list[dict] | None = None, cwd: str | None = None) -> dict:
+    content: list[dict] = []
+    if text is not None:
+        content.append({"type": "text", "text": text})
+    for t in tools or []:
+        content.append({"type": "tool_use", "id": t["id"], "name": t["name"], "input": t.get("input", {})})
+    record = {
+        "type": "assistant",
+        "message": {"role": "assistant", "model": "claude-opus-4-8", "content": content},
+    }
+    if cwd:
+        record["cwd"] = cwd
+    return record
+
+
+def _write_transcript(root: Path, project: str, session_id: str, records: list[dict]) -> Path:
+    project_dir = root / project
+    project_dir.mkdir(parents=True, exist_ok=True)
+    path = project_dir / f"{session_id}.jsonl"
+    path.write_text("\n".join(json.dumps(r) for r in records), encoding="utf-8")
+    return path
+
+
+def _write_mcp_json(project_dir: Path, servers: dict[str, dict]) -> None:
+    project_dir.mkdir(parents=True, exist_ok=True)
+    (project_dir / ".mcp.json").write_text(json.dumps({"mcpServers": servers}), encoding="utf-8")
+
+
+def _plain_session(root: Path, project: str, session_id: str, cwd: str) -> None:
+    """A session with no MCP activity at all — a server configured for its
+    project is present but never invoked."""
+    _write_transcript(root, project, session_id, [
+        _user_prompt("say hi", cwd=cwd),
+        _assistant("Hello!", cwd=cwd),
+    ])
+
+
+def _invoking_session(root: Path, project: str, session_id: str, cwd: str, tool_name: str) -> None:
+    _write_transcript(root, project, session_id, [
+        _user_prompt("use the tool", cwd=cwd),
+        _assistant("Calling it.", tools=[{"id": "t1", "name": tool_name, "input": {}}], cwd=cwd),
+    ])
+
+
+def _deferred_session(root: Path, project: str, session_id: str, cwd: str, tool_name: str) -> None:
+    """A session whose transcript shows the deferred-tools listing naming
+    ``tool_name`` — the server's schema was NOT fully loaded this session."""
+    reminder = (
+        "<system-reminder>\n"
+        "The following deferred tools are now available via ToolSearch. "
+        "Their schemas are NOT loaded — calling them directly will fail "
+        "with InputValidationError. Use ToolSearch to load their schema "
+        "before calling them:\n"
+        f"{tool_name}\n"
+        "</system-reminder>"
+    )
+    _write_transcript(root, project, session_id, [
+        _user_prompt(reminder, cwd=cwd),
+        _assistant("Understood.", cwd=cwd),
+    ])
+
+
+# --- enumerate_configured_servers -------------------------------------------
+
+def test_enumerate_project_scoped_server(tmp_path):
+    project_dir = tmp_path / "repo-a"
+    _write_mcp_json(project_dir, {"apollo": {"command": "apollo-mcp"}})
+
+    servers = enumerate_configured_servers({str(project_dir)})
+
+    assert "apollo" in servers
+    assert servers["apollo"].scope == "project"
+    assert str(project_dir) in servers["apollo"].cwds
+
+
+def test_enumerate_global_scoped_server(tmp_path, monkeypatch):
+    fake_home = tmp_path / "fake-home"
+    fake_home.mkdir()
+    (fake_home / ".claude.json").write_text(
+        json.dumps({"mcpServers": {"exa": {"command": "exa-mcp"}}}), encoding="utf-8",
+    )
+    monkeypatch.setenv("HOME", str(fake_home))
+
+    servers = enumerate_configured_servers(set())
+
+    assert "exa" in servers
+    assert servers["exa"].scope == "user"
+
+
+def test_global_scope_wins_over_same_named_project_entry(tmp_path, monkeypatch):
+    fake_home = tmp_path / "fake-home"
+    fake_home.mkdir()
+    (fake_home / ".claude.json").write_text(
+        json.dumps({"mcpServers": {"apollo": {}}}), encoding="utf-8",
+    )
+    monkeypatch.setenv("HOME", str(fake_home))
+    project_dir = tmp_path / "repo-a"
+    _write_mcp_json(project_dir, {"apollo": {}})
+
+    servers = enumerate_configured_servers({str(project_dir)})
+
+    assert servers["apollo"].scope == "user"
+
+
+def test_enumerate_no_config_returns_empty(tmp_path):
+    assert enumerate_configured_servers({str(tmp_path / "nope")}) == {}
+
+
+# --- C1: dead-weight detection ----------------------------------------------
+
+def test_no_configured_servers_is_a_no_op(tmp_path):
+    project_dir = tmp_path / "root" / "repo-a"
+    for i in range(MIN_SESSIONS_DEADWEIGHT):
+        _plain_session(tmp_path / "root", "-repo-a", f"s{i}", str(project_dir))
+
+    finding = compute_deadweight_finding(_SINCE, _UNTIL, projects_root=tmp_path / "root")
+
+    assert finding.configured_servers == 0
+    assert finding.dead_servers == []
+    assert finding.estimated_recoverable_tokens is None
+
+
+def test_detects_dead_server_at_threshold(tmp_path):
+    root = tmp_path / "root"
+    project_dir = root / "-repo-a"
+    _write_mcp_json(project_dir, {"apollo": {}})
+    for i in range(MIN_SESSIONS_DEADWEIGHT):
+        _plain_session(root, "-repo-a", f"s{i}", str(project_dir))
+
+    finding = compute_deadweight_finding(_SINCE, _UNTIL, projects_root=root)
+
+    assert finding.configured_servers == 1
+    assert len(finding.dead_servers) == 1
+    dead = finding.dead_servers[0]
+    assert dead.name == "apollo"
+    assert dead.sessions_present == MIN_SESSIONS_DEADWEIGHT
+    assert dead.invocations == 0
+    assert dead.estimated_tax_tokens_per_session == FULL_SCHEMA_TAX_TOKENS
+    assert finding.estimated_recoverable_tokens == dead.estimated_tax_tokens_90d
+    assert finding.estimated_recoverable_tokens > 0
+
+
+def test_dead_server_prices_tax_in_usd_via_pricing_table(tmp_path):
+    """The token tax is priced through core/pricing.py at the dominant model
+    observed across the server's sessions (every fixture session here runs
+    on claude-opus-4-8) -- never a hardcoded rate baked into this module."""
+    from tokenjam.core.pricing import get_rates
+
+    root = tmp_path / "root"
+    project_dir = root / "-repo-a"
+    _write_mcp_json(project_dir, {"apollo": {}})
+    for i in range(MIN_SESSIONS_DEADWEIGHT):
+        _plain_session(root, "-repo-a", f"s{i}", str(project_dir))
+
+    finding = compute_deadweight_finding(_SINCE, _UNTIL, projects_root=root)
+    dead = finding.dead_servers[0]
+
+    rates = get_rates("anthropic", "claude-opus-4-8")
+    assert dead.priced_model == "claude-opus-4-8"
+    assert dead.estimated_tax_usd_per_session == round(
+        dead.estimated_tax_tokens_per_session / 1_000_000 * rates.input_per_mtok, 6,
+    )
+    assert dead.estimated_tax_usd_90d > 0
+    assert finding.estimated_recoverable_usd == dead.estimated_tax_usd_90d
+    assert "Priced at claude-opus-4-8's input rate" in dead.tax_construction
+
+
+def test_no_priced_model_leaves_usd_none(tmp_path):
+    """A session with no assistant model recorded at all must never get a
+    fabricated dollar figure -- tokens-only, explicitly noted."""
+    root = tmp_path / "root"
+    project_dir = root / "-repo-a"
+    _write_mcp_json(project_dir, {"apollo": {}})
+    for i in range(MIN_SESSIONS_DEADWEIGHT):
+        _write_transcript(root, "-repo-a", f"s{i}", [
+            _user_prompt("say hi", cwd=str(project_dir)),
+            # No assistant turn at all -> no model signal for this session.
+        ])
+
+    finding = compute_deadweight_finding(_SINCE, _UNTIL, projects_root=root)
+    dead = finding.dead_servers[0]
+
+    assert dead.priced_model == ""
+    assert dead.estimated_tax_usd_per_session is None
+    assert dead.estimated_tax_usd_90d is None
+    assert finding.estimated_recoverable_usd is None
+    assert "No dollar estimate" in dead.tax_construction
+
+
+def test_below_threshold_is_not_flagged_dead(tmp_path):
+    root = tmp_path / "root"
+    project_dir = root / "-repo-a"
+    _write_mcp_json(project_dir, {"apollo": {}})
+    for i in range(MIN_SESSIONS_DEADWEIGHT - 1):
+        _plain_session(root, "-repo-a", f"s{i}", str(project_dir))
+
+    finding = compute_deadweight_finding(_SINCE, _UNTIL, projects_root=root)
+
+    assert finding.configured_servers == 1
+    assert finding.dead_servers == []
+    assert finding.estimated_recoverable_tokens is None
+    assert finding.notes  # the "no server cleared the bar" note fires
+
+
+def test_default_min_sessions_preserved_when_unspecified(tmp_path):
+    """compute_deadweight_finding's default `min_sessions` matches the module
+    constant unchanged — the config-thread contract for an unset [optimize]."""
+    root = tmp_path / "root"
+    project_dir = root / "-repo-a"
+    _write_mcp_json(project_dir, {"apollo": {}})
+    for i in range(MIN_SESSIONS_DEADWEIGHT - 1):
+        _plain_session(root, "-repo-a", f"s{i}", str(project_dir))
+
+    finding = compute_deadweight_finding(_SINCE, _UNTIL, projects_root=root)
+    assert finding.dead_servers == []
+
+
+def test_lower_min_sessions_flags_previously_hidden_server(tmp_path):
+    """The exact data from test_below_threshold_is_not_flagged_dead flags
+    nothing at the default bar; passing a lower min_sessions (what
+    [optimize] min_sessions_deadweight threads through to) flags the server."""
+    root = tmp_path / "root"
+    project_dir = root / "-repo-a"
+    _write_mcp_json(project_dir, {"apollo": {}})
+    for i in range(MIN_SESSIONS_DEADWEIGHT - 1):
+        _plain_session(root, "-repo-a", f"s{i}", str(project_dir))
+
+    default_finding = compute_deadweight_finding(_SINCE, _UNTIL, projects_root=root)
+    assert default_finding.dead_servers == []
+
+    lowered_finding = compute_deadweight_finding(
+        _SINCE, _UNTIL, projects_root=root, min_sessions=MIN_SESSIONS_DEADWEIGHT - 1,
+    )
+    assert len(lowered_finding.dead_servers) == 1
+    assert lowered_finding.dead_servers[0].name == "apollo"
+    assert lowered_finding.dead_servers[0].sessions_present == MIN_SESSIONS_DEADWEIGHT - 1
+
+
+def test_run_reads_min_sessions_deadweight_from_ctx_config(tmp_path, monkeypatch):
+    """The registered `run(ctx)` entry point (not just compute_deadweight_finding
+    directly) reads `ctx.config.optimize.min_sessions_deadweight` — the actual
+    wiring `tj optimize` exercises."""
+    from tokenjam.core.config import OptimizeConfig, TjConfig
+    from tokenjam.core.optimize.types import AnalyzerContext, OptimizeReport, WindowSummary
+
+    root = tmp_path / "root"
+    project_dir = root / "-repo-a"
+    _write_mcp_json(project_dir, {"apollo": {}})
+    for i in range(MIN_SESSIONS_DEADWEIGHT - 1):
+        _plain_session(root, "-repo-a", f"s{i}", str(project_dir))
+    monkeypatch.setenv("TJ_CLAUDE_PROJECTS_ROOT", str(root))
+
+    summary = WindowSummary(
+        since=_SINCE, until=_UNTIL, days=7.0, sessions=0, spans=0,
+        total_tokens=0, total_cost_usd=0.0, thin_data=False,
+    )
+
+    def _ctx(config) -> AnalyzerContext:
+        return AnalyzerContext(
+            conn=None, config=config, since=_SINCE, until=_UNTIL, agent_id=None,
+            window_days=7.0, summary=summary, report=OptimizeReport(window=summary),
+        )
+
+    default_ctx = _ctx(TjConfig(version="1"))
+    run_deadweight(default_ctx)
+    assert default_ctx.report.findings["deadweight"].dead_servers == []
+
+    lowered_ctx = _ctx(TjConfig(
+        version="1",
+        optimize=OptimizeConfig(min_sessions_deadweight=MIN_SESSIONS_DEADWEIGHT - 1),
+    ))
+    run_deadweight(lowered_ctx)
+    lowered = lowered_ctx.report.findings["deadweight"]
+    assert len(lowered.dead_servers) == 1
+    assert lowered.dead_servers[0].name == "apollo"
+
+
+def test_compute_deadweight_finding_cache_dir_opt_in_matches_uncached(tmp_path):
+    """Passing `cache_dir` must not change the finding — only skip re-parsing
+    on a warm hit (see the two tests below)."""
+    root = tmp_path / "root"
+    project_dir = root / "-repo-a"
+    _write_mcp_json(project_dir, {"apollo": {}})
+    for i in range(MIN_SESSIONS_DEADWEIGHT):
+        _plain_session(root, "-repo-a", f"s{i}", str(project_dir))
+
+    uncached = compute_deadweight_finding(_SINCE, _UNTIL, projects_root=root)
+    cached = compute_deadweight_finding(
+        _SINCE, _UNTIL, projects_root=root, cache_dir=tmp_path / "cache",
+    )
+
+    assert [s.name for s in cached.dead_servers] == [s.name for s in uncached.dead_servers]
+    assert cached.sessions_scanned == uncached.sessions_scanned
+
+
+def test_compute_deadweight_finding_warm_cache_skips_reparsing(tmp_path, monkeypatch):
+    """A second call over an UNCHANGED corpus with the same `cache_dir` must
+    not re-read/re-parse any transcript — the whole point of the cache."""
+    root = tmp_path / "root"
+    project_dir = root / "-repo-a"
+    _write_mcp_json(project_dir, {"apollo": {}})
+    for i in range(MIN_SESSIONS_DEADWEIGHT):
+        _plain_session(root, "-repo-a", f"s{i}", str(project_dir))
+    cache_dir = tmp_path / "cache"
+
+    first = compute_deadweight_finding(_SINCE, _UNTIL, projects_root=root, cache_dir=cache_dir)
+    assert first.dead_servers  # sanity: a real signal, not an empty no-op
+
+    def _boom(path):
+        raise AssertionError(f"transcript.read_records reparsed {path} on a warm cache run")
+
+    monkeypatch.setattr("tokenjam.core.transcript._parse_records", _boom)
+
+    second = compute_deadweight_finding(_SINCE, _UNTIL, projects_root=root, cache_dir=cache_dir)
+    assert [s.name for s in second.dead_servers] == [s.name for s in first.dead_servers]
+
+
+def test_compute_deadweight_finding_cache_invalidates_on_transcript_edit(tmp_path):
+    """A session whose transcript CHANGES between two cached runs (e.g. an
+    invocation gets appended) must be re-parsed, not served stale."""
+    root = tmp_path / "root"
+    project_dir = root / "-repo-a"
+    _write_mcp_json(project_dir, {"apollo": {}})
+    for i in range(MIN_SESSIONS_DEADWEIGHT):
+        _plain_session(root, "-repo-a", f"s{i}", str(project_dir))
+    cache_dir = tmp_path / "cache"
+
+    first = compute_deadweight_finding(_SINCE, _UNTIL, projects_root=root, cache_dir=cache_dir)
+    assert first.dead_servers  # apollo starts out dead (never invoked)
+
+    # Rewrite one of the sessions so apollo IS invoked — size and mtime both
+    # change, which must invalidate that session's cache entry.
+    _invoking_session(
+        root, "-repo-a", "s0", str(project_dir), "mcp__apollo__apollo_contacts_search",
+    )
+
+    second = compute_deadweight_finding(_SINCE, _UNTIL, projects_root=root, cache_dir=cache_dir)
+    assert second.dead_servers == []  # no longer dead — the edit was picked up
+
+
+def test_run_wires_the_persistent_transcript_cache(tmp_path, monkeypatch):
+    """The registered `run(ctx)` entry point (the path `tj optimize` and
+    `/cost/components` actually exercise) resolves and uses a real cache dir
+    from `ctx.config`, not just the standalone `compute_deadweight_finding`
+    function tested above."""
+    from tokenjam.core.config import TjConfig
+    from tokenjam.core.optimize.types import AnalyzerContext, OptimizeReport, WindowSummary
+
+    root = tmp_path / "root"
+    project_dir = root / "-repo-a"
+    _write_mcp_json(project_dir, {"apollo": {}})
+    for i in range(MIN_SESSIONS_DEADWEIGHT):
+        _plain_session(root, "-repo-a", f"s{i}", str(project_dir))
+    monkeypatch.setenv("TJ_CLAUDE_PROJECTS_ROOT", str(root))
+
+    summary = WindowSummary(
+        since=_SINCE, until=_UNTIL, days=7.0, sessions=0, spans=0,
+        total_tokens=0, total_cost_usd=0.0, thin_data=False,
+    )
+    config = TjConfig(version="1")
+
+    def _ctx() -> AnalyzerContext:
+        return AnalyzerContext(
+            conn=None, config=config, since=_SINCE, until=_UNTIL, agent_id=None,
+            window_days=7.0, summary=summary, report=OptimizeReport(window=summary),
+        )
+
+    first_ctx = _ctx()
+    run_deadweight(first_ctx)
+    first = first_ctx.report.findings["deadweight"]
+    assert first.dead_servers
+
+    def _boom(path):
+        raise AssertionError(f"transcript.read_records reparsed {path} on a warm cache run")
+
+    monkeypatch.setattr("tokenjam.core.transcript._parse_records", _boom)
+
+    second_ctx = _ctx()
+    run_deadweight(second_ctx)
+    second = second_ctx.report.findings["deadweight"]
+    assert [s.name for s in second.dead_servers] == [s.name for s in first.dead_servers]
+
+
+def test_invoked_server_is_never_flagged_dead(tmp_path):
+    root = tmp_path / "root"
+    project_dir = root / "-repo-a"
+    _write_mcp_json(project_dir, {"apollo": {}})
+    for i in range(MIN_SESSIONS_DEADWEIGHT - 1):
+        _plain_session(root, "-repo-a", f"s{i}", str(project_dir))
+    _invoking_session(
+        root, "-repo-a", "s-call", str(project_dir), "mcp__apollo__apollo_contacts_search",
+    )
+
+    finding = compute_deadweight_finding(_SINCE, _UNTIL, projects_root=root)
+
+    row = next(s for s in finding.servers if s.name == "apollo")
+    assert row.invocations == 1
+    assert row.dead is False
+    assert finding.dead_servers == []
+
+
+# --- Deferred-tools suppression ---------------------------------------------
+
+def test_deferred_listing_suppresses_full_tax_claim(tmp_path):
+    root = tmp_path / "root"
+    project_dir = root / "-repo-a"
+    _write_mcp_json(project_dir, {"apollo": {}})
+    for i in range(MIN_SESSIONS_DEADWEIGHT):
+        _deferred_session(
+            root, "-repo-a", f"s{i}", str(project_dir), "mcp__apollo__apollo_contacts_search",
+        )
+
+    finding = compute_deadweight_finding(_SINCE, _UNTIL, projects_root=root)
+
+    dead = finding.dead_servers[0]
+    assert dead.deferred_sessions == MIN_SESSIONS_DEADWEIGHT
+    # Every session was deferred -> the blended tax must equal the deferred
+    # constant, never the full-schema constant.
+    assert dead.estimated_tax_tokens_per_session == DEFERRED_SCHEMA_TAX_TOKENS
+    # Never claims the full-schema tax for a fully-deferred server.
+    assert str(FULL_SCHEMA_TAX_TOKENS) not in dead.tax_construction
+
+
+def test_partial_deferral_blends_the_two_constants(tmp_path):
+    root = tmp_path / "root"
+    project_dir = root / "-repo-a"
+    _write_mcp_json(project_dir, {"apollo": {}})
+    for i in range(5):
+        _plain_session(root, "-repo-a", f"s-full-{i}", str(project_dir))
+    for i in range(5):
+        _deferred_session(
+            root, "-repo-a", f"s-defer-{i}", str(project_dir), "mcp__apollo__apollo_contacts_search",
+        )
+
+    finding = compute_deadweight_finding(_SINCE, _UNTIL, projects_root=root)
+
+    dead = finding.dead_servers[0]
+    assert dead.sessions_present == 10
+    assert dead.deferred_sessions == 5
+    expected = round((5 * FULL_SCHEMA_TAX_TOKENS + 5 * DEFERRED_SCHEMA_TAX_TOKENS) / 10)
+    assert dead.estimated_tax_tokens_per_session == expected
+    assert dead.estimated_tax_tokens_per_session < FULL_SCHEMA_TAX_TOKENS
+
+
+# --- C2: context tax table --------------------------------------------------
+
+def test_tax_table_includes_claude_md_bucket(tmp_path):
+    root = tmp_path / "root"
+    project_dir = root / "-repo-a"
+    reminder = (
+        "<system-reminder>\n"
+        "Contents of /Users/dev/CLAUDE.md (project instructions):\n"
+        + ("word " * 500) +
+        "\n</system-reminder>"
+    )
+    _write_transcript(root, "-repo-a", "s0", [
+        _user_prompt(reminder, cwd=str(project_dir)),
+        _assistant("ok", cwd=str(project_dir)),
+    ])
+    _write_mcp_json(project_dir, {"apollo": {}})
+
+    finding = compute_deadweight_finding(_SINCE, _UNTIL, projects_root=root)
+
+    sources = {row.source for row in finding.tax_table}
+    assert "CLAUDE.md" in sources
+    claude_row = next(r for r in finding.tax_table if r.source == "CLAUDE.md")
+    assert claude_row.avg_tokens_per_session > 0
+    assert claude_row.tag == "estimated"
+
+
+def test_tax_table_includes_mcp_schema_rows_for_every_configured_server(tmp_path):
+    root = tmp_path / "root"
+    project_dir = root / "-repo-a"
+    _write_mcp_json(project_dir, {"apollo": {}})
+    _plain_session(root, "-repo-a", "s0", str(project_dir))
+
+    finding = compute_deadweight_finding(_SINCE, _UNTIL, projects_root=root)
+
+    assert any(row.source == "MCP schema: apollo" for row in finding.tax_table)
+
+
+# --- Dedup rule --------------------------------------------------------------
+
+def test_dead_server_tax_not_double_counted_between_table_and_total(tmp_path):
+    root = tmp_path / "root"
+    project_dir = root / "-repo-a"
+    _write_mcp_json(project_dir, {"apollo": {}})
+    for i in range(MIN_SESSIONS_DEADWEIGHT):
+        _plain_session(root, "-repo-a", f"s{i}", str(project_dir))
+
+    finding = compute_deadweight_finding(_SINCE, _UNTIL, projects_root=root)
+
+    dead = finding.dead_servers[0]
+    mcp_row = next(r for r in finding.tax_table if r.source == "MCP schema: apollo")
+    # The tax table's own MCP row and the recoverable total both derive from
+    # the SAME per-server figure, but the total must equal exactly the dead
+    # servers' sum -- never (tax table total) + (recoverable total).
+    assert finding.estimated_recoverable_tokens == dead.estimated_tax_tokens_90d
+    assert mcp_row.total_tokens_window == dead.estimated_tax_tokens_per_session * dead.sessions_present
+
+
+# --- Honesty / string-hygiene guards ----------------------------------------
+
+def test_no_em_dash_or_quota_in_user_facing_strings(tmp_path):
+    root = tmp_path / "root"
+    project_dir = root / "-repo-a"
+    _write_mcp_json(project_dir, {"apollo": {}})
+    for i in range(MIN_SESSIONS_DEADWEIGHT):
+        _deferred_session(
+            root, "-repo-a", f"s{i}", str(project_dir), "mcp__apollo__apollo_contacts_search",
+        )
+
+    finding = compute_deadweight_finding(_SINCE, _UNTIL, projects_root=root)
+
+    strings = [finding.caveat, finding.estimate_basis, *finding.notes]
+    for server in finding.servers:
+        # `fix` embeds the config's on-disk source path, which under pytest is
+        # the test's own tmp_path (and can coincidentally contain "quota" as a
+        # substring of the test name) -- redact it so the check is over the
+        # actual card template wording, not an incidental tmp-dir name.
+        strings += [server.fix.replace(server.source, "<source>"), server.tax_construction]
+    for row in finding.tax_table:
+        strings += [row.construction]
+    for s in strings:
+        assert "—" not in s, f"em dash found in: {s!r}"
+        assert "quota" not in s.lower(), f"'quota' found in: {s!r}"
+
+
+# --- Registration ------------------------------------------------------------
+
+def test_deadweight_is_registered_in_runner_order():
+    from tokenjam.core.optimize.runner import ANALYZER_ORDER
+    from tokenjam.core.optimize.registry import ANALYZER_REGISTRY
+
+    assert "deadweight" in ANALYZER_ORDER
+    assert "deadweight" in ANALYZER_REGISTRY
+
+
+# --- CLI text-view rendering regression --------------------------------------
+# Same class of defect the relearn analyzer hit: `deadweight` was registered in
+# ANALYZER_REGISTRY/ANALYZER_ORDER but never wired into cmd_optimize's
+# _FINDING_RENDERERS dispatch table, so _rank_findings silently dropped it and
+# `tj optimize deadweight` (text view) printed the generic empty state even
+# with real dead servers sitting in --json.
+
+def test_deadweight_in_click_choices_and_renderer():
+    from tokenjam.cli.cmd_optimize import (
+        _FINDING_RENDERERS,
+        _MINOR_FINDING_LABELS,
+        cmd_optimize,
+    )
+
+    findings_param = next(
+        p for p in cmd_optimize.params if getattr(p, "name", None) == "findings"
+    )
+    assert "deadweight" in findings_param.type.choices
+    assert "deadweight" in _FINDING_RENDERERS
+    assert "deadweight" in _MINOR_FINDING_LABELS
+
+
+def test_render_deadweight_names_the_dead_server(tmp_path, capsys):
+    """The finding renders through the CLI dispatch path and names the dead
+    server, its presence, its zero invocations and the token tax."""
+    from tokenjam.cli.cmd_optimize import _render_deadweight
+
+    root = tmp_path / "root"
+    project_dir = root / "-repo-a"
+    _write_mcp_json(project_dir, {"apollo": {}})
+    for i in range(MIN_SESSIONS_DEADWEIGHT):
+        _plain_session(root, "-repo-a", f"s{i}", str(project_dir))
+
+    finding = compute_deadweight_finding(_SINCE, _UNTIL, projects_root=root)
+    assert finding.dead_servers  # sanity: the analyzer actually flagged one
+
+    for mode in ("api", "subscription", "local", "unknown"):
+        _render_deadweight(finding, pricing_mode=mode, marker="①")
+    out = capsys.readouterr().out
+
+    assert "apollo" in out
+    assert f"{MIN_SESSIONS_DEADWEIGHT} sessions" in out
+    assert "0 invocations" in out
+    assert "No candidates flagged" not in out
+    # The construction footnote travels with the number.
+    assert "tok/session" in out
+
+
+def test_render_deadweight_omits_dollars_when_no_model_was_priced(tmp_path, capsys):
+    """No priced model observed means no dollar figure at all. Printing
+    $0.00 would read as "this server costs nothing"."""
+    from tokenjam.cli.cmd_optimize import _render_deadweight
+
+    root = tmp_path / "root"
+    project_dir = root / "-repo-a"
+    _write_mcp_json(project_dir, {"apollo": {}})
+    for i in range(MIN_SESSIONS_DEADWEIGHT):
+        _write_transcript(root, "-repo-a", f"s{i}", [
+            _user_prompt("say hi", cwd=str(project_dir)),
+        ])
+
+    finding = compute_deadweight_finding(_SINCE, _UNTIL, projects_root=root)
+    assert finding.dead_servers[0].estimated_tax_usd_90d is None
+
+    _render_deadweight(finding, pricing_mode="api", marker="①")
+    out = capsys.readouterr().out
+
+    assert "apollo" in out
+    assert "$" not in out
+    assert "no priced model observed" in out
+
+
+def test_render_report_surfaces_dead_servers_instead_of_no_candidates(tmp_path, capsys):
+    """End-to-end: a report whose only finding is a populated deadweight set
+    must not fall through to the generic "No candidates flagged" empty state."""
+    from tokenjam.cli.cmd_optimize import _render_report
+    from tokenjam.core.optimize.types import OptimizeReport, WindowSummary
+    from tokenjam.utils.time_parse import utcnow
+
+    root = tmp_path / "root"
+    project_dir = root / "-repo-a"
+    _write_mcp_json(project_dir, {"apollo": {}})
+    for i in range(MIN_SESSIONS_DEADWEIGHT):
+        _plain_session(root, "-repo-a", f"s{i}", str(project_dir))
+
+    finding = compute_deadweight_finding(_SINCE, _UNTIL, projects_root=root)
+    assert finding.dead_servers
+
+    now = utcnow()
+    report = OptimizeReport(
+        window=WindowSummary(
+            since=now, until=now, days=7, sessions=MIN_SESSIONS_DEADWEIGHT,
+            spans=0, total_tokens=100_000, total_cost_usd=0.0, thin_data=False,
+        ),
+        downgrade=None,
+        findings={"deadweight": finding},
+    )
+    _render_report(report, agent=None, requested=["deadweight"], pricing_mode="local")
+    out = capsys.readouterr().out
+
+    assert "No candidates flagged" not in out
+    assert "apollo" in out

--- a/tests/unit/test_optimize_clustering.py
+++ b/tests/unit/test_optimize_clustering.py
@@ -1,0 +1,101 @@
+"""Unit tests for the shared clustering primitives (core/optimize/clustering.py)
+plus a byte-stable regression guard: the three miners that now consume the
+helper (pothole, plan_reuse, workflow_restructure) must produce the SAME
+signatures/titles/groupings they did before the consolidation.
+
+The golden values here were captured from the pre-refactor code; if a future
+edit to the shared helper changes any analyzer's clustering output, one of these
+assertions fails.
+"""
+from __future__ import annotations
+
+import re
+
+from tokenjam.core.optimize.clustering import group_by_key, mask_variables, recurring
+
+
+# --- the primitives ----------------------------------------------------------
+
+def test_group_by_key_preserves_first_seen_order():
+    items = ["apple", "avocado", "banana", "cherry", "blueberry"]
+    buckets = group_by_key(items, lambda s: s[0])
+    assert list(buckets.keys()) == ["a", "b", "c"]        # first-seen order
+    assert buckets["a"] == ["apple", "avocado"]
+    assert buckets["b"] == ["banana", "blueberry"]
+
+
+def test_recurring_keeps_keys_and_filters_by_size():
+    buckets = {"x": [1, 2, 3], "y": [1], "z": [1, 2]}
+    kept = recurring(buckets, min_members=2)
+    assert kept == {"x": [1, 2, 3], "z": [1, 2]}          # keys preserved
+
+
+def test_recurring_honors_custom_size_fn():
+    # A bucket whose recurrence measure is distinct-sessions, not raw count.
+    buckets = {"a": ["s1", "s1", "s1"], "b": ["s1", "s2"]}
+    kept = recurring(buckets, min_members=2, size_fn=lambda m: len(set(m)))
+    assert set(kept) == {"b"}                             # "a" is 1 distinct session
+
+
+def test_mask_variables_applies_subs_then_ws_then_lower():
+    subs = [(re.compile(r"\d+"), "<N>"), (re.compile(r"/\w+"), "<P>")]
+    out = mask_variables("HIT  /tmp  at 42", subs, collapse_ws=True, lowercase=True)
+    assert out == "hit <p> at <n>"
+
+
+def test_mask_variables_default_is_substitutions_only():
+    subs = [(re.compile(r"\d+"), "<N>")]
+    assert mask_variables("Keep  Case 9", subs) == "Keep  Case <N>"
+
+
+# --- byte-stable regression guard: pothole -----------------------------------
+
+def test_pothole_normalizer_byte_stable():
+    from tokenjam.core.optimize.analyzers.pothole import _generic_signature, _normalize_generic
+    assert _normalize_generic(
+        "Error at /Users/x/proj/file.py line 42 at 2026-07-21T10:00:00Z id 3f2a1b9c8d7e"
+    ) == "error at <path> line <n> at <ts> id <id>"
+    assert _generic_signature("Bash", "no such file /a/b at 2026-01-01T00:00:00Z") == \
+        "Bash:no such file <path> at <ts>"
+
+
+def test_pothole_clustering_byte_stable():
+    from tokenjam.core.optimize.analyzers.pothole import (
+        FailureEpisode,
+        _recurring,
+        cluster_failures,
+    )
+    fs = [
+        FailureEpisode("s1", "r", None, "Read", "", "string to replace not found", "act", False, 0),
+        FailureEpisode("s2", "r", None, "Read", "", "string to replace not found", "act", False, 0),
+        FailureEpisode("s1", "r", None, "Bash", "", "weird err 111", "act", False, 0),
+        FailureEpisode("s3", "r", None, "Bash", "", "weird err 222", "act", False, 0),
+    ]
+    cl = cluster_failures(fs)
+    assert sorted(cl.keys()) == ["Bash:weird err <n>", "Read:string to replace not found"]
+    # Title comes from the FIRST failure's raw text — the byte-sensitive detail.
+    assert cl["Bash:weird err <n>"].title == "Bash: weird err 111"
+    assert sorted(cl["Bash:weird err <n>"].session_ids) == ["s1", "s3"]
+    assert {c.signature for c in _recurring(cl, 2)} == \
+        {"Bash:weird err <n>", "Read:string to replace not found"}
+    assert _recurring(cl, 3) == []                         # neither hits 3 sessions
+
+
+# --- byte-stable regression guard: plan_reuse --------------------------------
+
+def test_plan_reuse_clustering_byte_stable():
+    from tokenjam.core.optimize.analyzers.plan_reuse import (
+        _SessionPlan,
+        _cluster_sessions,
+        _strip_variables,
+    )
+    assert _strip_variables("release v0.3.4 on 2026-06-15 path /a/b/c") == \
+        "release v<NUM>.<NUM>.<NUM> on <DATE> path <PATH>"
+    plans = [
+        _SessionPlan("s1", 100, 0.1, None, ("Read", "Edit"), "ab"),
+        _SessionPlan("s2", 100, 0.1, None, ("Read", "Edit"), "ab"),
+        _SessionPlan("s3", 100, 0.1, None, ("Grep",), None),
+    ]
+    pc = _cluster_sessions(plans)
+    assert sorted(pc.keys()) == ["06a63bbd59ae", "e8cb6dd93de5-ab"]
+    assert {k: len(v) for k, v in pc.items()} == {"e8cb6dd93de5-ab": 2, "06a63bbd59ae": 1}

--- a/tests/unit/test_relearn.py
+++ b/tests/unit/test_relearn.py
@@ -1,0 +1,770 @@
+"""Unit tests for the cross-session relearn aggregator (core/optimize/analyzers/relearn.py).
+
+Mirrors ``test_transcript.py``'s fixture style — hand-written Claude Code
+on-disk JSONL records, no I/O beyond a ``tmp_path`` projects root. The
+``claude`` CLI distill pass is never invoked in these tests (either the
+residual bucket is empty, or ``distill_enabled=False`` is passed explicitly)
+so nothing here shells out.
+"""
+from __future__ import annotations
+
+import json
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+import pytest
+
+from tokenjam.core.optimize.analyzers.relearn import (
+    MIN_RECURRING_SESSIONS,
+    FailureEpisode,
+    analyze_relearns,
+    classify_known_family,
+    cluster_failures,
+    compute_relearn_finding,
+    extract_failures_for_session,
+    is_already_codified,
+)
+
+
+# --- Fixture builders (mirrors test_transcript.py) ----------------------------
+
+def _user_prompt(text: str) -> dict:
+    return {"type": "user", "message": {"role": "user", "content": text}}
+
+
+def _assistant(text: str | None, tools: list[dict] | None = None,
+               ts: str = "2026-06-15T09:11:36.133Z") -> dict:
+    content: list[dict] = []
+    if text is not None:
+        content.append({"type": "text", "text": text})
+    for t in tools or []:
+        content.append({"type": "tool_use", "id": t["id"], "name": t["name"],
+                         "input": t.get("input", {})})
+    return {"type": "assistant", "timestamp": ts,
+            "message": {"role": "assistant", "model": "claude-opus-4-8", "content": content}}
+
+
+def _tool_error(tool_use_id: str, error_text: str) -> dict:
+    return {"type": "user", "message": {"role": "user", "content": [{
+        "type": "tool_result", "tool_use_id": tool_use_id, "is_error": True,
+        "content": error_text,
+    }]}}
+
+
+def _tool_ok(tool_use_id: str) -> dict:
+    return {"type": "user", "message": {"role": "user", "content": [{
+        "type": "tool_result", "tool_use_id": tool_use_id, "content": "ok",
+    }]}}
+
+
+def _write_transcript(projects_root: Path, project: str, session_id: str, records: list[dict]) -> Path:
+    project_dir = projects_root / project
+    project_dir.mkdir(parents=True, exist_ok=True)
+    path = project_dir / f"{session_id}.jsonl"
+    path.write_text("\n".join(json.dumps(r) for r in records), encoding="utf-8")
+    return path
+
+
+def _cwd_confusion_session(root: Path, project: str, session_id: str) -> None:
+    """One session hitting the wrong-cwd Bash error."""
+    records = [
+        _user_prompt("run the build"),
+        _assistant("Running the build.", tools=[
+            {"id": "t1", "name": "Bash", "input": {"command": "cd orchestrator && make"}},
+        ]),
+        _tool_error("t1", "(eval):cd:1: no such file or directory: orchestrator"),
+        _assistant("Let me check the path first.", tools=[
+            {"id": "t2", "name": "Bash", "input": {"command": "pwd"}},
+        ]),
+        _tool_ok("t2"),
+    ]
+    _write_transcript(root, project, session_id, records)
+
+
+def _edit_before_read_session(root: Path, project: str, session_id: str) -> None:
+    records = [
+        _user_prompt("fix the bug"),
+        _assistant("Editing directly.", tools=[
+            {"id": "e1", "name": "Edit", "input": {"file_path": "src/app.py"}},
+        ]),
+        _tool_error("e1", "File has not been read yet. Read it first before writing to it."),
+        _assistant("Reading first.", tools=[
+            {"id": "e2", "name": "Read", "input": {"file_path": "src/app.py"}},
+        ]),
+        _tool_ok("e2"),
+    ]
+    _write_transcript(root, project, session_id, records)
+
+
+def _command_not_found_session(root: Path, project: str, session_id: str) -> None:
+    records = [
+        _user_prompt("run the script"),
+        _assistant("Running it.", tools=[
+            {"id": "c1", "name": "Bash", "input": {"command": "python script.py"}},
+        ]),
+        _tool_error("c1", "Exit code 127\nbash: python: command not found"),
+        _assistant("Trying python3.", tools=[
+            {"id": "c2", "name": "Bash", "input": {"command": "python3 script.py"}},
+        ]),
+        _tool_ok("c2"),
+    ]
+    _write_transcript(root, project, session_id, records)
+
+
+def _clean_session(root: Path, project: str, session_id: str) -> None:
+    """A session with no errors at all — must contribute nothing."""
+    records = [
+        _user_prompt("say hi"),
+        _assistant("Hello!"),
+    ]
+    _write_transcript(root, project, session_id, records)
+
+
+# --- Pure classifier tests -----------------------------------------------------
+
+def test_classify_cwd_confusion():
+    assert classify_known_family(
+        "Bash", "(eval):cd:1: no such file or directory: orchestrator"
+    ) == "cwd_confusion"
+
+
+def test_classify_edit_before_read():
+    assert classify_known_family(
+        "Edit", "File has not been read yet. Read it first before writing to it."
+    ) == "edit_before_read"
+
+
+def test_classify_sleep_chain_needs_leading_sleep_label():
+    # Error text matches, but the command doesn't lead with sleep -> no match.
+    assert classify_known_family("Bash", "Blocked: foreground sleep", label="ls && sleep 5") is None
+    # Leading sleep command -> matches.
+    assert classify_known_family("Bash", "Blocked: foreground sleep", label="sleep 5 && ls") == "sleep_chain"
+
+
+def test_classify_no_match_returns_none():
+    assert classify_known_family("Bash", "some unrelated transient network blip") is None
+
+
+def test_classify_empty_error_returns_none():
+    assert classify_known_family("Bash", "") is None
+
+
+def test_classify_webfetch_domain_blocked():
+    # Real wording validated against the local corpus, not "not allowed"/"blocked".
+    assert classify_known_family(
+        "WebFetch", "Claude Code is unable to fetch from www.reddit.com"
+    ) == "webfetch_domain_blocked"
+
+
+def test_classify_read_offset_array_not_shadowed_by_deferred_tool_cold():
+    # Real evidence (validated against the local corpus, 2026-07-14): this
+    # exact wording matches BOTH deferred_tool_cold's generic
+    # "inputvalidationerror" pattern (tools=None -> any tool) AND
+    # read_offset_malformed's tools={"Read"}-scoped pattern. The more
+    # specific family must win, or ~35% of deferred_tool_cold's Read-tool
+    # evidence gets mislabeled with the wrong fix (family-ordering shadow bug).
+    text = (
+        "InputValidationError: Read failed due to the following issue:\n"
+        "The parameter `offset` type is expected as `number` but provided as `array`"
+    )
+    assert classify_known_family("Read", text) == "read_offset_malformed"
+
+
+def test_classify_deferred_tool_cold_still_matches_non_offset_errors():
+    # A generic InputValidationError on a DIFFERENT tool/parameter must still
+    # land in deferred_tool_cold — the reorder must not swallow its own family.
+    text = (
+        "InputValidationError: Monitor failed due to the following issues:\n"
+        "The required parameter `description` is missing"
+    )
+    assert classify_known_family("Monitor", text) == "deferred_tool_cold"
+
+
+def test_command_not_found_is_rung_one_with_real_guidance():
+    # Downgraded from rung 5 (no safe automatic config/env writer exists) to
+    # a rung-1 CLAUDE.md note with genuinely useful guidance — not a stub.
+    from tokenjam.core.optimize.analyzers.relearn import _FAMILY_BY_KEY
+
+    fam = _FAMILY_BY_KEY["command_not_found"]
+    assert fam["rung"] == 1
+    assert "python3" in fam["fix"]
+    assert "mapfile" in fam["fix"] or "shopt" in fam["fix"]
+
+
+# --- User-decline exclusion (not a relearn) ------------------------------------
+
+def test_user_decline_is_not_a_relearn(tmp_path):
+    from tokenjam.core.optimize.analyzers.relearn import is_user_decline
+
+    assert is_user_decline("The user doesn't want to proceed with this tool use.") is True
+    assert is_user_decline("Exit plan mode?") is True
+    assert is_user_decline("cd: no such file or directory: orchestrator") is False
+    assert is_user_decline("") is False
+
+
+def test_user_decline_excluded_from_extraction(tmp_path):
+    records = [
+        _user_prompt("do something"),
+        _assistant("Trying.", tools=[{"id": "d1", "name": "AskUserQuestion", "input": {}}]),
+        _tool_error("d1", "The user doesn't want to proceed with this tool use. The tool call has been cancelled."),
+        _assistant("Understood, skipping."),
+    ]
+    _write_transcript(tmp_path, "-Users-test-decline", "decline-1", records)
+    failures = extract_failures_for_session("decline-1", "repo-a", projects_root=tmp_path)
+    assert failures == []
+
+
+# --- Extraction ----------------------------------------------------------------
+
+def test_extract_failures_finds_the_errored_tool(tmp_path):
+    _cwd_confusion_session(tmp_path, "-Users-test-a", "sess-1")
+    failures = extract_failures_for_session("sess-1", "repo-a", projects_root=tmp_path)
+    assert len(failures) == 1
+    f = failures[0]
+    assert isinstance(f, FailureEpisode)
+    assert f.tool_name == "Bash"
+    assert "no such file or directory" in f.error_text
+    assert f.repo == "repo-a"
+    assert f.depth == 0
+
+
+def test_extract_failures_missing_session_returns_empty(tmp_path):
+    assert extract_failures_for_session("nope", "repo-a", projects_root=tmp_path) == []
+
+
+def test_extract_failures_clean_session_returns_empty(tmp_path):
+    _clean_session(tmp_path, "-Users-test-a", "sess-clean")
+    assert extract_failures_for_session("sess-clean", "repo-a", projects_root=tmp_path) == []
+
+
+# --- Clustering ------------------------------------------------------------
+
+def test_cluster_groups_same_family_across_sessions(tmp_path):
+    failures = [
+        FailureEpisode("s1", "repo-a", None, "Bash", "cd x", "cd: no such file or directory: x", "act", False, 0),
+        FailureEpisode("s2", "repo-b", None, "Bash", "cd y", "cd: no such file or directory: y", "act", False, 0),
+    ]
+    clusters = cluster_failures(failures)
+    assert len(clusters) == 1
+    cluster = next(iter(clusters.values()))
+    assert cluster.family_key == "cwd_confusion"
+    assert cluster.session_ids == {"s1", "s2"}
+    assert cluster.repos == {"repo-a", "repo-b"}
+
+
+def test_cluster_separates_different_families(tmp_path):
+    failures = [
+        FailureEpisode("s1", "repo-a", None, "Bash", "cd x", "no such file or directory", "act", False, 0),
+        FailureEpisode("s2", "repo-a", None, "Edit", "a.py", "File has not been read yet.", "act", False, 0),
+    ]
+    clusters = cluster_failures(failures)
+    assert len(clusters) == 2
+
+
+# --- Full pipeline (analyze_relearns) ------------------------------------------
+
+def test_recurring_cluster_surfaces_as_a_proposal(tmp_path):
+    for i in range(MIN_RECURRING_SESSIONS):
+        _cwd_confusion_session(tmp_path, f"-Users-test-repo{i}", f"cwd-{i}")
+    sessions = [(f"cwd-{i}", f"repo{i}") for i in range(MIN_RECURRING_SESSIONS)]
+
+    finding = analyze_relearns(sessions, projects_root=tmp_path, distill_enabled=False)
+
+    assert finding.sessions_scanned == MIN_RECURRING_SESSIONS
+    assert len(finding.clusters) == 1
+    cluster = finding.clusters[0]
+    assert cluster.family_key == "cwd_confusion"
+    assert cluster.sessions == MIN_RECURRING_SESSIONS
+    assert cluster.rung == 3
+    # Spread across 3 distinct repos -> user-global scope (§7).
+    assert cluster.scope == "user-global"
+    assert cluster.estimated_recoverable_tokens > 0
+    assert len(cluster.examples) <= 3
+    assert finding.estimated_recoverable_tokens == cluster.estimated_recoverable_tokens
+
+
+def test_command_not_found_proposal_is_rung_one_note(tmp_path):
+    for i in range(MIN_RECURRING_SESSIONS):
+        _command_not_found_session(tmp_path, f"-Users-test-cnf{i}", f"cnf-{i}")
+    sessions = [(f"cnf-{i}", f"repo{i}") for i in range(MIN_RECURRING_SESSIONS)]
+
+    finding = analyze_relearns(sessions, projects_root=tmp_path, distill_enabled=False)
+
+    assert len(finding.clusters) == 1
+    cluster = finding.clusters[0]
+    assert cluster.family_key == "command_not_found"
+    assert cluster.rung == 1
+    assert "python3" in cluster.proposed_fix
+
+
+def test_below_threshold_cluster_is_dropped(tmp_path):
+    for i in range(MIN_RECURRING_SESSIONS - 1):
+        _edit_before_read_session(tmp_path, f"-Users-test-repo{i}", f"ebr-{i}")
+    sessions = [(f"ebr-{i}", f"repo{i}") for i in range(MIN_RECURRING_SESSIONS - 1)]
+
+    finding = analyze_relearns(sessions, projects_root=tmp_path, distill_enabled=False)
+
+    assert finding.clusters == []
+    assert finding.failures_examined == MIN_RECURRING_SESSIONS - 1
+    assert finding.min_sessions == MIN_RECURRING_SESSIONS
+
+
+def test_config_lowers_recurrence_bar_surfaces_previously_hidden_cluster(tmp_path):
+    """The exact data from test_below_threshold_cluster_is_dropped clusters
+    nothing at the default bar; passing a lower min_sessions (what run()
+    threads from [optimize] min_recurring_sessions) surfaces it."""
+    for i in range(MIN_RECURRING_SESSIONS - 1):
+        _edit_before_read_session(tmp_path, f"-Users-test-repo{i}", f"ebr-{i}")
+    sessions = [(f"ebr-{i}", f"repo{i}") for i in range(MIN_RECURRING_SESSIONS - 1)]
+
+    default_finding = analyze_relearns(sessions, projects_root=tmp_path, distill_enabled=False)
+    assert default_finding.clusters == []
+
+    lowered_finding = analyze_relearns(
+        sessions, projects_root=tmp_path, distill_enabled=False,
+        min_sessions=MIN_RECURRING_SESSIONS - 1,
+    )
+    assert len(lowered_finding.clusters) == 1
+    assert lowered_finding.clusters[0].sessions == MIN_RECURRING_SESSIONS - 1
+    assert lowered_finding.min_sessions == MIN_RECURRING_SESSIONS - 1
+
+
+def test_run_reads_min_recurring_sessions_from_ctx_config(tmp_path, monkeypatch):
+    """The registered run(ctx) entry point reads
+    ctx.config.optimize.min_recurring_sessions (not just analyze_relearns's
+    direct min_sessions param)."""
+    from tokenjam.core.config import OptimizeConfig, TjConfig
+    from tokenjam.core.optimize.analyzers.relearn import run as run_relearn
+    from tokenjam.core.optimize.types import AnalyzerContext, OptimizeReport, WindowSummary
+
+    monkeypatch.setenv("TJ_CLAUDE_PROJECTS_ROOT", str(tmp_path))
+    for i in range(MIN_RECURRING_SESSIONS - 1):
+        _edit_before_read_session(tmp_path, f"-Users-test-repo{i}", f"ebr-{i}")
+
+    since = datetime.now(timezone.utc) - timedelta(days=1)
+    summary = WindowSummary(
+        since=since, until=datetime.now(timezone.utc), days=1.0, sessions=0,
+        spans=0, total_tokens=0, total_cost_usd=0.0, thin_data=False,
+    )
+
+    def _ctx(config) -> AnalyzerContext:
+        return AnalyzerContext(
+            conn=None, config=config, since=since, until=datetime.now(timezone.utc),
+            agent_id=None, window_days=1.0, summary=summary,
+            report=OptimizeReport(window=summary),
+        )
+
+    default_ctx = _ctx(TjConfig(version="1"))
+    run_relearn(default_ctx)
+    assert default_ctx.report.findings["relearn"].clusters == []
+
+    lowered_ctx = _ctx(TjConfig(
+        version="1",
+        optimize=OptimizeConfig(min_recurring_sessions=MIN_RECURRING_SESSIONS - 1),
+    ))
+    run_relearn(lowered_ctx)
+    assert len(lowered_ctx.report.findings["relearn"].clusters) == 1
+
+
+def test_extract_failures_transcript_cache_dir_opt_in_matches_uncached(tmp_path):
+    """Passing `transcript_cache_dir` must not change what's extracted."""
+    _cwd_confusion_session(tmp_path, "-Users-test-cache", "sess-cache")
+
+    uncached = extract_failures_for_session("sess-cache", "repo-a", projects_root=tmp_path)
+    cached = extract_failures_for_session(
+        "sess-cache", "repo-a", projects_root=tmp_path,
+        transcript_cache_dir=tmp_path / "cache",
+    )
+    assert [f.tool_name for f in cached] == [f.tool_name for f in uncached]
+    assert [f.error_text for f in cached] == [f.error_text for f in uncached]
+
+
+def test_extract_failures_warm_cache_skips_reparsing(tmp_path, monkeypatch):
+    _cwd_confusion_session(tmp_path, "-Users-test-cache", "sess-cache")
+    cache_dir = tmp_path / "cache"
+
+    first = extract_failures_for_session(
+        "sess-cache", "repo-a", projects_root=tmp_path, transcript_cache_dir=cache_dir,
+    )
+    assert first  # sanity: a real failure, not an empty no-op
+
+    def _boom(path):
+        raise AssertionError(f"transcript.read_records reparsed {path} on a warm cache run")
+
+    monkeypatch.setattr("tokenjam.core.transcript._parse_records", _boom)
+
+    second = extract_failures_for_session(
+        "sess-cache", "repo-a", projects_root=tmp_path, transcript_cache_dir=cache_dir,
+    )
+    assert [f.tool_name for f in second] == [f.tool_name for f in first]
+
+
+def test_compute_relearn_finding_cache_invalidates_on_transcript_edit(tmp_path):
+    """A session rewritten between two cached scans (its failure resolved,
+    say) must be re-parsed, not served a stale extraction."""
+    for i in range(MIN_RECURRING_SESSIONS):
+        _cwd_confusion_session(tmp_path, f"-Users-test-inv{i}", f"inv-{i}")
+    cache_dir = tmp_path / "cache"
+
+    first = compute_relearn_finding(
+        projects_root=tmp_path, distill_enabled=False, transcript_cache_dir=cache_dir,
+    )
+    assert len(first.clusters) == 1  # the recurring cwd-confusion cluster
+
+    # Rewrite one session so it's clean (no more failure) — size + mtime both
+    # change, which must invalidate that session's cache entry and drop the
+    # cluster below the recurrence bar.
+    _clean_session(tmp_path, "-Users-test-inv0", "inv-0")
+
+    second = compute_relearn_finding(
+        projects_root=tmp_path, distill_enabled=False, transcript_cache_dir=cache_dir,
+    )
+    assert second.clusters == []
+
+
+def test_run_wires_the_persistent_transcript_cache(tmp_path, monkeypatch):
+    """The registered `run(ctx)` entry point (the path `tj optimize` and
+    `/cost/components` actually exercise) resolves and uses a real cache dir
+    from `ctx.config`, not just the standalone functions tested above."""
+    from tokenjam.core.config import TjConfig
+    from tokenjam.core.optimize.analyzers.relearn import run as run_relearn
+    from tokenjam.core.optimize.types import AnalyzerContext, OptimizeReport, WindowSummary
+
+    monkeypatch.setenv("TJ_CLAUDE_PROJECTS_ROOT", str(tmp_path))
+    for i in range(MIN_RECURRING_SESSIONS):
+        _cwd_confusion_session(tmp_path, f"-Users-test-run{i}", f"run-{i}")
+
+    since = datetime.now(timezone.utc) - timedelta(days=1)
+    summary = WindowSummary(
+        since=since, until=datetime.now(timezone.utc), days=1.0, sessions=0,
+        spans=0, total_tokens=0, total_cost_usd=0.0, thin_data=False,
+    )
+    config = TjConfig(version="1")
+
+    def _ctx() -> AnalyzerContext:
+        return AnalyzerContext(
+            conn=None, config=config, since=since, until=datetime.now(timezone.utc),
+            agent_id=None, window_days=1.0, summary=summary,
+            report=OptimizeReport(window=summary),
+        )
+
+    first_ctx = _ctx()
+    run_relearn(first_ctx)
+    first = first_ctx.report.findings["relearn"]
+    assert len(first.clusters) == 1
+
+    def _boom(path):
+        raise AssertionError(f"transcript.read_records reparsed {path} on a warm cache run")
+
+    monkeypatch.setattr("tokenjam.core.transcript._parse_records", _boom)
+
+    second_ctx = _ctx()
+    run_relearn(second_ctx)
+    second = second_ctx.report.findings["relearn"]
+    assert len(second.clusters) == 1
+
+
+def test_single_repo_cluster_scopes_to_project(tmp_path):
+    for i in range(MIN_RECURRING_SESSIONS):
+        _edit_before_read_session(tmp_path, "-Users-test-onerepo", f"ebr-one-{i}")
+    sessions = [(f"ebr-one-{i}", "onerepo") for i in range(MIN_RECURRING_SESSIONS)]
+
+    finding = analyze_relearns(sessions, projects_root=tmp_path, distill_enabled=False)
+
+    assert len(finding.clusters) == 1
+    assert finding.clusters[0].scope == "project"
+    assert finding.clusters[0].repos == ["onerepo"]
+
+
+def test_clean_sessions_produce_no_proposals(tmp_path):
+    for i in range(5):
+        _clean_session(tmp_path, "-Users-test-clean", f"clean-{i}")
+    sessions = [(f"clean-{i}", "cleanrepo") for i in range(5)]
+
+    finding = analyze_relearns(sessions, projects_root=tmp_path, distill_enabled=False)
+
+    assert finding.clusters == []
+    assert finding.failures_examined == 0
+    assert finding.estimated_recoverable_tokens is None
+
+
+# --- Novelty filter -------------------------------------------------------------
+
+def test_already_codified_cluster_is_dropped(tmp_path):
+    for i in range(MIN_RECURRING_SESSIONS):
+        _cwd_confusion_session(tmp_path, f"-Users-test-doc{i}", f"cwd-doc-{i}")
+    sessions = [(f"cwd-doc-{i}", f"repo{i}") for i in range(MIN_RECURRING_SESSIONS)]
+
+    doc_text = "known gotcha: always confirm cwd — errors read 'no such file or directory'."
+
+    finding = analyze_relearns(
+        sessions, projects_root=tmp_path, distill_enabled=False, codified_doc_text=doc_text,
+    )
+
+    assert finding.clusters == []
+    assert finding.dropped_codified == 1
+
+
+def test_is_already_codified_requires_the_exact_phrase():
+    from tokenjam.core.optimize.analyzers.relearn import _RawCluster
+
+    cluster = _RawCluster(signature="cwd_confusion", family_key="cwd_confusion", title="x")
+    # A generic, partial mention isn't enough — the exact phrase must appear.
+    assert is_already_codified(cluster, "mentions cwd but nothing else relevant") is False
+    assert is_already_codified(cluster, "watch for 'no such file or directory' errors") is True
+    assert is_already_codified(cluster, "") is False
+
+
+def test_is_already_codified_never_drops_a_residual_cluster():
+    """No known family_key -> always treated as novel (see is_already_codified
+    docstring: a wrongful drop here would silently hide new signal)."""
+    from tokenjam.core.optimize.analyzers.relearn import _RawCluster
+
+    cluster = _RawCluster(signature="Bash:some weird thing", family_key=None, title="Bash: some weird thing")
+    assert is_already_codified(cluster, "some weird thing is a documented gotcha") is False
+
+
+# --- Distill confidence gate ----------------------------------------------------
+# Real confabulation examples pulled from the local corpus (2026-07-14): distill,
+# fed only bare/near-empty evidence from a benign multi-command `&&` Bash chain
+# (last command exits nonzero with no error text of its own — often a trailing
+# grep/find "no match"), invented FIVE different confident-but-wrong "fixes" for
+# the SAME phenomenon. The gate must suppress all five while leaving genuinely
+# well-evidenced clusters (branch-already-exists, EISDIR) untouched.
+
+_REAL_THIN_SAMPLES: dict[str, list[str]] = {
+    # -> was confabulated as "bash_stderr_missing"
+    "bash_stderr_missing": ["Exit code 1", "Exit code 1", "Exit code 2"],
+    # -> was confabulated as "bash_env_setup"
+    "bash_env_setup": ["Exit code 1\n0", "Exit code 1\n0", "Exit code 7\n000"],
+    # -> was confabulated as "bash_error_reporting"
+    "bash_error_reporting": ["Exit code 1\n---", "Exit code 2\n---", "Exit code 1\n---"],
+    # -> was confabulated as "bash_output_buffer_limit" — real content, but it's
+    # leftover `ls -la` stdout from an EARLIER, successful chain step, not an
+    # error description of why the chain's last command failed.
+    "bash_output_buffer_limit": [
+        "Exit code 1\ntotal 240\ndrwxr-xr-x@ 21 anshs  staff    672 Jun 28 14:44 .\n"
+        "drwxr-xr-x@ 16 anshs  staff    512 Jun 28 14:44 ..\n"
+        "-rw-r--r--@  1 anshs  staff     75 Jun 28 14:44 .git",
+        "Exit code 1\ntotal 280\ndrwxr-xr-x@ 25 anshs  staff    800 Jun 25 17:52 .\n"
+        "drwxr-xr-x@ 33 anshs  staff   1056 Jun 25 17:53 ..",
+    ],
+    # -> was confabulated as "bash_output_truncation"
+    "bash_output_truncation": [
+        "Exit code 1\ntotal 288\ndrwxr-xr-x@ 24 anshs  staff    768 Jul  3 12:56 .\n"
+        "drwxr-xr-x@ 16 anshs  staff    512 Jul  3 12:56 ..\n"
+        "-rw-r--r--@  1 anshs  staff    553 Jul  3 12:56 .dockerignore",
+        "Exit code 1\ntotal 400\ndrwxr-xr-x@ 32 anshs  staff   1024 Jul  3 00:37 .",
+    ],
+}
+
+_REAL_LEGIT_SAMPLES: dict[str, list[str]] = {
+    "branch_already_exists": [
+        "Exit code 128\nfatal: a branch named 'ticket-28' already exists",
+        "Exit code 128\nfatal: a branch named 'ticket-322' already exists",
+        "Exit code 128\nfatal: a branch named 'ticket-22' already exists",
+    ],
+    "read_tool_dir_not_file": [
+        "EISDIR: illegal operation on a directory, read "
+        "'/Users/anshs/Folder/code/shiploop.wt/ticket-5/shiploop/templates'",
+        "EISDIR: illegal operation on a directory, read "
+        "'/Users/anshs/Folder/code/vibelab.wt/ticket-5'",
+    ],
+}
+
+
+@pytest.mark.parametrize("family, samples", _REAL_THIN_SAMPLES.items())
+def test_confabulated_bash_chain_evidence_is_too_thin(family, samples):
+    from tokenjam.core.optimize.analyzers.relearn import (
+        FailureEpisode,
+        _RawCluster,
+        _evidence_too_thin_for_distill,
+    )
+
+    cluster = _RawCluster(
+        signature=f"Bash:{family}", family_key=None, title=family,
+        failures=[
+            FailureEpisode(f"s{i}", "repo", None, "Bash", "cmd1 && cmd2", s, "act", False, 0)
+            for i, s in enumerate(samples)
+        ],
+    )
+    assert _evidence_too_thin_for_distill(cluster) is True
+
+
+@pytest.mark.parametrize("family, samples", _REAL_LEGIT_SAMPLES.items())
+def test_legit_evidence_is_not_too_thin(family, samples):
+    from tokenjam.core.optimize.analyzers.relearn import (
+        FailureEpisode,
+        _RawCluster,
+        _evidence_too_thin_for_distill,
+    )
+
+    cluster = _RawCluster(
+        signature=f"X:{family}", family_key=None, title=family,
+        failures=[
+            FailureEpisode(f"s{i}", "repo", None, "Bash", "cmd", s, "act", False, 0)
+            for i, s in enumerate(samples)
+        ],
+    )
+    assert _evidence_too_thin_for_distill(cluster) is False
+
+
+def test_confidence_gate_suppresses_confabulations_even_with_a_warm_cache(tmp_path):
+    """The gate runs BEFORE the cache is ever consulted — even a stale cache
+    entry from before this fix (holding the exact real confabulated answer)
+    must not resurrect a suppressed cluster."""
+    import hashlib
+    import json
+
+    from tokenjam.core.optimize.analyzers.relearn import (
+        MIN_DISTILL_CLUSTER_SESSIONS,
+        FailureEpisode,
+        _RawCluster,
+        apply_distill_to_residual,
+    )
+
+    cache_dir = tmp_path / "distill_cache"
+    clusters = []
+    fake_answers = {
+        "bash_stderr_missing": {
+            "title": "Bash tool suppressing stderr output", "family_key": "bash_stderr_missing",
+            "fix": "Verify the Bash tool is capturing and displaying stderr.",
+        },
+        "bash_env_setup": {
+            "title": "Shell environment initialization incomplete", "family_key": "bash_env_setup",
+            "fix": "Ensure PATH, working directory, and shell state are explicitly configured.",
+        },
+    }
+    for family, samples in _REAL_THIN_SAMPLES.items():
+        n = max(len(samples), MIN_DISTILL_CLUSTER_SESSIONS)
+        failures = [
+            FailureEpisode(f"{family}-s{i}", "repo", None, "Bash", "cmd1 && cmd2",
+                            samples[i % len(samples)], "act", False, 0)
+            for i in range(n)
+        ]
+        cluster = _RawCluster(signature=f"Bash:{family}", family_key=None, title=family, failures=failures)
+        clusters.append(cluster)
+        # Pre-seed the cache with the REAL confabulated answer where we have
+        # one — proves the gate short-circuits before the cache read.
+        answer = fake_answers.get(family)
+        if answer:
+            payload = cluster.signature + "|" + "|".join(sorted(f.error_text for f in cluster.failures[:10]))
+            cache_key = hashlib.sha256(payload.encode("utf-8")).hexdigest()[:24]
+            cache_dir.mkdir(parents=True, exist_ok=True)
+            (cache_dir / f"{cache_key}.json").write_text(json.dumps(answer), encoding="utf-8")
+
+    result = apply_distill_to_residual(clusters, cache_dir=cache_dir, enabled=True)
+    result_family_keys = {c.family_key for c in result}
+    for family in _REAL_THIN_SAMPLES:
+        assert f"distilled:{family}" not in result_family_keys
+    # Nothing survives at all — every seeded cluster here was thin evidence.
+    assert result == []
+
+
+# --- CLI text-view rendering regression -------------------------------------
+# `relearn` was registered in ANALYZER_REGISTRY/ANALYZER_ORDER but never wired
+# into cmd_optimize's `_FINDING_RENDERERS` dispatch table, so `_rank_findings`
+# silently dropped it and `tj optimize relearn` (text view) fell through to
+# the generic "No candidates flagged in this window" empty state — even with
+# real clusters sitting in `--json`.
+
+def test_relearn_in_click_choices_and_renderer():
+    """relearn appears in the positional Click choices (auto-derived from the
+    registry) and has a human-readable renderer wired into the dispatch
+    table — mirrors the same regression guard used for `verbosity`."""
+    from tokenjam.cli.cmd_optimize import _FINDING_RENDERERS, cmd_optimize
+
+    findings_param = next(
+        p for p in cmd_optimize.params if getattr(p, "name", None) == "findings"
+    )
+    assert "relearn" in findings_param.type.choices
+    assert "relearn" in _FINDING_RENDERERS
+
+
+def test_render_relearn_shows_clusters_without_error(tmp_path, capsys):
+    """The finding renders through the CLI dispatch path and surfaces the
+    cluster signature + occurrences + rung — not a generic empty state."""
+    from tokenjam.cli.cmd_optimize import _render_relearn
+
+    for i in range(MIN_RECURRING_SESSIONS):
+        _cwd_confusion_session(tmp_path, f"-Users-test-render{i}", f"render-{i}")
+    sessions = [(f"render-{i}", f"repo{i}") for i in range(MIN_RECURRING_SESSIONS)]
+    finding = analyze_relearns(sessions, projects_root=tmp_path, distill_enabled=False)
+    assert finding.clusters  # sanity: the analyzer actually found the cluster
+
+    for mode in ("api", "subscription", "local", "unknown"):
+        _render_relearn(finding, pricing_mode=mode, marker="①")
+    out = capsys.readouterr().out
+    assert "cwd_confusion" in out
+    assert f"{finding.clusters[0].occurrences}" in out
+    assert "rung 3" in out
+    assert "No candidates flagged" not in out
+
+
+def test_render_report_surfaces_relearn_clusters_instead_of_no_candidates(tmp_path, capsys):
+    """End-to-end regression: a report whose only finding is a
+    populated `relearn` cluster set must NOT fall through to the
+    cost-optimizer's generic "No candidates flagged" empty state."""
+    from tokenjam.cli.cmd_optimize import _render_report
+    from tokenjam.core.optimize.types import OptimizeReport, WindowSummary
+    from tokenjam.utils.time_parse import utcnow
+
+    for i in range(MIN_RECURRING_SESSIONS):
+        _cwd_confusion_session(tmp_path, f"-Users-test-e2e{i}", f"e2e-{i}")
+    sessions = [(f"e2e-{i}", f"repo{i}") for i in range(MIN_RECURRING_SESSIONS)]
+    finding = analyze_relearns(sessions, projects_root=tmp_path, distill_enabled=False)
+    assert finding.clusters
+
+    now = utcnow()
+    report = OptimizeReport(
+        window=WindowSummary(
+            since=now, until=now, days=365, sessions=len(sessions), spans=0,
+            total_tokens=100_000, total_cost_usd=0.0, thin_data=False,
+        ),
+        downgrade=None,
+        findings={"relearn": finding},
+    )
+    _render_report(report, agent=None, requested=["relearn"], pricing_mode="local")
+    out = capsys.readouterr().out
+    assert "No candidates flagged" not in out
+    assert "cwd_confusion" in out
+
+
+def test_render_report_surfaces_clusters_even_in_a_huge_token_window(tmp_path, capsys):
+    """Collapse variant: a relearn finding must surface its clusters in
+    full even when the window's total tokens are enormous (a heavy
+    `tj optimize relearn --since 365d` run). Relearns are recurring-failure
+    clusters, not a token-reclamation finding, so a huge window denominator
+    must NOT push them below DE_MINIMIS_SHARE and collapse them into the
+    "Minor findings — ~0.0% of window tokens" pointer — that hides the headline
+    self-improve signal exactly as the "No candidates flagged" empty state did.
+    """
+    from tokenjam.cli.cmd_optimize import _render_report
+    from tokenjam.core.optimize.types import OptimizeReport, WindowSummary
+    from tokenjam.utils.time_parse import utcnow
+
+    for i in range(MIN_RECURRING_SESSIONS):
+        _cwd_confusion_session(tmp_path, f"-Users-test-huge{i}", f"huge-{i}")
+    sessions = [(f"huge-{i}", f"repo{i}") for i in range(MIN_RECURRING_SESSIONS)]
+    finding = analyze_relearns(sessions, projects_root=tmp_path, distill_enabled=False)
+    assert finding.clusters
+    assert finding.estimated_recoverable_tokens  # a positive, rank-able estimate
+
+    now = utcnow()
+    report = OptimizeReport(
+        window=WindowSummary(
+            # 2B tokens — the cluster's occurrence×heuristic estimate is a ~0%
+            # share of this window, the exact condition that collapsed it.
+            since=now, until=now, days=365, sessions=len(sessions), spans=0,
+            total_tokens=2_000_000_000, total_cost_usd=0.0, thin_data=False,
+        ),
+        downgrade=None,
+        findings={"relearn": finding},
+    )
+    _render_report(report, agent=None, requested=["relearn"], pricing_mode="local")
+    out = capsys.readouterr().out
+    assert "cwd_confusion" in out                 # clusters surfaced in full
+    assert f"{finding.clusters[0].occurrences}" in out
+    assert "Minor findings" not in out            # NOT collapsed to the pointer
+    assert "of window tokens" not in out          # no de-minimis token framing
+    assert "No candidates flagged" not in out

--- a/tests/unit/test_transcript_cache.py
+++ b/tests/unit/test_transcript_cache.py
@@ -1,0 +1,162 @@
+"""Unit tests for the persistent transcript parse cache
+(core/transcript_cache.py).
+
+No I/O beyond a ``tmp_path`` cache dir and ``tmp_path``-rooted transcript
+files — mirrors test_deadweight.py / test_relearn.py's fixture style.
+"""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from tokenjam.core import transcript_cache as tc
+
+
+def _write(path: Path, records: list[dict]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text("\n".join(json.dumps(r) for r in records), encoding="utf-8")
+
+
+def test_cold_cache_parses_and_returns_records(tmp_path):
+    src = tmp_path / "session.jsonl"
+    _write(src, [{"type": "user", "message": {"content": "hi"}}])
+    cache_dir = tmp_path / "cache"
+
+    records = tc.cached_read_records(src, cache_dir)
+
+    assert records == [{"type": "user", "message": {"content": "hi"}}]
+    # A cache entry was actually written (not just an in-memory shortcut).
+    assert list(cache_dir.glob("*.json"))
+
+
+def test_warm_cache_skips_reparsing_the_source_file(tmp_path, monkeypatch):
+    src = tmp_path / "session.jsonl"
+    _write(src, [{"type": "user", "message": {"content": "hi"}}])
+    cache_dir = tmp_path / "cache"
+
+    first = tc.cached_read_records(src, cache_dir)
+
+    # Any second call against an UNCHANGED file must be served from the cache
+    # entry, never re-invoking the real parser — patch it to blow up if it's
+    # called again so a regression here fails loudly instead of just slowly.
+    def _boom(_path):
+        raise AssertionError("_parse_records was called on a warm cache hit")
+
+    monkeypatch.setattr("tokenjam.core.transcript._parse_records", _boom)
+
+    second = tc.cached_read_records(src, cache_dir)
+    assert second == first
+
+
+def test_cache_invalidates_when_the_file_changes(tmp_path):
+    src = tmp_path / "session.jsonl"
+    _write(src, [{"type": "user", "message": {"content": "v1"}}])
+    cache_dir = tmp_path / "cache"
+
+    first = tc.cached_read_records(src, cache_dir)
+    assert first[0]["message"]["content"] == "v1"
+
+    # Mutate the source: both size and mtime change (a real edit/append, not
+    # a no-op rewrite), so the cached (size, mtime) pair no longer matches.
+    _write(src, [{"type": "user", "message": {"content": "v2-longer-content"}}])
+
+    second = tc.cached_read_records(src, cache_dir)
+    assert second[0]["message"]["content"] == "v2-longer-content"
+    assert second != first
+
+
+def test_cache_invalidates_on_mtime_change_even_at_same_size(tmp_path):
+    """Two distinct edits can coincidentally leave the file the same size —
+    the cache must still catch that via mtime, not just size."""
+    src = tmp_path / "session.jsonl"
+    _write(src, [{"type": "user", "message": {"content": "aaa"}}])
+    cache_dir = tmp_path / "cache"
+
+    tc.cached_read_records(src, cache_dir)
+
+    import os
+
+    st = src.stat()
+    _write(src, [{"type": "user", "message": {"content": "bbb"}}])
+    # Force a distinct mtime (filesystem mtime resolution can be coarse, and
+    # the rewrite above may otherwise land in the same tick).
+    os.utime(src, (st.st_atime, st.st_mtime + 5))
+    st2 = src.stat()
+    assert st.st_size == st2.st_size  # same size, different content
+
+    second = tc.cached_read_records(src, cache_dir)
+    assert second[0]["message"]["content"] == "bbb"
+
+
+def test_missing_source_returns_empty_list_and_no_cache_write(tmp_path):
+    src = tmp_path / "gone.jsonl"
+    cache_dir = tmp_path / "cache"
+
+    assert tc.cached_read_records(src, cache_dir) == []
+    assert not cache_dir.exists() or not list(cache_dir.glob("*.json"))
+
+
+def test_corrupt_cache_entry_falls_back_to_reparsing(tmp_path):
+    src = tmp_path / "session.jsonl"
+    _write(src, [{"type": "user", "message": {"content": "hi"}}])
+    cache_dir = tmp_path / "cache"
+
+    tc.cached_read_records(src, cache_dir)
+    entry = next(cache_dir.glob("*.json"))
+    entry.write_text("not json{{{", encoding="utf-8")
+
+    # Must degrade to a fresh parse, not raise.
+    records = tc.cached_read_records(src, cache_dir)
+    assert records == [{"type": "user", "message": {"content": "hi"}}]
+
+
+def test_prune_orphaned_entries_removes_only_dead_sources(tmp_path):
+    alive = tmp_path / "alive.jsonl"
+    dying = tmp_path / "dying.jsonl"
+    _write(alive, [{"type": "user"}])
+    _write(dying, [{"type": "user"}])
+    cache_dir = tmp_path / "cache"
+
+    tc.cached_read_records(alive, cache_dir)
+    tc.cached_read_records(dying, cache_dir)
+    assert len(list(cache_dir.glob("*.json"))) == 2
+
+    dying.unlink()
+    removed = tc.prune_orphaned_entries(cache_dir)
+
+    assert removed == 1
+    remaining = list(cache_dir.glob("*.json"))
+    assert len(remaining) == 1
+    assert json.loads(remaining[0].read_text())["path"] == str(alive)
+
+
+def test_prune_orphaned_entries_on_missing_cache_dir_is_a_noop(tmp_path):
+    assert tc.prune_orphaned_entries(tmp_path / "never-created") == 0
+
+
+def test_default_cache_dir_honors_env_override(tmp_path, monkeypatch):
+    monkeypatch.setenv("TJ_TRANSCRIPT_CACHE_DIR", str(tmp_path / "custom"))
+    assert tc.default_cache_dir() == tmp_path / "custom"
+
+
+def test_default_cache_dir_falls_back_to_home_tj_without_config(monkeypatch):
+    monkeypatch.delenv("TJ_TRANSCRIPT_CACHE_DIR", raising=False)
+    assert tc.default_cache_dir() == Path.home() / ".tj" / "transcript_cache"
+
+
+def test_concurrent_writers_never_corrupt_the_cache_file(tmp_path):
+    """Two 'processes' (simulated by calling the private writer twice with
+    different pids-in-name) racing the same entry must never leave a
+    partially-written / unparseable file behind — the atomic rename
+    guarantees the last writer's COMPLETE payload wins."""
+    src = tmp_path / "session.jsonl"
+    _write(src, [{"type": "user", "message": {"content": "hi"}}])
+    cache_dir = tmp_path / "cache"
+    cache_path = cache_dir / tc._cache_key(src)
+
+    tc._store(cache_path, src, 100, 1.0, [{"a": 1}])
+    tc._store(cache_path, src, 100, 1.0, [{"a": 2}])
+
+    loaded = tc._load(cache_path)
+    assert loaded is not None
+    assert loaded["records"] == [{"a": 2}]

--- a/tokenjam/api/routes/cost.py
+++ b/tokenjam/api/routes/cost.py
@@ -335,11 +335,30 @@ async def get_cost_components(
     recoverable: list[dict] = []
     if conn is not None:
         try:
-            from tokenjam.core.optimize import build_report
+            from tokenjam.core.optimize import ANALYZER_REGISTRY, build_report
+
+            # `relearn` is a full-corpus scan the analyzer's OWN docstring
+            # says is too heavy for per-request HTTP use ("callers that serve
+            # this over HTTP MUST cache the result, not compute it per-
+            # request" — core/optimize/analyzers/relearn.py). Worse, its
+            # `RelearnFinding` never carries `estimated_recoverable_usd`, so
+            # `_collect_recoverable` below silently discards its result no
+            # matter what — running it here was guaranteed dead work on every
+            # request. Excluding it by name changes nothing about what this
+            # endpoint returns (verified: no output field ever came from it)
+            # while removing that tax; the Review inbox
+            # (api/routes/relearn.py) already serves relearn's finding from
+            # its own background-refreshed cache. `deadweight` DOES
+            # contribute (it has `estimated_recoverable_usd`) so it still
+            # runs here, but now via the persistent transcript parse cache
+            # (core.transcript_cache, wired into its `run(ctx)` entry point)
+            # so a warm cache makes repeat requests cheap instead of
+            # re-scanning every transcript from scratch each time.
+            findings = [name for name in ANALYZER_REGISTRY if name != "relearn"]
             report = build_report(
                 db=db, config=config,
                 since=since_dt or utcnow(), until=until_dt or utcnow(),
-                agent_id=agent_id,
+                agent_id=agent_id, findings=findings,
             )
             recoverable = _collect_recoverable(report)
         except Exception:

--- a/tokenjam/core/atomic_write.py
+++ b/tokenjam/core/atomic_write.py
@@ -1,0 +1,48 @@
+"""Atomic file write — the shared write primitive for every apply rail.
+
+``atomic_write`` writes text to an existing file via a temp file in the same
+dir → ``os.replace`` (so a reader never sees a partial write, and a crash
+mid-write leaves the original untouched), preserving the file's mode. It
+refuses a symlinked target outright — every caller gets that guard for free,
+including one that forgets its own pre-check.
+
+This is deliberately feature-agnostic: ``core.summarize.apply`` (the prompt
+summarizer's apply/undo path) and ``core.optimize.relearn_apply`` (the
+self-improve loop's apply/revert path) both reuse it. Neither owns it; each
+maps ``AtomicWriteRefused`` to its own domain exception at the call site.
+"""
+from __future__ import annotations
+
+import os
+import stat
+import tempfile
+from pathlib import Path
+
+
+class AtomicWriteRefused(Exception):
+    """Refusing an atomic write — the target is a symlink, so writing through it
+    could land outside where the caller expects. Callers map this to their own
+    domain exception (e.g. summarize's ``SummarizeRefused``, relearn's
+    ``RelearnApplyRefused``)."""
+
+
+def atomic_write(p: Path, text: str) -> None:
+    """Write ``text`` to ``p`` atomically (temp in the same dir → ``os.replace``), preserving mode.
+
+    Raises ``AtomicWriteRefused`` if ``p`` is a symlink.
+    """
+    if p.is_symlink():
+        raise AtomicWriteRefused(f"{p} is a symlink — refusing to write through it.")
+    mode = stat.S_IMODE(p.stat().st_mode)
+    fd, tmp = tempfile.mkstemp(dir=str(p.parent), prefix=f".{p.name}.", suffix=".tj-tmp")
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as f:
+            f.write(text)
+        os.chmod(tmp, mode)
+        os.replace(tmp, p)
+    except Exception:
+        try:
+            os.unlink(tmp)
+        except FileNotFoundError:
+            pass
+        raise

--- a/tokenjam/core/optimize/accounting.py
+++ b/tokenjam/core/optimize/accounting.py
@@ -1,0 +1,110 @@
+"""Token and dollar accounting primitives shared by every cost surface.
+
+Two rules live here, both of which have cost real money by being re-derived
+per analyzer instead of shared.
+
+**Four token types, always.** A span bills across four buckets: input, output,
+cache READ (``cache_tokens``) and cache WRITE (``cache_write_tokens``). Cache
+writes are the expensive ones (1.25x or 2x input), so an aggregate that omits
+them under-reports exactly the traffic a cache card is about. That omission has
+shipped three separate times in this package. ``four_type_token_sum_sql`` is
+the canonical form; use it rather than hand-writing another ``SUM(...)``.
+
+**Call identity, not row identity.** A single LLM call can reach the store more
+than once: the live path and the backfill path both observe it, each minting
+its own ``span_id``, so a row-level ``SUM`` counts it twice. Money figures must
+therefore be summed over CALLS, not over rows. ``call_identity`` names the
+call; ``dedupe_by_call_identity`` collapses repeats last-wins, matching the
+policy ``core.usage.session_usage`` applies to transcript records (the last
+record for a message carries the finalized usage).
+
+Today a span only carries an explicit call id when an ingest path stamps one;
+without it the fallback is the row's own ``span_id``, which is what the store
+has always keyed on. That makes this a seam, not a rewrite: adopting it changes
+no current number, and the day the ingest paths agree on a call id, every
+figure routed through here becomes single-counted with no further edits. The
+ingest-side deduplication is separate work on its own track; nothing here
+modifies how spans are written.
+"""
+from __future__ import annotations
+
+import json
+from typing import Any, Iterable, Sequence
+
+#: The four billable token columns on a span row, in canonical order.
+TOKEN_TYPE_COLUMNS: tuple[str, ...] = (
+    "input_tokens", "output_tokens", "cache_tokens", "cache_write_tokens",
+)
+
+#: Attribute keys, in precedence order, that name the underlying API call.
+#: First non-empty one wins. ``gen_ai.response.id`` is the provider's own id
+#: for the response; ``tj.call_id`` is the internal stamp.
+CALL_ID_ATTRIBUTE_KEYS: tuple[str, ...] = ("tj.call_id", "gen_ai.response.id")
+
+
+def four_type_token_sum_sql(prefix: str = "", alias: str | None = None) -> str:
+    """The canonical all-four-token-types SQL sum.
+
+    ``prefix`` qualifies the columns (e.g. ``"s."``). Pass ``alias`` to append
+    an ``AS <alias>``. Every new token aggregate should be built from this, so
+    a missing cache bucket is impossible rather than merely discouraged.
+    """
+    inner = " + ".join(f"COALESCE({prefix}{col},0)" for col in TOKEN_TYPE_COLUMNS)
+    sql = f"COALESCE(SUM({inner}), 0)"
+    return f"{sql} AS {alias}" if alias else sql
+
+
+def four_type_token_total(row: Any) -> int:
+    """The all-four-types total for one mapping-like row (or any object
+    exposing the four columns as keys). Missing buckets read as 0."""
+    getter = row.get if hasattr(row, "get") else (lambda k, d=0: getattr(row, k, d))
+    return sum(int(getter(col, 0) or 0) for col in TOKEN_TYPE_COLUMNS)
+
+
+def _attributes_dict(attributes: Any) -> dict[str, Any]:
+    """Span attributes as a dict. Stored as a JSON string by some backends and
+    as a dict by others; anything unparseable reads as empty, never raises."""
+    if isinstance(attributes, dict):
+        return attributes
+    if isinstance(attributes, (str, bytes)):
+        try:
+            parsed = json.loads(attributes)
+        except (ValueError, TypeError):
+            return {}
+        return parsed if isinstance(parsed, dict) else {}
+    return {}
+
+
+def call_identity(span_id: Any, session_id: Any = None, attributes: Any = None) -> str:
+    """The identity of the underlying API call this span row describes.
+
+    Prefers an explicit call id off the span's attributes; falls back to the
+    row's own ``span_id``, which is unique per row and so preserves today's
+    behaviour exactly for spans that carry no call id.
+    """
+    attrs = _attributes_dict(attributes)
+    for key in CALL_ID_ATTRIBUTE_KEYS:
+        value = attrs.get(key)
+        if isinstance(value, str) and value:
+            return f"{session_id or ''}|{value}"
+    return f"{session_id or ''}|{span_id or ''}"
+
+
+def dedupe_by_call_identity(
+    rows: Iterable[Sequence[Any]], *, identity_index: int = 0,
+) -> list[Sequence[Any]]:
+    """Collapse rows describing the same call, LAST WINS.
+
+    Last-wins mirrors ``core.usage.session_usage``: when one call is observed
+    more than once, the later observation is the finalized one. Order among
+    distinct calls is preserved (first appearance), so callers that report
+    counts get a stable result.
+    """
+    latest: dict[Any, Sequence[Any]] = {}
+    order: list[Any] = []
+    for row in rows:
+        key = row[identity_index]
+        if key not in latest:
+            order.append(key)
+        latest[key] = row
+    return [latest[key] for key in order]

--- a/tokenjam/core/optimize/analyzers/deadweight.py
+++ b/tokenjam/core/optimize/analyzers/deadweight.py
@@ -1,0 +1,906 @@
+"""
+MCP dead-weight + always-injected context tax analyzer (self-improve loop,
+cost quick-wins Component C).
+
+Claude Code transcripts lane only (C1 + C2 of the cost quick-wins spec,
+``.claude/self-improve-loop/COST-SPEC.md`` §2 Component C).
+
+C1 — MCP dead weight: enumerate the MCP servers configured for a session
+(project ``.mcp.json`` / ``.claude/settings*.json``, global ``~/.claude.json``
+— all read-only, this module never writes to any of them) and count how
+often each server's tools are actually INVOKED (``mcp__<server>__<tool>``
+tool_use blocks) across the window's sessions. A server present in at least
+``MIN_SESSIONS_DEADWEIGHT`` distinct sessions with ZERO invocations across all
+of them is dead weight: its tool schemas are still injected into context for
+no return.
+
+Deferred-tools caveat (mandatory, spec hard rule). When a session's
+transcript shows a deferred/ToolSearch-style listing naming a server's tools,
+that server's full schemas were NOT loaded that turn — only a short
+name+description line per tool appears in the listing, so the real per-turn
+tax is much smaller. This module detects that marker per session and blends
+``DEFERRED_SCHEMA_TAX_TOKENS`` into the estimate for those sessions; it never
+claims the full ``FULL_SCHEMA_TAX_TOKENS`` tax for a deferred session.
+
+C2 — always-injected context tax table (report-only, no proposals): a ranked,
+per-source, per-session token-tax table for what actually shows up verbatim
+in a session's first turn — session-start hook/environment output, rules
+files, CLAUDE.md — plus the MCP schema-injection line per configured server.
+Every figure is ``estimated``. The "never referenced" judgment (whether a
+source's content ever gets used downstream) is explicitly OUT of scope for
+this pass — see the spec's cut list.
+
+Dedup. A server's MCP-schema tax-table row is purely informational and never
+feeds ``DeadweightFinding.estimated_recoverable_tokens`` — only the C1
+dead-weight servers' own tax does, so a server's tax is never counted twice
+(see ``compute_deadweight_finding``'s dedup note).
+
+Never raises: an unreadable transcript, a malformed config file, or a missing
+projects root is skipped, not fatal — mirrors relearn.py's unattended
+robustness (this runs on the same schedule).
+"""
+from __future__ import annotations
+
+import json
+import re
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from json.decoder import scanstring
+from pathlib import Path
+from typing import Any
+
+from tokenjam.core.optimize.registry import register
+from tokenjam.core.optimize.types import AnalyzerContext
+from tokenjam.core.transcript import _SYSTEM_REMINDER_RE, read_records, resolve_projects_root
+
+# --- Tunables ------------------------------------------------------------
+
+#: A server must be configured-present in at least this many DISTINCT
+#: sessions, with zero invocations across all of them, before it's flagged
+#: dead weight. Originally 10 (spec: "start N=10"); lowered to 5 after an
+#: audit of all twelve analyzers found this the single biggest one-shot fix
+#: for analyzers that rarely fire on a normal user's window — a server
+#: configured-but-never-called is unlikely to be a fluke even at a much
+#: lower bar. False-positive shape (modeling each session as an independent
+#: Bernoulli trial with per-session use probability p): a server actually
+#: needed 1-in-4 sessions has a (1-p)^N ~= 42% chance of a spurious
+#: zero-invocation read at N=3, vs ~24% at N=5, vs ~6% at N=10 -- N=5 keeps
+#: that chance in the same order of magnitude as the old default while
+#: needing HALF the silent evidence to surface, materially increasing how
+#: often this analyzer fires. N=3 was considered and rejected: it nearly
+#: doubles the false-positive rate over N=5 for the same occasional-use
+#: server, and this finding is apply-capable (see the removal machinery
+#: below), so a wrongly-flagged server costs a real (user-approved, but
+#: still avoidable) config edit, not just a noisy card. The module's own
+#: DEADWEIGHT_HONESTY_CAVEAT and review-before-apply gate remain the
+#: backstop for whatever residual false-positive risk N=5 still carries.
+MIN_SESSIONS_DEADWEIGHT = 5
+
+#: How many example session ids a dead server's card carries as evidence
+#: (mirrors relearn.py's MAX_EXAMPLE_SESSIONS convention).
+MAX_EXAMPLE_SESSIONS = 3
+
+#: Full MCP-connector schema-injection tax, per server, when its tool schemas
+#: are loaded (not deferred) — a documented community/founder-research figure
+#: (~25K tokens/call for an attached MCP connector's injected tool
+#: definitions; see .claude/context/research/evidence/
+#: subscription-vs-cost-framing.md and feature-context-diagnostic.md), NOT a
+#: live per-call measurement — the on-disk transcript carries no per-schema
+#: token count (see core/context_diagnostic.py's MCP_INJECTION_PARK_NOTE).
+#: `estimated`, conservative, cited in the card footnote.
+FULL_SCHEMA_TAX_TOKENS = 25_000
+
+#: When a session's transcript shows this server's tools in a DEFERRED
+#: listing (ToolSearch-style), its schemas are NOT loaded that turn — only a
+#: short name+description line per tool appears in the listing.
+#: Conservative estimate: ~10 tools x ~40 tokens/line for a typically-sized
+#: server. Never used to claim the full tax for a deferred session.
+DEFERRED_SCHEMA_TAX_TOKENS = 400
+
+#: Chars-per-token conversion for text measured directly off transcripts
+#: (system-reminder blocks) — same convention as prompt_bloat.py's
+#: CHARS_PER_TOKEN.
+CHARS_PER_TOKEN = 4
+
+DEADWEIGHT_HONESTY_CAVEAT = (
+    "Structural detection off configured MCP servers and their measured "
+    "tool-call counts, not a judgment about whether the server is useful. "
+    "Review the window before removing a server; a low-traffic server can "
+    "still be load-bearing for an occasional task."
+)
+
+
+# --- MCP config enumeration (read-only; never writes a config file) -------
+
+_PROJECT_CONFIG_RELPATHS = (
+    ".mcp.json", ".claude/settings.json", ".claude/settings.local.json",
+)
+
+
+def _read_json_safe(path: Path) -> dict:
+    try:
+        return json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, ValueError):
+        return {}
+
+
+def _mcp_server_names(path: Path) -> set[str]:
+    data = _read_json_safe(path)
+    servers = data.get("mcpServers")
+    if not isinstance(servers, dict):
+        return set()
+    return {str(name) for name in servers if str(name).strip()}
+
+
+def _global_config_path() -> Path:
+    # Resolved LAZILY (never at import time) so a test patching HOME sees the
+    # fake home, never the developer's real ~/.claude.json.
+    return Path.home() / ".claude.json"
+
+
+@dataclass
+class ConfiguredServer:
+    """One MCP server as read off config, and where it reaches."""
+    name:   str
+    scope:  str                      # "user" | "project"
+    source: str                      # config file path (str, for the card)
+    cwds:   set[str] = field(default_factory=set)  # project scope: reachable cwds
+
+
+def enumerate_configured_servers(repo_cwds: set[str]) -> dict[str, ConfiguredServer]:
+    """Read-only enumeration of MCP servers across the three config
+    locations: project ``.mcp.json`` / ``.claude/settings*.json`` under each
+    given session cwd, plus the global ``~/.claude.json``. Never edits a
+    config file (advise-only in v1 — see the module docstring).
+
+    A user-scoped (global) server always wins scope over a same-named
+    project entry: the global entry already reaches every session, so
+    downgrading it to "project" would only narrow its true presence.
+    """
+    servers: dict[str, ConfiguredServer] = {}
+
+    global_path = _global_config_path()
+    if global_path.is_file():
+        for name in _mcp_server_names(global_path):
+            servers[name] = ConfiguredServer(name=name, scope="user", source=str(global_path))
+
+    for cwd in repo_cwds:
+        if not cwd:
+            continue
+        base = Path(cwd)
+        if not base.is_dir():
+            continue
+        for rel in _PROJECT_CONFIG_RELPATHS:
+            path = base / rel
+            if not path.is_file():
+                continue
+            for name in _mcp_server_names(path):
+                existing = servers.get(name)
+                if existing is not None and existing.scope == "user":
+                    continue  # already global, broaden nothing
+                entry = servers.setdefault(
+                    name, ConfiguredServer(name=name, scope="project", source=str(path)),
+                )
+                entry.cwds.add(cwd)
+    return servers
+
+
+def server_still_configured(name: str, source: str) -> bool:
+    """Read-only re-check: does ``name`` still appear in the ``mcpServers``
+    block of its ORIGINAL detected config file (``source``)?
+
+    Distinguishes "still configured" from "actually removed or
+    project-scoped". A missing file and a present-but-empty-of-this-entry
+    file both read as "no longer configured" — either way the tax stopped.
+    Missing ``name``/``source`` can't be verified at all, so this
+    conservatively reports "still configured" rather than falsely claiming a
+    removal.
+    """
+    if not name or not source:
+        return True
+    path = Path(source)
+    if not path.is_file():
+        return False
+    return name in _mcp_server_names(path)
+
+
+# --- Deterministic apply: remove one server's entry from its config file --
+#
+# A dead server's fix is machine-editable — ``ConfiguredServer`` already
+# resolved the exact config file, so there is no search step the way
+# ``model_apply.model_swap`` needs one. The removal is a TARGETED TEXT SPLICE,
+# never a ``json.loads`` -> mutate -> ``json.dumps`` round trip: re-serializing
+# the whole document would reformat every byte (key order, indentation,
+# spacing), turning a one-entry diff into a wholesale rewrite of the user's
+# config. The functions below locate the exact character span of one server's
+# entry inside its ``mcpServers`` block by walking the raw text — using
+# ``json.decoder.scanstring`` only to skip string literals correctly
+# (including escapes), never to reformat anything — and delete only that
+# span. Every other byte in the file is untouched.
+
+#: Apply-kind discriminator for this write, carried on the proposal and the
+#: ledger record (mirrors ``model_apply.APPLY_KIND_*``).
+APPLY_KIND_MCP_REMOVE = "mcp_remove"
+
+_WS_CHARS = " \t\r\n"
+
+
+def _skip_ws(text: str, i: int) -> int:
+    n = len(text)
+    while i < n and text[i] in _WS_CHARS:
+        i += 1
+    return i
+
+
+def _skip_json_value(text: str, i: int) -> int:
+    """Index just past the JSON value starting at ``text[i]`` (already past
+    leading whitespace). Handles strings, objects, arrays and bare scalars
+    (numbers / true / false / null) — enough to walk any value a ``.mcp.json``
+    /``settings.json`` server entry can hold, without needing to know its
+    shape ahead of time."""
+    ch = text[i]
+    if ch == '"':
+        _, end = scanstring(text, i + 1)
+        return end
+    if ch in "{[":
+        depth = 1
+        i += 1
+        n = len(text)
+        while depth > 0 and i < n:
+            c = text[i]
+            if c == '"':
+                _, i = scanstring(text, i + 1)
+                continue
+            if c in "{[":
+                depth += 1
+            elif c in "}]":
+                depth -= 1
+            i += 1
+        return i
+    j = i
+    n = len(text)
+    while j < n and text[j] not in ",}] \t\r\n":
+        j += 1
+    return j
+
+
+def _object_entries(text: str, obj_open: int) -> list[tuple[str, int, int, int]]:
+    """Every TOP-LEVEL entry of the object opening at ``text[obj_open] ==
+    '{'``, as ``(key, key_start, value_start, value_end)``. Nested keys (a
+    server's own ``env``/``args`` block, say) never surface here — depth
+    tracking inside ``_skip_json_value`` is what keeps this to one level."""
+    entries: list[tuple[str, int, int, int]] = []
+    i = _skip_ws(text, obj_open + 1)
+    while i < len(text) and text[i] != "}":
+        key_start = i
+        _key, i = scanstring(text, i + 1)
+        i = _skip_ws(text, i)
+        i += 1  # the colon
+        i = _skip_ws(text, i)
+        value_start = i
+        value_end = _skip_json_value(text, i)
+        entries.append((_key, key_start, value_start, value_end))
+        i = _skip_ws(text, value_end)
+        if i < len(text) and text[i] == ",":
+            i = _skip_ws(text, i + 1)
+    return entries
+
+
+def _mcp_servers_object_open(text: str) -> int | None:
+    """Index of the ``{`` opening the top-level ``mcpServers`` object, or
+    ``None`` when the document doesn't open with an object or carries no such
+    key — the caller falls back to a refusal rather than a guess."""
+    root_open = _skip_ws(text, 0)
+    if root_open >= len(text) or text[root_open] != "{":
+        return None
+    for key, _key_start, value_start, _value_end in _object_entries(text, root_open):
+        if key == "mcpServers" and value_start < len(text) and text[value_start] == "{":
+            return value_start
+    return None
+
+
+def _mcp_server_entry_span(text: str, server_name: str) -> tuple[int, int] | None:
+    """The ``(start, end)`` character span to delete from ``text`` to remove
+    ``server_name``'s entry from the ``mcpServers`` block, or ``None`` when it
+    can't be located this way (no ``mcpServers`` object, or no such key).
+
+    The span always reuses an ADJACENT separator rather than inventing new
+    whitespace: removing a first/middle entry keeps the punctuation that sat
+    between the PRECEDING entry and this one (which becomes the new
+    connector to whatever follows); removing the last (or only) entry instead
+    deletes the separator that sat between the entry before it and this one,
+    so no dangling trailing comma is left before the closing ``}``.
+    """
+    obj_open = _mcp_servers_object_open(text)
+    if obj_open is None:
+        return None
+    entries = _object_entries(text, obj_open)
+    idx = next((i for i, e in enumerate(entries) if e[0] == server_name), None)
+    if idx is None:
+        return None
+    _key, key_start, _value_start, value_end = entries[idx]
+    is_last = idx == len(entries) - 1
+    if is_last:
+        prev_end = entries[idx - 1][3] if idx > 0 else obj_open + 1
+        return prev_end, value_end
+    next_key_start = entries[idx + 1][1]
+    return key_start, next_key_start
+
+
+def render_mcp_remove(pre_image: str | None, server_name: str) -> tuple[str | None, str]:
+    """The config file's new content with ``server_name``'s entry removed
+    from its ``mcpServers`` block.
+
+    Returns ``(content, "")`` on success and ``(None, reason)`` when the
+    removal cannot be made deterministically: no file, invalid JSON, no
+    ``mcpServers`` block, or the server no longer named there (already
+    removed by hand, or by a concurrent edit).
+    """
+    if not server_name:
+        return None, "no server name given for the MCP removal."
+    if pre_image is None:
+        return None, "no config file at that path to edit."
+    try:
+        doc = json.loads(pre_image)
+    except ValueError as exc:
+        return None, f"that file is not valid JSON ({exc}) — refusing to edit it."
+    servers = doc.get("mcpServers") if isinstance(doc, dict) else None
+    if not isinstance(servers, dict) or server_name not in servers:
+        return None, f"`{server_name}` is not in that file's mcpServers block any more."
+    span = _mcp_server_entry_span(pre_image, server_name)
+    if span is None:
+        return None, (
+            f"could not locate `{server_name}`'s entry precisely in the file "
+            f"text — refusing a risky edit."
+        )
+    start, end = span
+    return pre_image[:start] + pre_image[end:], ""
+
+
+def mcp_remove_precheck(source_path: str, server_name: str) -> dict:
+    """Whether ``server_name``'s entry may be removed from ``source_path``,
+    re-checked at apply time — the repo can have moved, the file can have
+    gone missing, or a human can have already hand-removed the entry between
+    the moment the card was built and the moment it is approved.
+
+    Every precondition must hold; any failure returns ``{"ok": False,
+    "reason": ...}`` and the caller falls back to the one-paste ``claude mcp
+    remove`` command, saying why on the card.
+    """
+    if not source_path or not server_name:
+        return {"ok": False, "reason": (
+            "no source config path or server name given for this MCP removal."
+        )}
+    path = Path(source_path).expanduser()
+    if not path.is_file():
+        return {"ok": False, "reason": f"{path} no longer exists on disk — nothing to edit."}
+    try:
+        json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, ValueError) as exc:
+        return {"ok": False, "reason": f"{path} is not valid JSON ({exc}) — refusing to edit it."}
+    if not server_still_configured(server_name, str(path)):
+        return {"ok": False, "reason": (
+            f"`{server_name}` is no longer in {path}'s mcpServers block — it may "
+            f"already have been removed by hand."
+        )}
+    return {"ok": True, "reason": "", "target_path": str(path)}
+
+
+def build_mcp_remove_plan(cluster: dict, target: Path, pre_image: str | None) -> str:
+    """New content for an ``mcp_remove`` apply: ``cluster``'s server entry
+    deleted from its ``mcpServers`` block, every other byte untouched.
+
+    Raises ``RelearnApplyRefused`` with the refusal reason, which the API
+    layer surfaces as a 409 and the card renders as the fallback explanation
+    — mirrors ``model_apply.build_model_plan``'s contract so the two slot
+    into the same ``relearn_apply._build_write_plan`` dispatch.
+    """
+    from tokenjam.core.optimize.relearn_apply import RelearnApplyRefused
+
+    server_name = str(cluster.get("agent_name") or "")
+    source_path = str(cluster.get("source_path") or "")
+    check = mcp_remove_precheck(source_path, server_name)
+    if not check["ok"]:
+        raise RelearnApplyRefused(check["reason"])
+    if Path(check["target_path"]) != target:
+        raise RelearnApplyRefused(
+            f"the MCP config now lives at {check['target_path']}, not {target}. "
+            f"Refusing to write the stale target."
+        )
+    content, reason = render_mcp_remove(pre_image, server_name)
+    if content is None:
+        raise RelearnApplyRefused(reason)
+    return content
+
+
+# --- Transcript scanning ---------------------------------------------------
+
+#: ``mcp__<server>__<tool>`` — server names may contain single underscores
+#: (e.g. ``claude_ai_Apollo_io``) but never a literal ``__``, which is the
+#: delimiter to the tool name; the non-greedy group stops at the FIRST ``__``.
+_MCP_TOOL_NAME_RE = re.compile(r"^mcp__([A-Za-z0-9][\w.-]*?)__")
+_MCP_TOOL_MENTION_RE = re.compile(r"\bmcp__([A-Za-z0-9][\w.-]*?)__")
+_DEFERRED_MARKER_RE = re.compile(r"deferred tool", re.IGNORECASE)
+_TOOLSEARCH_MARKER_RE = re.compile(r"toolsearch", re.IGNORECASE)
+#: Claude Code emits a "Contents of <path> (...)" heading ahead of each doc it
+#: injects verbatim into a system-reminder block (CLAUDE.md, rules files,
+#: MEMORY.md, ...) — the C2 tax-table splitter keys off these.
+_CONTENTS_OF_RE = re.compile(r"Contents of ([^\n(:]+)", re.IGNORECASE)
+
+
+def _mcp_server_from_tool_name(tool_name: str) -> str | None:
+    """``mcp__<server>__<tool>`` -> ``<server>``, else None for a non-MCP tool."""
+    match = _MCP_TOOL_NAME_RE.match(tool_name or "")
+    return match.group(1) if match else None
+
+
+def _session_cwd(records: list[dict[str, Any]]) -> str:
+    """Best-effort session cwd, from the first record that carries one
+    (mirrors relearn.py's ``_repo_cwd_map_for``)."""
+    for record in records[:5]:
+        cwd = record.get("cwd")
+        if isinstance(cwd, str) and cwd:
+            return cwd
+    return ""
+
+
+def _bucket_for_doc(label: str) -> str:
+    base = label.strip().rstrip("):").strip()
+    name = base.rsplit("/", 1)[-1].lower()
+    if name == "claude.md":
+        return "CLAUDE.md"
+    if name == "learnings.md":
+        return "learnings.md"
+    if "/rules/" in base.lower() or base.lower().startswith("rules/"):
+        return "rules files"
+    return "other referenced docs"
+
+
+def _split_reminder_sources(blob: str) -> dict[str, int]:
+    """Bucket ONE system-reminder blob's char count by source, using the
+    ``Contents of <path> (...)`` headings ahead of each injected doc.
+    Whatever isn't inside a doc segment (environment info, date, hook output)
+    is lumped into "session-start hook output & environment" — finer
+    attribution of that residual isn't attempted (heuristic, `estimated`).
+    """
+    matches = list(_CONTENTS_OF_RE.finditer(blob))
+    buckets: dict[str, int] = {}
+    doc_chars = 0
+    for i, m in enumerate(matches):
+        start = m.start()
+        end = matches[i + 1].start() if i + 1 < len(matches) else len(blob)
+        segment_len = end - start
+        doc_chars += segment_len
+        bucket = _bucket_for_doc(m.group(1))
+        buckets[bucket] = buckets.get(bucket, 0) + segment_len
+    other = len(blob) - doc_chars
+    if other > 0:
+        buckets["session-start hook output & environment"] = (
+            buckets.get("session-start hook output & environment", 0) + other
+        )
+    return buckets
+
+
+@dataclass
+class _SessionSignal:
+    mcp_invocations: dict[str, int] = field(default_factory=dict)
+    deferred_servers: set[str] = field(default_factory=set)
+    reminder_chars_by_source: dict[str, int] = field(default_factory=dict)
+    #: assistant-turn model -> turn count, for pricing the token tax at a
+    #: representative model's input rate (see ``_dominant_model``).
+    models: dict[str, int] = field(default_factory=dict)
+
+
+def _analyze_session(records: list[dict[str, Any]]) -> _SessionSignal:
+    """One pass over a session's raw records: MCP invocation counts, which
+    servers appeared in a deferred-tools listing, the C2 tax-table source
+    buckets (measured off the FIRST system-reminder blob only — Claude Code
+    injects it once at session start; later turns don't repeat it, so
+    summing across turns would overcount), and the assistant model(s) used
+    (for pricing the token tax)."""
+    signal = _SessionSignal()
+    reminder_measured = False
+
+    for record in records:
+        message = record.get("message")
+        if not isinstance(message, dict):
+            continue
+        content = message.get("content")
+        role = message.get("role") or record.get("type")
+
+        text = content if isinstance(content, str) else ""
+        blocks = content if isinstance(content, list) else []
+        if not text and blocks:
+            text = "\n".join(
+                b.get("text", "") for b in blocks
+                if isinstance(b, dict) and b.get("type") == "text"
+            )
+
+        if text:
+            if _DEFERRED_MARKER_RE.search(text) and _TOOLSEARCH_MARKER_RE.search(text):
+                signal.deferred_servers.update(_MCP_TOOL_MENTION_RE.findall(text))
+            if not reminder_measured and role == "user":
+                reminder_blobs = _SYSTEM_REMINDER_RE.findall(text)
+                if reminder_blobs:
+                    signal.reminder_chars_by_source = _split_reminder_sources(reminder_blobs[0])
+                    reminder_measured = True
+
+        if role == "assistant":
+            model = message.get("model")
+            if isinstance(model, str) and model:
+                signal.models[model] = signal.models.get(model, 0) + 1
+
+        for block in blocks:
+            if isinstance(block, dict) and block.get("type") == "tool_use":
+                server = _mcp_server_from_tool_name(str(block.get("name") or ""))
+                if server:
+                    signal.mcp_invocations[server] = signal.mcp_invocations.get(server, 0) + 1
+
+    return signal
+
+
+def _dominant_model(model_counts: dict[str, int]) -> str:
+    """The most-frequent assistant model across the counted turns, or "" when
+    none were observed. Ties broken by first-seen (dict insertion order)."""
+    if not model_counts:
+        return ""
+    return max(model_counts.items(), key=lambda kv: kv[1])[0]
+
+
+def _tax_construction_note(
+    non_deferred: int, deferred_sessions: int, sessions_present: int,
+    *, model: str = "", input_per_mtok: float | None = None,
+    usd_per_session: float | None = None,
+) -> str:
+    if sessions_present == 0:
+        return ""
+    if deferred_sessions == 0:
+        note = (
+            f"{FULL_SCHEMA_TAX_TOKENS:,} tok/session (full schema injection), "
+            f"cited estimate, not a live per-call measurement."
+        )
+    elif non_deferred == 0:
+        note = (
+            f"{DEFERRED_SCHEMA_TAX_TOKENS:,} tok/session; ToolSearch deferred "
+            f"this server's schemas in every observed session (name and "
+            f"description line only, never the full schema tax)."
+        )
+    else:
+        note = (
+            f"{FULL_SCHEMA_TAX_TOKENS:,} tok/session when fully loaded "
+            f"({non_deferred} of {sessions_present} sessions) blended with "
+            f"{DEFERRED_SCHEMA_TAX_TOKENS:,} tok/session when ToolSearch defers "
+            f"this server's schemas ({deferred_sessions} of {sessions_present} "
+            f"sessions); never claims the full tax for a deferred session."
+        )
+    return note + " " + _pricing_note(model, input_per_mtok, usd_per_session)
+
+
+def _pricing_note(model: str, input_per_mtok: float | None, usd_per_session: float | None) -> str:
+    """The dollar-conversion clause appended to a server's construction
+    footnote. Never fabricates a rate: when no priced model was observed
+    across the server's sessions, states that plainly and stays tokens-only.
+    """
+    if not model or input_per_mtok is None or usd_per_session is None:
+        return (
+            "No dollar estimate: no priced model observed across these "
+            "sessions (core/pricing.py has no rate for it); tokens only."
+        )
+    return (
+        f"Priced at {model}'s input rate (${input_per_mtok:.2f}/MTok via "
+        f"core/pricing.py) -> ${usd_per_session:,.4f}/session estimated."
+    )
+
+
+# --- Proposal + finding shapes ---------------------------------------------
+
+@dataclass
+class ServerDeadweight:
+    """One configured MCP server's presence/invocation signal in the window."""
+    name:                             str
+    scope:                            str    # "user" | "project"
+    source:                           str
+    sessions_present:                 int
+    invocations:                      int
+    deferred_sessions:                int
+    dead:                             bool
+    estimated_tax_tokens_per_session: int
+    estimated_tax_tokens_90d:         int
+    tax_construction:                 str
+    fix:                              str
+    example_sessions:                 list[str] = field(default_factory=list)
+    #: Dollar conversion of the token tax, priced through core/pricing.py at
+    #: the dominant model observed across this server's present sessions.
+    #: ``None`` when no priced model was observed (never a fabricated rate).
+    priced_model:                     str = ""
+    estimated_tax_usd_per_session:    float | None = None
+    estimated_tax_usd_90d:            float | None = None
+
+
+@dataclass
+class ContextTaxRow:
+    """One always-injected content source's measured/estimated per-session tax."""
+    source:                 str
+    sessions:                int
+    avg_tokens_per_session:  int
+    total_tokens_window:      int
+    tag:                       str = "estimated"
+    construction:               str = ""
+
+
+@dataclass
+class DeadweightFinding:
+    sessions_scanned:             int = 0
+    configured_servers:           int = 0
+    servers:                      list[ServerDeadweight] = field(default_factory=list)
+    dead_servers:                 list[ServerDeadweight] = field(default_factory=list)
+    tax_table:                    list[ContextTaxRow] = field(default_factory=list)
+    estimated_recoverable_tokens: int | None = None
+    estimated_recoverable_usd:    float | None = None
+    estimate_basis:                str = ""
+    estimate_confidence:            str = "estimated"
+    caveat:                          str = DEADWEIGHT_HONESTY_CAVEAT
+    notes:                            list[str] = field(default_factory=list)
+
+
+# --- Orchestration (pure, no ctx dependency — testable directly) ----------
+
+def compute_deadweight_finding(
+    since: datetime,
+    until: datetime,
+    *,
+    projects_root: Path | str | None = None,
+    window_days: float | None = None,
+    min_sessions: int = MIN_SESSIONS_DEADWEIGHT,
+    cache_dir: Path | None = None,
+) -> DeadweightFinding:
+    """Full pipeline over a window of Claude Code transcripts. Never raises —
+    a missing projects root, an unreadable transcript, or a malformed config
+    file is skipped, not fatal.
+
+    ``min_sessions`` overrides ``MIN_SESSIONS_DEADWEIGHT`` (config-overridable
+    via ``core.config.OptimizeConfig.min_sessions_deadweight``); the module
+    constant remains the default so a caller that omits it sees today's
+    behaviour unchanged.
+
+    ``cache_dir``, when given, transparently caches each transcript's parsed
+    records on disk (``core.transcript_cache``) so a re-run over an unchanged
+    corpus skips the read + parse entirely. ``None`` (the default) preserves
+    this function's original always-reparse behavior — only the registered
+    ``run(ctx)`` entry point below opts in, so this function's existing
+    "no I/O beyond the passed-in tmp_path root" test contract is unchanged
+    for direct callers.
+    """
+    finding = DeadweightFinding()
+    root = resolve_projects_root(projects_root)
+    if not root.exists():
+        return finding
+
+    session_paths: list[tuple[str, Path]] = []
+    for path in sorted(root.rglob("*.jsonl")):
+        try:
+            mtime = datetime.fromtimestamp(path.stat().st_mtime, tz=timezone.utc)
+        except OSError:
+            continue
+        if mtime < since or mtime >= until:
+            continue
+        session_paths.append((path.stem, path))
+
+    finding.sessions_scanned = len(session_paths)
+    if not session_paths:
+        return finding
+
+    per_session: dict[str, _SessionSignal] = {}
+    session_cwds: dict[str, str] = {}
+    for session_id, path in session_paths:
+        try:
+            records = read_records(path, cache_dir=cache_dir)
+        except Exception:
+            continue
+        session_cwds[session_id] = _session_cwd(records)
+        per_session[session_id] = _analyze_session(records)
+
+    repo_cwds = {c for c in session_cwds.values() if c}
+    configured = enumerate_configured_servers(repo_cwds)
+    finding.configured_servers = len(configured)
+    if not configured:
+        return finding
+
+    days = window_days if window_days and window_days > 0 else max(
+        (until - since).total_seconds() / 86400.0, 1.0,
+    )
+    projection_factor = 90.0 / days
+
+    from tokenjam.core.pricing import get_rates, provider_for_model
+
+    tax_rows: list[ContextTaxRow] = []
+    reminder_bucket_totals: dict[str, list[int]] = {}
+
+    for server in configured.values():
+        sessions_present = 0
+        invocations = 0
+        deferred_sessions = 0
+        example_sessions: list[str] = []
+        model_counts: dict[str, int] = {}
+        for session_id, signal in per_session.items():
+            deferred_here = server.name in signal.deferred_servers
+            present = deferred_here or server.scope == "user" or (
+                session_cwds.get(session_id, "") in server.cwds
+            )
+            if not present:
+                continue
+            sessions_present += 1
+            invocations += signal.mcp_invocations.get(server.name, 0)
+            if deferred_here:
+                deferred_sessions += 1
+            if len(example_sessions) < MAX_EXAMPLE_SESSIONS:
+                example_sessions.append(session_id)
+            for model, count in signal.models.items():
+                model_counts[model] = model_counts.get(model, 0) + count
+
+        dead = sessions_present >= min_sessions and invocations == 0
+        non_deferred = max(sessions_present - deferred_sessions, 0)
+        tax_per_session = (
+            round(
+                (non_deferred * FULL_SCHEMA_TAX_TOKENS + deferred_sessions * DEFERRED_SCHEMA_TAX_TOKENS)
+                / sessions_present
+            )
+            if sessions_present else 0
+        )
+        tax_90d = round(tax_per_session * sessions_present * projection_factor)
+
+        # Price the token tax through core/pricing.py at the dominant model
+        # observed across this server's present sessions -- never a
+        # hardcoded rate. usd stays None when no priced model was seen.
+        priced_model = _dominant_model(model_counts)
+        input_per_mtok: float | None = None
+        usd_per_session: float | None = None
+        usd_90d: float | None = None
+        if priced_model:
+            provider = provider_for_model(priced_model) or "unknown"
+            rates = get_rates(provider, priced_model)
+            if rates is not None and rates.input_per_mtok > 0:
+                input_per_mtok = rates.input_per_mtok
+                usd_per_session = round(tax_per_session / 1_000_000 * input_per_mtok, 6)
+                usd_90d = round(tax_90d / 1_000_000 * input_per_mtok, 6)
+            else:
+                priced_model = ""  # no rate available -- don't claim a model we can't price
+
+        row = ServerDeadweight(
+            name=server.name,
+            scope=server.scope,
+            source=server.source,
+            sessions_present=sessions_present,
+            invocations=invocations,
+            deferred_sessions=deferred_sessions,
+            dead=dead,
+            estimated_tax_tokens_per_session=tax_per_session,
+            estimated_tax_tokens_90d=tax_90d,
+            tax_construction=_tax_construction_note(
+                non_deferred, deferred_sessions, sessions_present,
+                model=priced_model, input_per_mtok=input_per_mtok,
+                usd_per_session=usd_per_session,
+            ),
+            fix=(
+                f"Remove or project-scope the `{server.name}` MCP server "
+                f"({server.source}); zero tool calls across {sessions_present} "
+                f"session(s) in this window."
+            ),
+            example_sessions=example_sessions,
+            priced_model=priced_model,
+            estimated_tax_usd_per_session=usd_per_session,
+            estimated_tax_usd_90d=usd_90d,
+        )
+        finding.servers.append(row)
+        if sessions_present > 0:
+            tax_rows.append(ContextTaxRow(
+                source=f"MCP schema: {server.name}",
+                sessions=sessions_present,
+                avg_tokens_per_session=tax_per_session,
+                total_tokens_window=tax_per_session * sessions_present,
+                tag="estimated",
+                construction=row.tax_construction,
+            ))
+
+    finding.servers.sort(key=lambda s: s.sessions_present, reverse=True)
+    finding.dead_servers = sorted(
+        (s for s in finding.servers if s.dead),
+        key=lambda s: s.sessions_present, reverse=True,
+    )
+
+    # C2: fold the reminder-source buckets across sessions.
+    for signal in per_session.values():
+        for bucket, chars in signal.reminder_chars_by_source.items():
+            reminder_bucket_totals.setdefault(bucket, []).append(chars)
+
+    for bucket, char_counts in reminder_bucket_totals.items():
+        sessions_with = len(char_counts)
+        if sessions_with == 0:
+            continue
+        avg_tokens = round((sum(char_counts) / sessions_with) / CHARS_PER_TOKEN)
+        tax_rows.append(ContextTaxRow(
+            source=bucket,
+            sessions=sessions_with,
+            avg_tokens_per_session=avg_tokens,
+            total_tokens_window=round(sum(char_counts) / CHARS_PER_TOKEN),
+            tag="estimated",
+            construction=(
+                f"chars/{CHARS_PER_TOKEN} over the verbatim system-reminder "
+                f"content Claude Code injects at session start, measured on "
+                f"the first turn of each session."
+            ),
+        ))
+
+    tax_rows.sort(key=lambda r: r.total_tokens_window, reverse=True)
+    finding.tax_table = tax_rows
+
+    # Dedup rule (spec, Component C): the recoverable total is ONLY the
+    # dead-weight servers' own tax. The C2 tax table repeats a "MCP schema:
+    # <name>" row for EVERY configured server (dead or alive) for visibility,
+    # but that row never feeds this sum — so a server's tax is never counted
+    # twice between the tax table and a dead-weight proposal.
+    if finding.dead_servers:
+        finding.estimated_recoverable_tokens = sum(
+            s.estimated_tax_tokens_90d for s in finding.dead_servers
+        )
+        priced = [
+            s.estimated_tax_usd_90d for s in finding.dead_servers
+            if s.estimated_tax_usd_90d is not None
+        ]
+        basis = (
+            f"sum of each dead server's projected 90-day schema-injection tax "
+            f"({FULL_SCHEMA_TAX_TOKENS:,} tok/session full, "
+            f"{DEFERRED_SCHEMA_TAX_TOKENS:,} tok/session when deferred); the "
+            f"tax table's own MCP-schema rows are informational only and "
+            f"never double-count into this total."
+        )
+        if priced:
+            finding.estimated_recoverable_usd = round(sum(priced), 6)
+            basis += (
+                " Dollar figure priced per server through core/pricing.py "
+                "at the dominant model observed in that server's sessions "
+                "(never a hardcoded rate)."
+            )
+            if len(priced) < len(finding.dead_servers):
+                basis += (
+                    f" {len(finding.dead_servers) - len(priced)} of "
+                    f"{len(finding.dead_servers)} dead server(s) had no "
+                    f"priced model observed and are excluded from the "
+                    f"dollar sum (token figure still includes them)."
+                )
+        finding.estimate_basis = basis
+    elif configured:
+        finding.notes.append(
+            f"No configured MCP server cleared the dead-weight bar "
+            f"(>= {min_sessions} sessions present, 0 invocations). Lower "
+            f"[optimize] min_sessions_deadweight in tj.toml to see servers "
+            f"present in fewer sessions."
+        )
+
+    return finding
+
+
+# --- Registry entry point ---------------------------------------------------
+
+@register("deadweight")
+def run(ctx: AnalyzerContext) -> None:
+    """Registry entry point. Attaches a ``DeadweightFinding`` to
+    ``ctx.report.findings["deadweight"]``. Claude Code transcripts lane only
+    — reads on-disk JSONL directly, never ``ctx.conn`` (no DB spans needed).
+
+    Passes the resolved persistent parse cache dir (``core.transcript_cache.
+    default_cache_dir``) so a re-run over an unchanged corpus — including a
+    repeat HTTP request against a live ``tj serve`` — skips re-parsing every
+    session it already has a fresh cache entry for.
+    """
+    from tokenjam.core.transcript_cache import default_cache_dir
+
+    optimize_cfg = getattr(ctx.config, "optimize", None)
+    min_sessions = getattr(
+        optimize_cfg, "min_sessions_deadweight", MIN_SESSIONS_DEADWEIGHT,
+    )
+    ctx.report.findings["deadweight"] = compute_deadweight_finding(
+        ctx.since, ctx.until, window_days=ctx.window_days,
+        min_sessions=min_sessions,
+        cache_dir=default_cache_dir(ctx.config),
+    )

--- a/tokenjam/core/optimize/analyzers/plan_reuse.py
+++ b/tokenjam/core/optimize/analyzers/plan_reuse.py
@@ -39,6 +39,7 @@ import json
 import re
 from typing import Any, Literal, NamedTuple
 
+from tokenjam.core.optimize.clustering import group_by_key, mask_variables, recurring
 from tokenjam.core.optimize.registry import register
 from tokenjam.core.optimize.types import AnalyzerContext, ReuseCluster, ReuseFinding
 from tokenjam.otel.semconv import GenAIAttributes
@@ -98,13 +99,14 @@ _PATH_RE = re.compile(r"(?:~|\.{0,2})?/[\w.\-/]+")
 _DATE_RE = re.compile(r"\d{4}-\d{2}-\d{2}")
 _NUM_RE = re.compile(r"\d+")
 
+#: Ordered substitutions for the prompt-prefix normalizer (path before date
+#: before bare digits, so internal digits aren't partially replaced first).
+_STRIP_SUBS = [(_PATH_RE, "<PATH>"), (_DATE_RE, "<DATE>"), (_NUM_RE, "<NUM>")]
+
 
 def _strip_variables(text: str) -> str:
     """Replace path-, date-, and number-looking spans with fixed placeholders."""
-    text = _PATH_RE.sub("<PATH>", text)
-    text = _DATE_RE.sub("<DATE>", text)
-    text = _NUM_RE.sub("<NUM>", text)
-    return text
+    return mask_variables(text, _STRIP_SUBS)
 
 
 def _is_llm(row: _SpanRow) -> bool:
@@ -183,11 +185,9 @@ def _cluster_sessions(plans: list[_SessionPlan]) -> dict[str, list[_SessionPlan]
     plans by their deterministic cluster key. Swapping in semantic clustering
     later is a one-function change.
     """
-    clusters: dict[str, list[_SessionPlan]] = {}
-    for plan in plans:
-        key = _cluster_key(plan.tool_signature, plan.prompt_prefix_hash)
-        clusters.setdefault(key, []).append(plan)
-    return clusters
+    return group_by_key(
+        plans, lambda plan: _cluster_key(plan.tool_signature, plan.prompt_prefix_hash),
+    )
 
 
 @register("reuse")
@@ -255,10 +255,10 @@ def run(ctx: AnalyzerContext) -> None:
     clusters_raw = _cluster_sessions(plans)
 
     surfaced: list[ReuseCluster] = []
-    for cluster_id, members in clusters_raw.items():
+    # Recurrence gate first (the shared threshold filter); the remaining
+    # per-cluster gates (avg tokens, recoverable floor) stay analyzer-specific.
+    for cluster_id, members in recurring(clusters_raw, min_members=MIN_REPETITIONS).items():
         reps = len(members)
-        if reps < MIN_REPETITIONS:
-            continue
 
         avg_tokens = round(sum(m.planning_tokens for m in members) / reps)
         if avg_tokens < MIN_PLANNING_TOKENS:

--- a/tokenjam/core/optimize/analyzers/pothole.py
+++ b/tokenjam/core/optimize/analyzers/pothole.py
@@ -1,7 +1,7 @@
 """
-Cross-session pothole aggregator (self-improve loop, Phase 1: detect + surface).
+Cross-session relearn aggregator (self-improve loop, Phase 1: detect + surface).
 
-A "pothole" is a blocker a Claude Code agent silently re-hits across many
+A "relearn" is a blocker a Claude Code agent silently re-hits across many
 unwatched sessions — a wrong-cwd Read, an Edit before a Read, a blocked
 sleep-chain, a stale-read race, a domain-blocked WebFetch, and so on. shiploop
 only codifies what a human noticed; this module catches what nobody watched.
@@ -61,7 +61,7 @@ from tokenjam.core.transcript import build_session_story, resolve_projects_root
 MIN_RECURRING_SESSIONS = 3
 #: How many example sessions to carry per cluster (repro links).
 MAX_EXAMPLE_SESSIONS = 3
-#: Conservative per-occurrence token cost. A pothole occurrence costs roughly
+#: Conservative per-occurrence token cost. A relearn occurrence costs roughly
 #: one extra assistant turn's overhead (re-issue the tool call, re-parse the
 #: harness context, re-narrate) — NOT the inflated whole-afflicted-session
 #: footprint the spec explicitly warns against. This is a heuristic magnitude
@@ -84,7 +84,7 @@ HONESTY_CAVEAT = (
     "Review the example sessions and the proposed fix before applying it."
 )
 
-# --- Known, validated pothole families ----------------------------------------
+# --- Known, validated relearn families ----------------------------------------
 # Each entry: (family key, human title, tool-name filter (None = any),
 # regex over the raw error text, default rung, default proposed fix).
 # Rungs follow the intervention ladder (SPEC §6): 1 CLAUDE.md note,
@@ -137,7 +137,7 @@ _KNOWN_FAMILIES: list[dict[str, Any]] = [
         "title": "blocked sleep-chain",
         "tools": {"Bash"},
         # The block usually reads generically ("blocked"/"disallowed"/timed out)
-        # with nothing pothole-specific in the wording — the ONE reliable tell is
+        # with nothing relearn-specific in the wording — the ONE reliable tell is
         # the command itself leading with `sleep`. So this family also matches on
         # the tool's LABEL (its Bash command), not just the error text; see
         # `classify_known_family`.
@@ -288,7 +288,7 @@ def _generic_signature(tool_name: str, error_text: str) -> str:
     return f"{tool_name}:{normalized}"
 
 
-#: Not potholes: the tool_result carries ``is_error`` because a HUMAN declined
+#: Not relearns: the tool_result carries ``is_error`` because a HUMAN declined
 #: the action (a permission prompt, an AskUserQuestion decline, "Exit plan
 #: mode?" answered no) — expected interactive UI, not a blocker an agent
 #: silently re-hits. Validated against the local corpus (2026-07-12): these
@@ -304,7 +304,7 @@ _USER_DECLINE_RE = re.compile(
 
 def is_user_decline(error_text: str) -> bool:
     """True if this 'failure' is really a human declining an action, not a
-    pothole — see ``_USER_DECLINE_RE``."""
+    relearn — see ``_USER_DECLINE_RE``."""
     return bool(error_text) and bool(_USER_DECLINE_RE.search(error_text.strip()))
 
 
@@ -314,7 +314,7 @@ def classify_known_family(tool_name: str, error_text: str, label: str = "") -> s
 
     Most families match on the raw error text alone. A few (e.g. the blocked
     sleep-chain, whose block message is often generic — "timed out"/"blocked"
-    with nothing pothole-specific in the wording) additionally require the
+    with nothing relearn-specific in the wording) additionally require the
     tool's ``label`` (its command/arg) to match a ``label_pattern`` — the
     reliable tell is the command itself, not the error text.
     """
@@ -376,14 +376,24 @@ def extract_failures_for_session(
     session_id: str,
     repo: str,
     projects_root: Path | str | None = None,
+    *,
+    transcript_cache_dir: Path | None = None,
 ) -> list[FailureEpisode]:
     """Every erroring tool call in one session (main thread + subagents).
 
     Returns ``[]`` when the session has no on-disk transcript (SDK session,
     pruned). Never raises — a malformed transcript yields whatever could be
     parsed (``build_session_story`` already tolerates bad lines).
+
+    ``transcript_cache_dir`` is forwarded straight to ``build_session_story``'s
+    ``cache_dir`` — see that function's docstring and ``core.transcript_cache``.
+    Named distinctly from this module's own ``distill_cache_dir`` (a different,
+    unrelated cache) to avoid the two being confused at a call site.
     """
-    story = build_session_story(session_id, projects_root=projects_root, include_subagents=True)
+    story = build_session_story(
+        session_id, projects_root=projects_root, include_subagents=True,
+        cache_dir=transcript_cache_dir,
+    )
     if story is None:
         return []
 
@@ -397,7 +407,7 @@ def extract_failures_for_session(
                 continue
             error_text = tool.get("error") or ""
             if is_user_decline(error_text):
-                continue  # a human's own choice, not a pothole — see is_user_decline
+                continue  # a human's own choice, not a relearn — see is_user_decline
             failures.append(FailureEpisode(
                 session_id=session_id,
                 repo=repo,
@@ -470,7 +480,7 @@ def _recurring(clusters: dict[str, _RawCluster], min_sessions: int) -> list[_Raw
 # --- Distill pass over the residual (non-family) bucket -----------------------
 
 def _distill_cache_dir() -> Path:
-    return Path.home() / ".tj" / "distill_cache" / "pothole"
+    return Path.home() / ".tj" / "distill_cache" / "relearn"
 
 
 def _cluster_hash(cluster: _RawCluster) -> str:
@@ -480,7 +490,7 @@ def _cluster_hash(cluster: _RawCluster) -> str:
     return hashlib.sha256(payload.encode("utf-8")).hexdigest()[:24]
 
 
-def distill_pothole_cluster(
+def distill_relearn_cluster(
     tool_name: str, samples: list[str], *, model: str = DISTILL_MODEL, timeout: int = 60,
 ) -> dict[str, str]:
     """Ask the local ``claude`` CLI to name a residual failure cluster.
@@ -599,7 +609,7 @@ def _distill_cached(tool_name: str, cluster: _RawCluster, cache_dir: Path) -> di
         pass
 
     samples = [f.error_text for f in cluster.failures if f.error_text][:8]
-    result = distill_pothole_cluster(tool_name, samples)
+    result = distill_relearn_cluster(tool_name, samples)
     if not result:
         return {}
     try:
@@ -702,13 +712,13 @@ def _doc_text(paths: list[Path], max_chars: int = 200_000) -> str:
 #: novelty heuristic (NOT an LLM call): "already codified" iff every keyword
 #: co-occurs somewhere in the reachable docs. Deliberately conservative (few,
 #: specific terms) so a coincidental single-word match doesn't wrongly drop a
-#: real, still-uncodified pothole.
+#: real, still-uncodified relearn.
 #: One DISTINCTIVE multi-word phrase per known family — deliberately full
 #: phrases (not independent short words ANDed together). Validated the hard
 #: way (2026-07-12): an earlier version used tuples like ("read", "before
 #: editing") ANDed independently, and "read" alone is common enough that it
 #: co-occurred with unrelated text in reachable docs, silently dropping the
-#: single BIGGEST validated pothole (edit-before-read, 178 sessions) as
+#: single BIGGEST validated relearn (edit-before-read, 178 sessions) as
 #: "already codified" when it demonstrably wasn't. A short generic word is
 #: not a novelty signal; a verbatim-ish multi-word phrase close to the
 #: harness's actual wording is.
@@ -747,7 +757,7 @@ def is_already_codified(cluster: _RawCluster, doc_text: str) -> bool:
 # --- Proposal building -----------------------------------------------------
 
 @dataclass
-class PotholeExample:
+class RelearnExample:
     session_id: str
     repo:       str
     ts:         str | None
@@ -755,7 +765,7 @@ class PotholeExample:
 
 
 @dataclass
-class PotholeCluster:
+class RelearnCluster:
     signature:                 str
     family_key:                str | None
     title:                     str
@@ -765,7 +775,7 @@ class PotholeCluster:
     rung:                       int             # 1-5, SPEC §6 intervention ladder
     scope:                      str              # "project" | "user-global"
     proposed_fix:                str
-    examples:                    list[PotholeExample] = field(default_factory=list)
+    examples:                    list[RelearnExample] = field(default_factory=list)
     estimated_recoverable_tokens: int = 0
     confidence:                   str = "heuristic"
     novel:                        bool = True
@@ -781,13 +791,13 @@ class PotholeCluster:
     # a checkout) — so there is no apply path at all: the card carries a
     # recommendation the user applies themselves, `suggested_target` stays "",
     # and Verify runs off spans instead of transcripts. See
-    # `core/optimize/pothole_otel.py`.
+    # `core/optimize/relearn_otel.py`.
     advise_only:                  bool = False
 
 
 @dataclass
-class PotholeFinding:
-    clusters:            list[PotholeCluster] = field(default_factory=list)
+class RelearnFinding:
+    clusters:            list[RelearnCluster] = field(default_factory=list)
     sessions_scanned:     int = 0
     failures_examined:    int = 0
     distilled_clusters:   int = 0
@@ -796,6 +806,11 @@ class PotholeFinding:
     estimate_basis:        str = ESTIMATE_BASIS
     estimate_confidence:   str = "heuristic"
     caveat:                 str = HONESTY_CAVEAT
+    # The effective recurrence bar this run applied (config-overridable, see
+    # core.config.OptimizeConfig.min_recurring_sessions) — carried on the
+    # finding so a renderer's empty-state message never hardcodes a number
+    # that could be stale against the user's own config.
+    min_sessions:           int = MIN_RECURRING_SESSIONS
 
 
 def _snippet(failure: FailureEpisode) -> str:
@@ -815,7 +830,7 @@ def build_proposals(
     doc_text: str = "",
     repo_cwd_map: dict[str, str] | None = None,
     advise_only_repos: set[str] | None = None,
-) -> tuple[list[PotholeCluster], int]:
+) -> tuple[list[RelearnCluster], int]:
     """Turn surviving raw clusters into ranked proposals. Returns
     ``(proposals, dropped_codified_count)``.
 
@@ -824,14 +839,14 @@ def build_proposals(
     target path (Phase 2) — clustering itself needs none of it.
 
     ``advise_only_repos`` names the agents tokenjam has NO workspace for (the
-    OTel lane — see ``core/optimize/pothole_otel.py``). A cluster whose repos are
+    OTel lane — see ``core/optimize/relearn_otel.py``). A cluster whose repos are
     all in that set is marked ``advise_only`` and gets NO suggested target: there
     is nothing to apply into, so the card must not imply an apply path exists.
     """
-    from tokenjam.core.optimize.pothole_apply import default_target_path, slugify
+    from tokenjam.core.optimize.relearn_apply import default_target_path, slugify
 
     repo_cwd_map = repo_cwd_map or {}
-    proposals: list[PotholeCluster] = []
+    proposals: list[RelearnCluster] = []
     dropped = 0
     for cluster in clusters:
         sessions = cluster.session_ids
@@ -848,7 +863,7 @@ def build_proposals(
         repos = sorted(cluster.repos)
         occurrences = len(cluster.failures)
         examples = [
-            PotholeExample(
+            RelearnExample(
                 session_id=f.session_id, repo=f.repo, ts=f.ts, snippet=_snippet(f),
             )
             for f in sorted(cluster.failures, key=lambda f: f.ts or "", reverse=True)[:MAX_EXAMPLE_SESSIONS]
@@ -857,8 +872,11 @@ def build_proposals(
         scope = _scope_for(cluster.repos)
         # Workspace-less (OTel) clusters have nowhere to write: no cwd, no
         # target, and the card must not offer an apply path it can't honor.
-        advise_only = bool(advise_only_repos) and all(
-            r in advise_only_repos for r in repos
+        # `bool(advise_only_repos) and ...` defeats mypy's None-narrowing since
+        # it's wrapped in a call; guarding on the name itself narrows it to
+        # `set[str]` inside the genexpr while keeping identical truthiness.
+        advise_only = bool(
+            advise_only_repos and all(r in advise_only_repos for r in repos)
         )
         repo_cwd = "" if advise_only else (
             repo_cwd_map.get(repos[0], "") if len(repos) == 1 else ""
@@ -873,7 +891,7 @@ def build_proposals(
             except Exception:
                 suggested_target = ""   # never let a bad path computation sink the proposal
 
-        proposals.append(PotholeCluster(
+        proposals.append(RelearnCluster(
             signature=cluster.signature,
             family_key=cluster.family_key,
             title=cluster.title,
@@ -897,33 +915,38 @@ def build_proposals(
 
 # --- Orchestration (pure, no ctx dependency — testable directly) --------------
 
-def analyze_potholes(
+def analyze_relearns(
     sessions: list[tuple[str, str]],     # [(session_id, repo), ...]
     *,
     projects_root: Path | str | None = None,
     min_sessions: int = MIN_RECURRING_SESSIONS,
     distill_enabled: bool = True,
     distill_cache_dir: Path | None = None,
+    transcript_cache_dir: Path | None = None,
     codified_doc_text: str = "",
     repo_cwd_map: dict[str, str] | None = None,
     extra_failures: list[FailureEpisode] | None = None,
     advise_only_repos: set[str] | None = None,
-) -> PotholeFinding:
+) -> RelearnFinding:
     """Full pipeline over an explicit session list — the pure core the
     registry entry point and the on-disk cache job both call. Never raises.
 
     ``extra_failures`` are episodes extracted somewhere other than an on-disk
     transcript — today the OTel lane's failing spans (see
-    ``core/optimize/pothole_otel.py``). They join the SAME clustering pass, so a
-    signature that recurs across both lanes clusters as one pothole.
+    ``core/optimize/relearn_otel.py``). They join the SAME clustering pass, so a
+    signature that recurs across both lanes clusters as one relearn.
     ``advise_only_repos`` is forwarded to ``build_proposals`` to mark the
-    workspace-less clusters.
+    workspace-less clusters. ``transcript_cache_dir`` (distinct from
+    ``distill_cache_dir``, the LLM-distill cache) is forwarded to every
+    per-session transcript parse — see ``core.transcript_cache``.
     """
     all_failures: list[FailureEpisode] = []
     scanned = 0
     for session_id, repo in sessions:
         try:
-            failures = extract_failures_for_session(session_id, repo, projects_root)
+            failures = extract_failures_for_session(
+                session_id, repo, projects_root, transcript_cache_dir=transcript_cache_dir,
+            )
         except Exception:
             continue
         scanned += 1
@@ -948,13 +971,14 @@ def analyze_potholes(
     )
     total_tokens = sum(p.estimated_recoverable_tokens for p in proposals)
 
-    return PotholeFinding(
+    return RelearnFinding(
         clusters=proposals,
         sessions_scanned=scanned,
         failures_examined=len(all_failures),
         distilled_clusters=distilled_count,
         dropped_codified=dropped,
         estimated_recoverable_tokens=total_tokens if proposals else None,
+        min_sessions=min_sessions,
     )
 
 
@@ -978,7 +1002,12 @@ def _repo_map_from_db(conn) -> dict[str, str]:
     return out
 
 
-def _repo_cwd_map_for(sessions: list[tuple[str, str]], projects_root: Path) -> dict[str, str]:
+def _repo_cwd_map_for(
+    sessions: list[tuple[str, str]],
+    projects_root: Path,
+    *,
+    transcript_cache_dir: Path | None = None,
+) -> dict[str, str]:
     """Best-effort repo-label -> cwd, for the novelty doc search AND (Phase 2)
     the Apply stage's suggested target path. Derived from the encoded project
     directory name is unreliable, so this reads each session's transcript's
@@ -993,7 +1022,7 @@ def _repo_cwd_map_for(sessions: list[tuple[str, str]], projects_root: Path) -> d
         path = _locate_transcript(session_id, projects_root)
         if path is None:
             continue
-        for record in read_records(path)[:5]:
+        for record in read_records(path, cache_dir=transcript_cache_dir)[:5]:
             cwd = record.get("cwd")
             if isinstance(cwd, str) and cwd:
                 out[repo] = cwd
@@ -1001,22 +1030,24 @@ def _repo_cwd_map_for(sessions: list[tuple[str, str]], projects_root: Path) -> d
     return out
 
 
-def compute_pothole_finding(
+def compute_relearn_finding(
     conn: Any | None = None,
     since: Any | None = None,
     *,
     projects_root: Path | str | None = None,
     distill_enabled: bool = True,
-) -> PotholeFinding:
+    min_sessions: int = MIN_RECURRING_SESSIONS,
+    transcript_cache_dir: Path | None = None,
+) -> RelearnFinding:
     """Standalone entry point that doesn't need a full ``AnalyzerContext`` —
-    used by the serve-time background cache job (``api/routes/pothole.py``)
+    used by the serve-time background cache job (``api/routes/relearn.py``)
     and by tests. ``conn`` is an OPTIONAL DuckDB connection used only for
     repo-name enrichment (``sessions.agent_id``); pass ``None`` and every
     session falls back to a ``"unknown"`` repo label — clustering itself needs
     no DB at all, it's a pure filesystem scan.
 
     Full-corpus by design: enumerates every on-disk Claude Code transcript
-    (not window-scoped like the other analyzers — a pothole recurring across
+    (not window-scoped like the other analyzers — a relearn recurring across
     months of history is exactly the signal this detector exists to find),
     optionally pre-filtered to ``since`` when the caller wants an incremental
     scan. Heavy (tens of seconds over a full local corpus) — callers that
@@ -1025,8 +1056,15 @@ def compute_pothole_finding(
     TWO LANES. On-disk transcripts cover the workspace agents; when ``conn`` is
     given, failing spans from NON-coding agents are folded into the same
     clustering pass so SDK/OTel services are no longer invisible to the
-    detector (``core/optimize/pothole_otel.py``). Their clusters come back
+    detector (``core/optimize/relearn_otel.py``). Their clusters come back
     ``advise_only``: detect and advise, never apply.
+
+    ``transcript_cache_dir``, when given, transparently caches each session's
+    parsed transcript on disk (``core.transcript_cache``) so a re-run over an
+    unchanged corpus skips re-parsing every session it already has a fresh
+    cache entry for. ``None`` (the default) preserves this function's
+    original always-reparse behavior — only the registered ``run(ctx)`` entry
+    point and the serve-time background job opt in.
     """
     root = resolve_projects_root(projects_root)
     repo_map = _repo_map_from_db(conn) if conn is not None else {}
@@ -1037,7 +1075,7 @@ def compute_pothole_finding(
     advise_only_repos: set[str] = set()
     if conn is not None:
         try:
-            from tokenjam.core.optimize.pothole_otel import (
+            from tokenjam.core.optimize.relearn_otel import (
                 extract_span_failures,
                 non_coding_agent_ids,
             )
@@ -1065,22 +1103,38 @@ def compute_pothole_finding(
     doc_text = ""
     repo_cwd_map: dict[str, str] = {}
     try:
-        repo_cwd_map = _repo_cwd_map_for(sessions, root)
+        repo_cwd_map = _repo_cwd_map_for(
+            sessions, root, transcript_cache_dir=transcript_cache_dir,
+        )
         doc_text = _doc_text(_candidate_doc_paths(set(repo_cwd_map.values())))
     except Exception:
         doc_text = ""
 
-    return analyze_potholes(
+    return analyze_relearns(
         sessions, projects_root=root, codified_doc_text=doc_text,
         distill_enabled=distill_enabled, repo_cwd_map=repo_cwd_map,
         extra_failures=span_failures, advise_only_repos=advise_only_repos,
+        min_sessions=min_sessions, transcript_cache_dir=transcript_cache_dir,
     )
 
 
-@register("pothole")
+@register("relearn")
 def run(ctx: AnalyzerContext) -> None:
-    """Registry entry point. Attaches a ``PotholeFinding`` to
-    ``ctx.report.findings["pothole"]`` — see ``compute_pothole_finding`` for
+    """Registry entry point. Attaches a ``RelearnFinding`` to
+    ``ctx.report.findings["relearn"]`` — see ``compute_relearn_finding`` for
     the full-corpus behaviour and performance note.
+
+    Passes the resolved persistent parse cache dir (``core.transcript_cache.
+    default_cache_dir``) so a re-run over an unchanged corpus skips
+    re-parsing every session it already has a fresh cache entry for.
     """
-    ctx.report.findings["pothole"] = compute_pothole_finding(ctx.conn, ctx.since)
+    from tokenjam.core.transcript_cache import default_cache_dir
+
+    optimize_cfg = getattr(ctx.config, "optimize", None)
+    min_sessions = getattr(
+        optimize_cfg, "min_recurring_sessions", MIN_RECURRING_SESSIONS,
+    )
+    ctx.report.findings["relearn"] = compute_relearn_finding(
+        ctx.conn, ctx.since, min_sessions=min_sessions,
+        transcript_cache_dir=default_cache_dir(ctx.config),
+    )

--- a/tokenjam/core/optimize/analyzers/pothole.py
+++ b/tokenjam/core/optimize/analyzers/pothole.py
@@ -1,0 +1,1086 @@
+"""
+Cross-session pothole aggregator (self-improve loop, Phase 1: detect + surface).
+
+A "pothole" is a blocker a Claude Code agent silently re-hits across many
+unwatched sessions — a wrong-cwd Read, an Edit before a Read, a blocked
+sleep-chain, a stale-read race, a domain-blocked WebFetch, and so on. shiploop
+only codifies what a human noticed; this module catches what nobody watched.
+
+Pipeline (validated 2026-07-12 against the full local corpus, see
+``.claude/self-improve-loop/SPEC.md`` §2/§9):
+
+  1. EXTRACT  — for each session, build the Story (``core.transcript.
+     build_session_story``) and fold it through ``core.method_spine.
+     build_method_spine`` for the ``delegate``/``dead_end``/``verify``/``act``
+     tags, walking subagents recursively. Every step whose tool errored is a
+     raw failure episode; its RAW error text comes straight from the Story's
+     tool dict (``step["tools"][i]["error"]``) — method_spine's own
+     ``_evidence()`` strips that field for privacy, so this module reads the
+     Story directly rather than trusting the spine's evidence.
+  2. CLUSTER  — normalize each failure into a signature. A handful of known,
+     validated families (cwd confusion, edit-before-read, blocked sleep-chain,
+     stale-read race, edit string-not-found, deferred-tool-cold, command not
+     found, malformed Read offset, WebFetch domain-block) match via regex
+     against the raw error text. Regex alone only recovers about half the
+     recurring signal (validated) — everything else falls into a generic
+     bucket normalized by stripping paths/ids/numbers/timestamps.
+  3. DISTILL  — a bounded, cached pass over the residual generic clusters via
+     the local ``claude`` CLI (``core.distill``) recovers a human title +
+     root cause + proposed fix, and a ``family_key`` so distill can merge
+     multiple generic signatures that share one root cause.
+  4. NOVELTY  — clusters already codified in a reachable CLAUDE.md/
+     learnings.md (walking up from each contributing session's cwd) are
+     dropped — the shiploop-miss check.
+  5. PROPOSE  — surviving, recurring (>=3 distinct sessions) clusters get a
+     conservative token estimate (occurrences x grounded per-turn cost, never
+     the inflated afflicted-session footprint), a target rung (§6 of the
+     intervention ladder) and a scope (project vs user-global, by how many
+     distinct repos the cluster's sessions span).
+
+Never raises: a single unreadable transcript, a distill failure, or a missing
+CLAUDE.md is skipped, not fatal — this runs unattended on a schedule.
+"""
+from __future__ import annotations
+
+import hashlib
+import re
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Iterable
+
+from tokenjam.core import distill as distill_mod
+from tokenjam.core.method_spine import build_method_spine
+from tokenjam.core.optimize.clustering import group_by_key, mask_variables, recurring
+from tokenjam.core.optimize.registry import register
+from tokenjam.core.optimize.types import AnalyzerContext
+from tokenjam.core.transcript import build_session_story, resolve_projects_root
+
+# --- Tunables ----------------------------------------------------------------
+
+#: Recurrence threshold (§7 of the spec: K approx 3 distinct sessions).
+MIN_RECURRING_SESSIONS = 3
+#: How many example sessions to carry per cluster (repro links).
+MAX_EXAMPLE_SESSIONS = 3
+#: Conservative per-occurrence token cost. A pothole occurrence costs roughly
+#: one extra assistant turn's overhead (re-issue the tool call, re-parse the
+#: harness context, re-narrate) — NOT the inflated whole-afflicted-session
+#: footprint the spec explicitly warns against. This is a heuristic magnitude
+#: signal, never a causal claim; surfaced with ``estimate_basis`` below.
+GROUNDED_TOKENS_PER_OCCURRENCE = 1_500
+#: Cap on how many residual (non-family-matched) clusters get a distill call,
+#: bounding both latency and $ spend on a full-corpus run.
+MAX_DISTILL_CLUSTERS = 20
+#: Minimum cluster size before it's even worth a distill call.
+MIN_DISTILL_CLUSTER_SESSIONS = MIN_RECURRING_SESSIONS
+DISTILL_MODEL = "haiku"
+
+ESTIMATE_BASIS = (
+    "occurrences x a conservative per-turn token cost (one re-issued tool "
+    "call + re-narration) — never the inflated whole-session footprint; "
+    "review the example sessions before applying a fix"
+)
+HONESTY_CAVEAT = (
+    "Structural failure-signature clustering, not a quality judgment. "
+    "Review the example sessions and the proposed fix before applying it."
+)
+
+# --- Known, validated pothole families ----------------------------------------
+# Each entry: (family key, human title, tool-name filter (None = any),
+# regex over the raw error text, default rung, default proposed fix).
+# Rungs follow the intervention ladder (SPEC §6): 1 CLAUDE.md note,
+# 2 skill/scoped doc, 3 hook, 4 wrapper/script, 5 config/env.
+_KNOWN_FAMILIES: list[dict[str, Any]] = [
+    {
+        "key": "cwd_confusion",
+        "title": "cwd / relative-path confusion",
+        "tools": None,
+        "pattern": re.compile(
+            r"no such file or directory|"
+            r"file does not exist\.\s*note:\s*your current working directory",
+            re.IGNORECASE,
+        ),
+        "rung": 3,
+        "fix": (
+            "PostToolUseFailure hook (Bash/Read): react only after a "
+            "'no such file or directory' failure by injecting the real cwd + "
+            "a short directory listing as additionalContext, so the agent "
+            "recovers in one shot instead of a PreToolUse guess-and-block on "
+            "every relative path (which would misfire on normal usage)."
+        ),
+    },
+    {
+        "key": "edit_before_read",
+        "title": "Edit/Write before Read",
+        "tools": {"Edit", "Write", "MultiEdit", "NotebookEdit"},
+        "pattern": re.compile(r"has not been read yet", re.IGNORECASE),
+        # Downgraded from rung 3 (Phase 2.5): the harness already errors
+        # clearly on this ("has not been read yet") and the agent virtually
+        # always self-corrects on the very next turn by reading the file —
+        # there's no failure-recovery gap for a reactive hook to close. A
+        # PreToolUse guard would need to track per-session read-state itself
+        # (which files has THIS session read, reset per session/compaction) —
+        # exactly the kind of fragile, easy-to-get-wrong state the harness
+        # already maintains authoritatively. Duplicating it in a hook risks a
+        # false block on a file the harness knows was read but our own
+        # tracking missed (a session resume, a compaction, a subagent read).
+        # Safer to note the pattern than to guess at its state.
+        "rung": 1,
+        "fix": (
+            "CLAUDE.md/skill note: the harness already blocks an Edit/Write "
+            "before a Read with a clear error ('has not been read yet') and "
+            "agents reliably self-correct by reading next turn — no hook "
+            "needed, this is advisory awareness only."
+        ),
+    },
+    {
+        "key": "sleep_chain",
+        "title": "blocked sleep-chain",
+        "tools": {"Bash"},
+        # The block usually reads generically ("blocked"/"disallowed"/timed out)
+        # with nothing pothole-specific in the wording — the ONE reliable tell is
+        # the command itself leading with `sleep`. So this family also matches on
+        # the tool's LABEL (its Bash command), not just the error text; see
+        # `classify_known_family`.
+        "pattern": re.compile(
+            r"sleep.{0,40}(block|disallow|not permit)|"
+            r"(block|disallow|not permit).{0,40}sleep|"
+            r"long.{0,10}leading sleep",
+            re.IGNORECASE,
+        ),
+        "label_pattern": re.compile(r"^\s*sleep\b", re.IGNORECASE),
+        "rung": 3,
+        "fix": (
+            "PreToolUse hook: block a `sleep N && <check>` Bash chain and point the "
+            "agent at the Monitor tool instead of a busy-wait."
+        ),
+    },
+    {
+        "key": "stale_read_race",
+        "title": "file modified since read (linter/hook race)",
+        "tools": {"Edit", "Write", "MultiEdit"},
+        "pattern": re.compile(r"modified since (it was last read|read)", re.IGNORECASE),
+        "rung": 3,
+        "fix": (
+            "PostToolUseFailure hook (Edit/Write/MultiEdit): react only after "
+            "a 'modified since read' failure by injecting a re-Read reminder "
+            "as additionalContext — never touches a successful edit."
+        ),
+    },
+    {
+        "key": "edit_string_not_found",
+        "title": "Edit string-not-found (stale/whitespace/conflict)",
+        "tools": {"Edit", "MultiEdit"},
+        "pattern": re.compile(
+            r"string to replace not found|old_string not found|not found in file",
+            re.IGNORECASE,
+        ),
+        "rung": 3,
+        "fix": (
+            "PostToolUseFailure hook (Edit/MultiEdit): react only after a "
+            "string-not-found failure by injecting a re-Read reminder as "
+            "additionalContext — never touches a successful edit."
+        ),
+    },
+    {
+        # MUST stay ordered before "deferred_tool_cold" below: that family's
+        # pattern (`inputvalidationerror`, tools=None -> matches ANY tool)
+        # also fires on the real wording of THIS family's evidence --
+        # "InputValidationError: Read failed due to the following issue:\n
+        # The parameter `offset` type is expected as `number` but provided
+        # as `array`" matches both patterns. classify_known_family is
+        # first-match-wins over declaration order, so the more-specific
+        # family (Read-only, offset-specific) has to be checked first or its
+        # evidence is silently absorbed by the generic one and mislabeled
+        # with the wrong fix. Validated against the real corpus (2026-07-14):
+        # with the old order, 100% of read_offset_malformed's evidence
+        # (~35% of deferred_tool_cold's Read-tool occurrences) was shadowed
+        # this way -- the family never once surfaced a proposal despite
+        # matching real, recurring evidence.
+        "key": "read_offset_malformed",
+        "title": "Read malformed offset (array, not scalar)",
+        "tools": {"Read"},
+        "pattern": re.compile(r"offset.{0,20}(must be|invalid|expected)|invalid.{0,20}offset", re.IGNORECASE),
+        "rung": 1,
+        "fix": "CLAUDE.md/skill note: Read's `offset`/`limit` are scalars, not arrays.",
+    },
+    {
+        "key": "deferred_tool_cold",
+        "title": "deferred tool called cold (no ToolSearch first)",
+        "tools": None,
+        "pattern": re.compile(
+            r"inputvalidationerror|the following issues|required parameter.{0,20}is missing",
+            re.IGNORECASE,
+        ),
+        "rung": 2,
+        "fix": (
+            "Skill/scoped note: deferred tools need a ToolSearch lookup for their "
+            "schema before the first call; optionally a PreToolUse intercept hook."
+        ),
+    },
+    {
+        # Downgraded from rung 5 (Phase 2.5, 2026-07-14): rung 5 promises a
+        # "config/env fix", but there is no safe automatic config/env writer
+        # in this codebase -- Apply used to render an inert stub hook for
+        # this family (`_render_stub_hook`, never wired to block/inject
+        # anything), advertising a fix that did nothing. A rung-1 CLAUDE.md
+        # note is honest about what's actually deliverable and still useful.
+        "key": "command_not_found",
+        "title": "command not found (bashisms under zsh, bare interpreter)",
+        "tools": {"Bash"},
+        "pattern": re.compile(r"command not found", re.IGNORECASE),
+        "rung": 1,
+        "fix": (
+            "CLAUDE.md/skill note: this shell doesn't have that binary/builtin on "
+            "PATH. Common causes here: using bare `python` instead of `python3`, "
+            "or a bash-only builtin (`mapfile`, `shopt`, `[[ ... ]]` extensions) "
+            "that doesn't exist under this shell (e.g. zsh, sh) or POSIX mode. "
+            "Prefer the portable/explicit form."
+        ),
+    },
+    {
+        "key": "webfetch_domain_blocked",
+        "title": "WebFetch domain-blocked",
+        "tools": {"WebFetch"},
+        # Real wording (validated against the local corpus): "Claude Code is
+        # unable to fetch from <domain>" — not "not allowed"/"blocked" as the
+        # phrasing might suggest.
+        "pattern": re.compile(
+            r"unable to fetch from|domain.{0,30}(not allowed|block)|"
+            r"not allowed to fetch|blocked domain",
+            re.IGNORECASE,
+        ),
+        "rung": 1,
+        "fix": "CLAUDE.md/skill note: this domain is blocked — use a search tool or a different source instead.",
+    },
+]
+
+_FAMILY_BY_KEY = {fam["key"]: fam for fam in _KNOWN_FAMILIES}
+
+# --- Generic (residual-bucket) normalization ----------------------------------
+
+_PATH_RE = re.compile(r"(/[\w.\-]+){2,}")
+_UUID_RE = re.compile(r"[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}")
+_HEX_ID_RE = re.compile(r"\b[0-9a-fA-F]{12,}\b")
+_NUMBER_RE = re.compile(r"\b\d+\b")
+_TIMESTAMP_RE = re.compile(r"\d{4}-\d{2}-\d{2}[T ]\d{2}:\d{2}:\d{2}(\.\d+)?(Z|[+-]\d{2}:?\d{2})?")
+
+#: Ordered substitutions for the generic-signature normalizer. Order matters:
+#: timestamps and uuids are masked before bare hex/number runs so their internal
+#: digits aren't partially replaced first (see mask_variables).
+_GENERIC_SUBS = [
+    (_TIMESTAMP_RE, "<TS>"),
+    (_UUID_RE, "<UUID>"),
+    (_PATH_RE, "<PATH>"),
+    (_HEX_ID_RE, "<ID>"),
+    (_NUMBER_RE, "<N>"),
+]
+
+
+def _normalize_generic(text: str) -> str:
+    """Strip paths/uuids/hex-ids/numbers/timestamps so unrelated values collapse
+    into the same signature. Deterministic, no LLM — the fast path before the
+    distill pass on whatever this misses."""
+    return mask_variables(text, _GENERIC_SUBS, collapse_ws=True, lowercase=True)
+
+
+def _generic_signature(tool_name: str, error_text: str) -> str:
+    normalized = _normalize_generic(error_text)[:160]
+    return f"{tool_name}:{normalized}"
+
+
+#: Not potholes: the tool_result carries ``is_error`` because a HUMAN declined
+#: the action (a permission prompt, an AskUserQuestion decline, "Exit plan
+#: mode?" answered no) — expected interactive UI, not a blocker an agent
+#: silently re-hits. Validated against the local corpus (2026-07-12): these
+#: were the single biggest source of noise in the raw failure count, easily
+#: mistaken for a recurring "gotcha" by naive clustering. Excluded at
+#: extraction time so they never enter a cluster at all.
+_USER_DECLINE_RE = re.compile(
+    r"doesn.t want to proceed with this tool use|"
+    r"^exit plan mode\?\s*$",
+    re.IGNORECASE,
+)
+
+
+def is_user_decline(error_text: str) -> bool:
+    """True if this 'failure' is really a human declining an action, not a
+    pothole — see ``_USER_DECLINE_RE``."""
+    return bool(error_text) and bool(_USER_DECLINE_RE.search(error_text.strip()))
+
+
+def classify_known_family(tool_name: str, error_text: str, label: str = "") -> str | None:
+    """Return the matching known family key, or None. Tried in declaration order
+    (first match wins; the families are mutually near-exclusive by wording).
+
+    Most families match on the raw error text alone. A few (e.g. the blocked
+    sleep-chain, whose block message is often generic — "timed out"/"blocked"
+    with nothing pothole-specific in the wording) additionally require the
+    tool's ``label`` (its command/arg) to match a ``label_pattern`` — the
+    reliable tell is the command itself, not the error text.
+    """
+    if not error_text:
+        return None
+    for fam in _KNOWN_FAMILIES:
+        tools = fam["tools"]
+        if tools is not None and tool_name not in tools:
+            continue
+        if not fam["pattern"].search(error_text):
+            continue
+        label_pattern = fam.get("label_pattern")
+        if label_pattern is not None and not label_pattern.search(label or ""):
+            continue
+        return fam["key"]
+    return None
+
+
+# --- Extraction ----------------------------------------------------------------
+
+@dataclass
+class FailureEpisode:
+    """One erroring tool call, structurally tagged, with its raw error text."""
+    session_id:  str
+    repo:        str            # human-ish repo label (agent_id sans provider prefix, or "unknown")
+    ts:          str | None
+    tool_name:   str
+    label:       str            # the tool's short arg label (never full input)
+    error_text:  str            # RAW, already length-capped by transcript.py
+    kind:        str            # method_spine move kind: delegate/dead_end/verify/act
+    is_retry:    bool
+    depth:       int            # 0 = main thread, >0 = nested subagent
+
+
+def _walk_moves(
+    steps: list[dict[str, Any]], moves: list[dict[str, Any]], depth: int,
+) -> Iterable[tuple[dict[str, Any], dict[str, Any], int]]:
+    """Zip a Story's raw steps with method_spine's moves (1:1, same order),
+    recursing into delegate moves' expanded subagent stories. Mirrors
+    method_spine's own recursion so kinds line up exactly; never re-derives
+    them independently."""
+    for step, move in zip(steps, moves):
+        yield step, move, depth
+        if move.get("kind") != "delegate":
+            continue
+        subs = ([step["subagent"]] if step.get("subagent") else []) + list(
+            step.get("subagents") or []
+        )
+        delegations = move.get("delegations") or []
+        for sub_dict, delegation in zip(subs, delegations):
+            if delegation.get("capped") is not None:
+                continue  # not expanded — nothing to walk
+            sub_steps = [s for s in (sub_dict.get("steps") or []) if "omitted" not in s]
+            sub_spine = delegation.get("spine") or []
+            yield from _walk_moves(sub_steps, sub_spine, depth + 1)
+
+
+def extract_failures_for_session(
+    session_id: str,
+    repo: str,
+    projects_root: Path | str | None = None,
+) -> list[FailureEpisode]:
+    """Every erroring tool call in one session (main thread + subagents).
+
+    Returns ``[]`` when the session has no on-disk transcript (SDK session,
+    pruned). Never raises — a malformed transcript yields whatever could be
+    parsed (``build_session_story`` already tolerates bad lines).
+    """
+    story = build_session_story(session_id, projects_root=projects_root, include_subagents=True)
+    if story is None:
+        return []
+
+    real_steps = [s for s in (story.get("steps") or []) if "omitted" not in s]
+    spine = build_method_spine(story)
+
+    failures: list[FailureEpisode] = []
+    for step, move, depth in _walk_moves(real_steps, spine, 0):
+        for tool in step.get("tools") or []:
+            if tool.get("status") != "error":
+                continue
+            error_text = tool.get("error") or ""
+            if is_user_decline(error_text):
+                continue  # a human's own choice, not a pothole — see is_user_decline
+            failures.append(FailureEpisode(
+                session_id=session_id,
+                repo=repo,
+                ts=step.get("ts"),
+                tool_name=tool.get("name") or "unknown",
+                label=tool.get("label") or "",
+                error_text=error_text,
+                kind=move.get("kind", "act"),
+                is_retry=bool(move.get("is_retry")),
+                depth=depth,
+            ))
+    return failures
+
+
+# --- Clustering ------------------------------------------------------------
+
+@dataclass
+class _RawCluster:
+    signature:      str
+    family_key:     str | None      # None until a known family or distill assigns one
+    title:          str
+    failures:       list[FailureEpisode] = field(default_factory=list)
+
+    @property
+    def session_ids(self) -> set[str]:
+        return {f.session_id for f in self.failures}
+
+    @property
+    def repos(self) -> set[str]:
+        return {f.repo for f in self.failures}
+
+
+def _failure_signature(failure: FailureEpisode) -> tuple[str, str | None, str]:
+    """``(signature, family_key, title)`` for one failure: a known family (sig ==
+    family_key) or a generic normalized signature. The single classify point
+    ``cluster_failures`` keys on."""
+    family_key = classify_known_family(failure.tool_name, failure.error_text, failure.label)
+    if family_key is not None:
+        return family_key, family_key, _FAMILY_BY_KEY[family_key]["title"]
+    sig = _generic_signature(failure.tool_name, failure.error_text)
+    return sig, None, f"{failure.tool_name}: {failure.error_text[:60] or failure.label}"
+
+
+def cluster_failures(failures: list[FailureEpisode]) -> dict[str, _RawCluster]:
+    """Bucket failures by known family first, else a generic normalized signature.
+
+    Groups via the shared ``group_by_key`` (order-preserving), then builds one
+    ``_RawCluster`` per group with its title/family taken from the group's FIRST
+    failure — the same failure that used to create the bucket inline, so titles
+    stay byte-identical."""
+    buckets = group_by_key(failures, lambda f: _failure_signature(f)[0])
+    clusters: dict[str, _RawCluster] = {}
+    for sig, group in buckets.items():
+        _, family_key, title = _failure_signature(group[0])
+        clusters[sig] = _RawCluster(
+            signature=sig, family_key=family_key, title=title, failures=group,
+        )
+    return clusters
+
+
+def _recurring(clusters: dict[str, _RawCluster], min_sessions: int) -> list[_RawCluster]:
+    """Clusters seen across at least ``min_sessions`` DISTINCT sessions — the
+    recurrence gate, on distinct-session count (not raw occurrences)."""
+    kept = recurring(
+        clusters, min_members=min_sessions, size_fn=lambda c: len(c.session_ids),
+    )
+    return list(kept.values())
+
+
+# --- Distill pass over the residual (non-family) bucket -----------------------
+
+def _distill_cache_dir() -> Path:
+    return Path.home() / ".tj" / "distill_cache" / "pothole"
+
+
+def _cluster_hash(cluster: _RawCluster) -> str:
+    payload = cluster.signature + "|" + "|".join(
+        sorted(f.error_text for f in cluster.failures[:10])
+    )
+    return hashlib.sha256(payload.encode("utf-8")).hexdigest()[:24]
+
+
+def distill_pothole_cluster(
+    tool_name: str, samples: list[str], *, model: str = DISTILL_MODEL, timeout: int = 60,
+) -> dict[str, str]:
+    """Ask the local ``claude`` CLI to name a residual failure cluster.
+
+    Returns ``{"title", "family_key", "fix"}`` — ``family_key`` is a short
+    slug distill invents so several generic signatures sharing one root cause
+    merge under it. Returns ``{}`` on any failure (missing CLI, bad JSON,
+    timeout) — never raises. Shells out via ``core.distill._invoke_claude``,
+    the same pinned invocation ``distill_titles`` uses.
+    """
+    if not samples:
+        return {}
+
+    numbered = "\n".join(f"{i + 1}. {s[:300]}" for i, s in enumerate(samples[:8]))
+    prompt = (
+        "Below are raw error messages a coding agent hit repeatedly while using the "
+        f"`{tool_name}` tool.\n"
+        "Decide whether they share ONE root cause (an environmental/procedural/tooling "
+        "gotcha, NOT a one-off bug in the task's own code). "
+        'Return ONLY a JSON object: {"title": "<=8 word name>", "family_key": '
+        '"<short_snake_case_slug>", "fix": "<one sentence proposed fix>"}. '
+        "No prose, no code fence required.\n\n"
+        f"{numbered}"
+    )
+
+    result = distill_mod._invoke_claude(prompt, model=model, timeout=timeout)
+    if result is None:
+        return {}
+
+    match = distill_mod._JSON_OBJECT_RE.search(result)
+    if not match:
+        return {}
+    import json as _json
+
+    try:
+        raw = _json.loads(match.group(0))
+    except (_json.JSONDecodeError, ValueError):
+        return {}
+    if not isinstance(raw, dict):
+        return {}
+    title = str(raw.get("title") or "").strip()
+    family_key = str(raw.get("family_key") or "").strip().lower().replace(" ", "_")
+    fix = str(raw.get("fix") or "").strip()
+    if not title or not family_key:
+        return {}
+    return {"title": title, "family_key": family_key, "fix": fix}
+
+
+# --- Distill confidence gate (SPEC honesty requirement) ------------------------
+#
+# Validated against the real corpus (2026-07-14): fed only bare/near-empty
+# evidence, the distill model reliably CONFABULATES a specific-sounding but
+# ungrounded fix rather than declining. The single biggest real example: a
+# multi-command `&&` Bash chain whose LAST command exits nonzero with no
+# error text of its own (a trailing `grep`/`find` "no match", commonly) —
+# the captured "error" is either empty, a bare digit/punctuation residue
+# (`0`, `000`, `---`), or literally just leftover STDOUT from an EARLIER,
+# successful command in the chain (an `ls -la` dump) that has nothing to do
+# with why the chain's exit code was nonzero. Distill invented FIVE different
+# titled "fixes" for that one benign phenomenon (bash_stderr_missing,
+# bash_error_reporting, bash_env_setup, bash_output_buffer_limit,
+# bash_output_truncation) — each confident, each wrong, none traceable to any
+# actual quoted error text. A fix can only be grounded in evidence that
+# itself says something; this gate rejects a cluster BEFORE distillation when
+# none of its samples clear that bar, rather than trusting the model to
+# decline on its own.
+
+_EXIT_CODE_PREFIX_RE = re.compile(r"^\s*exit code\s+\d+\s*\n?", re.IGNORECASE)
+#: Body is "noise" if, after stripping a leading exit-code line, nothing but
+#: digits/whitespace/punctuation is left (catches "", "0", "000", "---").
+_ONLY_NOISE_RE = re.compile(r"^[\s\d\W]*$")
+#: A body that's actually just a raw `ls -la`-style directory dump — real
+#: text, but leftover stdout from an earlier chain step, not an error
+#: description of why the LAST command in the chain failed.
+_LS_LISTING_RE = re.compile(r"^\s*total\s+\d+\s*\n\s*[dlpscb\-][rwxst\-]{9}[@+.]?\s", re.IGNORECASE)
+
+
+def _is_substantive_error_text(text: str) -> bool:
+    """False for evidence too thin to ground a specific distilled fix in —
+    see the confidence-gate note above. Never raises."""
+    if not text:
+        return False
+    body = _EXIT_CODE_PREFIX_RE.sub("", text, count=1).strip()
+    if not body:
+        return False
+    if _ONLY_NOISE_RE.match(body):
+        return False
+    if _LS_LISTING_RE.match(body):
+        return False
+    return True
+
+
+def _evidence_too_thin_for_distill(cluster: _RawCluster, *, sample_cap: int = 8) -> bool:
+    """True when NONE of a cluster's (capped) raw samples carry substantive
+    error text — the distill confidence gate. A cluster failing this check is
+    suppressed entirely rather than distilled (see ``apply_distill_to_residual``):
+    showing a human a confident title + fix that traces to nothing but bare
+    exit codes / leftover stdout is worse than surfacing nothing."""
+    samples = [f.error_text for f in cluster.failures if f.error_text][:sample_cap]
+    if not samples:
+        return True
+    return not any(_is_substantive_error_text(s) for s in samples)
+
+
+def _distill_cached(tool_name: str, cluster: _RawCluster, cache_dir: Path) -> dict[str, str]:
+    """Cached wrapper (keyed by cluster content hash) — never re-spends on an
+    unchanged cluster. Best-effort: any I/O error degrades to a cache miss."""
+    import json as _json
+
+    cache_file = cache_dir / f"{_cluster_hash(cluster)}.json"
+    try:
+        cached = _json.loads(cache_file.read_text(encoding="utf-8"))
+        if isinstance(cached, dict) and cached.get("title"):
+            return cached
+    except (OSError, ValueError):
+        pass
+
+    samples = [f.error_text for f in cluster.failures if f.error_text][:8]
+    result = distill_pothole_cluster(tool_name, samples)
+    if not result:
+        return {}
+    try:
+        cache_dir.mkdir(parents=True, exist_ok=True)
+        cache_file.write_text(_json.dumps(result), encoding="utf-8")
+    except OSError:
+        pass
+    return result
+
+
+def apply_distill_to_residual(
+    clusters: list[_RawCluster], *, cache_dir: Path | None = None, enabled: bool = True,
+) -> list[_RawCluster]:
+    """Distill the top (by session count) residual clusters and merge any that
+    distill assigns the same ``family_key``. Bounded by ``MAX_DISTILL_CLUSTERS``
+    so a huge residual bucket never triggers unbounded $ spend.
+
+    Clusters already matched to a known family are left untouched. When
+    ``enabled`` is False (no ``claude`` CLI / caller opt-out) the residual
+    clusters pass through with their generic titles, unmerged.
+    """
+    if cache_dir is None:
+        cache_dir = _distill_cache_dir()
+
+    known = [c for c in clusters if c.family_key is not None]
+    residual = [c for c in clusters if c.family_key is None]
+    if not enabled or not residual:
+        return clusters
+
+    residual.sort(key=lambda c: len(c.session_ids), reverse=True)
+    to_distill = [c for c in residual if len(c.session_ids) >= MIN_DISTILL_CLUSTER_SESSIONS]
+    to_distill = to_distill[:MAX_DISTILL_CLUSTERS]
+    untouched = [c for c in residual if c not in to_distill]
+
+    merged: dict[str, _RawCluster] = {}
+    for cluster in to_distill:
+        if _evidence_too_thin_for_distill(cluster):
+            continue  # confidence gate: suppressed, not distilled — see note above
+        tool_name = cluster.failures[0].tool_name if cluster.failures else "unknown"
+        result = _distill_cached(tool_name, cluster, cache_dir)
+        if not result:
+            untouched.append(cluster)
+            continue
+        family_key = f"distilled:{result['family_key']}"
+        target = merged.get(family_key)
+        if target is None:
+            target = _RawCluster(signature=family_key, family_key=family_key, title=result["title"])
+            merged[family_key] = target
+            # Stash the distilled fix on the family table so proposal-building
+            # can look it up like a known family (keeps one code path).
+            _FAMILY_BY_KEY.setdefault(family_key, {
+                "key": family_key, "title": result["title"], "tools": None,
+                "pattern": None, "rung": 1, "fix": result.get("fix") or "",
+            })
+        target.failures.extend(cluster.failures)
+
+    return known + list(merged.values()) + untouched
+
+
+# --- Novelty filter (cross-ref codified knowledge) -----------------------------
+
+def _candidate_doc_paths(repo_cwds: set[str]) -> list[Path]:
+    """CLAUDE.md/learnings.md reachable from any contributing session's cwd,
+    walking up a few parent levels so a workspace-root doc (a meta-repo's
+    CLAUDE.md above the sub-repo) is found too, not just the sub-repo's own."""
+    names = ("CLAUDE.md", "learnings.md")
+    seen: set[Path] = set()
+    paths: list[Path] = []
+    for cwd in repo_cwds:
+        base = Path(cwd) if cwd else None
+        if base is None or not base.exists():
+            continue
+        for ancestor in [base, *base.parents[:3]]:
+            for name in names:
+                candidate = ancestor / name
+                if candidate in seen:
+                    continue
+                seen.add(candidate)
+                if candidate.is_file():
+                    paths.append(candidate)
+    return paths
+
+
+def _doc_text(paths: list[Path], max_chars: int = 200_000) -> str:
+    parts: list[str] = []
+    total = 0
+    for p in paths:
+        try:
+            text = p.read_text(encoding="utf-8", errors="replace")
+        except OSError:
+            continue
+        parts.append(text.lower())
+        total += len(text)
+        if total >= max_chars:
+            break
+    return "\n".join(parts)
+
+
+#: A few representative keywords per known family — a cheap, inspectable
+#: novelty heuristic (NOT an LLM call): "already codified" iff every keyword
+#: co-occurs somewhere in the reachable docs. Deliberately conservative (few,
+#: specific terms) so a coincidental single-word match doesn't wrongly drop a
+#: real, still-uncodified pothole.
+#: One DISTINCTIVE multi-word phrase per known family — deliberately full
+#: phrases (not independent short words ANDed together). Validated the hard
+#: way (2026-07-12): an earlier version used tuples like ("read", "before
+#: editing") ANDed independently, and "read" alone is common enough that it
+#: co-occurred with unrelated text in reachable docs, silently dropping the
+#: single BIGGEST validated pothole (edit-before-read, 178 sessions) as
+#: "already codified" when it demonstrably wasn't. A short generic word is
+#: not a novelty signal; a verbatim-ish multi-word phrase close to the
+#: harness's actual wording is.
+_FAMILY_NOVELTY_PHRASES: dict[str, str] = {
+    "cwd_confusion": "no such file or directory",
+    "edit_before_read": "has not been read yet",
+    "sleep_chain": "foreground sleep",
+    "stale_read_race": "modified since read",
+    "edit_string_not_found": "string to replace not found",
+    "deferred_tool_cold": "toolsearch",
+    "command_not_found": "command not found",
+    "read_offset_malformed": "offset must be a scalar",
+    "webfetch_domain_blocked": "unable to fetch from",
+}
+
+
+def is_already_codified(cluster: _RawCluster, doc_text: str) -> bool:
+    """Heuristic novelty check (the shiploop-miss check): does a reachable
+    CLAUDE.md/learnings.md already name this exact gotcha?
+
+    Deliberately narrow — a single distinctive phrase per KNOWN family (see
+    ``_FAMILY_NOVELTY_PHRASES``). Residual/distilled clusters (no known
+    family) have no safe phrase to check against, so they're always treated
+    as novel: a missed "already codified" drop costs a human one glance at
+    the review inbox; a wrongful drop silently hides the exact signal this
+    detector exists to surface. Never guess on a generic word.
+    """
+    if not doc_text or not cluster.family_key:
+        return False
+    phrase = _FAMILY_NOVELTY_PHRASES.get(cluster.family_key)
+    if not phrase:
+        return False
+    return phrase in doc_text
+
+
+# --- Proposal building -----------------------------------------------------
+
+@dataclass
+class PotholeExample:
+    session_id: str
+    repo:       str
+    ts:         str | None
+    snippet:    str            # short excerpt of the raw error (evidence)
+
+
+@dataclass
+class PotholeCluster:
+    signature:                 str
+    family_key:                str | None
+    title:                     str
+    sessions:                  int
+    occurrences:                int
+    repos:                      list[str]
+    rung:                       int             # 1-5, SPEC §6 intervention ladder
+    scope:                      str              # "project" | "user-global"
+    proposed_fix:                str
+    examples:                    list[PotholeExample] = field(default_factory=list)
+    estimated_recoverable_tokens: int = 0
+    confidence:                   str = "heuristic"
+    novel:                        bool = True
+    # Phase 2 (apply) — best-effort cwd of the cluster's (sole, if project-
+    # scoped) repo, and a suggested rung-1 write target derived from it. Both
+    # are just a DEFAULT for the Review inbox card's scope/target override
+    # (§7's "repo-identity is noisy" — never applied blindly); "" when
+    # unknown (multi-repo / user-global / no cwd could be resolved).
+    repo_cwd:                     str = ""
+    suggested_target:             str = ""
+    # ADVISE lane (workspace-less agents). True when every contributing repo is
+    # an agent tokenjam has no workspace to write into (an SDK/OTel service, not
+    # a checkout) — so there is no apply path at all: the card carries a
+    # recommendation the user applies themselves, `suggested_target` stays "",
+    # and Verify runs off spans instead of transcripts. See
+    # `core/optimize/pothole_otel.py`.
+    advise_only:                  bool = False
+
+
+@dataclass
+class PotholeFinding:
+    clusters:            list[PotholeCluster] = field(default_factory=list)
+    sessions_scanned:     int = 0
+    failures_examined:    int = 0
+    distilled_clusters:   int = 0
+    dropped_codified:     int = 0
+    estimated_recoverable_tokens: int | None = None
+    estimate_basis:        str = ESTIMATE_BASIS
+    estimate_confidence:   str = "heuristic"
+    caveat:                 str = HONESTY_CAVEAT
+
+
+def _snippet(failure: FailureEpisode) -> str:
+    text = failure.error_text or failure.label
+    return text[:200]
+
+
+def _scope_for(repos: set[str]) -> str:
+    """§7: concentrated in one repo -> project; spread across many -> user-global."""
+    return "project" if len(repos) <= 1 else "user-global"
+
+
+def build_proposals(
+    clusters: list[_RawCluster],
+    *,
+    min_sessions: int = MIN_RECURRING_SESSIONS,
+    doc_text: str = "",
+    repo_cwd_map: dict[str, str] | None = None,
+    advise_only_repos: set[str] | None = None,
+) -> tuple[list[PotholeCluster], int]:
+    """Turn surviving raw clusters into ranked proposals. Returns
+    ``(proposals, dropped_codified_count)``.
+
+    ``repo_cwd_map`` (repo label -> a representative cwd) is optional,
+    best-effort enrichment used only to pre-fill the Apply stage's suggested
+    target path (Phase 2) — clustering itself needs none of it.
+
+    ``advise_only_repos`` names the agents tokenjam has NO workspace for (the
+    OTel lane — see ``core/optimize/pothole_otel.py``). A cluster whose repos are
+    all in that set is marked ``advise_only`` and gets NO suggested target: there
+    is nothing to apply into, so the card must not imply an apply path exists.
+    """
+    from tokenjam.core.optimize.pothole_apply import default_target_path, slugify
+
+    repo_cwd_map = repo_cwd_map or {}
+    proposals: list[PotholeCluster] = []
+    dropped = 0
+    for cluster in clusters:
+        sessions = cluster.session_ids
+        if len(sessions) < min_sessions:
+            continue
+        if is_already_codified(cluster, doc_text):
+            dropped += 1
+            continue
+
+        family = _FAMILY_BY_KEY.get(cluster.family_key or "")
+        rung = family["rung"] if family else 1
+        fix = family["fix"] if family else "Review examples — no known fix template matched."
+
+        repos = sorted(cluster.repos)
+        occurrences = len(cluster.failures)
+        examples = [
+            PotholeExample(
+                session_id=f.session_id, repo=f.repo, ts=f.ts, snippet=_snippet(f),
+            )
+            for f in sorted(cluster.failures, key=lambda f: f.ts or "", reverse=True)[:MAX_EXAMPLE_SESSIONS]
+        ]
+
+        scope = _scope_for(cluster.repos)
+        # Workspace-less (OTel) clusters have nowhere to write: no cwd, no
+        # target, and the card must not offer an apply path it can't honor.
+        advise_only = bool(advise_only_repos) and all(
+            r in advise_only_repos for r in repos
+        )
+        repo_cwd = "" if advise_only else (
+            repo_cwd_map.get(repos[0], "") if len(repos) == 1 else ""
+        )
+        if advise_only:
+            suggested_target = ""
+        else:
+            try:
+                suggested_target = default_target_path(
+                    rung, scope, repo_cwd, slugify(cluster.title),
+                )
+            except Exception:
+                suggested_target = ""   # never let a bad path computation sink the proposal
+
+        proposals.append(PotholeCluster(
+            signature=cluster.signature,
+            family_key=cluster.family_key,
+            title=cluster.title,
+            sessions=len(sessions),
+            occurrences=occurrences,
+            repos=repos,
+            rung=rung,
+            scope=scope,
+            proposed_fix=fix,
+            examples=examples,
+            estimated_recoverable_tokens=occurrences * GROUNDED_TOKENS_PER_OCCURRENCE,
+            novel=True,
+            repo_cwd=repo_cwd,
+            suggested_target=suggested_target,
+            advise_only=advise_only,
+        ))
+
+    proposals.sort(key=lambda p: p.sessions, reverse=True)
+    return proposals, dropped
+
+
+# --- Orchestration (pure, no ctx dependency — testable directly) --------------
+
+def analyze_potholes(
+    sessions: list[tuple[str, str]],     # [(session_id, repo), ...]
+    *,
+    projects_root: Path | str | None = None,
+    min_sessions: int = MIN_RECURRING_SESSIONS,
+    distill_enabled: bool = True,
+    distill_cache_dir: Path | None = None,
+    codified_doc_text: str = "",
+    repo_cwd_map: dict[str, str] | None = None,
+    extra_failures: list[FailureEpisode] | None = None,
+    advise_only_repos: set[str] | None = None,
+) -> PotholeFinding:
+    """Full pipeline over an explicit session list — the pure core the
+    registry entry point and the on-disk cache job both call. Never raises.
+
+    ``extra_failures`` are episodes extracted somewhere other than an on-disk
+    transcript — today the OTel lane's failing spans (see
+    ``core/optimize/pothole_otel.py``). They join the SAME clustering pass, so a
+    signature that recurs across both lanes clusters as one pothole.
+    ``advise_only_repos`` is forwarded to ``build_proposals`` to mark the
+    workspace-less clusters.
+    """
+    all_failures: list[FailureEpisode] = []
+    scanned = 0
+    for session_id, repo in sessions:
+        try:
+            failures = extract_failures_for_session(session_id, repo, projects_root)
+        except Exception:
+            continue
+        scanned += 1
+        all_failures.extend(failures)
+
+    if extra_failures:
+        all_failures.extend(extra_failures)
+        # Span-sourced sessions are real scanned exposure too; counting them
+        # keeps sessions_scanned honest against the recurrence denominator.
+        scanned += len({f.session_id for f in extra_failures})
+
+    raw_clusters = cluster_failures(all_failures)
+    recurring = _recurring(raw_clusters, min_sessions)
+    distilled = apply_distill_to_residual(
+        recurring, cache_dir=distill_cache_dir, enabled=distill_enabled,
+    )
+    distilled_count = sum(1 for c in distilled if (c.family_key or "").startswith("distilled:"))
+
+    proposals, dropped = build_proposals(
+        distilled, min_sessions=min_sessions, doc_text=codified_doc_text,
+        repo_cwd_map=repo_cwd_map, advise_only_repos=advise_only_repos,
+    )
+    total_tokens = sum(p.estimated_recoverable_tokens for p in proposals)
+
+    return PotholeFinding(
+        clusters=proposals,
+        sessions_scanned=scanned,
+        failures_examined=len(all_failures),
+        distilled_clusters=distilled_count,
+        dropped_codified=dropped,
+        estimated_recoverable_tokens=total_tokens if proposals else None,
+    )
+
+
+# --- Registry entry point -----------------------------------------------------
+
+def _repo_map_from_db(conn) -> dict[str, str]:
+    """``session_id -> repo`` from the ``sessions`` table's ``agent_id``
+    (``claude-code-<basename(cwd)>`` — see ``core.backfill._agent_id_from_cwd``).
+    Best-effort: an empty/failed query just means every session falls back to
+    "unknown" and clusters still work, just with weaker repo/scope info."""
+    try:
+        rows = conn.execute("SELECT session_id, agent_id FROM sessions").fetchall()
+    except Exception:
+        return {}
+    out: dict[str, str] = {}
+    for session_id, agent_id in rows:
+        repo = str(agent_id or "unknown")
+        if repo.startswith("claude-code-"):
+            repo = repo[len("claude-code-"):]
+        out[str(session_id)] = repo
+    return out
+
+
+def _repo_cwd_map_for(sessions: list[tuple[str, str]], projects_root: Path) -> dict[str, str]:
+    """Best-effort repo-label -> cwd, for the novelty doc search AND (Phase 2)
+    the Apply stage's suggested target path. Derived from the encoded project
+    directory name is unreliable, so this reads each session's transcript's
+    first ``cwd`` field directly (cheap: short-circuits after the first hit)
+    for one representative session per repo."""
+    from tokenjam.core.transcript import _locate_transcript, read_records
+
+    out: dict[str, str] = {}
+    for session_id, repo in sessions:
+        if repo in out:
+            continue
+        path = _locate_transcript(session_id, projects_root)
+        if path is None:
+            continue
+        for record in read_records(path)[:5]:
+            cwd = record.get("cwd")
+            if isinstance(cwd, str) and cwd:
+                out[repo] = cwd
+                break
+    return out
+
+
+def compute_pothole_finding(
+    conn: Any | None = None,
+    since: Any | None = None,
+    *,
+    projects_root: Path | str | None = None,
+    distill_enabled: bool = True,
+) -> PotholeFinding:
+    """Standalone entry point that doesn't need a full ``AnalyzerContext`` —
+    used by the serve-time background cache job (``api/routes/pothole.py``)
+    and by tests. ``conn`` is an OPTIONAL DuckDB connection used only for
+    repo-name enrichment (``sessions.agent_id``); pass ``None`` and every
+    session falls back to a ``"unknown"`` repo label — clustering itself needs
+    no DB at all, it's a pure filesystem scan.
+
+    Full-corpus by design: enumerates every on-disk Claude Code transcript
+    (not window-scoped like the other analyzers — a pothole recurring across
+    months of history is exactly the signal this detector exists to find),
+    optionally pre-filtered to ``since`` when the caller wants an incremental
+    scan. Heavy (tens of seconds over a full local corpus) — callers that
+    serve this over HTTP MUST cache the result, not compute it per-request.
+
+    TWO LANES. On-disk transcripts cover the workspace agents; when ``conn`` is
+    given, failing spans from NON-coding agents are folded into the same
+    clustering pass so SDK/OTel services are no longer invisible to the
+    detector (``core/optimize/pothole_otel.py``). Their clusters come back
+    ``advise_only``: detect and advise, never apply.
+    """
+    root = resolve_projects_root(projects_root)
+    repo_map = _repo_map_from_db(conn) if conn is not None else {}
+
+    # The OTel lane. Best-effort: a failure here must never sink the (already
+    # working) transcript scan.
+    span_failures: list[FailureEpisode] = []
+    advise_only_repos: set[str] = set()
+    if conn is not None:
+        try:
+            from tokenjam.core.optimize.pothole_otel import (
+                extract_span_failures,
+                non_coding_agent_ids,
+            )
+
+            span_failures = extract_span_failures(conn, since)
+            advise_only_repos = non_coding_agent_ids(conn)
+        except Exception:
+            span_failures = []
+            advise_only_repos = set()
+
+    paths = sorted(root.rglob("*.jsonl")) if root.exists() else []
+    sessions: list[tuple[str, str]] = []
+    for path in paths:
+        if since is not None:
+            try:
+                from datetime import datetime, timezone
+                mtime = datetime.fromtimestamp(path.stat().st_mtime, tz=timezone.utc)
+                if mtime < since:
+                    continue
+            except OSError:
+                continue
+        session_id = path.stem
+        sessions.append((session_id, repo_map.get(session_id, "unknown")))
+
+    doc_text = ""
+    repo_cwd_map: dict[str, str] = {}
+    try:
+        repo_cwd_map = _repo_cwd_map_for(sessions, root)
+        doc_text = _doc_text(_candidate_doc_paths(set(repo_cwd_map.values())))
+    except Exception:
+        doc_text = ""
+
+    return analyze_potholes(
+        sessions, projects_root=root, codified_doc_text=doc_text,
+        distill_enabled=distill_enabled, repo_cwd_map=repo_cwd_map,
+        extra_failures=span_failures, advise_only_repos=advise_only_repos,
+    )
+
+
+@register("pothole")
+def run(ctx: AnalyzerContext) -> None:
+    """Registry entry point. Attaches a ``PotholeFinding`` to
+    ``ctx.report.findings["pothole"]`` — see ``compute_pothole_finding`` for
+    the full-corpus behaviour and performance note.
+    """
+    ctx.report.findings["pothole"] = compute_pothole_finding(ctx.conn, ctx.since)

--- a/tokenjam/core/optimize/analyzers/workflow_restructure.py
+++ b/tokenjam/core/optimize/analyzers/workflow_restructure.py
@@ -34,6 +34,7 @@ import re
 from dataclasses import dataclass, field
 from typing import Any
 
+from tokenjam.core.optimize.clustering import group_by_key, recurring
 from tokenjam.core.optimize.registry import register
 from tokenjam.core.optimize.types import AnalyzerContext
 from tokenjam.otel.semconv import GenAIAttributes
@@ -169,19 +170,19 @@ def run(ctx: AnalyzerContext) -> None:
         sig_seq.append((str(tool_name), arg_sig))
 
     # Cluster sessions by full signature (tuple of (tool, arg-shape)) tuples.
-    cluster_members: dict[tuple, list[str]] = {}
-    for session_id, seq in session_signatures.items():
-        key = tuple(seq)
-        cluster_members.setdefault(key, []).append(session_id)
+    cluster_members = group_by_key(
+        session_signatures.keys(),
+        key_fn=lambda sid: tuple(session_signatures[sid]),
+    )
 
-    # Build the report rows. Only clusters above the threshold are surfaced.
+    # Build the report rows. Only clusters above the recurrence threshold are
+    # surfaced (the shared filter); the per-cluster aggregation stays local.
     interesting: list[WorkflowCluster] = []
     total_cluster_cost = 0.0   # recoverable USD: full cost of clustered sessions
     total_cluster_tokens = 0   # recoverable tokens: replacing the call frees them
-    for signature, members in cluster_members.items():
-        if len(members) < MIN_CLUSTER_INSTANCES:
-            continue
-
+    for signature, members in recurring(
+        cluster_members, min_members=MIN_CLUSTER_INSTANCES,
+    ).items():
         # Aggregate session-level cost + tokens + duration for the cluster.
         placeholders = ",".join(f"${i + 1}" for i in range(len(members)))
         agg = ctx.conn.execute(

--- a/tokenjam/core/optimize/clustering.py
+++ b/tokenjam/core/optimize/clustering.py
@@ -1,0 +1,84 @@
+"""Shared clustering primitives for the pattern-mining analyzers.
+
+Three analyzers mine recurring cross-session patterns and shared the same
+control flow, each with its own hand-rolled copy:
+
+  * ``analyzers.pothole``            — clusters failure signatures.
+  * ``analyzers.plan_reuse``         — clusters planning skeletons.
+  * ``analyzers.workflow_restructure`` — clusters (tool, arg-shape) sequences.
+
+The genuinely shared mechanism is small and lives here: the setdefault-append
+grouping, the recurrence-threshold filter, and (for the two text-normalizing
+miners) the variable-masking apply loop. What stays analyzer-specific is the
+domain logic those primitives are pointed at — WHICH regexes a normalizer masks,
+HOW a domain object is built from a group, WHAT counts as one recurrence. Those
+differ on purpose and are not merged here; only the plumbing is.
+
+This module has no tokenjam imports — it's pure, dependency-free, and easy to
+test in isolation.
+"""
+from __future__ import annotations
+
+import re
+from typing import Any, Callable, Hashable, Iterable, Pattern
+
+
+def group_by_key(
+    items: Iterable[Any], key_fn: Callable[[Any], Hashable],
+) -> dict[Any, list[Any]]:
+    """Group ``items`` into ``{key: [items...]}`` in first-seen order.
+
+    The setdefault-append every miner used to write inline. Insertion order is
+    preserved (Python dicts), so a caller that reads the first member of each
+    group gets the same "first item to land in this bucket" it did before.
+    """
+    buckets: dict[Any, list[Any]] = {}
+    for item in items:
+        buckets.setdefault(key_fn(item), []).append(item)
+    return buckets
+
+
+def recurring(
+    buckets: dict[Any, Any], *, min_members: int,
+    size_fn: Callable[[Any], int] = len,
+) -> dict[Any, Any]:
+    """The sub-mapping of ``buckets`` whose ``size_fn(bucket) >= min_members``.
+
+    Keys are preserved (each miner still needs its group key to build the
+    surfaced finding), and insertion order is kept so downstream ranking is
+    unchanged. ``size_fn`` defaults to ``len`` (a bucket is a member list); pass
+    a custom one when the recurrence measure isn't the raw count — e.g. the
+    pothole lane counts DISTINCT sessions, not raw occurrences.
+    """
+    return {
+        key: bucket for key, bucket in buckets.items()
+        if size_fn(bucket) >= min_members
+    }
+
+
+_WS_RE = re.compile(r"\s+")
+
+
+def mask_variables(
+    text: str,
+    substitutions: Iterable[tuple[Pattern[str], str]],
+    *,
+    collapse_ws: bool = False,
+    lowercase: bool = False,
+) -> str:
+    """Apply an ordered list of ``(compiled_regex, replacement)`` substitutions,
+    then optionally collapse whitespace and lowercase.
+
+    The two text-normalizing miners share THIS apply loop; each supplies its own
+    ordered substitution list. The patterns are deliberately analyzer-specific —
+    a failure-signature normalizer masks timestamps/uuids/hex-ids that a
+    prompt-prefix hasher doesn't, and they use different placeholder tokens — so
+    only the loop is shared, never the pattern set.
+    """
+    for pattern, repl in substitutions:
+        text = pattern.sub(repl, text)
+    if collapse_ws:
+        text = _WS_RE.sub(" ", text).strip()
+    if lowercase:
+        text = text.lower()
+    return text

--- a/tokenjam/core/optimize/cost_verify.py
+++ b/tokenjam/core/optimize/cost_verify.py
@@ -1,0 +1,434 @@
+"""Delta-verify for applied cost proposals — the receipts.
+
+A cost proposal is advise-only, so there is no transcript recurrence to
+re-count (that is ``relearn_verify``'s job). What we CAN measure is whether the
+cost signal the analyzer flagged actually moved after the user marked their
+change: fewer dollars on the oversized model, a higher cache hit ratio, fewer
+input tokens per call on the bloated step.
+
+The marker is the applied record's ``applied_at`` (an ``Expectation.created_at``
+— see ``cost_apply``). For each analyzer we measure a metric over spans in the
+POST window ``[marker, now)`` against a comparable PRE window
+``[marker - W, marker)`` of the same duration ``W = now - marker``, scoped to
+the proposal's ``agent_id`` when it has one. All dollar figures are priced by
+the SAME ``core.cost.calculate_cost`` the rest of tokenjam uses (per-model,
+per-token-type, BOTH ``cache_tokens`` and ``cache_write_tokens`` included — the
+recurring omission this workspace guards against).
+
+Honesty (identical discipline to ``relearn_verify``):
+
+  * **Correlational, never causal.** The user's change is one of many things
+    that shifted at the marker. This measures co-occurrence and says so.
+  * **A non-improvement is marked, not hidden.** A realized delta that is
+    ~zero or negative is a ``regressed`` verdict, never silently kept as if the
+    advice paid off.
+  * **Admit thin data.** Too little post-window exposure -> ``insufficient_data``
+    ("check back later"), not a confident zero.
+
+Never raises: every public function degrades to a conservative
+"can't measure this" result.
+"""
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+from typing import Any
+
+from tokenjam.core.cost import calculate_cost
+from tokenjam.core.optimize import accounting
+from tokenjam.core.optimize.relearn_verify import (
+    VERDICT_IMPROVED,
+    VERDICT_INSUFFICIENT_DATA,
+    VERDICT_REGRESSED,
+)
+from tokenjam.core.pricing import get_rates
+
+#: Minimum post-window LLM calls before a verdict is trusted (else
+#: "insufficient_data"). Cost windows are call-dense, so this gates on calls,
+#: not sessions.
+MIN_POST_CALLS_FOR_VERDICT = 20
+#: A realized dollar delta at or below this (in absolute USD) is treated as
+#: no real movement -> regressed, so noise near zero never reads as a win.
+MIN_MEANINGFUL_USD = 1e-4
+
+ESTIMATE_BASIS_COST_VERIFY = (
+    "realized delta = the analyzer's own cost metric measured over spans after "
+    "your change vs a comparable window before it, priced per-model per-token-"
+    "type; estimated / correlational with your change, never proof tokenjam's "
+    "advice caused it"
+)
+
+#: Loop-ledger outcome per verdict — only a measured improvement passes; a
+#: measured non-improvement regresses. Insufficient data records nothing.
+_OUTCOME_FOR_VERDICT = {
+    VERDICT_IMPROVED: "pass",
+    VERDICT_REGRESSED: "regress",
+}
+
+
+def _as_aware(value: Any) -> datetime | None:
+    if value is None:
+        return None
+    if isinstance(value, datetime):
+        dt = value
+    else:
+        try:
+            dt = datetime.fromisoformat(str(value))
+        except (TypeError, ValueError):
+            return None
+    return dt if dt.tzinfo is not None else dt.replace(tzinfo=timezone.utc)
+
+
+def _window_bounds(marker: datetime, now: datetime) -> tuple[datetime, datetime, datetime, datetime]:
+    """(pre_start, pre_end, post_start, post_end) — two equal-duration windows
+    either side of the marker, so the two sides are comparable exposure."""
+    span = now - marker
+    if span < timedelta(0):
+        span = timedelta(0)
+    return marker - span, marker, marker, now
+
+
+def _rows_for(
+    conn: Any, since: datetime, until: datetime, agent_id: str | None,
+    *, model: str | None = None, provider: str | None = None,
+    subagent_only: bool = False,
+) -> list[tuple]:
+    """LLM spans in ``[since, until)`` with optional agent/model/provider
+    filters. Returns (session_id, provider, model, input, output, cache,
+    cache_write). ``subagent_only`` scopes to Task-dispatched subagent spans
+    (``sub_agent_id IS NOT NULL``) — the fan-out the subagent analyzer flags.
+    Never raises — a bad query yields ``[]``.
+
+    Rows are collapsed by CALL identity before they are returned
+    (``core.optimize.accounting``), so a call observed by more than one ingest
+    path is priced once rather than once per row. Every dollar figure in this
+    module is computed from these rows, which is what makes the receipts
+    immune to a duplicated ingest.
+    """
+    clauses = ["start_time >= $1", "start_time < $2", "model IS NOT NULL"]
+    params: list[Any] = [since, until]
+    if subagent_only:
+        clauses.append("sub_agent_id IS NOT NULL")
+    if agent_id:
+        params.append(agent_id)
+        clauses.append(f"agent_id = ${len(params)}")
+    if model:
+        params.append(model)
+        clauses.append(f"model = ${len(params)}")
+    if provider:
+        params.append(provider)
+        clauses.append(f"provider = ${len(params)}")
+    where = " AND ".join(clauses)
+    try:
+        raw = conn.execute(
+            "SELECT span_id, attributes, session_id, provider, model, "
+            "COALESCE(input_tokens,0), COALESCE(output_tokens,0), "
+            "COALESCE(cache_tokens,0), COALESCE(cache_write_tokens,0) "
+            f"FROM spans WHERE {where}",
+            params,
+        ).fetchall()
+    except Exception:
+        return []
+    keyed = [
+        (accounting.call_identity(r[0], r[2], r[1]), *r[2:])
+        for r in raw
+    ]
+    return [tuple(row[1:]) for row in accounting.dedupe_by_call_identity(keyed)]
+
+
+def _priced_usd(rows: list[tuple]) -> float:
+    """Total USD across rows, priced per-model per-token-type (both cache token
+    types included — the workspace's recurring omission guarded here)."""
+    total = 0.0
+    for _sid, provider, model, in_tok, out_tok, cache_tok, cache_write in rows:
+        total += calculate_cost(
+            str(provider or "unknown"), str(model or ""),
+            int(in_tok or 0), int(out_tok or 0),
+            cache_read_tokens=int(cache_tok or 0),
+            cache_write_tokens=int(cache_write or 0),
+        )
+    return total
+
+
+# --------------------------------------------------------------------------- #
+# Per-analyzer metrics. Each returns a dict with a comparable ``value`` for one
+# window plus the raw counts the realized-delta math needs.
+# --------------------------------------------------------------------------- #
+
+def _downsize_metric(rows: list[tuple], models: set[str]) -> dict[str, Any]:
+    """Per-session dollars spent on the oversized model(s)."""
+    sessions = {str(r[0] or "") for r in rows}
+    oversized = [r for r in rows if str(r[2] or "") in models]
+    oversized_usd = _priced_usd(oversized)
+    n_sessions = len(sessions) or 0
+    value = (oversized_usd / n_sessions) if n_sessions else 0.0
+    return {"value": value, "sessions": n_sessions, "calls": len(rows),
+            "oversized_usd": oversized_usd}
+
+
+def _cache_metric(rows: list[tuple]) -> dict[str, Any]:
+    """Cache-read efficacy = cache_tokens / (input + cache) for the flagged
+    (provider, model), plus the input-vs-cache priced value of the gap."""
+    input_tok = sum(int(r[3] or 0) for r in rows)
+    cache_tok = sum(int(r[5] or 0) for r in rows)
+    total = input_tok + cache_tok
+    efficacy = (cache_tok / total) if total else 0.0
+    return {"value": efficacy, "sessions": len({str(r[0] or "") for r in rows}),
+            "calls": len(rows), "input_tokens": input_tok, "cache_tokens": cache_tok}
+
+
+def _trim_metric(rows: list[tuple]) -> dict[str, Any]:
+    """Average input tokens per call on the flagged step."""
+    input_tok = sum(int(r[3] or 0) for r in rows)
+    calls = len(rows)
+    value = (input_tok / calls) if calls else 0.0
+    return {"value": value, "sessions": len({str(r[0] or "") for r in rows}),
+            "calls": calls, "input_tokens": input_tok}
+
+
+def _dominant_model(rows: list[tuple]) -> tuple[str, str]:
+    """(provider, model) of the most-called model in the rows — used to price a
+    token delta at the right input rate. ("unknown","") when rows are empty."""
+    counts: dict[tuple[str, str], int] = {}
+    for r in rows:
+        key = (str(r[1] or "unknown"), str(r[2] or ""))
+        counts[key] = counts.get(key, 0) + 1
+    if not counts:
+        return "unknown", ""
+    return max(counts.items(), key=lambda kv: kv[1])[0]
+
+
+def _verdict(realized_usd_delta: float, post_calls: int) -> tuple[str, str]:
+    """(verdict, reason). Insufficient below the exposure gate; else improved
+    iff the realized dollar delta cleared the meaningful-movement floor."""
+    if post_calls < MIN_POST_CALLS_FOR_VERDICT:
+        return (
+            VERDICT_INSUFFICIENT_DATA,
+            f"only {post_calls} call(s) observed since you marked this applied; "
+            f"check back after at least {MIN_POST_CALLS_FOR_VERDICT}",
+        )
+    if realized_usd_delta > MIN_MEANINGFUL_USD:
+        return (
+            VERDICT_IMPROVED,
+            f"measured ${realized_usd_delta:.4f} lower on the flagged cost "
+            f"dimension across {post_calls} call(s) after your change",
+        )
+    return (
+        VERDICT_REGRESSED,
+        f"no measured improvement on the flagged cost dimension (realized delta "
+        f"${realized_usd_delta:.4f}) across {post_calls} call(s) after your change",
+    )
+
+
+def measure_cost_delta(
+    conn: Any | None,
+    record: dict[str, Any],
+    *,
+    now: datetime | None = None,
+) -> dict[str, Any]:
+    """The realized-delta receipt for one applied cost record. Never raises.
+
+    Returns a dict merged onto the record's ``verify`` block: ``verdict``,
+    ``reason``, ``realized_usd_delta``, ``realized_tokens_delta``, the pre/post
+    metric values + call counts, and ``estimate_basis``.
+    """
+    from tokenjam.utils.time_parse import utcnow
+
+    empty = {
+        "verdict": VERDICT_INSUFFICIENT_DATA, "reason": None,
+        "realized_usd_delta": None, "realized_tokens_delta": None,
+        "pre_value": None, "post_value": None,
+        "pre_sessions": None, "post_sessions": None,
+        "estimate_basis": ESTIMATE_BASIS_COST_VERIFY,
+        "last_checked_at": (now or utcnow()).isoformat(),
+    }
+
+    marker = _as_aware(record.get("applied_at"))
+    if marker is None:
+        return {**empty, "reason": "no usable applied-at marker on this record"}
+    if conn is None:
+        return {**empty, "reason": "no database connection"}
+
+    now = now or utcnow()
+    pre_start, pre_end, post_start, post_end = _window_bounds(marker, now)
+    analyzer = str(record.get("analyzer") or "")
+    agent_id = str(record.get("agent_id") or "") or None
+    target = record.get("target_key") or {}
+
+    realized_usd = 0.0
+    realized_tokens: int | None = None
+
+    if analyzer == "downsize":
+        models = {str(m) for m in (target.get("models") or [])}
+        pre = _downsize_metric(_rows_for(conn, pre_start, pre_end, agent_id), models)
+        post_rows = _rows_for(conn, post_start, post_end, agent_id)
+        post = _downsize_metric(post_rows, models)
+        # Per-session oversized dollars that fell, projected across post sessions.
+        realized_usd = max(0.0, pre["value"] - post["value"]) * post["sessions"]
+        post_calls = post["calls"]
+
+    elif analyzer == "cache":
+        provider = str(target.get("provider") or "") or None
+        model = str(target.get("model") or "") or None
+        pre = _cache_metric(_rows_for(conn, pre_start, pre_end, agent_id,
+                                      model=model, provider=provider))
+        post_rows = _rows_for(conn, post_start, post_end, agent_id,
+                              model=model, provider=provider)
+        post = _cache_metric(post_rows)
+        # Tokens shifted from fresh input to cache, priced at the input-vs-cache
+        # rate delta for this model.
+        efficacy_gain = max(0.0, post["value"] - pre["value"])
+        shifted = efficacy_gain * post["input_tokens"]
+        realized_tokens = int(shifted)
+        rates = get_rates(provider or "unknown", model or "")
+        rate_delta = 0.0
+        if rates is not None:
+            rate_delta = max(0.0, rates.input_per_mtok - rates.cache_read_per_mtok)
+        realized_usd = (shifted / 1_000_000) * rate_delta
+        post_calls = post["calls"]
+
+    elif analyzer == "trim":
+        pre = _trim_metric(_rows_for(conn, pre_start, pre_end, agent_id))
+        post_rows = _rows_for(conn, post_start, post_end, agent_id)
+        post = _trim_metric(post_rows)
+        # Fewer input tokens/call, across post calls, priced at the dominant
+        # model's input rate.
+        per_call_drop = max(0.0, pre["value"] - post["value"])
+        saved_tokens = per_call_drop * post["calls"]
+        realized_tokens = int(saved_tokens)
+        prov, model = _dominant_model(post_rows)
+        rates = get_rates(prov, model)
+        input_rate = rates.input_per_mtok if rates is not None else 0.0
+        realized_usd = (saved_tokens / 1_000_000) * input_rate
+        post_calls = post["calls"]
+
+    elif analyzer == "subagent":
+        # Fan-out model-mix cost delta: per-session dollars spent on the
+        # oversized model(s) across SUBAGENT spans only (sub_agent_id NOT NULL),
+        # before vs after the marker. Same shape as downsize, scoped to the
+        # Task-dispatched fan-out the subagent analyzer flags.
+        models = {str(m) for m in (target.get("models") or [])}
+        pre = _downsize_metric(
+            _rows_for(conn, pre_start, pre_end, agent_id, subagent_only=True), models)
+        post_rows = _rows_for(conn, post_start, post_end, agent_id, subagent_only=True)
+        post = _downsize_metric(post_rows, models)
+        realized_usd = max(0.0, pre["value"] - post["value"]) * post["sessions"]
+        post_calls = post["calls"]
+
+    else:
+        return {**empty, "reason": f"unknown cost analyzer {analyzer!r}"}
+
+    realized_usd = round(realized_usd, 6)
+    verdict, reason = _verdict(realized_usd, post_calls)
+    # Below the exposure gate we don't claim a delta.
+    if verdict == VERDICT_INSUFFICIENT_DATA:
+        realized_usd = None  # type: ignore[assignment]
+        realized_tokens = None
+
+    return {
+        "verdict": verdict,
+        "reason": reason,
+        "realized_usd_delta": realized_usd,
+        "realized_tokens_delta": realized_tokens,
+        "pre_value": round(pre["value"], 6),
+        "post_value": round(post["value"], 6),
+        "pre_sessions": pre["sessions"],
+        "post_sessions": post["sessions"],
+        "estimate_basis": ESTIMATE_BASIS_COST_VERIFY,
+        "last_checked_at": now.isoformat(),
+    }
+
+
+def verify_record(
+    db_or_conn: Any,
+    config: Any,
+    record: dict[str, Any],
+    *,
+    record_outcome: bool = True,
+    now: datetime | None = None,
+) -> dict[str, Any]:
+    """Measure one record's realized delta, persist it into the record's
+    ``verify`` block, and (when decisive) write the pass/regress outcome to the
+    loop's fix-history ledger via ``record_expectation_run``. Never raises."""
+    from tokenjam.core.loop import _resolve_conn, record_expectation_run
+    from tokenjam.core.optimize import cost_apply
+
+    try:
+        conn = _resolve_conn(db_or_conn)
+    except Exception:
+        conn = None
+
+    verify = measure_cost_delta(conn, record, now=now)
+    try:
+        cost_apply.set_verify(config, record["id"], verify)
+    except Exception:
+        pass
+
+    outcome = _OUTCOME_FOR_VERDICT.get(verify.get("verdict", ""))
+    expectation_id = record.get("expectation_id")
+    if record_outcome and outcome is not None and expectation_id:
+        try:
+            record_expectation_run(
+                db_or_conn, expectation_id,
+                outcome=outcome, note=f"cost verify: {verify.get('reason', '')}",
+            )
+        except Exception:
+            pass  # a ledger write failure must not sink the measurement
+    return verify
+
+
+def rescan_all(
+    db_or_conn: Any,
+    config: Any,
+    *,
+    now: datetime | None = None,
+) -> dict[str, int]:
+    """Recompute the realized delta for every applied (non-reverted) cost
+    record — the entry point the Review-inbox refresh rides on the SAME cadence
+    as the proposal recompute. Never raises; one bad record is skipped."""
+    from tokenjam.core.optimize import cost_apply
+
+    checked = updated = 0
+    for rec in cost_apply.list_applied(config):
+        if rec.get("state") == "reverted":
+            continue
+        checked += 1
+        try:
+            verify_record(db_or_conn, config, rec, now=now)
+            updated += 1
+        except Exception:
+            continue
+    return {"checked": checked, "updated": updated}
+
+
+def cost_compound_ledger(records: list[dict[str, Any]]) -> dict[str, Any]:
+    """The Applied section's cost summary: total realized dollars across every
+    VERIFIED, improved (non-reverted) cost fix, plus a verdict breakdown. The
+    dollar-denominated sibling of ``relearn_verify.compound_ledger``."""
+    total_usd = 0.0
+    total_tokens = 0
+    verified = improved = regressed = insufficient = 0
+    for rec in records:
+        if rec.get("state") == "reverted":
+            continue
+        verify = rec.get("verify") or {}
+        verdict = verify.get("verdict")
+        if verdict is None:
+            continue
+        verified += 1
+        if verdict == VERDICT_IMPROVED:
+            improved += 1
+            total_usd += verify.get("realized_usd_delta") or 0.0
+            total_tokens += verify.get("realized_tokens_delta") or 0
+        elif verdict == VERDICT_REGRESSED:
+            regressed += 1
+        elif verdict == VERDICT_INSUFFICIENT_DATA:
+            insufficient += 1
+    return {
+        "total_realized_usd": round(total_usd, 6),
+        "total_realized_tokens": total_tokens,
+        "verified_count": verified,
+        "improved_count": improved,
+        "regressed_count": regressed,
+        "insufficient_data_count": insufficient,
+        "estimate_basis": ESTIMATE_BASIS_COST_VERIFY,
+    }

--- a/tokenjam/core/optimize/relearn_apply.py
+++ b/tokenjam/core/optimize/relearn_apply.py
@@ -1,0 +1,1132 @@
+"""The self-improve loop's Apply stage (SPEC.md §4 step 5, §6, §7).
+
+Routes an approved relearn-cluster proposal to a write at the right
+intervention-ladder rung (SPEC §6):
+
+  rung 1 (note)        -> append a marked section to a CLAUDE.md
+  rung 2 (skill)       -> write a new ``.claude/skills/<slug>/SKILL.md``
+  rung 3-5 (hook/wrapper/config) -> write the enforcement artifact (a hook
+      script + a staged settings.json patch) DISABLED; a human must call
+      ``enable_enforcement`` explicitly before it ever runs
+
+Reversibility (SPEC §10 — "reversible"): every write here is preceded by a
+pre-image snapshot (reusing ``core.atomic_write``'s atomic-write primitive),
+and git-committed when the target lives inside a git repo. A
+matching ``revert_applied_fix`` restores the pre-image (or deletes a
+freshly-created file) in one call and commits that too. Every apply /
+enable / disable / revert is recorded to a durable, DB-independent ledger
+(``applied_fixes.json`` — see ``record_applied``) shaped for Phase 3
+(verify) to read: did this signature's recurrence actually drop afterwards?
+
+Safety (SPEC §7): nothing here runs unless a caller passes ``go=True`` — the
+default is a dry-run that returns the would-be diff/content without writing
+(mirrors ``apply_staged``'s contract). The "never mid-session" idle-boundary
+check is a separate, best-effort concern (``active_session_warning``) so a
+caller (the API route) can warn or block *before* even calling apply.
+"""
+from __future__ import annotations
+
+import json
+import re
+import subprocess
+import tempfile
+import uuid
+from dataclasses import asdict, dataclass, field
+from pathlib import Path
+from typing import Any
+
+from tokenjam.core.atomic_write import AtomicWriteRefused, atomic_write
+from tokenjam.core.config import TjConfig
+
+# --- Rungs (SPEC §6) -----------------------------------------------------------
+
+RUNG_NOTE = 1
+RUNG_SKILL = 2
+ENFORCEMENT_RUNGS = {3, 4, 5}   # hook / wrapper / config — always human-gated to enable
+
+RUNG_KIND = {1: "note", 2: "skill", 3: "hook", 4: "wrapper", 5: "config"}
+
+
+class RelearnApplyRefused(Exception):
+    """Refusing to apply/enable/revert (house-voice message) — callers map to a 409."""
+
+
+def slugify(text: str) -> str:
+    """A filesystem/skill-name-safe slug. Never empty (falls back to 'fix')."""
+    s = re.sub(r"[^a-z0-9]+", "-", (text or "").lower()).strip("-")
+    return s[:60] or "fix"
+
+
+# --- Storage roots ---------------------------------------------------------
+
+def _storage_base_dir(config: TjConfig) -> Path:
+    """The directory every relearn_apply/relearn_store artifact is parented
+    under: ``<storage-parent>`` (mirrors ``core.summarize.session.
+    summary_root``'s DEC-026 convention) when ``storage.path`` names a real
+    file, else a TEMP directory — NEVER the real ``~/.tj`` (must-fix #4: an
+    InMemory-backed / ``:memory:``-configured caller must not leak writes
+    into a real local install).
+
+    The temp dir is minted once and cached ON the config object itself
+    (``config._relearn_memory_tmp_root``), so repeated calls against the SAME
+    config instance agree — apply, then a later revert against that same
+    live config (e.g. within one ``tj serve`` process), must resolve to the
+    same path. A DIFFERENT config object (a different process, a different
+    test) gets its own temp dir; nothing here ever shares state across them,
+    and nothing here ever falls back to ``Path.home()``.
+    """
+    sp = config.storage.path
+    if sp not in ("", ":memory:"):
+        return Path(sp).expanduser().parent
+    cached = getattr(config, "_relearn_memory_tmp_root", None)
+    if isinstance(cached, Path):
+        return cached
+    tmp_root = Path(tempfile.mkdtemp(prefix="tokenjam-relearn-mem-"))
+    try:
+        config._relearn_memory_tmp_root = tmp_root   # type: ignore[attr-defined]
+    except Exception:
+        pass   # best-effort caching only — a read-only/duck-typed config just re-mints each call
+    return tmp_root
+
+
+def relearn_apply_root(config: TjConfig) -> Path:
+    """``<storage-parent>/relearn_apply/`` — see ``_storage_base_dir``."""
+    return _storage_base_dir(config) / "relearn_apply"
+
+
+def _backups_dir(config: TjConfig) -> Path:
+    return relearn_apply_root(config) / "backups"
+
+
+def applied_fixes_path(config: TjConfig) -> Path:
+    """The durable ledger Phase 3 (verify) reads — see ``_storage_base_dir``."""
+    return _storage_base_dir(config) / "applied_fixes.json"
+
+
+# --- Default target-path suggestion (for the card's scope/target override) ----
+
+def default_target_path(rung: int, scope: str, repo_cwd: str, slug: str) -> str:
+    """Best-effort suggested write location — always user-editable before Approve
+    (SPEC's "scope override" requirement: repo-identity is noisy, never trust it
+    blindly). Returns ``""`` when there isn't enough information (no known cwd
+    for a project-scoped cluster) — the UI must then require an explicit path.
+    """
+    if scope == "user-global":
+        home = Path.home() / ".claude"
+        if rung == RUNG_NOTE:
+            return str(home / "CLAUDE.md")
+        if rung == RUNG_SKILL:
+            return str(home / "skills" / slug / "SKILL.md")
+        return str(home / "hooks" / f"{slug}.py")
+
+    if not repo_cwd:
+        return ""
+    base = Path(repo_cwd)
+    if rung == RUNG_NOTE:
+        return _nearest_claude_md(base)
+    if rung == RUNG_SKILL:
+        return str(base / ".claude" / "skills" / slug / "SKILL.md")
+    return str(base / ".claude" / "hooks" / f"{slug}.py")
+
+
+def _nearest_claude_md(base: Path) -> str:
+    """Walk up from ``base`` for an existing CLAUDE.md (a workspace-root doc
+    above a sub-repo counts too); default to ``base/CLAUDE.md`` (to be created)
+    when none is found."""
+    if base.exists():
+        for ancestor in [base, *base.parents[:3]]:
+            candidate = ancestor / "CLAUDE.md"
+            if candidate.is_file():
+                return str(candidate)
+    return str(base / "CLAUDE.md")
+
+
+# --- Git helpers (best-effort — never raise; a missing git/user config just
+# means the caller falls back to the gzip backup as the sole revert path) ------
+
+def _run_git(args: list[str], cwd: Path) -> subprocess.CompletedProcess | None:
+    try:
+        return subprocess.run(
+            ["git", *args], cwd=str(cwd), capture_output=True, text=True, timeout=15,
+        )
+    except (OSError, subprocess.SubprocessError):
+        return None
+
+
+def git_repo_root(path: Path) -> Path | None:
+    """The git repo root containing ``path``'s parent dir, or None."""
+    start = path if path.is_dir() else path.parent
+    if not start.exists():
+        start = start if start.parent.exists() else Path.cwd()
+    result = _run_git(["rev-parse", "--show-toplevel"], start)
+    if result is None or result.returncode != 0:
+        return None
+    out = (result.stdout or "").strip()
+    return Path(out) if out else None
+
+
+def _git_commit(repo_root: Path, rel_paths: list[str], message: str) -> str | None:
+    """Stage + commit specific paths; returns the new commit sha, or None on any
+    failure (git absent, nothing to commit, no user.email configured, etc.) —
+    the gzip backup remains the guaranteed revert path either way."""
+    add = _run_git(["add", "--", *rel_paths], repo_root)
+    if add is None or add.returncode != 0:
+        return None
+    commit = _run_git(
+        ["commit", "--no-verify", "-m", message, "--", *rel_paths], repo_root,
+    )
+    if commit is None or commit.returncode != 0:
+        return None
+    sha = _run_git(["rev-parse", "HEAD"], repo_root)
+    if sha is None or sha.returncode != 0:
+        return None
+    return (sha.stdout or "").strip() or None
+
+
+def _commit_message(
+    action: str, title: str, signature: str, rung: int, kind: str | None = None,
+) -> str:
+    # Neutral, tool-attributed, no internal ticket IDs — this lands in ANY
+    # target repo (including public ones), not just tokenjam's own. `kind` is
+    # passed for the apply kinds that sit outside the rung ladder (the model
+    # edits), so the message names what was actually written.
+    return (
+        f"tokenjam: {action} fix (rung {rung} · {kind or RUNG_KIND.get(rung, '?')})\n\n"
+        f"{title}\n\n"
+        f"Applied by TokenJam's loop (signature: {signature}).\n"
+        f"Revert from the Review inbox, or via the applied_fixes ledger."
+    )
+
+
+# --- Backup (pre-image) store — reuses `atomic_write`, own namespace so it
+# never collides with core.summarize's own backups keyed by resolved path ------
+
+def _backup_paths(config: TjConfig, fix_id: str) -> tuple[Path, Path]:
+    d = _backups_dir(config)
+    return d / f"{fix_id}.orig", d / f"{fix_id}.meta.json"
+
+def _read_pre_image(target: Path) -> str | None:
+    """The file's content before an apply, or None if it doesn't exist yet
+    (a fresh create — revert then means delete, not restore-to-empty)."""
+    if not target.is_file():
+        return None
+    try:
+        return target.read_text(encoding="utf-8")
+    except (OSError, UnicodeDecodeError):
+        return None
+
+
+def _save_backup(config: TjConfig, fix_id: str, target: str, pre_image: str | None) -> None:
+    orig_f, meta_f = _backup_paths(config, fix_id)
+    orig_f.parent.mkdir(parents=True, exist_ok=True)
+    if pre_image is None:
+        meta_f.write_text(json.dumps({"target_path": target, "created": True}), encoding="utf-8")
+        return
+    orig_f.write_text(pre_image, encoding="utf-8")
+    meta_f.write_text(json.dumps({"target_path": target, "created": False}), encoding="utf-8")
+
+
+def _restore_backup(config: TjConfig, fix_id: str) -> dict[str, Any]:
+    """Undo one apply: restore the pre-image, or delete the file this apply
+    created. Raises ``RelearnApplyRefused`` if there's no backup record, or
+    (must-fix #3) if the target has since become a symlink — checked BEFORE
+    branching on ``created``/``is_file`` so a swapped-in symlink can't
+    redirect either a restore-write or a delete through it.
+    """
+    orig_f, meta_f = _backup_paths(config, fix_id)
+    if not meta_f.is_file():
+        raise RelearnApplyRefused(f"no backup found for applied fix {fix_id} — cannot revert.")
+    try:
+        meta = json.loads(meta_f.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as exc:
+        raise RelearnApplyRefused(f"backup metadata for {fix_id} is unreadable — cannot revert.") from exc
+    target = Path(meta["target_path"]).expanduser()
+    if target.is_symlink():
+        raise RelearnApplyRefused(f"{target} is a symlink — refusing to revert through it.")
+    if meta.get("created"):
+        if target.is_file():
+            target.unlink()
+        return {"target_path": str(target), "action": "deleted"}
+    if not orig_f.is_file():
+        raise RelearnApplyRefused(f"backup blob for {fix_id} is missing — cannot revert.")
+    original = orig_f.read_text(encoding="utf-8")
+    if target.is_file():
+        try:
+            atomic_write(target, original)
+        except AtomicWriteRefused as exc:
+            raise RelearnApplyRefused(str(exc)) from exc
+    else:
+        target.parent.mkdir(parents=True, exist_ok=True)
+        target.write_text(original, encoding="utf-8")
+    return {"target_path": str(target), "action": "restored"}
+
+
+# --- The durable applied_fixes ledger (Phase 3 reads this) --------------------
+
+@dataclass
+class AppliedFix:
+    id:              str
+    signature:       str
+    family_key:      str | None
+    title:           str
+    rung:            int
+    kind:            str                    # note | skill | hook | wrapper | config
+    scope:           str                    # project | user-global
+    target_path:     str
+    repo_root:       str | None
+    applied_at:      str
+    diff:            str                    # unified diff (note) or full content (new file)
+    enforcement:     dict[str, Any] | None   # {"enabled": bool, "hook_path", "settings_path", "patch"}
+    git_commit:      str | None
+    state:           str = "applied"        # applied | reverted
+    reverted_at:     str | None = None
+    revert_commit:   str | None = None
+    # Historical scaffold from the (removed) verify pass: baseline counts
+    # captured at apply time. `baseline_sessions` is the cluster's distinct
+    # AFFECTED sessions (from the proposal); `baseline_total_sessions` is the
+    # exposure denominator (ALL sessions in scope up to apply time). Nothing
+    # recomputes these fields anymore; kept so an existing ``applied_fixes.
+    # json`` on disk still deserializes.
+    verify: dict[str, Any] = field(default_factory=lambda: {
+        "baseline_sessions": None, "baseline_occurrences": None,
+        "baseline_total_sessions": None,
+        "recurrence_since_apply": None, "post_sessions_since_apply": None,
+        "baseline_rate": None, "post_rate": None, "realized_tokens_saved": None,
+        "escalate_candidate": False, "reason": None,
+        "last_checked_at": None, "verdict": None,
+    })
+
+    def to_dict(self) -> dict:
+        return asdict(self)
+
+
+def _load_ledger(config: TjConfig) -> list[dict]:
+    p = applied_fixes_path(config)
+    if not p.is_file():
+        return []
+    try:
+        raw = json.loads(p.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return []
+    return raw if isinstance(raw, list) else []
+
+
+def _write_ledger(config: TjConfig, records: list[dict]) -> None:
+    p = applied_fixes_path(config)
+    p.parent.mkdir(parents=True, exist_ok=True)
+    tmp = p.with_suffix(".tmp")
+    tmp.write_text(json.dumps(records, ensure_ascii=False, indent=2), encoding="utf-8")
+    tmp.replace(p)
+
+
+def list_applied(config: TjConfig) -> list[dict]:
+    return _load_ledger(config)
+
+
+def get_applied(config: TjConfig, fix_id: str) -> dict | None:
+    for rec in _load_ledger(config):
+        if rec.get("id") == fix_id:
+            return rec
+    return None
+
+
+def _save_record(config: TjConfig, record: AppliedFix) -> dict:
+    records = _load_ledger(config)
+    records.append(record.to_dict())
+    _write_ledger(config, records)
+    return record.to_dict()
+
+
+def _update_record(config: TjConfig, fix_id: str, **fields: Any) -> dict:
+    records = _load_ledger(config)
+    for rec in records:
+        if rec.get("id") == fix_id:
+            rec.update(fields)
+            _write_ledger(config, records)
+            return rec
+    raise RelearnApplyRefused(f"no applied_fixes record {fix_id}.")
+
+
+# --- Active-session guard (SPEC §7 — never apply mid-session) ------------------
+
+def active_session_warning(conn: Any | None, target_path: str) -> str | None:
+    """Best-effort: is there a LIVE session in the repo ``target_path`` lives
+    in? Returns a human warning string, or None when it's safe (or unknown —
+    a missing/failed DB check never blocks; it just can't vouch for safety).
+    Mirrors the ``agent_id`` repo-label convention used by the relearn
+    detector itself (``analyzers.relearn._repo_map_from_db``).
+    """
+    if conn is None:
+        return None
+    try:
+        repo_hint = git_repo_root(Path(target_path).expanduser())
+        label = (repo_hint or Path(target_path).expanduser().parent).name
+        if not label:
+            return None
+        from tokenjam.core.models import SESSION_STALE_THRESHOLD
+        from tokenjam.utils.time_parse import utcnow
+
+        rows = conn.execute(
+            "SELECT agent_id, status, started_at, ended_at FROM sessions "
+            "WHERE status = 'active'"
+        ).fetchall()
+        now = utcnow()
+        for agent_id, status, started_at, ended_at in rows:
+            if not agent_id or label not in str(agent_id):
+                continue
+            last = ended_at or started_at
+            if last is None:
+                continue
+            gap = now - last   # TIMESTAMPTZ columns come back tz-aware (UTC)
+            if gap <= SESSION_STALE_THRESHOLD:
+                return (
+                    f"an active session was seen in a repo matching '{label}' "
+                    f"within the last {int(SESSION_STALE_THRESHOLD.total_seconds() // 60)} "
+                    f"minutes — applying now risks the exact 'file modified since read' "
+                    f"relearn this loop exists to fix. Prefer an idle boundary."
+                )
+        return None
+    except Exception:
+        return None   # best-effort — never let a DB hiccup block or falsely warn
+
+
+# --- Rung 1: CLAUDE.md note ------------------------------------------------
+
+NOTE_SECTION_HEADER = "## TokenJam fixes (auto-added)"
+_NOTE_INTRO = (
+    "Entries below are written by TokenJam's loop after a human "
+    "approves a proposed fix in the Review inbox. Safe to hand-edit the prose; "
+    "keep the `<!-- tokenjam:relearn:... -->` markers if you want the inbox's "
+    "Revert to keep working."
+)
+
+
+def _note_block(cluster: dict, signature: str) -> str:
+    repos = cluster.get("repos") or []
+    return (
+        f"<!-- tokenjam:relearn:{signature} -->\n"
+        f"### {cluster.get('title', signature)}\n\n"
+        f"{cluster.get('proposed_fix', '')}\n\n"
+        f"_Evidence: {cluster.get('sessions', 0)} session(s) across "
+        f"{len(repos)} repo(s). Rung {cluster.get('rung')}. "
+        f"Revert from the Review inbox._\n"
+        f"<!-- /tokenjam:relearn:{signature} -->"
+    )
+
+
+def render_note_content(existing: str, cluster: dict, signature: str) -> str:
+    """Idempotent: replaces a prior block for this exact signature (re-apply),
+    else appends one — creating the shared section header on first use."""
+    block = _note_block(cluster, signature)
+    marker_re = re.compile(
+        rf"<!-- tokenjam:relearn:{re.escape(signature)} -->.*?"
+        rf"<!-- /tokenjam:relearn:{re.escape(signature)} -->",
+        re.DOTALL,
+    )
+    if marker_re.search(existing):
+        return marker_re.sub(block, existing)
+
+    out = existing
+    if NOTE_SECTION_HEADER not in out:
+        sep = "\n\n" if out and not out.endswith("\n\n") else ""
+        out = f"{out}{sep}{NOTE_SECTION_HEADER}\n\n{_NOTE_INTRO}\n\n{block}\n"
+    else:
+        sep = "\n\n" if not out.endswith("\n\n") else ""
+        out = f"{out}{sep}{block}\n"
+    return out
+
+
+# --- Rung 2: skill ----------------------------------------------------------
+
+def render_skill_content(cluster: dict, signature: str, slug: str) -> str:
+    repos = cluster.get("repos") or []
+    title = cluster.get("title", slug)
+    description = (cluster.get("proposed_fix") or title)[:200].replace("\n", " ")
+    examples = cluster.get("examples") or []
+    ev_lines = "\n".join(
+        f"- `{ex.get('session_id', '')[:12]}` ({ex.get('repo', '')}): {ex.get('snippet', '')[:160]}"
+        for ex in examples
+    ) or "- No example sessions captured."
+    return (
+        f"---\n"
+        f"name: {slug}\n"
+        f"description: {description}\n"
+        f"---\n\n"
+        f"# {title}\n\n"
+        f"{cluster.get('proposed_fix', '')}\n\n"
+        f"## Why this exists\n\n"
+        f"Detected by TokenJam's loop: this pattern recurred in "
+        f"{cluster.get('sessions', 0)} distinct session(s) across {len(repos)} "
+        f"repo(s) (rung 2 · skill).\n\n"
+        f"## Evidence\n\n{ev_lines}\n\n"
+        f"<!-- tokenjam:relearn:{signature} -->\n"
+    )
+
+
+# --- Rungs 3-5: enforcement artifact (disabled by default) ---------------------
+#
+# SPEC §6/§10 mandate: precision over coverage. A false positive on normal
+# usage is worse than a no-op, so a REAL matcher ships only for families where
+# the bad pattern is unmistakable (a PreToolUse guard) or where we can react
+# to an ALREADY-FAILED tool call without ever touching a successful one (a
+# PostToolUseFailure context-injection). Every other family renders the safe
+# STUB below (never blocks, never injects) rather than guess at a matcher.
+#
+#   sleep_chain            -> GUARD     (PreToolUse, blocks an unmistakable
+#                                          `sleep N && ...` chain)
+#   cwd_confusion           -> REACTIVE  (PostToolUseFailure, fires only after
+#                                          a Bash/Read call already failed with
+#                                          a path/cwd error; injects the real
+#                                          cwd + a short listing)
+#   stale_read_race         -> REACTIVE  (PostToolUseFailure, fires only after
+#                                          an Edit/Write/MultiEdit already
+#                                          failed with a "modified since read"
+#                                          error; suggests re-Read)
+#   edit_string_not_found   -> REACTIVE  (PostToolUseFailure, fires only after
+#                                          an Edit/MultiEdit already failed
+#                                          with a string-not-found error;
+#                                          suggests re-Read)
+#
+# `PostToolUseFailure` (docs.claude.com/en/hooks): fires only when a tool call
+# already errored, carries the failure's error text + `tool_name` + `cwd` on
+# stdin, and supports `hookSpecificOutput.additionalContext` on stdout to hand
+# Claude recovery context for its NEXT turn. It can never block anything and
+# never fires on a successful call -- exactly the "reactive, not a guard"
+# shape the mandate asks for. The docs don't pin the exact field holding the
+# error, so the generated hook reads it defensively (`tool_error` -> `error`
+# -> `tool_response.error` -> stringified `tool_response`; see `_error_text`).
+
+_GUARD_FAMILIES = {"sleep_chain"}
+
+# family_key -> (tool names the failure can come from, the SAME validated
+# regex the analyzer clusters on, the recovery note to inject, whether to
+# append the actual cwd + a short directory listing).
+_REACTIVE_SPECS: dict[str, dict[str, Any]] = {
+    "cwd_confusion": {
+        "tools": ("Bash", "Read"),
+        "pattern": (
+            r"no such file or directory|"
+            r"file does not exist\.\s*note:\s*your current working directory"
+        ),
+        "note": (
+            "This tool call failed with a path/cwd error. Use an absolute "
+            "path, or cd into place, before retrying a relative path."
+        ),
+        "include_cwd_listing": True,
+    },
+    "stale_read_race": {
+        "tools": ("Edit", "Write", "MultiEdit"),
+        "pattern": r"modified since (it was last read|read)",
+        "note": (
+            "This file was modified since it was last read (likely a "
+            "formatter/linter hook rewrite) -- Read it again to get the "
+            "current bytes before retrying this edit."
+        ),
+        "include_cwd_listing": False,
+    },
+    "edit_string_not_found": {
+        "tools": ("Edit", "MultiEdit"),
+        "pattern": r"string to replace not found|old_string not found|not found in file",
+        "note": (
+            "The exact string to replace was not found -- Read the file "
+            "again for its current exact content (whitespace/indentation or "
+            "a prior edit may have changed it) before retrying."
+        ),
+        "include_cwd_listing": False,
+    },
+}
+
+_SLEEP_CHAIN_MATCHER = (
+    '    if tool_name == "Bash" and re.search(r"^\\s*sleep\\b.*(&&|;)", command, re.IGNORECASE):\n'
+    '        return True, ("blocked sleep-chain (TokenJam, signature '
+    '{signature}) — use the Monitor tool instead of a busy-wait sleep.")\n'
+)
+#: Families an enforcement rung can actually be written for: a hand-authored
+#: GUARD matcher (`_GUARD_FAMILIES`) or a hand-authored REACTIVE spec
+#: (`_REACTIVE_SPECS`). Anything else has no matcher, so a hook written for it
+#: could only ever be inert; `render_hook_content` refuses instead of writing
+#: one (see its docstring).
+def matchered_families() -> set[str]:
+    """The families a rung 3-5 hook can be rendered for. Resolved lazily so a
+    future matcher addition is picked up without a second registry to keep in
+    sync."""
+    return set(_GUARD_FAMILIES) | set(_REACTIVE_SPECS)
+
+
+def _render_guard_hook(title: str, rung: int | None, signature: str) -> str:
+    """A PreToolUse GUARD script -- can block, only for `_GUARD_FAMILIES`."""
+    matcher = _SLEEP_CHAIN_MATCHER.format(signature=signature)
+    return f'''#!/usr/bin/env python3
+"""TokenJam hook -- {title} (rung {rung}, signature {signature}).
+
+Auto-generated by TokenJam's loop after a human approved this
+fix in the Review inbox. DISABLED by default -- wiring this into
+settings.json requires an explicit "Enable enforcement" confirmation; see
+the staged patch sitting next to this file (``*.settings-patch.json``).
+
+GUARD: this runs on PreToolUse and can block an unmistakable bad pattern
+before it executes. FAIL-OPEN: the whole body runs under a blanket
+try/except. Any unexpected error here allows the tool call through (exit 0)
+rather than blocking it or crashing the session.
+"""
+import json
+import re
+import sys
+
+
+def _decide(payload: dict) -> tuple[bool, str]:
+    """Return (should_block, reason). Never raises -- see main()'s try/except."""
+    tool_name = payload.get("tool_name", "")
+    tool_input = payload.get("tool_input") or {{}}
+    command = str(tool_input.get("command", "")) if tool_name == "Bash" else ""
+{matcher}    return False, ""
+
+
+def main() -> int:
+    try:
+        raw = sys.stdin.read()
+        payload = json.loads(raw) if raw else {{}}
+        blocked, reason = _decide(payload)
+        if blocked:
+            print(reason, file=sys.stderr)
+            return 2
+        return 0
+    except Exception:
+        return 0   # fail-open: never block on our own bug
+
+
+if __name__ == "__main__":
+    sys.exit(main())
+
+# tokenjam:relearn:{signature}
+'''
+
+
+def _render_reactive_hook(
+    spec: dict[str, Any], title: str, rung: int | None, signature: str,
+) -> str:
+    """A PostToolUseFailure REACTIVE script -- never blocks, only fires after
+    a tool call already failed with this family's exact validated error
+    signature; injects `additionalContext` for the model's next turn."""
+    tools_repr = repr(tuple(spec["tools"]))
+    pattern_repr = repr(spec["pattern"])
+    note_repr = repr(spec["note"])
+    include_listing = bool(spec["include_cwd_listing"])
+    return f'''#!/usr/bin/env python3
+"""TokenJam hook -- {title} (rung {rung}, signature {signature}).
+
+Auto-generated by TokenJam's loop after a human approved this
+fix in the Review inbox. DISABLED by default -- wiring this into
+settings.json requires an explicit "Enable enforcement" confirmation; see
+the staged patch sitting next to this file (``*.settings-patch.json``).
+
+REACTIVE, not a guard: this runs on PostToolUseFailure -- i.e. only AFTER a
+tool call has already failed. It never blocks and never touches a successful
+call; it only appends recovery context for the model's next turn via
+`hookSpecificOutput.additionalContext`. FAIL-OPEN: the whole body runs under
+a blanket try/except, and emitting nothing (exit 0, no stdout) is always a
+safe no-op -- Claude Code proceeds exactly as if this hook were absent.
+"""
+import json
+import os
+import re
+import sys
+
+_TOOLS = {tools_repr}
+_PATTERN = re.compile({pattern_repr}, re.IGNORECASE)
+_NOTE = {note_repr}
+_INCLUDE_CWD_LISTING = {include_listing!r}
+
+
+def _error_text(payload: dict) -> str:
+    """The failure's error string, read defensively across field-name variants.
+
+    The PostToolUseFailure input schema does not pin the exact field carrying
+    the error, so we try, in order: ``tool_error`` -> ``error`` ->
+    ``tool_response.error`` -> a stringified ``tool_response``. The first
+    non-empty string wins; if none yields one, return "" (fail-open -- inject
+    nothing). Never raises."""
+    for key in ("tool_error", "error"):
+        val = payload.get(key)
+        if isinstance(val, str) and val.strip():
+            return val
+    resp = payload.get("tool_response")
+    if isinstance(resp, dict):
+        inner = resp.get("error")
+        if isinstance(inner, str) and inner.strip():
+            return inner
+    if isinstance(resp, str) and resp.strip():
+        return resp
+    if resp is not None and not isinstance(resp, str):
+        text = str(resp)
+        if text.strip():
+            return text
+    return ""
+
+
+def _context(payload: dict) -> str:
+    """The `additionalContext` string to inject, or "" (no match -- pass
+    through). Never raises -- see main()'s try/except."""
+    tool_name = payload.get("tool_name", "")
+    if tool_name not in _TOOLS:
+        return ""
+    error_text = _error_text(payload)
+    if not error_text or not _PATTERN.search(error_text):
+        return ""
+    extra = ""
+    if _INCLUDE_CWD_LISTING:
+        cwd = str(payload.get("cwd") or "")
+        listing = ""
+        try:
+            if cwd and os.path.isdir(cwd):
+                entries = sorted(os.listdir(cwd))[:40]
+                listing = ", ".join(entries) if entries else "(empty directory)"
+        except OSError:
+            listing = ""
+        extra = f" Actual working directory: {{cwd or '(unknown)'}}. Top-level entries: {{listing}}."
+    return f"[TokenJam, signature {signature}] {{_NOTE}}{{extra}}"
+
+
+def main() -> int:
+    try:
+        raw = sys.stdin.read()
+        payload = json.loads(raw) if raw else {{}}
+        context = _context(payload)
+        if not context:
+            return 0   # no match -- pass through, nothing printed
+        out = {{
+            "hookSpecificOutput": {{
+                "hookEventName": "PostToolUseFailure",
+                "additionalContext": context,
+            }}
+        }}
+        sys.stdout.write(json.dumps(out))
+        return 0
+    except Exception:
+        return 0   # fail-open: never disrupt the tool call on our own bug
+
+
+if __name__ == "__main__":
+    sys.exit(main())
+
+# tokenjam:relearn:{signature}
+'''
+
+
+def render_hook_content(cluster: dict, signature: str) -> str:
+    """The enforcement artifact for a rung 3-5 apply.
+
+    A family with no hand-authored matcher (neither a GUARD matcher nor a
+    REACTIVE spec) has nothing to fire on, so the only hook that could be
+    written for it is one that never does anything. Writing that would put a
+    record in the ledger, a file on disk and an "applied" badge on the card
+    for a fix that cannot possibly work; the honest move is to refuse and
+    offer rung 1 instead, which writes a real note carrying the same guidance.
+    """
+    family_key = cluster.get("family_key") or ""
+    title = cluster.get("title", signature)
+    rung = cluster.get("rung")
+    # `matchered_families()` answers "does a matcher exist at all", which is
+    # exactly the refusal question. Reading the two underlying tables here
+    # instead would make this the second registry that accessor exists to
+    # prevent; the dispatch below only picks WHICH renderer, once the family
+    # is already known to have one.
+    if family_key not in matchered_families():
+        raise RelearnApplyRefused(
+            f"no matcher exists for family '{family_key or 'unknown'}', so a rung "
+            f"{rung} hook for it would be written but never fire. Refusing to write "
+            f"a fix that looks applied and does nothing. Apply this at rung 1 "
+            f"instead: it writes the same guidance as a reversible note."
+        )
+    if family_key in _GUARD_FAMILIES:
+        return _render_guard_hook(title, rung, signature)
+    return _render_reactive_hook(_REACTIVE_SPECS[family_key], title, rung, signature)
+
+
+def _enforcement_wiring(family_key: str) -> tuple[str, str]:
+    """(event, tool-matcher) for the `settings.json` wiring `apply_relearn_fix`
+    stages -- the ONLY event/tools this rung-3 hook is ever invoked for. Only
+    reached for a family that HAS a matcher; `render_hook_content` refuses an
+    un-matchered family before any wiring is staged, so the trailing default
+    below is unreachable belt-and-braces, not a supported path."""
+    if family_key in _GUARD_FAMILIES:
+        return "PreToolUse", "Bash"
+    spec = _REACTIVE_SPECS.get(family_key)
+    if spec is not None:
+        return "PostToolUseFailure", "|".join(spec["tools"])
+    return "PreToolUse", "Bash"
+
+
+def render_settings_patch(hook_path: Path, event: str = "PreToolUse", matcher: str = "Bash") -> dict:
+    """The settings.json fragment ``enable_enforcement`` would merge in — staged
+    to disk alongside the hook, never merged until an explicit Enable."""
+    return {
+        "hooks": {
+            event: [
+                {"matcher": matcher, "hooks": [{"type": "command", "command": str(hook_path)}]},
+            ]
+        }
+    }
+
+
+def _write_target(target: Path, content: str) -> None:
+    """Write a rung's rendered content — atomically (preserving mode) when the
+    target already exists, else a plain create (``atomic_write`` needs an
+    existing file to stat for its mode).
+
+    Refuses a symlinked target outright (must-fix #3): checked here (not just
+    inside ``atomic_write``) because a BROKEN symlink's ``.exists()`` is
+    False, which would otherwise fall through to the plain-create branch and
+    write through the link unchecked.
+    """
+    if target.is_symlink():
+        raise RelearnApplyRefused(f"{target} is a symlink — refusing to write through it.")
+    target.parent.mkdir(parents=True, exist_ok=True)
+    if target.exists():
+        try:
+            atomic_write(target, content)
+        except AtomicWriteRefused as exc:
+            raise RelearnApplyRefused(str(exc)) from exc
+    else:
+        target.write_text(content, encoding="utf-8")
+
+
+# --- Rung 1: note target allowlist (must-fix #2) -------------------------------
+
+def _is_allowed_note_target(target: Path, pre_image: str | None) -> bool:
+    """A rung-1 note may only land on: (a) a ``*.md`` file (covers
+    ``CLAUDE.md``, the intended target — any Markdown doc is a reasonable
+    note home), or (b) a file that ALREADY carries a ``tokenjam:relearn:``
+    marker (a prior legitimate apply — the same rung 2/3 re-apply allowance).
+    Anything else (a ``.py``, ``.zshrc``, etc.) is refused outright, closing
+    the "rung=1 + arbitrary target_path corrupts any file" gap."""
+    if target.suffix.lower() == ".md":
+        return True
+    return pre_image is not None and "tokenjam:relearn:" in pre_image
+
+
+# --- Write plan (shared by dry-run preview and the real apply) ----------------
+
+def _build_write_plan(cluster: dict, target_path: str) -> dict[str, Any]:
+    """Render what WOULD be written for ``cluster`` at ``target_path`` — pure,
+    no disk writes. Raises ``RelearnApplyRefused`` if a non-TokenJam file
+    already sits at a create-only target (skill / hook), the target is a
+    symlink, or (rung 1) the target isn't an allowlisted note file."""
+    import difflib
+
+    from tokenjam.core.optimize.analyzers.deadweight import (
+        APPLY_KIND_MCP_REMOVE,
+        build_mcp_remove_plan,
+    )
+    from tokenjam.core.optimize.model_apply import APPLY_KINDS, build_model_plan
+
+    signature = cluster["signature"]
+    apply_kind = str(cluster.get("apply_kind") or "")
+    rung = int(cluster["rung"])
+    # The MCP-remove kind sits outside model_apply's own registry (it edits a
+    # config file, not a model id), so it's checked as a sibling here rather
+    # than folded into APPLY_KINDS itself — that constant stays scoped to
+    # "the model-routing kinds" its own module docstring promises.
+    known_apply_kinds = (*APPLY_KINDS, APPLY_KIND_MCP_REMOVE)
+    if not apply_kind and rung not in RUNG_KIND:
+        raise RelearnApplyRefused(f"unknown rung {rung}.")
+    if apply_kind and apply_kind not in known_apply_kinds:
+        raise RelearnApplyRefused(f"unknown apply kind {apply_kind!r}.")
+    if not target_path:
+        raise RelearnApplyRefused("no target path given — pick one before approving.")
+
+    slug = slugify(cluster.get("title") or cluster.get("family_key") or signature)
+    target = Path(target_path).expanduser()
+    if target.is_symlink():
+        raise RelearnApplyRefused(
+            f"{target} is a symlink — refusing to write through it. Point target_path "
+            f"at the real file."
+        )
+    pre_image = _read_pre_image(target)
+
+    if apply_kind == APPLY_KIND_MCP_REMOVE:
+        # A dead MCP server's config entry. Same shape as the model-routing
+        # kinds below (a deterministic edit of a value already written down),
+        # just rendered by the analyzer that already resolved the exact
+        # config file instead of by model_apply.
+        new_content = build_mcp_remove_plan(cluster, target, pre_image)
+    elif apply_kind:
+        # The two model-routing kinds (an agent file's `model:` key, a
+        # registered repo's model-id string). Both are edits of an existing
+        # value, so they skip the rung ladder entirely and only rewrite bytes
+        # that were already there; everything downstream (backup, git commit,
+        # ledger, revert) is the shared machinery.
+        new_content = build_model_plan(cluster, target, pre_image)
+    elif rung == RUNG_NOTE:
+        if not _is_allowed_note_target(target, pre_image):
+            raise RelearnApplyRefused(
+                f"{target} is not an allowlisted note target (must be a CLAUDE.md/*.md "
+                f"file, or already carry a tokenjam:relearn marker) — refusing to write "
+                f"a rung-1 note there."
+            )
+        new_content = render_note_content(pre_image or "", cluster, signature)
+    else:
+        if pre_image is not None and "tokenjam:relearn:" not in pre_image:
+            raise RelearnApplyRefused(
+                f"{target} already exists and wasn't written by TokenJam — refusing to "
+                f"overwrite it. Choose a different target path."
+            )
+        new_content = (
+            render_skill_content(cluster, signature, slug) if rung == RUNG_SKILL
+            else render_hook_content(cluster, signature)
+        )
+
+    diff = "".join(difflib.unified_diff(
+        (pre_image or "").splitlines(keepends=True), new_content.splitlines(keepends=True),
+        fromfile="before", tofile="after", n=2,
+    ))
+    return {
+        "signature": signature, "rung": rung, "slug": slug, "target_path": str(target),
+        "pre_image": pre_image, "new_content": new_content, "diff": diff,
+        "kind": apply_kind or RUNG_KIND[rung],
+    }
+
+
+def apply_relearn_fix(
+    config: TjConfig,
+    cluster: dict,
+    *,
+    target_path: str,
+    scope: str,
+    go: bool = False,
+    conn: Any | None = None,
+    force: bool = False,
+) -> dict:
+    """Write an approved proposal at its rung. Default dry-run (mirrors
+    ``apply_staged``'s contract) — pass ``go=True`` to actually write.
+
+    Raises ``RelearnApplyRefused`` (callers map to 409) when: the rung/target
+    is invalid, a non-TokenJam file already sits at a create-only target, or
+    (when ``force`` is not set) a live session was just seen in the target's
+    repo (SPEC §7 — never apply mid-session).
+    """
+    plan = _build_write_plan(cluster, target_path)
+    if not go:
+        return {"dry_run": True, **plan}
+
+    warning = active_session_warning(conn, plan["target_path"])
+    if warning and not force:
+        raise RelearnApplyRefused(warning)
+
+    target = Path(plan["target_path"]).expanduser()
+    rung = plan["rung"]
+    fix_id = uuid.uuid4().hex[:16]
+
+    _save_backup(config, fix_id, str(target), plan["pre_image"])
+    _write_target(target, plan["new_content"])
+
+    enforcement: dict[str, Any] | None = None
+    if rung in ENFORCEMENT_RUNGS and not cluster.get("apply_kind"):
+        target.chmod(0o755)
+        settings_path = target.parent.parent / "settings.json"
+        patch_path = target.parent / f"{plan['slug']}.settings-patch.json"
+        event, matcher = _enforcement_wiring(cluster.get("family_key") or "")
+        patch = render_settings_patch(target, event=event, matcher=matcher)
+        patch_path.write_text(json.dumps(patch, indent=2) + "\n", encoding="utf-8")
+        enforcement = {
+            "enabled": False,
+            "hook_path": str(target),
+            "settings_path": str(settings_path),
+            "patch_path": str(patch_path),
+            "patch": patch,
+        }
+
+    repo_root = git_repo_root(target)
+    commit_sha = None
+    if repo_root:
+        rel_paths = [str(target.relative_to(repo_root))]
+        if enforcement:
+            rel_paths.append(str(Path(enforcement["patch_path"]).relative_to(repo_root)))
+        commit_sha = _git_commit(
+            repo_root, rel_paths,
+            _commit_message(
+                "apply", cluster.get("title", plan["signature"]), plan["signature"],
+                rung, plan["kind"],
+            ),
+        )
+
+    from tokenjam.utils.time_parse import utcnow
+
+    applied_at_dt = utcnow()
+    record = AppliedFix(
+        id=fix_id, signature=plan["signature"], family_key=cluster.get("family_key"),
+        title=cluster.get("title", plan["signature"]), rung=rung, kind=plan["kind"],
+        scope=scope, target_path=str(target),
+        repo_root=str(repo_root) if repo_root else None,
+        applied_at=applied_at_dt.isoformat(), diff=plan["diff"], enforcement=enforcement,
+        git_commit=commit_sha,
+    )
+    record.verify["baseline_sessions"] = cluster.get("sessions")
+    record.verify["baseline_occurrences"] = cluster.get("occurrences")
+    # No verify pass reads this exposure denominator anymore (see the
+    # `verify` field's class docstring above); left unset rather than
+    # computed since nothing consumes it.
+    record.verify["baseline_total_sessions"] = None
+    return {"dry_run": False, "record": _save_record(config, record)}
+
+
+# --- Enforcement enable/disable (rungs 3-5 only) -------------------------------
+
+def _read_settings(path: Path) -> dict:
+    if not path.is_file():
+        return {}
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+        return data if isinstance(data, dict) else {}
+    except (OSError, json.JSONDecodeError):
+        return {}
+
+
+def _merge_hook_patch(settings: dict, patch: dict) -> dict:
+    """Immutable merge: returns a NEW settings dict with ``patch``'s hook
+    entries appended, skipping any event/command pair already present."""
+    out = json.loads(json.dumps(settings))
+    hooks_out = out.setdefault("hooks", {})
+    for event, entries in (patch.get("hooks") or {}).items():
+        existing = hooks_out.setdefault(event, [])
+        for entry in entries:
+            entry_commands = {h.get("command") for h in entry.get("hooks", [])}
+            already = any(
+                {h.get("command") for h in e.get("hooks", [])} & entry_commands
+                for e in existing if isinstance(e, dict)
+            )
+            if not already:
+                existing.append(entry)
+    return out
+
+
+def _remove_hook_command(settings: dict, hook_command: str) -> dict:
+    """Immutable removal: returns a NEW settings dict with any hook entry
+    whose command == ``hook_command`` stripped out (empty entries dropped)."""
+    out = json.loads(json.dumps(settings))
+    hooks = out.get("hooks") or {}
+    for event, entries in list(hooks.items()):
+        kept = []
+        for entry in entries:
+            entry_hooks = [h for h in entry.get("hooks", []) if h.get("command") != hook_command]
+            if entry_hooks:
+                kept.append({**entry, "hooks": entry_hooks})
+        hooks[event] = kept
+    out["hooks"] = hooks
+    return out
+
+
+def enable_enforcement(config: TjConfig, fix_id: str, *, confirm: bool) -> dict:
+    """Wire a generated hook into settings.json — the ONLY step that makes an
+    enforcement rung (3-5) live. Requires an explicit ``confirm=True`` (the
+    UI's "this intercepts your tools" warning); never auto-fires."""
+    rec = get_applied(config, fix_id)
+    if rec is None:
+        raise RelearnApplyRefused(f"no applied fix {fix_id}.")
+    if rec["rung"] not in ENFORCEMENT_RUNGS:
+        raise RelearnApplyRefused("only rung 3-5 (hook/wrapper/config) fixes need enabling.")
+    if rec["state"] != "applied":
+        raise RelearnApplyRefused("this fix was reverted — re-apply it before enabling.")
+    enforcement = rec.get("enforcement") or {}
+    if enforcement.get("enabled"):
+        return rec
+    if not confirm:
+        raise RelearnApplyRefused(
+            "enabling enforcement wires this hook into settings.json, where it "
+            "intercepts your tool calls on every matching call — pass an explicit "
+            "confirmation to proceed."
+        )
+
+    settings_path = Path(enforcement["settings_path"]).expanduser()
+    patch = enforcement["patch"]
+    merged = _merge_hook_patch(_read_settings(settings_path), patch)
+    _write_target(settings_path, json.dumps(merged, indent=2) + "\n")
+
+    repo_root = git_repo_root(settings_path)
+    commit_sha = None
+    if repo_root:
+        rel = str(settings_path.relative_to(repo_root))
+        commit_sha = _git_commit(
+            repo_root, [rel],
+            _commit_message("enable enforcement for", rec["title"], rec["signature"], rec["rung"]),
+        )
+    new_enforcement = {**enforcement, "enabled": True, "enable_commit": commit_sha}
+    return _update_record(config, fix_id, enforcement=new_enforcement)
+
+
+def disable_enforcement(config: TjConfig, fix_id: str) -> dict:
+    """Unwire the hook from settings.json (the file itself is left in place —
+    only the settings.json entry is removed) — a no-op if already disabled."""
+    rec = get_applied(config, fix_id)
+    if rec is None:
+        raise RelearnApplyRefused(f"no applied fix {fix_id}.")
+    enforcement = rec.get("enforcement") or {}
+    if not enforcement.get("enabled"):
+        return rec
+
+    settings_path = Path(enforcement["settings_path"]).expanduser()
+    if settings_path.is_file():
+        updated = _remove_hook_command(_read_settings(settings_path), enforcement["hook_path"])
+        _write_target(settings_path, json.dumps(updated, indent=2) + "\n")
+        repo_root = git_repo_root(settings_path)
+        if repo_root:
+            rel = str(settings_path.relative_to(repo_root))
+            _git_commit(
+                repo_root, [rel],
+                _commit_message("disable enforcement for", rec["title"], rec["signature"], rec["rung"]),
+            )
+    new_enforcement = {**enforcement, "enabled": False}
+    return _update_record(config, fix_id, enforcement=new_enforcement)
+
+
+# --- Revert (one-step, for any rung) -------------------------------------------
+
+def revert_applied_fix(config: TjConfig, fix_id: str) -> dict:
+    """Undo an apply: disables enforcement first (if it was live), restores
+    the pre-image (or deletes a freshly-created file), removes the enforcement
+    sidecar patch file, and git-commits the revert when the target is tracked.
+    Idempotent — reverting an already-reverted fix is a no-op."""
+    rec = get_applied(config, fix_id)
+    if rec is None:
+        raise RelearnApplyRefused(f"no applied fix {fix_id}.")
+    if rec["state"] == "reverted":
+        return rec
+
+    if (rec.get("enforcement") or {}).get("enabled"):
+        disable_enforcement(config, fix_id)
+        rec = get_applied(config, fix_id) or rec
+
+    restore = _restore_backup(config, fix_id)
+    target = Path(restore["target_path"])
+
+    enforcement = rec.get("enforcement")
+    if enforcement:
+        patch_path = Path(enforcement["patch_path"])
+        if patch_path.is_file():
+            patch_path.unlink()
+
+    repo_root = git_repo_root(target)
+    commit_sha = None
+    if repo_root:
+        rel = str(target.relative_to(repo_root))
+        add = _run_git(["add", "--", rel], repo_root)
+        if add is not None and add.returncode == 0:
+            commit = _run_git(
+                ["commit", "--no-verify", "-m",
+                 _commit_message(
+                     "revert", rec["title"], rec["signature"], rec["rung"],
+                     rec.get("kind"),
+                 ),
+                 "--", rel],
+                repo_root,
+            )
+            if commit is not None and commit.returncode == 0:
+                sha = _run_git(["rev-parse", "HEAD"], repo_root)
+                commit_sha = (sha.stdout or "").strip() if sha and sha.returncode == 0 else None
+
+    from tokenjam.utils.time_parse import utcnow
+
+    return _update_record(
+        config, fix_id, state="reverted",
+        reverted_at=utcnow().isoformat(), revert_commit=commit_sha,
+    )

--- a/tokenjam/core/optimize/relearn_store.py
+++ b/tokenjam/core/optimize/relearn_store.py
@@ -1,0 +1,239 @@
+"""On-disk cache for the relearn aggregator's (expensive, full-corpus) result.
+
+The detector (``core.optimize.analyzers.relearn``) takes tens of seconds over
+a real local corpus — far too slow to compute per HTTP request. ``tj serve``
+computes it on a background schedule using a FRESH DuckDB connection (mirrors
+the retention job's own-connection pattern in ``cli/cmd_serve.py``, so a slow
+scan never contends with the live request connection's write lock — see the
+DuckDB single-writer relearn this very module exists to help catch more of).
+This module is the read/write boundary: a small JSON file at
+``~/.tj/relearn_cache.json`` plus an in-process lock so two overlapping
+recomputes never race each other's writes.
+"""
+from __future__ import annotations
+
+import json
+import threading
+from dataclasses import asdict
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import TYPE_CHECKING, Any, Callable
+
+from tokenjam.core.optimize.analyzers.relearn import RelearnFinding, compute_relearn_finding
+
+if TYPE_CHECKING:
+    from tokenjam.core.config import TjConfig
+
+_LOCK = threading.Lock()
+_COMPUTING = threading.Event()
+
+
+def default_cache_path(config: TjConfig | None = None) -> Path:
+    """``<storage-parent>/relearn_cache.json`` when ``config`` is given — this
+    honors ``--config`` / ``storage.path`` (and falls back to a config-scoped
+    TEMP dir, never the real ``~/.tj``, when ``storage.path`` is ``""``/
+    ``":memory:"``; see ``relearn_apply._storage_base_dir``). Without a
+    ``config`` (legacy callers), the old hardcoded ``~/.tj`` default."""
+    if config is not None:
+        from tokenjam.core.optimize.relearn_apply import _storage_base_dir
+
+        return _storage_base_dir(config) / "relearn_cache.json"
+    return Path.home() / ".tj" / "relearn_cache.json"
+
+
+def read_cache(
+    path: Path | None = None, *, config: TjConfig | None = None,
+) -> dict[str, Any] | None:
+    """The last-written ``{"computed_at", "finding"}`` payload, or ``None`` if
+    no recompute has ever completed (fresh install) or the file is corrupt."""
+    p = path or default_cache_path(config)
+    try:
+        raw = json.loads(p.read_text(encoding="utf-8"))
+    except (OSError, ValueError):
+        return None
+    return raw if isinstance(raw, dict) else None
+
+
+def write_cache(
+    finding: RelearnFinding, path: Path | None = None, *, config: TjConfig | None = None,
+) -> dict[str, Any]:
+    """Atomically write the finding (temp file + rename), never a partial file
+    a concurrent reader could observe.
+
+    The cache file is shared with the cost-proposal producer (see
+    ``write_cost_proposals``): the two write on different cadences (the relearn
+    detector job vs the optimize path). To keep this "the same proposal store"
+    without one producer clobbering the other, an existing ``cost_proposals``
+    block is read back and preserved here rather than dropped.
+
+    Detection time is also when each cluster gets its stable ``proposal_id``
+    (``relearn_proposals.stamp_proposal_ids``): the apply paths accept a stored
+    proposal ID and nothing else, so the IDs have to exist on the record the
+    detector itself wrote.
+    """
+    from tokenjam.core.optimize.relearn_proposals import stamp_proposal_ids
+
+    p = path or default_cache_path(config)
+    existing = read_cache(p, config=config) or {}
+    # Explicit annotation: without it mypy infers the dict-literal's value
+    # type from the two initial values (str, dict[str, Any]) and joins them
+    # down to `Collection[str]`, rejecting the `cost_computed_at` assignment
+    # below even though the payload is really `dict[str, Any]`.
+    payload: dict[str, Any] = {
+        "computed_at": datetime.now(timezone.utc).isoformat(),
+        "finding": stamp_proposal_ids(asdict(finding)),
+    }
+    if "cost_proposals" in existing:
+        payload["cost_proposals"] = existing["cost_proposals"]
+        payload["cost_computed_at"] = existing.get("cost_computed_at")
+    _atomic_write(p, payload)
+    return payload
+
+
+def _atomic_write(p: Path, payload: dict[str, Any]) -> None:
+    """Temp-file + rename write; a concurrent reader never sees a partial file.
+    Best-effort — an OSError (read-only fs, missing parent that can't be made)
+    degrades to a no-op, never raises."""
+    try:
+        p.parent.mkdir(parents=True, exist_ok=True)
+        tmp = p.with_suffix(".tmp")
+        tmp.write_text(json.dumps(payload), encoding="utf-8")
+        tmp.replace(p)
+    except OSError:
+        pass
+
+
+def read_cost_proposals(
+    path: Path | None = None, *, config: TjConfig | None = None,
+) -> dict[str, Any] | None:
+    """The last-written cost-proposal block, or ``None`` if none has ever been
+    computed. Shape: ``{"cost_computed_at": iso, "cost_proposals": [dict, ...]}``."""
+    raw = read_cache(path, config=config)
+    if raw is None or "cost_proposals" not in raw:
+        return None
+    return {
+        "cost_computed_at": raw.get("cost_computed_at"),
+        "cost_proposals": raw.get("cost_proposals") or [],
+    }
+
+
+def write_cost_proposals(
+    proposals: list[Any], path: Path | None = None, *, config: TjConfig | None = None,
+) -> dict[str, Any]:
+    """Write the cost proposals into the SAME cache file the relearn finding
+    lives in, under a separate ``cost_proposals`` key, preserving the relearn
+    ``finding`` block. ``proposals`` is a list of ``CostProposal`` (or plain
+    dicts). Atomic; best-effort on I/O error."""
+    from dataclasses import is_dataclass
+
+    p = path or default_cache_path(config)
+    existing = read_cache(p, config=config) or {}
+    # `is_dataclass()` alone narrows to `DataclassInstance | type[DataclassInstance]`
+    # (it also accepts a dataclass *class*), but `asdict()` only accepts an
+    # instance. Excluding `type` narrows to the instance case for mypy and
+    # matches what we actually want here — `proposals` holds instances, never
+    # classes.
+    serialised = [
+        asdict(pr) if is_dataclass(pr) and not isinstance(pr, type) else dict(pr)
+        for pr in proposals
+    ]
+    payload = dict(existing)
+    payload["cost_proposals"] = serialised
+    payload["cost_computed_at"] = datetime.now(timezone.utc).isoformat()
+    _atomic_write(p, payload)
+    return payload
+
+
+def is_computing() -> bool:
+    return _COMPUTING.is_set()
+
+
+def recompute_now(
+    conn: Any | None, *, cache_path: Path | None = None, config: Any | None = None,
+) -> dict[str, Any] | None:
+    """Synchronous compute + cache write on the CALLING thread/connection.
+
+    Returns ``None`` (no-op) if a recompute is already in flight elsewhere —
+    never blocks waiting for the other one to finish. Callers that want
+    non-blocking HTTP-request behaviour should run this on a background
+    thread instead (see ``trigger_background_recompute``).
+    """
+    if not _LOCK.acquire(blocking=False):
+        return None
+    _COMPUTING.set()
+    try:
+        # `[loop].transcript_path` lets a Claude Agent SDK app point the loop at
+        # its OWN transcript root instead of ~/.claude/projects. None keeps the
+        # historical env/default resolution.
+        projects_root = None
+        if config is not None:
+            try:
+                from tokenjam.core.transcript import loop_transcript_root
+
+                projects_root = loop_transcript_root(config)
+            except Exception:
+                projects_root = None
+        # The persistent per-file parse cache (core.transcript_cache): this
+        # background job re-scans the FULL corpus on every scheduled tick, so
+        # warming/reusing the cache here is where the recurring cost actually
+        # gets paid down across ticks, not just within one `tj optimize` run.
+        transcript_cache_dir = None
+        if config is not None:
+            try:
+                from tokenjam.core.transcript_cache import default_cache_dir
+
+                transcript_cache_dir = default_cache_dir(config)
+            except Exception:
+                transcript_cache_dir = None
+        finding = compute_relearn_finding(
+            conn, projects_root=projects_root, transcript_cache_dir=transcript_cache_dir,
+        )
+        # cache_path, when omitted, resolves via `config` (honors --config /
+        # storage.path, and a :memory:/"" storage.path never falls through to
+        # the real ~/.tj — see default_cache_path).
+        result = write_cache(finding, cache_path, config=config)
+        return result
+    finally:
+        _COMPUTING.clear()
+        _LOCK.release()
+
+
+def trigger_background_recompute(
+    backend_factory: Callable[[], Any],
+    *,
+    cache_path: Path | None = None,
+    config: Any | None = None,
+) -> bool:
+    """Fire-and-forget a recompute on a daemon thread.
+
+    ``backend_factory`` builds a FRESH ``StorageBackend`` (e.g.
+    ``lambda: DuckDBBackend(config.storage)``) — never the caller's live
+    request connection, so the scan's DuckDB read never contends with a
+    concurrent writer. The backend is closed when the job finishes. Returns
+    ``False`` (no-op, nothing started) if a recompute is already running.
+
+    ``config`` (optional): passed straight through to ``recompute_now`` so
+    its Phase 3 verify pass can locate ``applied_fixes.json``.
+    """
+    if is_computing():
+        return False
+
+    def _job() -> None:
+        backend = None
+        try:
+            backend = backend_factory()
+            conn = getattr(backend, "conn", None)
+            recompute_now(conn, cache_path=cache_path, config=config)
+        except Exception:
+            # Best-effort background job — never crash the scheduler/thread pool.
+            pass
+        finally:
+            close = getattr(backend, "close", None)
+            if callable(close):
+                try:
+                    close()
+                except Exception:
+                    pass
+
+    threading.Thread(target=_job, name="relearn-recompute", daemon=True).start()
+    return True

--- a/tokenjam/core/summarize/apply.py
+++ b/tokenjam/core/summarize/apply.py
@@ -9,10 +9,9 @@ refusing on post-apply drift. No flag bypasses a guard (DEC-027 agent-safety).
 from __future__ import annotations
 
 import os
-import stat
-import tempfile
 from pathlib import Path
 
+from tokenjam.core.atomic_write import AtomicWriteRefused, atomic_write
 from tokenjam.core.config import TjConfig
 from tokenjam.core.summarize import backup
 from tokenjam.core.summarize.session import SummarizeRefused, clear, list_staged, read_staged, sha256
@@ -24,21 +23,17 @@ def _owned_by_current_user(p: Path) -> bool:
     return p.stat().st_uid == os.getuid()
 
 
-def _atomic_write(p: Path, text: str) -> None:
-    """Write ``text`` to ``p`` atomically (temp in the same dir → ``os.replace``), preserving mode."""
-    mode = stat.S_IMODE(p.stat().st_mode)
-    fd, tmp = tempfile.mkstemp(dir=str(p.parent), prefix=f".{p.name}.", suffix=".tj-tmp")
+def _write(p: Path, text: str) -> None:
+    """``atomic_write``, translated to the house ``SummarizeRefused`` on refusal.
+
+    ``apply_staged``/``undo`` already symlink-check ``p`` before calling this, so the
+    primitive's own guard is a TOCTOU backstop in practice — but callers of this module
+    still see ``SummarizeRefused``, never the primitive's own exception type.
+    """
     try:
-        with os.fdopen(fd, "w", encoding="utf-8") as f:
-            f.write(text)
-        os.chmod(tmp, mode)
-        os.replace(tmp, p)
-    except Exception:
-        try:
-            os.unlink(tmp)
-        except FileNotFoundError:
-            pass
-        raise
+        atomic_write(p, text)
+    except AtomicWriteRefused as exc:
+        raise SummarizeRefused(str(exc)) from exc
 
 
 def apply_staged(config: TjConfig, path: str | None = None, *, go: bool = False) -> dict:
@@ -81,7 +76,7 @@ def apply_staged(config: TjConfig, path: str | None = None, *, go: bool = False)
         if go:
             backup.save(config, sp, original=current, output=e["restored"],
                         est_tokens_saved=int(e.get("est_tokens_saved", 0) or 0))
-            _atomic_write(p, e["restored"])
+            _write(p, e["restored"])
             clear(config, sp)
             # Record the applied rewrite in the recommendation-outcome ledger so
             # `tj savings` / Lens can prove which recommendations got acted on.
@@ -112,7 +107,7 @@ def undo(config: TjConfig, path: str, *, go: bool = False) -> dict:
     original = backup.load_original(config, str(p), current)   # raises on drift / missing backup
     if go:
         if p.exists():
-            _atomic_write(p, original)
+            _write(p, original)
         else:
             p.write_text(original, encoding="utf-8")           # file was deleted — recreate it
     return {"path": str(p), "restored": go, "dry_run": not go}

--- a/tokenjam/core/transcript.py
+++ b/tokenjam/core/transcript.py
@@ -175,8 +175,33 @@ def _locate_transcript(session_id: str, projects_root: Path) -> Path | None:
     return Path(matches[0])
 
 
-def read_records(path: Path) -> list[dict[str, Any]]:
-    """Read a JSONL file into a list of dict records, tolerating bad lines."""
+def read_records(
+    path: Path, *, cache_dir: Path | None = None
+) -> list[dict[str, Any]]:
+    """Read a JSONL file into a list of dict records, tolerating bad lines.
+
+    ``cache_dir``, when given, transparently caches the parsed result on disk
+    keyed on ``(path, size, mtime)`` — see ``core.transcript_cache``. ``None``
+    (the default) preserves this function's original always-reparse behavior,
+    so every caller that doesn't opt in (session story rendering, resume-
+    brief, the API's session/status routes, and today's tests of this
+    function) is unaffected.
+    """
+    if cache_dir is not None:
+        from tokenjam.core.transcript_cache import cached_read_records
+
+        return cached_read_records(path, cache_dir)
+    return _parse_records(path)
+
+
+def _parse_records(path: Path) -> list[dict[str, Any]]:
+    """The actual (uncached) JSONL parse — ``read_records``'s cache-dispatch
+    ``if`` above delegates here, and ``core.transcript_cache.cached_read_records``
+    calls this directly on a cache miss. Factored out (rather than inlined in
+    ``read_records``) so it's the ONE place a cache miss pays for, distinct
+    from the dispatch wrapper itself — a cache-hit path never reaches this
+    function at all.
+    """
     try:
         text = path.read_text(encoding="utf-8", errors="replace")
     except OSError:
@@ -691,6 +716,7 @@ def build_session_story(
     session_id: str,
     projects_root: Path | str | None = None,
     include_subagents: bool = True,
+    cache_dir: Path | None = None,
 ) -> dict[str, Any] | None:
     """Build a deterministic story for a Claude Code session, or None if absent.
 
@@ -720,6 +746,12 @@ def build_session_story(
 
     Returns None when no transcript file exists for the session id (SDK session,
     or transcript pruned) — callers translate that into ``available: false``.
+
+    ``cache_dir`` is forwarded to every ``read_records`` call this story (and
+    its recursively-expanded subagents) makes — see that function's docstring
+    and ``core.transcript_cache``. ``None`` (the default) is a no-op, so this
+    function's original always-reparse behavior is unchanged for callers that
+    don't opt in.
     """
     if projects_root is None:
         root = DEFAULT_PROJECTS_ROOT
@@ -734,12 +766,16 @@ def build_session_story(
     subagents_dir = path.parent / session_id / "subagents"
 
     if not include_subagents:
-        story = _build_story_from_path(path, None, None, _Budget(TOTAL_STEP_BUDGET), 0, set())
+        story = _build_story_from_path(
+            path, None, None, _Budget(TOTAL_STEP_BUDGET), 0, set(), cache_dir=cache_dir,
+        )
         return story
 
     budget = _Budget(TOTAL_STEP_BUDGET)
     seen: set[str] = {session_id}
-    return _build_story_from_path(path, subagents_dir, None, budget, 0, seen)
+    return _build_story_from_path(
+        path, subagents_dir, None, budget, 0, seen, cache_dir=cache_dir,
+    )
 
 
 def build_session_asks(
@@ -830,10 +866,11 @@ def _build_story_from_path(
     budget: _Budget,
     depth: int,
     seen: set[str],
+    cache_dir: Path | None = None,
 ) -> dict[str, Any]:
     """Build one story from a located transcript ``path`` and (optionally) attach
     its subagents recursively, sharing ``budget`` / ``seen`` across the tree."""
-    records = read_records(path)
+    records = read_records(path, cache_dir=cache_dir)
 
     tool_status = _build_tool_status(records)
     # Mark ask boundaries on the main thread (depth 0) so the Timeline can show
@@ -855,7 +892,7 @@ def _build_story_from_path(
     outcome, _ = _trim(outcome_raw, MAX_TASK_OUTCOME_CHARS)
 
     if subagents_dir is not None:
-        _attach_subagents(steps, records, subagents_dir, budget, depth, seen)
+        _attach_subagents(steps, records, subagents_dir, budget, depth, seen, cache_dir=cache_dir)
     else:
         _strip_spawn_markers(steps)
 
@@ -886,6 +923,7 @@ def _attach_subagents(
     budget: _Budget,
     depth: int,
     seen: set[str],
+    cache_dir: Path | None = None,
 ) -> None:
     """For each Task/Agent step that spawned a child, attach its ``subagent``.
 
@@ -927,7 +965,9 @@ def _attach_subagents(
             resolved_id = id_map.get(tool_use_id)
             if resolved_id is None:
                 continue
-            sub = _build_subagent(resolved_id, fallback, subagents_dir, budget, depth, seen)
+            sub = _build_subagent(
+                resolved_id, fallback, subagents_dir, budget, depth, seen, cache_dir=cache_dir,
+            )
             if sub is not None:
                 attached.append(sub)
         if len(attached) == 1:
@@ -977,6 +1017,7 @@ def _build_subagent(
     budget: _Budget,
     depth: int,
     seen: set[str],
+    cache_dir: Path | None = None,
 ) -> dict[str, Any] | None:
     """Build one subagent reference, recursing into its own story.
 
@@ -1005,7 +1046,7 @@ def _build_subagent(
 
     seen.add(agent_id)
     child_story = _build_story_from_path(
-        child_path, subagents_dir, agent_id, budget, depth + 1, seen
+        child_path, subagents_dir, agent_id, budget, depth + 1, seen, cache_dir=cache_dir,
     )
     # Merge the recursive story onto the ref (keeps agent_id/name on top).
     child_story.pop("agent_id", None)

--- a/tokenjam/core/transcript_cache.py
+++ b/tokenjam/core/transcript_cache.py
@@ -1,0 +1,165 @@
+"""Persistent per-file cache for ``core.transcript.read_records``.
+
+The relearn and deadweight analyzers (``core.optimize.analyzers.{relearn,
+deadweight}``) each re-parse the FULL on-disk Claude Code transcript corpus
+on every run — a JSONL file per session, some spanning hundreds of turns.
+Profiling a real corpus (5,362 transcripts, 1.7GB) attributed most of
+``compute_deadweight_finding``'s wall time to ``transcript.read_records``,
+almost all of it in ``json.loads`` + the file read. Most of that corpus is
+closed, historic sessions whose content never changes between runs —
+re-parsing them on every invocation is pure waste, and both analyzers already
+mtime-filter their session list, so a cache trusting the same signal adds no
+correctness risk beyond what they already accept.
+
+This module is the cache: one small JSON file per transcript under a cache
+directory, keyed on ``(path, size, mtime)`` — the exact staleness signal the
+callers already trust. A cache hit skips the original file's read + parse
+entirely; a miss (cold entry, or a changed file) recomputes and rewrites
+atomically (temp file + rename), so a concurrent reader never observes a
+partial write.
+
+Opt-in only: ``core.transcript.read_records`` still defaults to its original
+always-reparse behavior. Only a caller that explicitly passes ``cache_dir``
+(today: the deadweight/relearn analyzers' registry entry points, resolved via
+``default_cache_dir`` below) pays a persistent-cache write — every other
+caller (session story rendering, resume-brief, the API's session/status
+routes, and every existing test of these functions) is unaffected.
+"""
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+from pathlib import Path
+from typing import Any
+
+#: Env override so tests (and anyone else) can point the cache at a temp dir
+#: without touching a real local install — mirrors ``TJ_CLAUDE_PROJECTS_ROOT``.
+_CACHE_DIR_ENV = "TJ_TRANSCRIPT_CACHE_DIR"
+
+
+def default_cache_dir(config: Any | None = None) -> Path:
+    """Resolve the cache directory a ``run(ctx)`` entry point should use.
+
+    Precedence: the env override (tests), else the config-honoring storage dir
+    (``relearn_apply._storage_base_dir`` — never the real ``~/.tj`` for an
+    in-memory-configured caller, matching every other on-disk cache this
+    codebase keeps under the storage parent), else the legacy ``~/.tj``
+    default when no config is available at all.
+    """
+    env = os.environ.get(_CACHE_DIR_ENV)
+    if env:
+        return Path(env)
+    if config is not None:
+        try:
+            from tokenjam.core.optimize.relearn_apply import _storage_base_dir
+
+            return _storage_base_dir(config) / "transcript_cache"
+        except Exception:
+            pass
+    return Path.home() / ".tj" / "transcript_cache"
+
+
+def _cache_key(path: Path) -> str:
+    """Filesystem-safe cache filename for ``path`` — a hash of the absolute
+    path string (never of the transcript's own content), so lookup is a
+    single stat + read with no directory-listing scan needed."""
+    resolved = str(path.resolve())
+    digest = hashlib.sha256(resolved.encode("utf-8")).hexdigest()[:32]
+    return f"{digest}.json"
+
+
+def cached_read_records(path: Path, cache_dir: Path) -> list[dict[str, Any]]:
+    """``read_records(path)``, transparently cached under ``cache_dir``.
+
+    Cache validity is ``(size, mtime)`` matching the live file's current
+    stat — the exact pair both analyzers already trust for their own mtime
+    filter. A stat failure (the transcript vanished mid-scan) degrades to
+    ``[]``, matching ``read_records``'s own tolerant-of-missing-files
+    contract rather than raising.
+    """
+    from tokenjam.core.transcript import _parse_records
+
+    try:
+        st = path.stat()
+    except OSError:
+        return []
+    size, mtime = st.st_size, st.st_mtime
+
+    cache_path = cache_dir / _cache_key(path)
+    cached = _load(cache_path)
+    if (
+        cached is not None
+        and cached.get("size") == size
+        and cached.get("mtime") == mtime
+    ):
+        records = cached.get("records")
+        if isinstance(records, list):
+            return records
+
+    records = _parse_records(path)
+    _store(cache_path, path, size, mtime, records)
+    return records
+
+
+def _load(cache_path: Path) -> dict[str, Any] | None:
+    try:
+        raw = json.loads(cache_path.read_text(encoding="utf-8"))
+    except (OSError, ValueError):
+        return None
+    return raw if isinstance(raw, dict) else None
+
+
+def _store(
+    cache_path: Path,
+    source: Path,
+    size: int,
+    mtime: float,
+    records: list[dict[str, Any]],
+) -> None:
+    """Atomic temp-file + rename write. Best-effort — a cache write must
+    never break the scan it exists to speed up; any OSError is swallowed."""
+    try:
+        cache_path.parent.mkdir(parents=True, exist_ok=True)
+        payload = {"path": str(source), "size": size, "mtime": mtime, "records": records}
+        # Per-pid temp name so two processes racing the same cache entry (a
+        # CLI run and a live `tj serve`) never collide mid-write — the loser
+        # just overwrites the winner's file a moment later with the same
+        # (deterministic) content, never a torn read in between.
+        tmp = cache_path.with_name(f"{cache_path.name}.tmp{os.getpid()}")
+        tmp.write_text(json.dumps(payload), encoding="utf-8")
+        tmp.replace(cache_path)
+    except OSError:
+        pass
+
+
+def prune_orphaned_entries(cache_dir: Path) -> int:
+    """Delete cache entries whose source transcript no longer exists on disk.
+
+    This is the cache's pruning story: entries track 1:1 with distinct
+    transcript paths ever seen, so the cache is bounded by corpus size, not
+    unbounded — but a retention job elsewhere can delete old transcripts
+    without this module knowing, so orphaned entries need an explicit sweep
+    rather than growing forever. Opportunistic and safe to call anytime (or
+    skip entirely); never raises. Returns the number of entries removed.
+    """
+    if not cache_dir.exists():
+        return 0
+    removed = 0
+    for entry in cache_dir.glob("*.json"):
+        data = _load(entry)
+        source = data.get("path") if data else None
+        if not isinstance(source, str) or not Path(source).exists():
+            try:
+                entry.unlink()
+                removed += 1
+            except OSError:
+                pass
+    return removed
+
+
+__all__ = [
+    "default_cache_dir",
+    "cached_read_records",
+    "prune_orphaned_entries",
+]


### PR DESCRIPTION
> **Stack slice of #482.** One of 12 concern-scoped PRs split out of #482. Its base is the previous slice, so the diff above shows only this slice's changes.
>
> **Do not merge this PR directly.** The complete change lands in one merge via the anchor PR #482, which contains every commit in this stack and is green. CI on a mid-stack slice may be red: slices are ordered by concern rather than by dependency, so a branch can reference code that lands in a later slice. That is an artifact of the ordering, not a defect in this diff.

Extracts plumbing that several analyzers had each hand-rolled. Behavior-preserving.

- `accounting.py`: a `four_type_token_sum_sql` helper that always sums input + output + cache-read + cache-write, plus call-identity dedupe so a call seen by both the live and backfill paths counts once.
- `clustering.py`: the grouping/threshold/masking plumbing shared by the cross-session miners.
- `transcript_cache.py`: an opt-in per-file parse cache keyed on `(path, size, mtime)`.
- the atomic-write primitive relocated to a neutral module that refuses a symlinked target for every caller.
