### PR TITLE
feat: capture prompt text and tool inputs by default

### DIFF
--- a/tests/integration/test_cli.py
+++ b/tests/integration/test_cli.py
@@ -1998,12 +1998,16 @@ class _StubProvider:
         return self._resp
 
 
-def test_validate_capture_off_fails_with_hint(runner, db, config):
-    """Capture is off by default -> actionable failure naming the config toggle,
-    and no provider client is ever constructed."""
-    _seed_validate_span(db)  # capture flag in `config` is off
+def test_validate_capture_off_fails_with_hint(runner, db):
+    """Capture explicitly off -> actionable failure naming the config toggle,
+    and no provider client is ever constructed. (`prompts` defaults on now —
+    E33 — so this builds an explicit capture-off config rather than relying
+    on the shared `config` fixture's default.)"""
+    from tokenjam.core.config import CaptureConfig
+    cfg = TjConfig(version="1", capture=CaptureConfig(prompts=False))
+    _seed_validate_span(db)
     with patch.dict("os.environ", {"TJ_ANTHROPIC_API_KEY": "sk-test"}):
-        result = _invoke(runner, db, config,
+        result = _invoke(runner, db, cfg,
                          ["optimize", "--validate", "downsize"])
     assert result.exit_code == 1
     assert "requires prompt" in result.output.lower()

--- a/tests/synthetic/test_request_capture.py
+++ b/tests/synthetic/test_request_capture.py
@@ -166,9 +166,9 @@ class TestPipelineGating:
         db.close()
 
     def test_no_behavior_change_when_capture_off(self):
-        # Acceptance #1: default capture (all off) -> nothing captured, and the
-        # raw attributes are gone, exactly like message content.
-        pipeline, db = _pipeline(CaptureConfig())
+        # Acceptance #1: every toggle explicitly off -> nothing captured, and
+        # the raw attributes are gone, exactly like message content.
+        pipeline, db = _pipeline(CaptureConfig(prompts=False))
         pipeline.process(_request_span())
 
         stored = db.get_recent_spans("s1", 1)[0]
@@ -176,6 +176,22 @@ class TestPipelineGating:
         assert stored.request_tools is None
         assert GenAIAttributes.REQUEST_TEMPERATURE not in stored.attributes
         assert TjAttributes.REQUEST_TOOLS not in stored.attributes
+        db.close()
+
+    def test_default_capture_captures_request_params_not_tools(self):
+        # `prompts` defaults on (E33) and gates request_params (sampling
+        # params ride with the prompt toggle); `tool_inputs` stays off, which
+        # gates request_tools.
+        pipeline, db = _pipeline(CaptureConfig())
+        pipeline.process(_request_span())
+
+        stored = db.get_recent_spans("s1", 1)[0]
+        assert stored.request_params == {
+            "temperature": 0.7,
+            "max_tokens": 1024,
+            "stop_sequences": ["STOP"],
+        }
+        assert stored.request_tools is None
         db.close()
 
     def test_params_captured_but_tools_gated_off(self):

--- a/tests/synthetic/test_request_capture.py
+++ b/tests/synthetic/test_request_capture.py
@@ -168,7 +168,7 @@ class TestPipelineGating:
     def test_no_behavior_change_when_capture_off(self):
         # Acceptance #1: every toggle explicitly off -> nothing captured, and
         # the raw attributes are gone, exactly like message content.
-        pipeline, db = _pipeline(CaptureConfig(prompts=False))
+        pipeline, db = _pipeline(CaptureConfig(prompts=False, tool_inputs=False))
         pipeline.process(_request_span())
 
         stored = db.get_recent_spans("s1", 1)[0]
@@ -178,10 +178,10 @@ class TestPipelineGating:
         assert TjAttributes.REQUEST_TOOLS not in stored.attributes
         db.close()
 
-    def test_default_capture_captures_request_params_not_tools(self):
-        # `prompts` defaults on (E33) and gates request_params (sampling
-        # params ride with the prompt toggle); `tool_inputs` stays off, which
-        # gates request_tools.
+    def test_default_capture_captures_request_params_and_tools(self):
+        # `prompts` gates request_params (sampling params ride with the
+        # prompt toggle) and `tool_inputs` gates request_tools; both default
+        # on (E33 / this fix), so a bare CaptureConfig() captures both.
         pipeline, db = _pipeline(CaptureConfig())
         pipeline.process(_request_span())
 
@@ -191,7 +191,10 @@ class TestPipelineGating:
             "max_tokens": 1024,
             "stop_sequences": ["STOP"],
         }
-        assert stored.request_tools is None
+        assert stored.request_tools == {
+            "tools": [{"name": "get_weather"}],
+            "tool_choice": "auto",
+        }
         db.close()
 
     def test_params_captured_but_tools_gated_off(self):

--- a/tests/unit/test_attribution_cache.py
+++ b/tests/unit/test_attribution_cache.py
@@ -153,9 +153,13 @@ def test_refresh_writes_top_driver_when_capture_on(db, tmp_path):
 
 
 def test_refresh_no_op_when_capture_off(db, tmp_path):
+    # prompts/tool_inputs both default on (E33 / this fix) — every toggle
+    # must be explicitly off here to exercise the actual all-off no-op path.
     _seed_recurring_file_read(db, path="CLAUDE.md")
     cache_path = tmp_path / "cache.json"
-    refresh_attribution_cache(db.conn, CaptureConfig(), path=cache_path)
+    refresh_attribution_cache(
+        db.conn, CaptureConfig(prompts=False, tool_inputs=False), path=cache_path
+    )
     assert not cache_path.exists()
 
 

--- a/tests/unit/test_backfill.py
+++ b/tests/unit/test_backfill.py
@@ -858,17 +858,31 @@ def _llm_and_tool(parsed):
 
 
 def test_capture_off_leaves_attributes_unchanged(tmp_path):
-    """Default (no capture / all-False) extracts NO content — attributes stay
+    """Every toggle explicitly off extracts NO content — attributes stay
     exactly {"source": ...} on both the LLM and tool span (#3 default-off)."""
     path = _content_session_file(tmp_path)
 
-    # Both the explicit None default and an all-False CaptureConfig.
+    parsed = parse_claude_code_session(path, capture=CaptureConfig(prompts=False))
+    assert parsed is not None
+    llm, tool = _llm_and_tool(parsed)
+    assert llm.attributes == {"source": "backfill.claude_code"}
+    assert tool.attributes == {"source": "backfill.claude_code"}
+
+
+def test_capture_default_extracts_prompt_only(tmp_path):
+    """`prompts` defaults on (E33) so `capture=None` and a bare `CaptureConfig()`
+    both extract prompt content — needed for `trim` / `cache-recommend` / `reuse`
+    out of the box — while completions/tool_inputs/tool_outputs stay off."""
+    path = _content_session_file(tmp_path)
+
     for capture in (None, CaptureConfig()):
         parsed = parse_claude_code_session(path, capture=capture)
         assert parsed is not None
         llm, tool = _llm_and_tool(parsed)
-        assert llm.attributes == {"source": "backfill.claude_code"}
-        assert tool.attributes == {"source": "backfill.claude_code"}
+        assert llm.attributes[GenAIAttributes.PROMPT_CONTENT] == \
+            "please read the config"
+        assert GenAIAttributes.COMPLETION_CONTENT not in llm.attributes
+        assert GenAIAttributes.TOOL_INPUT not in tool.attributes
 
 
 def test_capture_on_populates_prompt_completion_and_tool_input(tmp_path):
@@ -892,16 +906,25 @@ def test_capture_on_populates_prompt_completion_and_tool_input(tmp_path):
 
 
 def test_capture_flags_are_independent(tmp_path):
-    """Each toggle gates only its own field — flipping one never leaks another."""
+    """Each toggle gates only its own field — flipping one never leaks another.
+
+    `prompts` is explicitly off in both cases below: it defaults on (E33), so
+    leaving it unset would leak PROMPT_CONTENT into a test about `tool_inputs`
+    / `completions` gating independently of it.
+    """
     path = _content_session_file(tmp_path)
 
-    parsed = parse_claude_code_session(path, capture=CaptureConfig(tool_inputs=True))
+    parsed = parse_claude_code_session(
+        path, capture=CaptureConfig(prompts=False, tool_inputs=True),
+    )
     llm, tool = _llm_and_tool(parsed)
     assert GenAIAttributes.TOOL_INPUT in tool.attributes
     assert GenAIAttributes.PROMPT_CONTENT not in llm.attributes
     assert GenAIAttributes.COMPLETION_CONTENT not in llm.attributes
 
-    parsed = parse_claude_code_session(path, capture=CaptureConfig(completions=True))
+    parsed = parse_claude_code_session(
+        path, capture=CaptureConfig(prompts=False, completions=True),
+    )
     llm, tool = _llm_and_tool(parsed)
     assert GenAIAttributes.COMPLETION_CONTENT in llm.attributes
     assert GenAIAttributes.PROMPT_CONTENT not in llm.attributes
@@ -910,15 +933,18 @@ def test_capture_flags_are_independent(tmp_path):
 
 def test_ingest_persists_captured_content_when_config_enables_it(tmp_path):
     """End-to-end through ingest: with config.capture enabled, the stored span's
-    attributes column carries the content; default config stores nothing."""
+    attributes column carries the content; a capture-all-off config stores
+    nothing."""
     from tokenjam.core.config import TjConfig
 
     _content_session_file(tmp_path)
 
-    # Default config -> capture all-False -> no content persisted.
+    # Capture-all-off config -> no content persisted.
+    off_cfg = TjConfig(version="1")
+    off_cfg.capture = CaptureConfig(prompts=False)
     db = InMemoryBackend()
     try:
-        ingest_claude_code(db, root=tmp_path, config=TjConfig(version="1"))
+        ingest_claude_code(db, root=tmp_path, config=off_cfg)
         attrs = db.conn.execute(
             "SELECT attributes FROM spans WHERE name = $1",
             ["gen_ai.llm.call"],
@@ -1012,9 +1038,11 @@ def test_reingest_backfills_captured_content_onto_existing_spans(tmp_path):
 
     db = InMemoryBackend()
     try:
-        # 1. First ingest with capture OFF (default config) — spans land with
-        #    NO content, exactly the pre-#10 already-ingested state.
-        ingest_claude_code(db, root=tmp_path, config=TjConfig(version="1"))
+        # 1. First ingest with capture explicitly OFF — spans land with NO
+        #    content, exactly the pre-#10 already-ingested state.
+        off_cfg = TjConfig(version="1")
+        off_cfg.capture = CaptureConfig(prompts=False)
+        ingest_claude_code(db, root=tmp_path, config=off_cfg)
 
         def _attrs(name: str) -> dict:
             raw = db.conn.execute(

--- a/tests/unit/test_backfill.py
+++ b/tests/unit/test_backfill.py
@@ -862,17 +862,21 @@ def test_capture_off_leaves_attributes_unchanged(tmp_path):
     exactly {"source": ...} on both the LLM and tool span (#3 default-off)."""
     path = _content_session_file(tmp_path)
 
-    parsed = parse_claude_code_session(path, capture=CaptureConfig(prompts=False))
+    parsed = parse_claude_code_session(
+        path, capture=CaptureConfig(prompts=False, tool_inputs=False),
+    )
     assert parsed is not None
     llm, tool = _llm_and_tool(parsed)
     assert llm.attributes == {"source": "backfill.claude_code"}
     assert tool.attributes == {"source": "backfill.claude_code"}
 
 
-def test_capture_default_extracts_prompt_only(tmp_path):
-    """`prompts` defaults on (E33) so `capture=None` and a bare `CaptureConfig()`
-    both extract prompt content — needed for `trim` / `cache-recommend` / `reuse`
-    out of the box — while completions/tool_inputs/tool_outputs stay off."""
+def test_capture_default_extracts_prompt_and_tool_input(tmp_path):
+    """`prompts` and `tool_inputs` both default on (E33 / this fix) so
+    `capture=None` and a bare `CaptureConfig()` both extract prompt content
+    (needed for `trim` / `cache-recommend` / `reuse`) and tool_input (needed
+    for `script` / `verbosity`'s argument-shape clustering) out of the box,
+    while completions/tool_outputs stay off."""
     path = _content_session_file(tmp_path)
 
     for capture in (None, CaptureConfig()):
@@ -882,7 +886,8 @@ def test_capture_default_extracts_prompt_only(tmp_path):
         assert llm.attributes[GenAIAttributes.PROMPT_CONTENT] == \
             "please read the config"
         assert GenAIAttributes.COMPLETION_CONTENT not in llm.attributes
-        assert GenAIAttributes.TOOL_INPUT not in tool.attributes
+        assert tool.attributes[GenAIAttributes.TOOL_INPUT] == \
+            {"file_path": "/etc/app/config.toml"}
 
 
 def test_capture_on_populates_prompt_completion_and_tool_input(tmp_path):
@@ -908,9 +913,10 @@ def test_capture_on_populates_prompt_completion_and_tool_input(tmp_path):
 def test_capture_flags_are_independent(tmp_path):
     """Each toggle gates only its own field — flipping one never leaks another.
 
-    `prompts` is explicitly off in both cases below: it defaults on (E33), so
-    leaving it unset would leak PROMPT_CONTENT into a test about `tool_inputs`
-    / `completions` gating independently of it.
+    `prompts` and `tool_inputs` are both explicitly set in the cases below:
+    they default on (E33 / this fix), so leaving either unset would leak
+    PROMPT_CONTENT / TOOL_INPUT into a test about the other flags gating
+    independently of them.
     """
     path = _content_session_file(tmp_path)
 
@@ -923,7 +929,7 @@ def test_capture_flags_are_independent(tmp_path):
     assert GenAIAttributes.COMPLETION_CONTENT not in llm.attributes
 
     parsed = parse_claude_code_session(
-        path, capture=CaptureConfig(prompts=False, completions=True),
+        path, capture=CaptureConfig(prompts=False, completions=True, tool_inputs=False),
     )
     llm, tool = _llm_and_tool(parsed)
     assert GenAIAttributes.COMPLETION_CONTENT in llm.attributes
@@ -941,7 +947,7 @@ def test_ingest_persists_captured_content_when_config_enables_it(tmp_path):
 
     # Capture-all-off config -> no content persisted.
     off_cfg = TjConfig(version="1")
-    off_cfg.capture = CaptureConfig(prompts=False)
+    off_cfg.capture = CaptureConfig(prompts=False, tool_inputs=False)
     db = InMemoryBackend()
     try:
         ingest_claude_code(db, root=tmp_path, config=off_cfg)
@@ -1041,7 +1047,7 @@ def test_reingest_backfills_captured_content_onto_existing_spans(tmp_path):
         # 1. First ingest with capture explicitly OFF — spans land with NO
         #    content, exactly the pre-#10 already-ingested state.
         off_cfg = TjConfig(version="1")
-        off_cfg.capture = CaptureConfig(prompts=False)
+        off_cfg.capture = CaptureConfig(prompts=False, tool_inputs=False)
         ingest_claude_code(db, root=tmp_path, config=off_cfg)
 
         def _attrs(name: str) -> dict:
@@ -1103,7 +1109,8 @@ def test_reingest_capture_off_does_not_wipe_existing_content(tmp_path):
         cfg_on.capture = CaptureConfig(prompts=True, completions=True, tool_inputs=True)
         ingest_claude_code(db, root=tmp_path, config=cfg_on)
 
-        # Reingest with capture OFF (default config): content must survive.
+        # Reingest with a plain default config (prompts/tool_inputs on,
+        # completions off): existing content must survive the merge either way.
         ingest_claude_code(db, root=tmp_path, config=TjConfig(version="1"), reingest=True)
 
         raw = db.conn.execute(

--- a/tests/unit/test_cmd_policy.py
+++ b/tests/unit/test_cmd_policy.py
@@ -127,6 +127,7 @@ def test_agent_rows_emitted_only_for_overrides():
 def test_capture_row_always_shown():
     # Capture is a policy choice even when all toggles are off (#71 fix).
     cfg = _empty_config()
+    cfg.capture = CaptureConfig(prompts=False)
     row = next(r for r in _collect_rows(cfg) if r.policy == "capture")
     assert "prompts=false" in row.setting
     cfg.capture = CaptureConfig(prompts=True)

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -99,11 +99,12 @@ class TestParse:
         config = _parse({})
         assert config.version == "1"
         assert config.agents == {}
-        # prompts defaults on (needed by trim / cache-recommend / reuse);
-        # completions/tool_outputs/tool_inputs stay off.
+        # prompts (needed by trim / cache-recommend / reuse) and tool_inputs
+        # (needed by script / verbosity's argument-shape clustering) both
+        # default on; completions/tool_outputs stay off.
         assert config.capture.prompts is True
         assert config.capture.completions is False
-        assert config.capture.tool_inputs is False
+        assert config.capture.tool_inputs is True
         assert config.capture.tool_outputs is False
 
     def test_agents_parsed(self):

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -6,7 +6,7 @@ import pytest
 from tokenjam.core.config import (
     find_config_file, load_config, _parse, _serialise, TjConfig, AgentConfig,
     BudgetConfig, DefaultsConfig, SensitiveAction, SecurityConfig, CaptureConfig,
-    OptimizeConfig, StorageConfig, resolve_effective_budget, validate_budget_value,
+    StorageConfig, resolve_effective_budget, validate_budget_value,
 )
 
 
@@ -99,16 +99,12 @@ class TestParse:
         config = _parse({})
         assert config.version == "1"
         assert config.agents == {}
-        # prompts (needed by trim / cache-recommend / reuse) and tool_inputs
-        # (needed by script / verbosity's argument-shape clustering) both
-        # default on; completions/tool_outputs stay off.
+        # prompts defaults on (needed by trim / cache-recommend / reuse);
+        # completions/tool_outputs/tool_inputs stay off.
         assert config.capture.prompts is True
         assert config.capture.completions is False
-        assert config.capture.tool_inputs is True
+        assert config.capture.tool_inputs is False
         assert config.capture.tool_outputs is False
-        # An unset [optimize] section reproduces every analyzer's historical
-        # module-constant threshold exactly (config-thread contract).
-        assert config.optimize == OptimizeConfig()
 
     def test_agents_parsed(self):
         raw = {
@@ -144,39 +140,6 @@ class TestParse:
         assert config.capture.prompts is True
         assert config.capture.completions is False
         assert config.capture.tool_outputs is True
-
-    def test_optimize_parsed(self):
-        raw = {
-            "optimize": {
-                "min_cluster_instances": 5,
-                "cache_efficacy_threshold": 0.1,
-                "min_flag_cost_usd": 0.01,
-            }
-        }
-        config = _parse(raw)
-        assert config.optimize.min_cluster_instances == 5
-        assert config.optimize.cache_efficacy_threshold == 0.1
-        assert config.optimize.min_flag_cost_usd == 0.01
-        # Every field this test doesn't set falls back to the OptimizeConfig
-        # default (not a hardcoded literal in _parse) — same discipline as
-        # test_capture_parsed's untouched fields above.
-        assert config.optimize.min_sessions_deadweight == OptimizeConfig.min_sessions_deadweight
-        assert config.optimize.min_cache_input_tokens == OptimizeConfig.min_cache_input_tokens
-        assert config.optimize.min_calls_for_root_cause == OptimizeConfig.min_calls_for_root_cause
-        assert config.optimize.min_cohort_sessions == OptimizeConfig.min_cohort_sessions
-        assert config.optimize.min_prefix_occurrences == OptimizeConfig.min_prefix_occurrences
-        assert config.optimize.trim_significance_threshold == OptimizeConfig.trim_significance_threshold
-        assert config.optimize.min_reuse_repetitions == OptimizeConfig.min_reuse_repetitions
-        assert config.optimize.min_stretch_turns == OptimizeConfig.min_stretch_turns
-        assert config.optimize.min_recurring_sessions == OptimizeConfig.min_recurring_sessions
-        assert config.optimize.min_sessions_for_cadence == OptimizeConfig.min_sessions_for_cadence
-        assert config.optimize.min_group_cost_usd == OptimizeConfig.min_group_cost_usd
-
-    def test_optimize_missing_section_uses_all_defaults(self):
-        """A config predating [optimize] entirely (or one that omits it) picks
-        up every current default rather than being frozen at some literal."""
-        config = _parse({"version": "1"})
-        assert config.optimize == OptimizeConfig()
 
     def test_alerts_channels_parsed(self):
         raw = {
@@ -254,20 +217,6 @@ class TestSerialise:
         assert restored.proxy.mode == "suggest"
         # Defaults when [proxy] is absent.
         assert _parse({"version": "1"}).proxy.enabled is False
-
-    def test_optimize_roundtrip(self):
-        """[optimize] analyzer-threshold overrides round-trip through
-        serialise/parse, and an absent section still parses to defaults."""
-        config = TjConfig(version="1")
-        config.optimize.min_cluster_instances = 5
-        config.optimize.cache_efficacy_threshold = 0.1
-        restored = _parse(_serialise(config))
-        assert restored.optimize.min_cluster_instances == 5
-        assert restored.optimize.cache_efficacy_threshold == 0.1
-        # Untouched fields still round-trip at their defaults.
-        assert restored.optimize.min_sessions_deadweight == OptimizeConfig.min_sessions_deadweight
-        # Defaults when [optimize] is absent.
-        assert _parse({"version": "1"}).optimize == OptimizeConfig()
 
     def test_policies_roundtrip(self):
         """[[policies]] enforcement-plane policies round-trip (#220)."""

--- a/tests/unit/test_doctor_capture_prompts.py
+++ b/tests/unit/test_doctor_capture_prompts.py
@@ -1,0 +1,27 @@
+"""Doctor "Prompt capture" check (E33 follow-up): `capture.prompts` now
+defaults on, so this check flags the degraded case — off — rather than
+silently letting `trim` / `cache-recommend` / `reuse` go dark with no
+signal in `tj doctor`."""
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+from tokenjam.cli.cmd_doctor import _check_capture_prompts
+
+
+def _config(prompts: bool):
+    return SimpleNamespace(capture=SimpleNamespace(prompts=prompts))
+
+
+def test_ok_when_prompts_captured():
+    check = _check_capture_prompts(_config(True))
+    assert check["level"] == "ok"
+
+
+def test_info_when_prompts_off():
+    check = _check_capture_prompts(_config(False))
+    assert check["level"] == "info"
+    assert "trim" in check["message"]
+    assert "cache-recommend" in check["message"]
+    assert "reuse" in check["message"]
+    assert "capture.prompts = true" in check["message"]

--- a/tests/unit/test_no_tracker_ids_in_printed_strings.py
+++ b/tests/unit/test_no_tracker_ids_in_printed_strings.py
@@ -1,0 +1,164 @@
+"""No UNQUALIFIED tracker reference may reach a string the product prints.
+
+The problem is ambiguity, not references. A bare ``#56`` resolves against
+whatever repository the reader happens to be looking at, and internal and
+public number spaces genuinely collide, so the same token can be correct here
+and confidently wrong once pasted into an issue, a screenshot or another
+repo's thread. A printed string travels further than any other kind, straight
+out of the terminal and into all three.
+
+So this guard bans the BARE form and permits a qualified one, either
+``owner/repo#56`` or a full URL. A pointer to real background is useful
+information the user should get; deleting it is a loss. An earlier version of
+this guard banned every reference, and it promptly pushed a scrub into
+removing a correct public issue link from the spans-column-statistics warning,
+which is precisely the failure mode a blunt rule produces. Prefer the URL form
+in anything printed: a terminal linkifies nothing, and a URL survives being
+pasted anywhere.
+
+This guard also exists because a test used to assert the OPPOSITE: it required
+an internal id to be PRESENT in the doctor's MCP warning, so the suite
+actively defended the leak, and anyone who removed it was told by CI that they
+had broken something. See the leak-pinning entry in CLAUDE.md.
+
+Scope is deliberately the printed surface only. Comments and docstrings are
+developer-facing prose where a bare reference is legitimate shorthand, so
+docstrings are skipped and comments are never parsed as string constants at
+all.
+"""
+from __future__ import annotations
+
+import ast
+import re
+from pathlib import Path
+
+import pytest
+
+PACKAGE_ROOT = Path(__file__).resolve().parents[2] / "tokenjam"
+
+#: The shape of a tracker reference: a number sign and at least TWO digits.
+#: Two digits is the discriminator against an ordinal, as in "Your #1 fix",
+#: which is a number sign and a single digit used as a word.
+_TRACKER_REF = re.compile(r"#\d{2,}")
+
+#: An ``owner/repo`` immediately before the number sign qualifies the
+#: reference, so it resolves to the same artifact from anywhere. A full URL
+#: contains no number sign at all and never reaches this check.
+_QUALIFIER = re.compile(r"[A-Za-z0-9._-]+/[A-Za-z0-9._-]+\Z")
+
+
+def _is_qualified(value: str, ref_start: int) -> bool:
+    """True when the reference at ``ref_start`` names its repository."""
+    return bool(_QUALIFIER.search(value[:ref_start]))
+
+#: A tag opening: a number sign inside a markup or stylesheet blob is a colour
+#: literal (``color: #555``), never a tracker reference. Detected by the shape
+#: of the surrounding literal rather than by listing the files that contain
+#: one, so a new report template is covered the day it lands.
+_MARKUP = re.compile(r"<[a-zA-Z/]")
+
+
+def _is_markup(value: str) -> bool:
+    return bool(_MARKUP.search(value)) or "style=" in value
+
+
+def _docstring_nodes(tree: ast.AST) -> set[int]:
+    """Identity of every docstring constant, which this guard does not cover."""
+    found: set[int] = set()
+    for node in ast.walk(tree):
+        if not isinstance(
+            node, (ast.Module, ast.ClassDef, ast.FunctionDef, ast.AsyncFunctionDef)
+        ):
+            continue
+        body = getattr(node, "body", None)
+        if not body:
+            continue
+        first = body[0]
+        if (
+            isinstance(first, ast.Expr)
+            and isinstance(first.value, ast.Constant)
+            and isinstance(first.value.value, str)
+        ):
+            found.add(id(first.value))
+    return found
+
+
+def _offending_literals(path: Path) -> list[tuple[int, str]]:
+    tree = ast.parse(path.read_text(encoding="utf-8"))
+    docstrings = _docstring_nodes(tree)
+    hits: list[tuple[int, str]] = []
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Constant) or not isinstance(node.value, str):
+            continue
+        if id(node) in docstrings or _is_markup(node.value):
+            continue
+        for match in _TRACKER_REF.finditer(node.value):
+            if _is_qualified(node.value, match.start()):
+                continue
+            excerpt = node.value[max(0, match.start() - 60):match.end() + 20]
+            hits.append((node.lineno, " ".join(excerpt.split())))
+    return hits
+
+
+def _source_files() -> list[Path]:
+    return sorted(PACKAGE_ROOT.rglob("*.py"))
+
+
+def test_the_scan_actually_reaches_the_source_tree():
+    """A guard that silently walks an empty tree passes forever."""
+    files = _source_files()
+    assert len(files) > 100
+    assert any(f.name == "cmd_doctor.py" for f in files)
+
+
+@pytest.mark.parametrize("path", _source_files(), ids=lambda p: p.name)
+def test_no_tracker_reference_in_a_printed_string(path):
+    hits = _offending_literals(path)
+    assert not hits, (
+        f"{path.relative_to(PACKAGE_ROOT.parent)} has an UNQUALIFIED tracker "
+        f"reference in a string the product can print: {hits}. A bare number "
+        f"resolves against whatever repo the reader is looking at. If it names "
+        f"a real public artifact, qualify it (a full "
+        f"https://github.com/<owner>/<repo>/issues/<n> URL reads best in a "
+        f"terminal). If it names our own queue, describe what it referred to "
+        f"instead."
+    )
+
+
+def test_the_pattern_separates_references_from_colours_and_ordinals():
+    """The discriminators, pinned. If someone loosens the pattern to silence a
+    failure, this says which cases it was built to tell apart."""
+    # Tracker references: caught.
+    assert _TRACKER_REF.search("landed (see #55); ingest fails")
+    assert _TRACKER_REF.search("(+36% measured, ticket #59)")
+    # An ordinal is a number sign and ONE digit used as a word.
+    assert not _TRACKER_REF.search("[bold]Your #1 fix:[/bold]")
+    # Colour literals live in markup, which is excluded by literal shape.
+    assert _is_markup("<span style='color:#555'>x</span>")
+    assert _is_markup("h1 { color: #222; }\n</style>")
+    # A plain sentence with a comparison is not markup.
+    assert not _is_markup("keep this under <  10 sessions")
+
+
+def test_a_qualified_reference_passes_where_its_bare_twin_fails(tmp_path):
+    """THE WHOLE RULE, as one pair. Same number, same sentence: unqualified is
+    ambiguous and rejected, qualified is unambiguous and kept. The guard must
+    never make deleting a true reference look like the correct move."""
+    sentence = 'MSG = "column statistics are corrupt. Background: {ref}."\n'
+    bare = tmp_path / "bare.py"
+    bare.write_text(sentence.format(ref="see issue #56"), encoding="utf-8")
+    qualified = tmp_path / "qualified.py"
+    qualified.write_text(
+        sentence.format(ref="see Metabuilder-Labs/tokenjam#56"), encoding="utf-8",
+    )
+    url = tmp_path / "url.py"
+    url.write_text(
+        sentence.format(
+            ref="see https://github.com/Metabuilder-Labs/tokenjam/issues/56",
+        ),
+        encoding="utf-8",
+    )
+
+    assert _offending_literals(bare), "a bare reference must be rejected"
+    assert not _offending_literals(qualified), "owner/repo#n must be permitted"
+    assert not _offending_literals(url), "a full URL must be permitted"

--- a/tests/unit/test_onboard_capture_default.py
+++ b/tests/unit/test_onboard_capture_default.py
@@ -1,0 +1,160 @@
+"""Prompt capture defaults on (E33): `cache-recommend` and `trim` were dark,
+and `reuse` never reached its prompt-prefix mode, for every onboarded user
+because `capture.prompts` stayed false even though `capture.tool_inputs` was
+already flipped on. Covers:
+
+- The plain-flow config template writes `prompts = true`.
+- `--claude-code` / `--codex` fresh onboard inherit `prompts = true` from the
+  `CaptureConfig` dataclass default (they build `TjConfig(...)` directly,
+  with no literal template — see `core/config.py::CaptureConfig`).
+- The onboarding disclosure line names the new local-only capture.
+- Migration: re-running `--claude-code`/`--codex` with `--reconfigure` over
+  an existing config that has a stale `prompts = false` picks up the new
+  default; a plain re-run (no `--reconfigure`) leaves an explicit value
+  alone.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+from click.testing import CliRunner
+
+from tokenjam.cli.cmd_onboard import cmd_onboard
+from tokenjam.core.config import load_config
+
+# --- Plain flow ---------------------------------------------------------
+
+
+@pytest.fixture(autouse=True)
+def _no_existing_config(monkeypatch):
+    monkeypatch.setattr("tokenjam.cli.cmd_onboard.find_config_file", lambda: None)
+
+
+def _run_plain(tmp_path):
+    runner = CliRunner()
+    with runner.isolated_filesystem(temp_dir=tmp_path):
+        res = runner.invoke(cmd_onboard, ["--no-daemon", "--budget", "0"], obj={})
+        cfg = Path(".tj/config.toml")
+        return res, (cfg.read_text() if cfg.exists() else "")
+
+
+def test_plain_onboard_writes_prompts_true(tmp_path):
+    res, cfg_text = _run_plain(tmp_path)
+    assert res.exit_code == 0, res.output
+    assert "prompts = true" in cfg_text
+    assert "tool_inputs = true" in cfg_text
+    # completions/tool_outputs stay off — this fix is scoped to prompts only.
+    assert "completions = false" in cfg_text
+    assert "tool_outputs = false" in cfg_text
+
+
+def test_plain_onboard_prints_capture_disclosure(tmp_path):
+    res, _ = _run_plain(tmp_path)
+    assert res.exit_code == 0, res.output
+    assert "Prompt capture" in res.output
+    assert "locally" in res.output
+    assert "capture.prompts = false" in res.output  # the opt-out instruction
+
+
+# --- --claude-code / --codex fresh onboard: dataclass default ----------
+#
+# Neither `_onboard_claude_code` nor `_onboard_codex` write a literal
+# `[capture]` block on a fresh config — they build `TjConfig(...)` directly,
+# so a fresh onboard here is exercising the `CaptureConfig` dataclass default,
+# not a template string. If that default ever regresses to False, these are
+# the tests that catch it (the plain-flow test above only covers the
+# template).
+
+
+@pytest.fixture
+def _isolated_home(monkeypatch, tmp_path):
+    monkeypatch.setattr("pathlib.Path.home", lambda: tmp_path)
+    monkeypatch.setattr(
+        "tokenjam.cli.cmd_onboard._stop_serve_for_db_write", lambda: False,
+    )
+    monkeypatch.setattr(
+        "tokenjam.cli.cmd_onboard._finish_onboard_serve", lambda *a, **k: None,
+    )
+    monkeypatch.setattr(
+        "tokenjam.cli.cmd_onboard._try_apply_declared_plans", lambda *a, **k: None,
+    )
+    monkeypatch.setattr("tokenjam.cli.cmd_onboard.shutil.which", lambda _x: None)
+    import tokenjam.core.backfill as backfill_mod
+    monkeypatch.setattr(
+        backfill_mod, "CLAUDE_CODE_PROJECTS_ROOT", tmp_path / "no-such-claude",
+    )
+
+
+def _invoke(tmp_path, *args, input_text: str = ""):
+    runner = CliRunner()
+    with runner.isolated_filesystem(temp_dir=tmp_path):
+        res = runner.invoke(cmd_onboard, ["--no-daemon", *args], input=input_text, obj={})
+        cfg_path = tmp_path / ".config" / "tj" / "config.toml"
+        return res, cfg_path
+
+
+def test_claude_code_fresh_onboard_captures_prompts_by_default(_isolated_home, tmp_path):
+    res, cfg_path = _invoke(
+        tmp_path, "--claude-code", "--project", "testproj", "--plan", "max_5x",
+    )
+    assert res.exit_code == 0, res.output
+    config = load_config(str(cfg_path))
+    assert config.capture.prompts is True
+    assert "Prompt capture" in res.output
+
+
+def test_codex_fresh_onboard_captures_prompts_by_default(_isolated_home, tmp_path):
+    res, cfg_path = _invoke(tmp_path, "--codex", "--plan", "plus")
+    assert res.exit_code == 0, res.output
+    config = load_config(str(cfg_path))
+    assert config.capture.prompts is True
+    assert "Prompt capture" in res.output
+
+
+# --- Migration: re-onboarding over a pre-existing stale config ---------
+
+
+def _seed_stale_config(tmp_path, *, provider: str, plan: str):
+    cfg_dir = tmp_path / ".config" / "tj"
+    cfg_dir.mkdir(parents=True)
+    (cfg_dir / "config.toml").write_text(
+        f'version = "1"\n'
+        f"[security]\ningest_secret = \"{'a' * 64}\"\n"
+        f"[budget.{provider}]\nplan = \"{plan}\"\ncycle_start_day = 1\n"
+        f"[capture]\nprompts = false\ntool_inputs = true\n"
+    )
+
+
+def test_claude_code_reconfigure_upgrades_stale_prompts_false(_isolated_home, tmp_path):
+    _seed_stale_config(tmp_path, provider="anthropic", plan="max_20x")
+    res, cfg_path = _invoke(
+        tmp_path, "--claude-code", "--project", "testproj",
+        "--reconfigure", "--plan", "max_20x",
+    )
+    assert res.exit_code == 0, res.output
+    config = load_config(str(cfg_path))
+    assert config.capture.prompts is True
+    assert "Prompt capture" in res.output
+
+
+def test_codex_reconfigure_upgrades_stale_prompts_false(_isolated_home, tmp_path):
+    _seed_stale_config(tmp_path, provider="openai", plan="team")
+    res, cfg_path = _invoke(tmp_path, "--codex", "--reconfigure", "--plan", "team")
+    assert res.exit_code == 0, res.output
+    config = load_config(str(cfg_path))
+    assert config.capture.prompts is True
+    assert "Prompt capture" in res.output
+
+
+def test_claude_code_plain_rerun_leaves_explicit_false_alone(_isolated_home, tmp_path):
+    """No --reconfigure: an explicit `prompts = false` is left as-is rather
+    than silently flipped — only the deliberate `--reconfigure` action picks
+    up the new default (see the comment at the call site in
+    `_onboard_claude_code`)."""
+    _seed_stale_config(tmp_path, provider="anthropic", plan="max_20x")
+    res, cfg_path = _invoke(tmp_path, "--claude-code", "--project", "testproj")
+    assert res.exit_code == 0, res.output
+    config = load_config(str(cfg_path))
+    assert config.capture.prompts is False
+    assert "Prompt capture" not in res.output

--- a/tests/unit/test_onboard_hygiene.py
+++ b/tests/unit/test_onboard_hygiene.py
@@ -26,12 +26,15 @@ def test_capture_block_has_all_four_toggles(tmp_path):
     # #15: onboard previously omitted tool_inputs (CLAUDE.md documents four).
     res, cfg = _run(tmp_path)
     assert res.exit_code == 0, res.output
-    for key in ("prompts", "completions", "tool_outputs"):
+    for key in ("completions", "tool_outputs"):
         assert f"{key} = false" in cfg, f"[capture] missing {key}"
     # tool_inputs defaults ON: it only captures file paths / search queries
     # (not message or tool-output content), which is what lets the recurring-
     # inclusion attribution (statusline / `tj context`) work out of the box.
     assert "tool_inputs = true" in cfg, "[capture] tool_inputs should default on"
+    # prompts defaults ON too (E33): without it, trim / cache-recommend / the
+    # sharper mode of reuse are dark for every onboarded user.
+    assert "prompts = true" in cfg, "[capture] prompts should default on"
 
 
 def test_no_stale_openclawwatch_url(tmp_path):

--- a/tests/unit/test_onboard_tool_inputs_default.py
+++ b/tests/unit/test_onboard_tool_inputs_default.py
@@ -1,0 +1,168 @@
+"""Tool-input capture was inverted across onboarding flows: the plain/SDK
+flow wrote `[capture] tool_inputs = true` in its literal TOML template (whose
+own comment mistakenly credited it to `tj context` / the statusline — both
+Claude Code-only features the SDK/bare persona never reaches), while
+`--claude-code` / `--codex` never set it at all and silently inherited the
+`CaptureConfig.tool_inputs` dataclass default of `False`. That default is
+exactly backwards: Claude Code's JSONL backfill is the persona that actually
+populates `gen_ai.tool.input` (Read/Grep/Glob file paths and search queries),
+which the `script` (workflow-restructure) and `verbosity` analyzers need for
+argument-shape clustering instead of falling back to tool-names-only,
+degraded mode.
+
+This mirrors `test_onboard_capture_default.py`'s coverage of the earlier
+`prompts` default-flip, applied to `tool_inputs`. Covers:
+
+- The plain-flow config template still writes `tool_inputs = true` (unchanged
+  value, corrected comment).
+- `--claude-code` / `--codex` fresh onboard now inherit `tool_inputs = true`
+  from the `CaptureConfig` dataclass default (they build `TjConfig(...)`
+  directly, with no literal template — see `core/config.py::CaptureConfig`).
+- The onboarding disclosure line names the newly-corrected local-only capture.
+- Migration: re-running `--claude-code`/`--codex` with `--reconfigure` over
+  an existing config that has a stale `tool_inputs = false` picks up the new
+  default; a plain re-run (no `--reconfigure`) leaves an explicit value alone.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+from click.testing import CliRunner
+
+from tokenjam.cli.cmd_onboard import cmd_onboard
+from tokenjam.core.config import load_config
+
+# --- Plain flow ---------------------------------------------------------
+
+
+@pytest.fixture(autouse=True)
+def _no_existing_config(monkeypatch):
+    monkeypatch.setattr("tokenjam.cli.cmd_onboard.find_config_file", lambda: None)
+
+
+def _run_plain(tmp_path):
+    runner = CliRunner()
+    with runner.isolated_filesystem(temp_dir=tmp_path):
+        res = runner.invoke(cmd_onboard, ["--no-daemon", "--budget", "0"], obj={})
+        cfg = Path(".tj/config.toml")
+        return res, (cfg.read_text() if cfg.exists() else "")
+
+
+def test_plain_onboard_still_writes_tool_inputs_true(tmp_path):
+    # Value is unchanged (it was already correct here); this guards against a
+    # future edit accidentally flipping it while fixing the misleading comment.
+    res, cfg_text = _run_plain(tmp_path)
+    assert res.exit_code == 0, res.output
+    assert "tool_inputs = true" in cfg_text
+
+
+def test_plain_onboard_prints_tool_input_disclosure(tmp_path):
+    res, _ = _run_plain(tmp_path)
+    assert res.exit_code == 0, res.output
+    assert "Tool-input capture" in res.output
+    assert "locally" in res.output
+    assert "capture.tool_inputs = false" in res.output  # the opt-out instruction
+
+
+# --- --claude-code / --codex fresh onboard: dataclass default ----------
+#
+# Neither `_onboard_claude_code` nor `_onboard_codex` write a literal
+# `[capture]` block on a fresh config — they build `TjConfig(...)` directly,
+# so a fresh onboard here is exercising the `CaptureConfig` dataclass default,
+# not a template string. If that default ever regresses to False, these are
+# the tests that catch it (the plain-flow test above only covers the
+# template).
+
+
+@pytest.fixture
+def _isolated_home(monkeypatch, tmp_path):
+    monkeypatch.setattr("pathlib.Path.home", lambda: tmp_path)
+    monkeypatch.setattr(
+        "tokenjam.cli.cmd_onboard._stop_serve_for_db_write", lambda: False,
+    )
+    monkeypatch.setattr(
+        "tokenjam.cli.cmd_onboard._finish_onboard_serve", lambda *a, **k: None,
+    )
+    monkeypatch.setattr(
+        "tokenjam.cli.cmd_onboard._try_apply_declared_plans", lambda *a, **k: None,
+    )
+    monkeypatch.setattr("tokenjam.cli.cmd_onboard.shutil.which", lambda _x: None)
+    import tokenjam.core.backfill as backfill_mod
+    monkeypatch.setattr(
+        backfill_mod, "CLAUDE_CODE_PROJECTS_ROOT", tmp_path / "no-such-claude",
+    )
+
+
+def _invoke(tmp_path, *args, input_text: str = ""):
+    runner = CliRunner()
+    with runner.isolated_filesystem(temp_dir=tmp_path):
+        res = runner.invoke(cmd_onboard, ["--no-daemon", *args], input=input_text, obj={})
+        cfg_path = tmp_path / ".config" / "tj" / "config.toml"
+        return res, cfg_path
+
+
+def test_claude_code_fresh_onboard_captures_tool_inputs_by_default(_isolated_home, tmp_path):
+    res, cfg_path = _invoke(
+        tmp_path, "--claude-code", "--project", "testproj", "--plan", "max_5x",
+    )
+    assert res.exit_code == 0, res.output
+    config = load_config(str(cfg_path))
+    assert config.capture.tool_inputs is True
+    assert "Tool-input capture" in res.output
+
+
+def test_codex_fresh_onboard_captures_tool_inputs_by_default(_isolated_home, tmp_path):
+    res, cfg_path = _invoke(tmp_path, "--codex", "--plan", "plus")
+    assert res.exit_code == 0, res.output
+    config = load_config(str(cfg_path))
+    assert config.capture.tool_inputs is True
+    assert "Tool-input capture" in res.output
+
+
+# --- Migration: re-onboarding over a pre-existing stale config ---------
+
+
+def _seed_stale_config(tmp_path, *, provider: str, plan: str):
+    cfg_dir = tmp_path / ".config" / "tj"
+    cfg_dir.mkdir(parents=True)
+    (cfg_dir / "config.toml").write_text(
+        f'version = "1"\n'
+        f"[security]\ningest_secret = \"{'a' * 64}\"\n"
+        f"[budget.{provider}]\nplan = \"{plan}\"\ncycle_start_day = 1\n"
+        f"[capture]\nprompts = true\ntool_inputs = false\n"
+    )
+
+
+def test_claude_code_reconfigure_upgrades_stale_tool_inputs_false(_isolated_home, tmp_path):
+    _seed_stale_config(tmp_path, provider="anthropic", plan="max_20x")
+    res, cfg_path = _invoke(
+        tmp_path, "--claude-code", "--project", "testproj",
+        "--reconfigure", "--plan", "max_20x",
+    )
+    assert res.exit_code == 0, res.output
+    config = load_config(str(cfg_path))
+    assert config.capture.tool_inputs is True
+    assert "Tool-input capture" in res.output
+
+
+def test_codex_reconfigure_upgrades_stale_tool_inputs_false(_isolated_home, tmp_path):
+    _seed_stale_config(tmp_path, provider="openai", plan="team")
+    res, cfg_path = _invoke(tmp_path, "--codex", "--reconfigure", "--plan", "team")
+    assert res.exit_code == 0, res.output
+    config = load_config(str(cfg_path))
+    assert config.capture.tool_inputs is True
+    assert "Tool-input capture" in res.output
+
+
+def test_claude_code_plain_rerun_leaves_explicit_false_alone(_isolated_home, tmp_path):
+    """No --reconfigure: an explicit `tool_inputs = false` is left as-is
+    rather than silently flipped — only the deliberate `--reconfigure` action
+    picks up the new default (see the comment at the call site in
+    `_onboard_claude_code`)."""
+    _seed_stale_config(tmp_path, provider="anthropic", plan="max_20x")
+    res, cfg_path = _invoke(tmp_path, "--claude-code", "--project", "testproj")
+    assert res.exit_code == 0, res.output
+    config = load_config(str(cfg_path))
+    assert config.capture.tool_inputs is False
+    assert "Tool-input capture" not in res.output

--- a/tests/unit/test_provider_content_capture.py
+++ b/tests/unit/test_provider_content_capture.py
@@ -293,12 +293,21 @@ class TestIngestGate:
         return IngestPipeline(db=db, config=TjConfig(version="1", capture=capture)), db
 
     def test_stripped_when_capture_off(self):
-        # Default capture (all off) — content must be gone from the stored span,
-        # exactly like the litellm path.
-        pipeline, db = self._pipeline(CaptureConfig())
+        # Every toggle explicitly off — content must be gone from the stored
+        # span, exactly like the litellm path.
+        pipeline, db = self._pipeline(CaptureConfig(prompts=False))
         pipeline.process(self._span_with_content())
         stored = db.get_recent_spans("s1", 1)[0]
         assert GenAIAttributes.PROMPT_CONTENT not in stored.attributes
+        assert GenAIAttributes.COMPLETION_CONTENT not in stored.attributes
+        db.close()
+
+    def test_default_capture_keeps_prompt_strips_completion(self):
+        # `prompts` defaults on (E33); `completions` stays off.
+        pipeline, db = self._pipeline(CaptureConfig())
+        pipeline.process(self._span_with_content())
+        stored = db.get_recent_spans("s1", 1)[0]
+        assert "secret prompt" in stored.attributes[GenAIAttributes.PROMPT_CONTENT]
         assert GenAIAttributes.COMPLETION_CONTENT not in stored.attributes
         db.close()
 

--- a/tokenjam/cli/cmd_doctor.py
+++ b/tokenjam/cli/cmd_doctor.py
@@ -43,6 +43,9 @@ def cmd_doctor(ctx: click.Context, output_json: bool, repair: bool) -> None:
     # 6. Drift configured but inactive
     checks.append(_check_drift_inactive(config, ctx.obj["db"]))
 
+    # 6b. Prompt capture off — trim / cache-recommend / reuse degraded
+    checks.append(_check_capture_prompts(config))
+
     # 7. Webhook URL security
     checks.extend(_check_webhook_security(config))
 
@@ -194,6 +197,25 @@ def _check_schema_vs_capture(config: object) -> dict:
                            "Schema validation will have no data to validate."}
     return {"name": "Schema vs capture", "level": "ok",
             "message": "Schema and capture settings are consistent."}
+
+
+def _check_capture_prompts(config: object) -> dict:
+    """`capture.prompts` defaults on; flag when it's off so the user (running
+    a config that predates the default, or one that turned it off on
+    purpose) knows `trim` and `cache-recommend` produce no findings and
+    `reuse` never reaches its prompt-prefix mode without it — not that
+    they're broken."""
+    if getattr(config.capture, "prompts", False):
+        return {"name": "Prompt capture", "level": "ok",
+                "message": "capture.prompts is on: trim, cache-recommend, "
+                           "and reuse's prompt-prefix mode have data."}
+    return {"name": "Prompt capture", "level": "info",
+            "message": "capture.prompts is off. `tj optimize trim` and "
+                       "`cache-recommend` will produce no findings, and "
+                       "`reuse` stays on tool-sequence-only clustering. Set "
+                       "capture.prompts = true under [capture] in your "
+                       "config to enable them (stored locally in your "
+                       "telemetry DB, never sent anywhere)."}
 
 
 def _check_drift_inactive(config: object, db: object) -> dict:

--- a/tokenjam/cli/cmd_doctor.py
+++ b/tokenjam/cli/cmd_doctor.py
@@ -16,7 +16,8 @@ from tokenjam.utils.formatting import console, display_path
     "--repair",
     is_flag=True,
     help="Attempt to fix issues that have a known repair path (e.g. rebuild the "
-         "spans table when DuckDB column statistics are corrupt — see issue #56).",
+         "spans table when DuckDB column statistics are corrupt: "
+         "https://github.com/Metabuilder-Labs/tokenjam/issues/56).",
 )
 @click.pass_context
 def cmd_doctor(ctx: click.Context, output_json: bool, repair: bool) -> None:
@@ -283,7 +284,8 @@ def _check_spans_stats(db: object) -> dict:
                        "— trace-detail queries (`tj traces <id>`, dashboard "
                        "trace view) will return no spans. Run `tj doctor "
                        "--repair` to rebuild the table (data is preserved). "
-                       "See issue #56.",
+                       "Background: "
+                       "https://github.com/Metabuilder-Labs/tokenjam/issues/56.",
             "repair_action": "rebuild_spans",
         }
     return {"name": "Spans column statistics", "level": "ok",
@@ -324,7 +326,7 @@ def _check_schema_integrity(db: object) -> dict:
             "message": (
                 "Live schema is missing column(s) the code writes on ingest: "
                 f"{', '.join(missing)}. These were recorded as migrated but never "
-                "landed (see #55); ingest of affected rows fails with a DuckDB "
+                "landed; ingest of affected rows fails with a DuckDB "
                 "Binder Error and is silently dropped, surfacing as a blank/stale "
                 "Status page. Run `tj doctor --repair` to add them (idempotent, "
                 "data preserved)."
@@ -546,8 +548,8 @@ def _check_mcp_wiring(config: object) -> dict:
             "level": "warning",
             "message": (
                 f"MCP server registered in {', '.join(found_locations)} — an "
-                "in-loop MCP is a per-turn quota tax on subscription users "
-                "(+36% measured, ticket #59), not the recommended surface for "
+                "in-loop MCP is a per-turn token tax on subscription users "
+                "(+36% measured), not the recommended surface for "
                 "Claude Code / Codex. Remove it: " + "; ".join(removal_hints) + ". "
                 "The MCP is meant for SDK / API integrations only."
             ),

--- a/tokenjam/cli/cmd_onboard.py
+++ b/tokenjam/cli/cmd_onboard.py
@@ -347,6 +347,28 @@ def _print_matched_instrument_snippet(match: SdkMatch) -> None:
         console.print(f"[dim]     {escape(hint)}[/dim]")
 
 
+def _print_capture_disclosure(prompts_captured: bool) -> None:
+    """Disclose prompt-text capture state at the end of onboarding.
+
+    `capture.prompts` defaults on (see `CaptureConfig` in `core/config.py`)
+    so `tj optimize trim` / `cache-recommend` and `reuse`'s sharper mode work
+    without extra setup. Storage stays local — the user's own telemetry DB —
+    but that doesn't make it exempt from disclosure: this is new data at
+    rest the user didn't have before, so every onboarding path says so
+    explicitly rather than leaving it to a comment in the config file.
+    """
+    if not prompts_captured:
+        return
+    # escape(): "[capture]" would otherwise be parsed as a Rich markup tag
+    # and silently stripped — same class of bug as issue #157.
+    console.print(
+        "  Prompt capture:      [bold]on[/bold], prompt text is stored "
+        "locally in your telemetry DB (needed for trim / cache-recommend / "
+        "reuse). Set [bold]capture.prompts = false[/bold] under "
+        f"{escape('[capture]')} in your config to turn it off."
+    )
+
+
 def _print_instrument_agent_snippet() -> None:
     """Print the bare-onboard "instrument your agent" snippet (issue #85).
 
@@ -582,13 +604,17 @@ def cmd_onboard(ctx: click.Context, claude_code: bool, codex: bool, budget: floa
 ingest_secret = "{ingest_secret}"
 
 [capture]
-prompts = false
+# prompts is on by default: `tj optimize trim` / `cache-recommend` and the
+# sharper mode of `reuse` all read captured prompt text, and stay dark
+# without it. Storage is local-only (your own telemetry DB below); nothing
+# is sent anywhere. Set this to false to turn it off.
+prompts = true
 completions = false
 # tool_inputs captures Read/Grep/Glob file paths + search queries (not their
 # content) so `tj context` / the statusline can name files or searches you
-# keep re-reading across sessions. prompts/tool_outputs stay off by default
-# since those would persist actual message/tool-output text; turn them on for
-# deeper analysis.
+# keep re-reading across sessions. completions/tool_outputs stay off by
+# default since those would persist actual completion/tool-output text; turn
+# them on for deeper analysis.
 tool_inputs = true
 tool_outputs = false
 
@@ -648,6 +674,7 @@ retention_days = 90
                       f"[bold]{plan_tier}[/bold] (written to {plan_section})")
     if daemon_msg:
         console.print(f"[green]\u2713[/green] {daemon_msg}")
+    _print_capture_disclosure(plain_config.capture.prompts)
 
     console.print()
     console.print("[bold]Next steps:[/bold]")
@@ -1508,6 +1535,16 @@ def _onboard_claude_code(
         if agent_id not in config.agents:
             config.agents[agent_id] = AgentConfig()
 
+        # A config written before prompt capture defaulted on has an explicit
+        # `prompts = false` baked in — don't skip a stale-value rewrite just
+        # because the key is already present (the same dotfile-managed-block
+        # stale-marker trap CLAUDE.md documents elsewhere). `--reconfigure` is
+        # a deliberate "redo my setup" action, so treat it as license to pick
+        # up the current default rather than leaving that stale value in
+        # place forever.
+        if reconfigure:
+            config.capture.prompts = True
+
         existing_plan = (
             config.budgets["anthropic"].plan
             if "anthropic" in config.budgets else None
@@ -1879,6 +1916,7 @@ def _onboard_claude_code(
             f"  Lens (web UI):       http://127.0.0.1:{port}/ "
             "(the daemon keeps it running)"
         )
+    _print_capture_disclosure(config.capture.prompts)
     console.print()
     # tj is out-of-band for Claude Code: the statusline (zero model tokens),
     # not an in-loop MCP server. Say so explicitly so users know where tj lives.
@@ -2021,6 +2059,12 @@ def _onboard_codex(
         config = load_config(str(config_path))
         if agent_id not in config.agents:
             config.agents[agent_id] = AgentConfig()
+
+        # See the matching comment in `_onboard_claude_code`: `--reconfigure`
+        # is license to pick up the current capture default rather than
+        # leaving a stale pre-default `prompts = false` in place forever.
+        if reconfigure:
+            config.capture.prompts = True
 
         existing_plan = (
             config.budgets["openai"].plan
@@ -2239,6 +2283,7 @@ def _onboard_codex(
     console.print("  Integration:         out-of-band (OTel telemetry — zero token cost)")
     if codex_backfill_msg:
         console.print(f"  Backfilled:          {codex_backfill_msg}")
+    _print_capture_disclosure(config.capture.prompts)
     if mcp_was_removed:
         # Plain echo: Rich would treat [mcp_servers.tj] as a markup tag and strip it.
         click.echo(

--- a/tokenjam/cli/cmd_onboard.py
+++ b/tokenjam/cli/cmd_onboard.py
@@ -347,26 +347,37 @@ def _print_matched_instrument_snippet(match: SdkMatch) -> None:
         console.print(f"[dim]     {escape(hint)}[/dim]")
 
 
-def _print_capture_disclosure(prompts_captured: bool) -> None:
-    """Disclose prompt-text capture state at the end of onboarding.
+def _print_capture_disclosure(prompts_captured: bool, tool_inputs_captured: bool = False) -> None:
+    """Disclose prompt-text / tool-input capture state at the end of onboarding.
 
-    `capture.prompts` defaults on (see `CaptureConfig` in `core/config.py`)
-    so `tj optimize trim` / `cache-recommend` and `reuse`'s sharper mode work
-    without extra setup. Storage stays local — the user's own telemetry DB —
-    but that doesn't make it exempt from disclosure: this is new data at
-    rest the user didn't have before, so every onboarding path says so
-    explicitly rather than leaving it to a comment in the config file.
+    `capture.prompts` and `capture.tool_inputs` both default on (see
+    `CaptureConfig` in `core/config.py`) so `tj optimize trim` /
+    `cache-recommend` / `reuse`'s sharper mode, and the `script` / `verbosity`
+    analyzers' argument-shape clustering, work without extra setup. Storage
+    stays local — the user's own telemetry DB — but that doesn't make it
+    exempt from disclosure: this is new data at rest the user didn't have
+    before, so every onboarding path says so explicitly rather than leaving
+    it to a comment in the config file.
     """
-    if not prompts_captured:
+    if not (prompts_captured or tool_inputs_captured):
         return
     # escape(): "[capture]" would otherwise be parsed as a Rich markup tag
     # and silently stripped — same class of bug as issue #157.
-    console.print(
-        "  Prompt capture:      [bold]on[/bold], prompt text is stored "
-        "locally in your telemetry DB (needed for trim / cache-recommend / "
-        "reuse). Set [bold]capture.prompts = false[/bold] under "
-        f"{escape('[capture]')} in your config to turn it off."
-    )
+    if prompts_captured:
+        console.print(
+            "  Prompt capture:      [bold]on[/bold], prompt text is stored "
+            "locally in your telemetry DB (needed for trim / cache-recommend / "
+            "reuse). Set [bold]capture.prompts = false[/bold] under "
+            f"{escape('[capture]')} in your config to turn it off."
+        )
+    if tool_inputs_captured:
+        console.print(
+            "  Tool-input capture:  [bold]on[/bold], tool call arguments are "
+            "stored locally in your telemetry DB (needed for script / "
+            "verbosity's argument-shape clustering). Set "
+            "[bold]capture.tool_inputs = false[/bold] under "
+            f"{escape('[capture]')} in your config to turn it off."
+        )
 
 
 def _print_instrument_agent_snippet() -> None:
@@ -610,11 +621,12 @@ ingest_secret = "{ingest_secret}"
 # is sent anywhere. Set this to false to turn it off.
 prompts = true
 completions = false
-# tool_inputs captures Read/Grep/Glob file paths + search queries (not their
-# content) so `tj context` / the statusline can name files or searches you
-# keep re-reading across sessions. completions/tool_outputs stay off by
-# default since those would persist actual completion/tool-output text; turn
-# them on for deeper analysis.
+# tool_inputs is on by default too: it captures the tool call arguments your
+# instrumentation records (e.g. via `record_tool_call`, or the declared tool
+# schema on an Anthropic/OpenAI/etc. request) so the `script` and `verbosity`
+# analyzers can cluster on argument shape instead of tool names alone.
+# completions/tool_outputs stay off by default since those would persist
+# actual completion/tool-output text; turn them on for deeper analysis.
 tool_inputs = true
 tool_outputs = false
 
@@ -674,7 +686,7 @@ retention_days = 90
                       f"[bold]{plan_tier}[/bold] (written to {plan_section})")
     if daemon_msg:
         console.print(f"[green]\u2713[/green] {daemon_msg}")
-    _print_capture_disclosure(plain_config.capture.prompts)
+    _print_capture_disclosure(plain_config.capture.prompts, plain_config.capture.tool_inputs)
 
     console.print()
     console.print("[bold]Next steps:[/bold]")
@@ -1535,15 +1547,16 @@ def _onboard_claude_code(
         if agent_id not in config.agents:
             config.agents[agent_id] = AgentConfig()
 
-        # A config written before prompt capture defaulted on has an explicit
-        # `prompts = false` baked in — don't skip a stale-value rewrite just
-        # because the key is already present (the same dotfile-managed-block
-        # stale-marker trap CLAUDE.md documents elsewhere). `--reconfigure` is
-        # a deliberate "redo my setup" action, so treat it as license to pick
-        # up the current default rather than leaving that stale value in
-        # place forever.
+        # A config written before prompt/tool-input capture defaulted on has
+        # an explicit `prompts = false` / `tool_inputs = false` baked in —
+        # don't skip a stale-value rewrite just because the key is already
+        # present (the same dotfile-managed-block stale-marker trap CLAUDE.md
+        # documents elsewhere). `--reconfigure` is a deliberate "redo my
+        # setup" action, so treat it as license to pick up the current
+        # defaults rather than leaving those stale values in place forever.
         if reconfigure:
             config.capture.prompts = True
+            config.capture.tool_inputs = True
 
         existing_plan = (
             config.budgets["anthropic"].plan
@@ -1916,7 +1929,7 @@ def _onboard_claude_code(
             f"  Lens (web UI):       http://127.0.0.1:{port}/ "
             "(the daemon keeps it running)"
         )
-    _print_capture_disclosure(config.capture.prompts)
+    _print_capture_disclosure(config.capture.prompts, config.capture.tool_inputs)
     console.print()
     # tj is out-of-band for Claude Code: the statusline (zero model tokens),
     # not an in-loop MCP server. Say so explicitly so users know where tj lives.
@@ -2061,10 +2074,12 @@ def _onboard_codex(
             config.agents[agent_id] = AgentConfig()
 
         # See the matching comment in `_onboard_claude_code`: `--reconfigure`
-        # is license to pick up the current capture default rather than
-        # leaving a stale pre-default `prompts = false` in place forever.
+        # is license to pick up the current capture defaults rather than
+        # leaving stale pre-default `prompts = false` / `tool_inputs = false`
+        # in place forever.
         if reconfigure:
             config.capture.prompts = True
+            config.capture.tool_inputs = True
 
         existing_plan = (
             config.budgets["openai"].plan
@@ -2283,7 +2298,7 @@ def _onboard_codex(
     console.print("  Integration:         out-of-band (OTel telemetry — zero token cost)")
     if codex_backfill_msg:
         console.print(f"  Backfilled:          {codex_backfill_msg}")
-    _print_capture_disclosure(config.capture.prompts)
+    _print_capture_disclosure(config.capture.prompts, config.capture.tool_inputs)
     if mcp_was_removed:
         # Plain echo: Rich would treat [mcp_servers.tj] as a markup tag and strip it.
         click.echo(

--- a/tokenjam/cli/cmd_optimize.py
+++ b/tokenjam/cli/cmd_optimize.py
@@ -491,13 +491,14 @@ def _run_validate(
             "while tj serve holds the lock. Stop the daemon (tj stop) and retry."
         )
 
-    # Gate 1: prompt capture must be on — off by default for privacy, so this is
-    # an opt-in power feature. Actionable message + the exact config hint.
+    # Gate 1: prompt capture must be on. Capture defaults on, so this only
+    # fires when it's been explicitly turned off. Actionable message + the
+    # exact config hint either way.
     if not getattr(config.capture, "prompts", False):
         _fail(
             "tj optimize --validate re-runs your recorded prompts, which requires "
-            "prompt capture. It is off by default (privacy). Enable it in your "
-            "config under [capture]:\n\n    [capture]\n    prompts = true\n\n"
+            "prompt capture. It is currently off in your config. Enable it "
+            "under [capture]:\n\n    [capture]\n    prompts = true\n\n"
             "then let a few captured calls accumulate and try again."
         )
 

--- a/tokenjam/core/config.py
+++ b/tokenjam/core/config.py
@@ -193,13 +193,22 @@ class CaptureConfig:
     local-only (the user's own telemetry DB), which is why this defaults on
     rather than opt-in. ``completions`` and ``tool_outputs`` stay off by
     default — no analyzer needs them yet, and completion text is the
-    largest, least useful payload to store. ``tool_inputs`` stays off here
-    too; the onboarding templates explicitly enable it (Read/Grep/Glob file
-    paths, not content) for `tj context` / the statusline.
+    largest, least useful payload to store.
+
+    ``tool_inputs`` also defaults ON: without tool-call arguments, the
+    `script` (workflow-restructure) and `verbosity` analyzers fall back to
+    tool-names-only clustering — the same "dark by default" problem
+    ``prompts`` had. Claude Code's JSONL backfill is the persona that
+    actually populates this (Read/Grep/Glob file paths and search queries,
+    not their content), and it's also what `tj context` / the statusline
+    read from. SDK/API callers gain little from it today (no automatic
+    instrumentation records ``gen_ai.tool.input`` there yet), but the
+    default stays uniform across onboarding paths rather than carving out
+    an exception per persona.
     """
     prompts:      bool = True
     completions:  bool = False
-    tool_inputs:  bool = False
+    tool_inputs:  bool = True
     tool_outputs: bool = False
 
 

--- a/tokenjam/core/config.py
+++ b/tokenjam/core/config.py
@@ -185,7 +185,19 @@ class PolicyConfig:
 
 @dataclass
 class CaptureConfig:
-    prompts:      bool = False
+    """What raw content gets persisted alongside token counts / model names.
+
+    ``prompts`` defaults ON: without prompt text, `cache-recommend` and
+    `trim` never fire and `reuse` never reaches its prompt-prefix mode (all
+    three stay dark for every onboarded user otherwise). Storage is
+    local-only (the user's own telemetry DB), which is why this defaults on
+    rather than opt-in. ``completions`` and ``tool_outputs`` stay off by
+    default — no analyzer needs them yet, and completion text is the
+    largest, least useful payload to store. ``tool_inputs`` stays off here
+    too; the onboarding templates explicitly enable it (Read/Grep/Glob file
+    paths, not content) for `tj context` / the statusline.
+    """
+    prompts:      bool = True
     completions:  bool = False
     tool_inputs:  bool = False
     tool_outputs: bool = False
@@ -575,12 +587,16 @@ def _parse(raw: dict) -> TjConfig:
         openai_base_url=proxy_raw.get("openai_base_url", ProxyConfig.openai_base_url),
     )
 
+    # Fall back to the CaptureConfig defaults (not a hardcoded False) so a
+    # config that predates a given flag — or a hand-authored one that omits
+    # `[capture]` entirely — picks up the current default rather than being
+    # frozen at whatever the flag defaulted to when the file was written.
     capture_raw = raw.get("capture", {})
     capture = CaptureConfig(
-        prompts=capture_raw.get("prompts", False),
-        completions=capture_raw.get("completions", False),
-        tool_inputs=capture_raw.get("tool_inputs", False),
-        tool_outputs=capture_raw.get("tool_outputs", False),
+        prompts=capture_raw.get("prompts", CaptureConfig.prompts),
+        completions=capture_raw.get("completions", CaptureConfig.completions),
+        tool_inputs=capture_raw.get("tool_inputs", CaptureConfig.tool_inputs),
+        tool_outputs=capture_raw.get("tool_outputs", CaptureConfig.tool_outputs),
     )
 
     # [loop] — optional transcript root for non-Claude-Code workspace agents


### PR DESCRIPTION
> **Stack slice of #482.** One of 12 concern-scoped PRs split out of #482. Its base is the previous slice, so the diff above shows only this slice's changes.
>
> **Do not merge this PR directly.** The complete change lands in one merge via the anchor PR #482, which contains every commit in this stack and is green. CI on a mid-stack slice may be red: slices are ordered by concern rather than by dependency, so a branch can reference code that lands in a later slice. That is an artifact of the ordering, not a defect in this diff.

**Behavioral change worth explicit review.** Flips `capture.prompts` and `capture.tool_inputs` to default **true**.

Rationale: cache-recommend, trim, and the clustering miners are dark without prompt text and tool-call arguments. The consequence is that new installs begin capturing prompt content by default, which is why this is isolated in its own PR rather than folded into a larger change.
