### PR TITLE
feat: accept --json as a global flag on any command

### DIFF
--- a/incidents/hallucination-drift/scenario.py
+++ b/incidents/hallucination-drift/scenario.py
@@ -33,8 +33,13 @@ def run() -> None:
     """
     import click
 
+    from tokenjam.cli.json_option import resolve_output_json
+
     ctx = click.get_current_context(silent=True)
-    output_json = ctx.params.get("output_json", False) if ctx else False
+    output_json = (
+        resolve_output_json(ctx, ctx.params.get("output_json_flag", False))
+        if ctx else False
+    )
 
     env, result = _execute()
 

--- a/incidents/retry-loop/scenario.py
+++ b/incidents/retry-loop/scenario.py
@@ -33,8 +33,13 @@ def run() -> None:
     """
     import click
 
+    from tokenjam.cli.json_option import resolve_output_json
+
     ctx = click.get_current_context(silent=True)
-    output_json = ctx.params.get("output_json", False) if ctx else False
+    output_json = (
+        resolve_output_json(ctx, ctx.params.get("output_json_flag", False))
+        if ctx else False
+    )
 
     env, result = _execute()
 

--- a/incidents/surprise-cost/scenario.py
+++ b/incidents/surprise-cost/scenario.py
@@ -44,8 +44,13 @@ def run() -> None:
     """
     import click
 
+    from tokenjam.cli.json_option import resolve_output_json
+
     ctx = click.get_current_context(silent=True)
-    output_json = ctx.params.get("output_json", False) if ctx else False
+    output_json = (
+        resolve_output_json(ctx, ctx.params.get("output_json_flag", False))
+        if ctx else False
+    )
 
     env, result, model_breakdown = _execute()
 

--- a/tests/integration/test_global_json_flag.py
+++ b/tests/integration/test_global_json_flag.py
@@ -1,0 +1,172 @@
+"""Regression coverage for the global `tj --json <cmd>` flag.
+
+The root `tj` group defines a `--json` option (`tj --json status`), but until
+now most subcommands only honored their OWN local `--json` (`tj status
+--json`) — they read a local flag straight into their render branch and never
+looked at `ctx.obj["output_json"]`, so the two spellings silently diverged:
+one printed Rich text, the other JSON. `tokenjam/cli/json_option.py` fixes
+this with a shared `json_option` decorator + `resolve_output_json()` helper
+that ORs the local flag with the global one; every command below is wired
+through it (or, for the handful with no local flag at all, reads
+`ctx.obj["output_json"]` directly).
+
+This file walks every registered command that supports JSON output and
+asserts `tj --json <cmd>` and `tj <cmd> --json` are equivalent: same exit
+code, and both stdouts parse as JSON (proving the global spelling actually
+renders the JSON branch, not the human-text one — the exact failure mode of
+the bug this locks in). That single parametrized walk is the regression
+test; the rest of the suite (test_cli.py, test_cmd_policy.py, test_ping.py,
+test_demos.py, ...) covers each command's actual JSON *content*.
+"""
+from __future__ import annotations
+
+import json
+from collections.abc import Callable
+from unittest.mock import patch
+
+import pytest
+from click.testing import CliRunner
+from opentelemetry import trace
+from opentelemetry.sdk.trace import TracerProvider
+
+from tokenjam.cli.main import cli
+from tokenjam.core.config import TjConfig
+from tokenjam.core.db import InMemoryBackend
+from tokenjam.core.models import AgentRecord
+from tokenjam.utils.time_parse import utcnow
+from tests.factories import make_llm_span, make_session
+
+
+@pytest.fixture
+def runner():
+    return CliRunner()
+
+
+@pytest.fixture
+def db():
+    backend = InMemoryBackend()
+    yield backend
+    backend.close()
+
+
+@pytest.fixture
+def config():
+    return TjConfig(version="1")
+
+
+def _no_setup(db: InMemoryBackend) -> list[str]:
+    """No seeding needed; the command must render its empty/no-data JSON
+    branch cleanly for this test to be meaningful."""
+    return []
+
+
+def _seed_trace(db: InMemoryBackend) -> list[str]:
+    """One span so `tj trace <trace_id>` has something to resolve, returning
+    the trace_id as the extra positional arg."""
+    span = make_llm_span(agent_id="test-agent")
+    db.upsert_agent(AgentRecord(
+        agent_id="test-agent", first_seen=utcnow(), last_seen=utcnow(),
+    ))
+    db.upsert_session(make_session(agent_id="test-agent"))
+    db.insert_span(span)
+    return [span.trace_id]
+
+
+# (subcommand path, setup callable returning extra args appended before --json)
+JSON_COMMAND_CASES: list[tuple[str, tuple[str, ...], Callable[[InMemoryBackend], list[str]]]] = [
+    ("status", (), _no_setup),
+    ("cost", (), _no_setup),
+    ("alerts", (), _no_setup),
+    ("tools", (), _no_setup),
+    ("traces", (), _no_setup),
+    ("trace", (), _seed_trace),
+    ("drift", (), _no_setup),
+    ("budget", (), _no_setup),
+    ("context", (), _no_setup),
+    ("tokenmaxx", (), _no_setup),
+    ("quota-audit", (), _no_setup),
+    ("optimize", (), _no_setup),
+    ("session-story", (), _no_setup),
+    ("policy", ("list",), _no_setup),
+    ("pricing", ("list",), _no_setup),
+    ("summarize", ("list",), _no_setup),
+    ("route", ("export", "--check"), _no_setup),
+    ("demo", ("retry-loop",), _no_setup),
+]
+
+
+@pytest.mark.parametrize(
+    "root, base_args, setup",
+    JSON_COMMAND_CASES,
+    ids=[c[0] if not c[1] else f"{c[0]}-{'-'.join(c[1])}" for c in JSON_COMMAND_CASES],
+)
+def test_global_json_flag_matches_local_json_flag(
+    runner, db, config, root, base_args, setup,
+):
+    """`tj --json <cmd>` must render the same JSON branch as `tj <cmd> --json`.
+
+    A regression here means the global flag went back to being silently
+    dropped for this command — the exact bug class this test locks in.
+    """
+    extra = setup(db)
+    argv = [root, *base_args, *extra]
+
+    with patch("tokenjam.cli.main.load_config", return_value=config), \
+         patch("tokenjam.cli.main.open_db", return_value=db):
+        global_result = runner.invoke(cli, ["--json", *argv])
+        local_result = runner.invoke(cli, [*argv, "--json"])
+
+    assert global_result.exit_code == local_result.exit_code, (
+        f"tj --json {' '.join(argv)} exited {global_result.exit_code} but "
+        f"tj {' '.join(argv)} --json exited {local_result.exit_code}:\n"
+        f"global: {global_result.output}\nlocal: {local_result.output}"
+    )
+    # The core assertion: both must actually be JSON. If the global flag were
+    # silently ignored, `global_result.output` would be Rich human text and
+    # this json.loads would raise.
+    global_payload = json.loads(global_result.output)
+    local_payload = json.loads(local_result.output)
+
+    # Same shape: for dict payloads, the same top-level keys came back either
+    # way (a handful of commands embed a fresh `utcnow()` timestamp per call,
+    # so full deep-equality isn't reliable — the key set is).
+    if isinstance(global_payload, dict) and isinstance(local_payload, dict):
+        assert set(global_payload) == set(local_payload)
+    else:
+        assert type(global_payload) is type(local_payload)
+
+
+def test_global_json_flag_matches_local_json_flag_for_ping(monkeypatch):
+    """`ping` needs its own harness (a real SDK TracerProvider + stubbed
+    bootstrap/delivery-confirmation) — mirrors test_ping.py's `_run` helper,
+    so it's kept out of the main parametrize above rather than forcing every
+    case through ping's setup."""
+    provider = trace.get_tracer_provider()
+    if not hasattr(provider, "add_span_processor"):
+        trace.set_tracer_provider(TracerProvider())
+
+    monkeypatch.setattr("tokenjam.sdk.bootstrap.ensure_initialised", lambda: None)
+    monkeypatch.setattr("tokenjam.sdk.bootstrap.get_mode", lambda: "http")
+    monkeypatch.setattr(
+        "tokenjam.cli.cmd_ping._confirm_delivery", lambda *a, **k: (True, None)
+    )
+
+    runner = CliRunner()
+    global_result = runner.invoke(cli, ["--json", "ping"])
+    local_result = runner.invoke(cli, ["ping", "--json"])
+
+    assert global_result.exit_code == local_result.exit_code == 0
+    global_payload = json.loads(global_result.output)
+    local_payload = json.loads(local_result.output)
+    assert set(global_payload) == set(local_payload)
+    assert global_payload["delivery_mode"] == local_payload["delivery_mode"] == "http"
+
+
+def test_command_with_no_json_support_rejects_json_flag(runner, db, config):
+    """`tj stop` never claimed --json support; the fix must not accidentally
+    add a --json option to commands that don't render one."""
+    with patch("tokenjam.cli.main.load_config", return_value=config), \
+         patch("tokenjam.cli.main.open_db", return_value=db):
+        result = runner.invoke(cli, ["stop", "--json"])
+    assert result.exit_code != 0
+    assert "no such option" in result.output.lower()

--- a/tokenjam/cli/cmd_alerts.py
+++ b/tokenjam/cli/cmd_alerts.py
@@ -2,6 +2,7 @@ import json
 
 import click
 
+from tokenjam.cli.json_option import json_option, resolve_output_json
 from tokenjam.core.models import AlertFilters, AlertType, Severity
 from tokenjam.utils.formatting import console, make_table, severity_colour
 from tokenjam.utils.time_parse import parse_since
@@ -18,7 +19,7 @@ from tokenjam.utils.time_parse import parse_since
 )
 @click.option("--type", "alert_type", default=None, help="Filter by alert type")
 @click.option("--unread", is_flag=True, help="Show only unacknowledged alerts")
-@click.option("--json", "output_json", is_flag=True, help="Output as JSON")
+@json_option
 @click.pass_context
 def cmd_alerts(
     ctx: click.Context,
@@ -27,9 +28,10 @@ def cmd_alerts(
     severity: str | None,
     alert_type: str | None,
     unread: bool,
-    output_json: bool,
+    output_json_flag: bool,
 ) -> None:
     """Show alert history."""
+    output_json = resolve_output_json(ctx, output_json_flag)
     db = ctx.obj["db"]
     try:
         since_dt = parse_since(since)

--- a/tokenjam/cli/cmd_budget.py
+++ b/tokenjam/cli/cmd_budget.py
@@ -6,6 +6,7 @@ from typing import TypedDict
 
 import click
 
+from tokenjam.cli.json_option import json_option, resolve_output_json
 from tokenjam.core.config import (
     AgentConfig,
     find_config_file,
@@ -31,17 +32,17 @@ class _BudgetRow(TypedDict):
               help="Daily budget in USD (0 = remove limit)")
 @click.option("--session", "session_usd", type=float, default=None,
               help="Per-session budget in USD (0 = remove limit)")
-@click.option("--json", "output_json", is_flag=True,
-              help="Emit machine-readable JSON.")
+@json_option
 @click.pass_context
 def cmd_budget(
     ctx: click.Context,
     agent: str | None,
     daily_usd: float | None,
     session_usd: float | None,
-    output_json: bool,
+    output_json_flag: bool,
 ) -> None:
     """View or set cost budgets for agents."""
+    output_json = resolve_output_json(ctx, output_json_flag)
     config = ctx.obj["config"]
     writing = daily_usd is not None or session_usd is not None
 

--- a/tokenjam/cli/cmd_context.py
+++ b/tokenjam/cli/cmd_context.py
@@ -30,6 +30,7 @@ from typing import Any
 import click
 
 from tokenjam.cli.data_access import resolve_data_access
+from tokenjam.cli.json_option import json_option, resolve_output_json
 from tokenjam.core.context_diagnostic import (
     INCLUSION_FILE_READ,
     INCLUSION_PROMPT,
@@ -55,12 +56,12 @@ _INCLUSION_LABELS = {
 @click.option("--agent", default=None, help="Filter to a specific agent_id.")
 @click.option("--since", default="30d",
               help="Window for analysis (e.g. 7d, 30d, 2026-03-01). Default 30d.")
-@click.option("--json", "output_json", is_flag=True,
-              help="Emit machine-readable JSON.")
+@json_option
 @click.pass_context
 def cmd_context(ctx: click.Context, agent: str | None, since: str,
-                output_json: bool) -> None:
+                output_json_flag: bool) -> None:
     """Diagnose where your Claude Code quota goes: re-reading vs. real work."""
+    output_json = resolve_output_json(ctx, output_json_flag)
     db = ctx.obj.get("db")
     config = ctx.obj.get("config")
     agent = agent or ctx.obj.get("agent")

--- a/tokenjam/cli/cmd_cost.py
+++ b/tokenjam/cli/cmd_cost.py
@@ -1,5 +1,6 @@
 import click
 import json
+from tokenjam.cli.json_option import json_option, resolve_output_json
 from tokenjam.core.cost import compute_cost_diff
 from tokenjam.core.models import CostFilters
 from tokenjam.utils.formatting import console, make_table, format_cost, format_tokens
@@ -15,11 +16,12 @@ from tokenjam.utils.time_parse import parse_since, utcnow
 @click.option("--compare", "compare", default=None,
               help="Compare to a prior window. Accepts 'previous', 'last-week', "
                    "'last-month', 'last-7d', 'last-30d', or 'YYYY-MM-DD:YYYY-MM-DD'.")
-@click.option("--json", "output_json", is_flag=True)
+@json_option
 @click.pass_context
 def cmd_cost(ctx: click.Context, agent: str | None, since: str,
-             group_by: str, compare: str | None, output_json: bool) -> None:
+             group_by: str, compare: str | None, output_json_flag: bool) -> None:
     """Show cost breakdown by agent, model, day, or tool."""
+    output_json = resolve_output_json(ctx, output_json_flag)
     db = ctx.obj["db"]
     try:
         since_dt = parse_since(since)

--- a/tokenjam/cli/cmd_demo.py
+++ b/tokenjam/cli/cmd_demo.py
@@ -7,6 +7,7 @@ from types import ModuleType
 
 import click
 
+from tokenjam.cli.json_option import json_option, resolve_output_json
 from tokenjam.utils.formatting import console
 
 # The scenarios live at repo-root `incidents/` in the dev tree, but ship INSIDE
@@ -57,7 +58,7 @@ def _discover_scenarios() -> dict[str, ModuleType]:
 
 @click.command("demo")
 @click.argument("scenario", required=False, default=None)
-@click.option("--json", "output_json", is_flag=True, help="Output JSON instead of Rich panels")
+@json_option
 @click.option(
     "--live",
     "live",
@@ -67,7 +68,7 @@ def _discover_scenarios() -> dict[str, ModuleType]:
 )
 @click.pass_context
 def cmd_demo(
-    ctx: click.Context, scenario: str | None, output_json: bool, live: bool
+    ctx: click.Context, scenario: str | None, output_json_flag: bool, live: bool
 ) -> None:
     """Run a reproducible AI agent incident scenario.
 
@@ -77,6 +78,7 @@ def cmd_demo(
     tj demo retry-loop --json   Machine-readable output
     tj demo retry-loop --live   Also replay into a running `tj serve`
     """
+    output_json = resolve_output_json(ctx, output_json_flag)
     scenarios = _discover_scenarios()
 
     if scenario is None:

--- a/tokenjam/cli/cmd_doctor.py
+++ b/tokenjam/cli/cmd_doctor.py
@@ -6,12 +6,13 @@ import click
 import duckdb
 from rich.markup import escape
 
+from tokenjam.cli.json_option import json_option, resolve_output_json
 from tokenjam.core.config import find_config_file, load_config
 from tokenjam.utils.formatting import console, display_path
 
 
 @click.command("doctor")
-@click.option("--json", "output_json", is_flag=True)
+@json_option
 @click.option(
     "--repair",
     is_flag=True,
@@ -20,8 +21,9 @@ from tokenjam.utils.formatting import console, display_path
          "https://github.com/Metabuilder-Labs/tokenjam/issues/56).",
 )
 @click.pass_context
-def cmd_doctor(ctx: click.Context, output_json: bool, repair: bool) -> None:
+def cmd_doctor(ctx: click.Context, output_json_flag: bool, repair: bool) -> None:
     """Run health checks on tj configuration and environment."""
+    output_json = resolve_output_json(ctx, output_json_flag)
     config = ctx.obj["config"]
     checks: list[dict] = []
 

--- a/tokenjam/cli/cmd_drift.py
+++ b/tokenjam/cli/cmd_drift.py
@@ -6,16 +6,18 @@ import json as json_mod
 import click
 from rich.table import Table
 
+from tokenjam.cli.json_option import json_option, resolve_output_json
 from tokenjam.core.drift import evaluate_drift
 from tokenjam.utils.formatting import console
 
 
 @click.command("drift")
 @click.option("--agent", default=None, help="Filter to specific agent_id")
-@click.option("--json", "output_json", is_flag=True, help="JSON output")
+@json_option
 @click.pass_context
-def cmd_drift(ctx: click.Context, agent: str | None, output_json: bool) -> None:
+def cmd_drift(ctx: click.Context, agent: str | None, output_json_flag: bool) -> None:
     """Show drift baselines and Z-scores for recent sessions."""
+    output_json = resolve_output_json(ctx, output_json_flag)
     db = ctx.obj["db"]
     config = ctx.obj["config"]
     agent_filter = agent or ctx.obj.get("agent")

--- a/tokenjam/cli/cmd_optimize.py
+++ b/tokenjam/cli/cmd_optimize.py
@@ -7,6 +7,7 @@ from typing import Any, NoReturn
 import click
 from rich.markup import escape as _rich_escape
 
+from tokenjam.cli.json_option import json_option, resolve_output_json
 from tokenjam.core.framing import (
     PLAN_LABEL_AND_FEE,
     agent_persona_mix,
@@ -79,8 +80,7 @@ from tokenjam.utils.time_parse import parse_since, utcnow
                    "(default 5, max 20).")
 @click.option("--yes", "-y", "assume_yes", is_flag=True, default=False,
               help="Skip the --validate cost-estimate confirmation prompt.")
-@click.option("--json", "output_json", is_flag=True,
-              help="Emit machine-readable JSON.")
+@json_option
 @click.pass_context
 def cmd_optimize(
     ctx: click.Context,
@@ -95,9 +95,10 @@ def cmd_optimize(
     validate_finding: str | None,
     samples: int | None,
     assume_yes: bool,
-    output_json: bool,
+    output_json_flag: bool,
 ) -> None:
     """Analyze recent usage for cost-saving candidates and budget exposure."""
+    output_json = resolve_output_json(ctx, output_json_flag)
     db = ctx.obj.get("db")
     config = ctx.obj.get("config")
     if db is None or config is None:

--- a/tokenjam/cli/cmd_ping.py
+++ b/tokenjam/cli/cmd_ping.py
@@ -29,6 +29,7 @@ from typing import cast
 
 import click
 
+from tokenjam.cli.json_option import json_option, resolve_output_json
 from tokenjam.utils.formatting import console
 
 # Clearly-labeled test identity so a ping span is never mistaken for real
@@ -68,10 +69,9 @@ class _ProofExporter:
 @click.command("ping")
 @click.option("--agent", "agent_id", default=PING_AGENT_ID, show_default=True,
               help="agent_id to stamp on the test span.")
-@click.option("--json", "output_json", is_flag=True,
-              help="Emit a machine-readable result instead of prose.")
+@json_option
 @click.pass_context
-def cmd_ping(ctx: click.Context, agent_id: str, output_json: bool) -> None:
+def cmd_ping(ctx: click.Context, agent_id: str, output_json_flag: bool) -> None:
     """Emit a labeled test span to prove SDK instrumentation is wired up.
 
     Exits 0 only once delivery is *confirmed* — HTTP mode polls the daemon's
@@ -79,6 +79,7 @@ def cmd_ping(ctx: click.Context, agent_id: str, output_json: bool) -> None:
     just "attempted". See the module docstring for why that distinction
     matters.
     """
+    output_json = resolve_output_json(ctx, output_json_flag)
     config = ctx.obj["config"]
 
     from opentelemetry import trace as trace_api

--- a/tokenjam/cli/cmd_policy.py
+++ b/tokenjam/cli/cmd_policy.py
@@ -20,6 +20,7 @@ from typing import Any
 import click
 from rich.markup import escape
 
+from tokenjam.cli.json_option import json_option, resolve_output_json
 from tokenjam.core.config import (
     AgentConfig,
     AlertChannelConfig,
@@ -64,15 +65,12 @@ def cmd_policy() -> None:
 
 
 @cmd_policy.command("list")
-@click.option("--json", "output_json_flag", is_flag=True,
-              help="Emit machine-readable JSON.")
+@json_option
 @click.pass_context
 def cmd_policy_list(ctx: click.Context, output_json_flag: bool) -> None:
     """List existing alerts, drift, schema, and budget configuration."""
     config: TjConfig = ctx.obj["config"]
-    # Honour either the root `tj --json policy list` form or the
-    # command-level `tj policy list --json` form (#71 finding 6).
-    output_json: bool = output_json_flag or ctx.obj.get("output_json", False)
+    output_json = resolve_output_json(ctx, output_json_flag)
 
     rows = _collect_rows(config)
     has_engine_policies = bool(config.policies)
@@ -150,8 +148,7 @@ def _read_decisions_from_db(config: TjConfig, since, limit: int):
 
 
 @cmd_policy.command("decisions")
-@click.option("--json", "output_json_flag", is_flag=True,
-              help="Emit machine-readable JSON.")
+@json_option
 @click.option("--limit", default=20, show_default=True,
               help="Max number of recent decisions to show.")
 @click.option("--since", default=None,
@@ -161,7 +158,7 @@ def cmd_policy_decisions(ctx: click.Context, output_json_flag: bool, limit: int,
                          since: str | None) -> None:
     """Show recent persisted policy decisions + the estimated-recoverable meter."""
     config: TjConfig = ctx.obj["config"]
-    output_json: bool = output_json_flag or ctx.obj.get("output_json", False)
+    output_json = resolve_output_json(ctx, output_json_flag)
 
     since_dt = None
     if since:

--- a/tokenjam/cli/cmd_pricing.py
+++ b/tokenjam/cli/cmd_pricing.py
@@ -2,6 +2,7 @@ import json
 
 import click
 
+from tokenjam.cli.json_option import json_option, resolve_output_json
 from tokenjam.core.pricing import load_pricing_sources, load_pricing_table
 from tokenjam.utils.formatting import console, make_table
 
@@ -14,14 +15,12 @@ def cmd_pricing() -> None:
 @cmd_pricing.command("list")
 @click.option("--model", default=None,
               help="Filter to model names containing this substring.")
-@click.option("--json", "output_json_flag", is_flag=True,
-              help="Emit machine-readable JSON.")
+@json_option
 @click.pass_context
 def cmd_pricing_list(ctx: click.Context, model: str | None,
                      output_json_flag: bool) -> None:
     """List the resolved per-model rates (input/output/cache, in $/MTok)."""
-    # Honour either `tj --json pricing list` or `tj pricing list --json`.
-    output_json: bool = output_json_flag or ctx.obj.get("output_json", False)
+    output_json = resolve_output_json(ctx, output_json_flag)
 
     table = load_pricing_table()  # {provider: {model: ModelRates}}
     sources = load_pricing_sources()  # {(provider, model): "override"|"packaged"}

--- a/tokenjam/cli/cmd_quota_audit.py
+++ b/tokenjam/cli/cmd_quota_audit.py
@@ -32,6 +32,7 @@ from typing import Any
 import click
 
 from tokenjam.cli.data_access import resolve_data_access
+from tokenjam.cli.json_option import json_option, resolve_output_json
 from tokenjam.core.framing import Framing
 from tokenjam.core.model_tiers import PREMIUM_TIER_LABEL
 from tokenjam.core.optimize.types import (
@@ -52,12 +53,12 @@ from tokenjam.utils.time_parse import parse_since
               help="Write a tuned routing snippet (currently claude-code) under "
                    "the TokenJam config directory. Does not modify any external "
                    "config — you merge it manually.")
-@click.option("--json", "output_json", is_flag=True,
-              help="Emit machine-readable JSON.")
+@json_option
 @click.pass_context
 def cmd_quota_audit(ctx: click.Context, agent: str | None, since: str,
-                    export_target: str | None, output_json: bool) -> None:
+                    export_target: str | None, output_json_flag: bool) -> None:
     """Audit your Opus quota: which past Opus sessions were Sonnet-shaped?"""
+    output_json = resolve_output_json(ctx, output_json_flag)
     db = ctx.obj.get("db")
     config = ctx.obj.get("config")
     agent = agent or ctx.obj.get("agent")

--- a/tokenjam/cli/cmd_route.py
+++ b/tokenjam/cli/cmd_route.py
@@ -20,6 +20,7 @@ from pathlib import Path
 
 import click
 
+from tokenjam.cli.json_option import json_option, resolve_output_json
 from tokenjam.core.framing import dominant_plan, plan_tier_mix, pricing_mode_for
 from tokenjam.core.optimize import OptimizeReport, build_report, report_from_dict
 from tokenjam.utils.formatting import console
@@ -48,8 +49,7 @@ def cmd_route() -> None:
 @click.option("--agent", default=None, help="Scope to a specific agent_id.")
 @click.option("--since", default="30d",
               help="Lookback window for the findings (e.g. 7d, 30d).")
-@click.option("--json", "output_json", is_flag=True, default=False,
-              help="Emit machine-readable JSON.")
+@json_option
 @click.pass_context
 def cmd_route_export(
     ctx: click.Context,
@@ -57,9 +57,10 @@ def cmd_route_export(
     check: bool,
     agent: str | None,
     since: str,
-    output_json: bool,
+    output_json_flag: bool,
 ) -> None:
     """Write (or --check) an advisory router config from the downsize findings."""
+    output_json = resolve_output_json(ctx, output_json_flag)
     if not check and target is None:
         raise click.UsageError("Pass --target ccr|litellm (or --check).")
 

--- a/tokenjam/cli/cmd_session_story.py
+++ b/tokenjam/cli/cmd_session_story.py
@@ -33,6 +33,7 @@ from typing import Any
 import click
 from rich.markup import escape
 
+from tokenjam.cli.json_option import json_option, resolve_output_json
 from tokenjam.core.method_capture import load_session_method
 from tokenjam.core.method_spine import build_method_spine
 from tokenjam.core.transcript import build_session_story, resolve_projects_root
@@ -73,11 +74,10 @@ _KIND_STYLE = {
 @click.option("--last", is_flag=True,
               help="Reconstruct the most recent substantial session "
                    "(the default when no --session is given).")
-@click.option("--json", "output_json", is_flag=True,
-              help="Emit machine-readable JSON (the folded method spine).")
+@json_option
 @click.pass_context
 def cmd_session_story(ctx: click.Context, session_id: str | None,
-                      last: bool, output_json: bool) -> None:
+                      last: bool, output_json_flag: bool) -> None:
     """Show turn-by-turn HOW a Claude Code session attempted its task.
 
     Reconstructs the session's method — its ordered moves and, for each
@@ -85,6 +85,7 @@ def cmd_session_story(ctx: click.Context, session_id: str | None,
     transcript (or a persisted snapshot when the transcript was pruned). With no
     ``--session``, auto-selects the most recent substantial session.
     """
+    output_json = resolve_output_json(ctx, output_json_flag)
     db = ctx.obj.get("db")
     if db is None:
         raise click.ClickException("session-story requires a database connection.")

--- a/tokenjam/cli/cmd_status.py
+++ b/tokenjam/cli/cmd_status.py
@@ -4,6 +4,7 @@ import json
 
 import click
 
+from tokenjam.cli.json_option import json_option, resolve_output_json
 from tokenjam.core.models import Alert, AlertFilters
 from tokenjam.utils.formatting import console, format_cost, format_tokens, status_icon
 from tokenjam.utils.time_parse import utcnow
@@ -11,10 +12,11 @@ from tokenjam.utils.time_parse import utcnow
 
 @click.command("status")
 @click.option("--agent", default=None, help="Filter to specific agent_id")
-@click.option("--json", "output_json", is_flag=True)
+@json_option
 @click.pass_context
-def cmd_status(ctx: click.Context, agent: str | None, output_json: bool) -> None:
+def cmd_status(ctx: click.Context, agent: str | None, output_json_flag: bool) -> None:
     """Show agent status overview."""
+    output_json = resolve_output_json(ctx, output_json_flag)
     db = ctx.obj["db"]
     agent_filter = agent or ctx.obj.get("agent")
 

--- a/tokenjam/cli/cmd_summarize.py
+++ b/tokenjam/cli/cmd_summarize.py
@@ -18,6 +18,7 @@ from pathlib import Path
 import click
 from rich.markup import escape
 
+from tokenjam.cli.json_option import json_option, resolve_output_json
 from tokenjam.core.config import TjConfig
 from tokenjam.core.summarize.apply import apply_staged, undo
 from tokenjam.core.summarize.candidates import list_candidates
@@ -98,8 +99,7 @@ def cmd_summarize() -> None:
 @click.option("--ext", "ext", default=None,
               help="Also scan these comma-separated extensions, e.g. txt,rst "
                    "(opens beyond the catalog).")
-@click.option("--json", "output_json_flag", is_flag=True,
-              help="Emit machine-readable JSON.")
+@json_option
 @click.option("--min-prose", "min_prose", default=None, type=int,
               help="Minimum prose words to flag a file (default 100).")
 @click.pass_context
@@ -109,7 +109,7 @@ def cmd_summarize_list(
 ) -> None:
     """List prompt files worth summarizing (bare = catalog; a PATH/--repo/--recursive/--ext opens to .md)."""
     config: TjConfig = ctx.obj["config"]
-    output_json: bool = output_json_flag or ctx.obj.get("output_json", False)
+    output_json = resolve_output_json(ctx, output_json_flag)
 
     if repo and recursive:
         raise click.UsageError("--repo and --recursive are mutually exclusive.")
@@ -190,7 +190,7 @@ def cmd_summarize_list(
                    "(needs [summarize] api_model). Omit it to rewrite the prompt yourself, then `check`.")
 @click.option("--ratio", default=DEFAULT_TARGET_RATIO, show_default=True, type=float,
               help="Target prose ratio (0.5 = keep ~half the prose words).")
-@click.option("--json", "output_json_flag", is_flag=True, help="Emit machine-readable JSON.")
+@json_option
 @click.pass_context
 def cmd_summarize_prep(
     ctx: click.Context, path: str, via: str | None, ratio: float, output_json_flag: bool,
@@ -198,7 +198,7 @@ def cmd_summarize_prep(
     """Wrap a prompt's structure. Bare: emit the wrapped prompt + rules + hash for you to rewrite,
     then `check`. With --via: TJ runs the rewrite, verifies, and stages it in one shot."""
     config: TjConfig = ctx.obj["config"]
-    output_json: bool = output_json_flag or ctx.obj.get("output_json", False)
+    output_json = resolve_output_json(ctx, output_json_flag)
 
     if via is not None:                             # automated: wrap → rewrite → check → stage
         on_progress = None if output_json else (
@@ -262,14 +262,14 @@ def cmd_summarize_prep(
               help="File holding the model's summary ('-' for stdin).")
 @click.option("--prepped-hash", "prepped_hash", required=True,
               help="The source_sha256 returned by `prep`.")
-@click.option("--json", "output_json_flag", is_flag=True, help="Emit machine-readable JSON.")
+@json_option
 @click.pass_context
 def cmd_summarize_check(
     ctx: click.Context, path: str, summary_path: str, prepped_hash: str, output_json_flag: bool,
 ) -> None:
     """Verify a summary (hash-guards the file) and stage it for review."""
     config: TjConfig = ctx.obj["config"]
-    output_json: bool = output_json_flag or ctx.obj.get("output_json", False)
+    output_json = resolve_output_json(ctx, output_json_flag)
     summary_text = (
         click.get_text_stream("stdin").read() if summary_path == "-"
         else Path(summary_path).expanduser().read_text(encoding="utf-8")
@@ -290,14 +290,14 @@ def cmd_summarize_check(
               help="Write the files (default is dry-run; can't combine with --dry-run).")
 @click.option("--dry-run", "dry_run", is_flag=True,
               help="Preview only; the default (can't combine with --go).")
-@click.option("--json", "output_json_flag", is_flag=True, help="Emit machine-readable JSON.")
+@json_option
 @click.pass_context
 def cmd_summarize_apply(
     ctx: click.Context, path: str | None, go: bool, dry_run: bool, output_json_flag: bool,
 ) -> None:
     """Apply staged results to their files — take-all, or one PATH. Default dry-run; --go writes."""
     config: TjConfig = ctx.obj["config"]
-    output_json: bool = output_json_flag or ctx.obj.get("output_json", False)
+    output_json = resolve_output_json(ctx, output_json_flag)
     if dry_run and go:
         raise click.UsageError("Choose one of --dry-run or --go (--dry-run is the default with neither).")
     if path is not None and Path(path).expanduser().is_dir():
@@ -328,14 +328,14 @@ def cmd_summarize_apply(
               help="Restore the file (default is dry-run; can't combine with --dry-run).")
 @click.option("--dry-run", "dry_run", is_flag=True,
               help="Preview only; the default (can't combine with --go).")
-@click.option("--json", "output_json_flag", is_flag=True, help="Emit machine-readable JSON.")
+@json_option
 @click.pass_context
 def cmd_summarize_undo(
     ctx: click.Context, path: str, go: bool, dry_run: bool, output_json_flag: bool,
 ) -> None:
     """Restore a file from its summarize backup. Default dry-run; --go writes. Refuses on drift."""
     config: TjConfig = ctx.obj["config"]
-    output_json: bool = output_json_flag or ctx.obj.get("output_json", False)
+    output_json = resolve_output_json(ctx, output_json_flag)
     if dry_run and go:
         raise click.UsageError("Choose one of --dry-run or --go (--dry-run is the default with neither).")
     if Path(path).expanduser().is_dir():

--- a/tokenjam/cli/cmd_tokenmaxx.py
+++ b/tokenjam/cli/cmd_tokenmaxx.py
@@ -30,6 +30,7 @@ from dataclasses import dataclass
 import click
 
 from tokenjam.cli.data_access import resolve_data_access
+from tokenjam.cli.json_option import json_option, resolve_output_json
 from tokenjam.core.context_diagnostic import ContextDiagnostic
 from tokenjam.core.framing import Framing
 from tokenjam.utils.formatting import console, format_tokens
@@ -77,12 +78,12 @@ def _classify(overhead_share: float) -> Tier:
 @click.option("--since", default="30d", help="Window for analysis (default 30d).")
 @click.option("--weekly", is_flag=True,
               help="Weekly 'quota Wrapped' recap mode (last 7 days, recap copy).")
-@click.option("--json", "output_json", is_flag=True,
-              help="Emit machine-readable JSON.")
+@json_option
 @click.pass_context
 def cmd_tokenmaxx(ctx: click.Context, agent: str | None, since: str,
-                  weekly: bool, output_json: bool) -> None:
+                  weekly: bool, output_json_flag: bool) -> None:
     """Your quota/efficiency card: how lean is your context? (screenshottable)"""
+    output_json = resolve_output_json(ctx, output_json_flag)
     db = ctx.obj.get("db")
     config = ctx.obj.get("config")
     agent = agent or ctx.obj.get("agent")

--- a/tokenjam/cli/cmd_tools.py
+++ b/tokenjam/cli/cmd_tools.py
@@ -4,6 +4,7 @@ import json
 
 import click
 
+from tokenjam.cli.json_option import json_option, resolve_output_json
 from tokenjam.utils.formatting import console, make_table
 from tokenjam.utils.time_parse import parse_since
 
@@ -12,11 +13,12 @@ from tokenjam.utils.time_parse import parse_since
 @click.option("--agent", default=None, help="Filter to specific agent_id")
 @click.option("--since", default="24h", help="Time window (e.g. 1h, 7d)")
 @click.option("--name", "tool_name", default=None, help="Filter to specific tool")
-@click.option("--json", "output_json", is_flag=True)
+@json_option
 @click.pass_context
 def cmd_tools(ctx: click.Context, agent: str | None, since: str,
-              tool_name: str | None, output_json: bool) -> None:
+              tool_name: str | None, output_json_flag: bool) -> None:
     """Show tool call summary."""
+    output_json = resolve_output_json(ctx, output_json_flag)
     db = ctx.obj["db"]
     agent_filter = agent or ctx.obj.get("agent")
     since_dt = parse_since(since)

--- a/tokenjam/cli/cmd_traces.py
+++ b/tokenjam/cli/cmd_traces.py
@@ -4,6 +4,7 @@ import json
 
 import click
 
+from tokenjam.cli.json_option import json_option, resolve_output_json
 from tokenjam.core.models import NormalizedSpan, TraceFilters
 from tokenjam.utils.formatting import console, format_cost, make_table
 from tokenjam.utils.time_parse import parse_since
@@ -15,11 +16,13 @@ from tokenjam.utils.time_parse import parse_since
 @click.option("--limit", default=50, type=int)
 @click.option("--type", "span_type", default=None, help="Filter by span name/type")
 @click.option("--status", default=None, type=click.Choice(["ok", "error"]))
-@click.option("--json", "output_json", is_flag=True)
+@json_option
 @click.pass_context
 def cmd_traces(ctx: click.Context, agent: str | None, since: str, limit: int,
-               span_type: str | None, status: str | None, output_json: bool) -> None:
+               span_type: str | None, status: str | None,
+               output_json_flag: bool) -> None:
     """List recent traces."""
+    output_json = resolve_output_json(ctx, output_json_flag)
     db = ctx.obj["db"]
     agent_filter = agent or ctx.obj.get("agent")
     try:
@@ -73,10 +76,11 @@ def cmd_traces(ctx: click.Context, agent: str | None, since: str, limit: int,
 
 @click.command("trace")
 @click.argument("trace_id")
-@click.option("--json", "output_json", is_flag=True)
+@json_option
 @click.pass_context
-def cmd_trace(ctx: click.Context, trace_id: str, output_json: bool) -> None:
+def cmd_trace(ctx: click.Context, trace_id: str, output_json_flag: bool) -> None:
     """Show span waterfall for a single trace."""
+    output_json = resolve_output_json(ctx, output_json_flag)
     db = ctx.obj["db"]
     spans = db.get_trace_spans(trace_id)
 

--- a/tokenjam/cli/json_option.py
+++ b/tokenjam/cli/json_option.py
@@ -1,0 +1,48 @@
+"""Shared `--json` option plumbing for CLI commands.
+
+The root `tj` group defines a global `--json` (`tj --json <cmd>`), stashed on
+`ctx.obj["output_json"]`. Click params never inherit from an ancestor Context
+automatically, so a subcommand that defines its own local `--json` and reads
+only its own parameter silently ignores the global one — `tj --json status`
+would print human text while `tj status --json` prints JSON. Every command
+that supports JSON output should wire its option through the pair below
+instead of a bare `@click.option("--json", ...)`, so the two spellings are
+always equivalent.
+
+Usage::
+
+    from tokenjam.cli.json_option import json_option, resolve_output_json
+
+    @cmd_group.command("foo")
+    @json_option
+    @click.pass_context
+    def cmd_foo(ctx: click.Context, output_json_flag: bool) -> None:
+        output_json = resolve_output_json(ctx, output_json_flag)
+        ...
+
+A command with no JSON support at all should keep using plain `click.option`
+calls for its own flags (or none) — don't reach for this pair unless the
+command actually renders a JSON branch.
+"""
+from __future__ import annotations
+
+import click
+
+# Reusable option decorator: `click.option(...)` builds a fresh Option
+# instance per command it's applied to, so sharing this one object across
+# every command file is safe and is the standard way to DRY up a repeated
+# click.option() call.
+json_option = click.option(
+    "--json", "output_json_flag", is_flag=True,
+    help="Emit machine-readable JSON.",
+)
+
+
+def resolve_output_json(ctx: click.Context, output_json_flag: bool) -> bool:
+    """Whether JSON output was requested, locally or via the global flag.
+
+    Either `tj --json <cmd>` or `tj <cmd> --json` enables JSON — there is no
+    way to use one to force the other back off for a single invocation.
+    """
+    global_flag = bool(ctx.obj.get("output_json")) if ctx.obj else False
+    return output_json_flag or global_flag


### PR DESCRIPTION
> **Stack slice of #482.** One of 12 concern-scoped PRs split out of #482. Its base is the previous slice, so the diff above shows only this slice's changes.
>
> **Do not merge this PR directly.** The complete change lands in one merge via the anchor PR #482, which contains every commit in this stack and is green. CI on a mid-stack slice may be red: slices are ordered by concern rather than by dependency, so a branch can reference code that lands in a later slice. That is an artifact of the ordering, not a defect in this diff.

Makes `tj --json <cmd>` and `tj <cmd> --json` equivalent on every command that supports JSON output, instead of a local flag silently ignoring the global one.
