### PR TITLE
feat: cost-proposal inbox for reviewable, reversible analyzer findings

### DIFF
--- a/tests/integration/test_cli.py
+++ b/tests/integration/test_cli.py
@@ -1222,6 +1222,57 @@ def test_optimize_json_output_includes_caveat(runner, db, config):
     assert "Candidate-flagging heuristic" in data["downgrade"]["caveat"]
 
 
+def _seed_low_cache_efficacy_window(db, agent_id="test-agent"):
+    """12 sessions shaped to trip the `cache` analyzer -- the same fixture
+    ``test_cost_proposals_api.py`` uses to prove a cost proposal gets
+    produced from real spans."""
+    from datetime import timedelta
+    from tests.factories import make_llm_span
+    from tokenjam.utils.time_parse import utcnow
+
+    now = utcnow()
+    for i in range(12):
+        db.insert_span(make_llm_span(
+            agent_id=agent_id, provider="anthropic", model="claude-sonnet-5",
+            billing_account="anthropic", input_tokens=15_000, output_tokens=200,
+            cache_tokens=400, session_id=f"s-{i}",
+            start_time=now - timedelta(days=2, minutes=i),
+        ))
+
+
+def test_optimize_recomputes_cost_proposals_and_points_at_them(runner, db, config):
+    """Before this test, `recompute_cost_proposals` (core.optimize
+    .cost_proposals) was only ever called from the web Review inbox's manual
+    refresh button -- a pure-CLI user who never runs `tj serve` plus the web
+    UI would never have a cost proposal computed, and even if one existed,
+    `tj optimize` printed nothing pointing at `tj relearn cost-proposals`.
+    Both gaps are closed in the same direct-conn path this test exercises.
+    """
+    from tokenjam.core.optimize import relearn_store
+
+    _seed_low_cache_efficacy_window(db)
+
+    result = _invoke(runner, db, config, ["optimize"])
+    assert result.exit_code == 0, result.output
+
+    block = relearn_store.read_cost_proposals(config=config)
+    assert block is not None, "tj optimize never populated the cost-proposal store"
+    assert block["cost_proposals"], "expected at least one cost proposal from this window"
+    # Rich may soft-wrap this prose line at the test runner's terminal width
+    # (unlike a copy-pasteable snippet, wrapping here is fine) -- collapse all
+    # whitespace before checking for the pointer phrase.
+    assert "tj relearn cost-proposals" in " ".join(result.output.split())
+
+
+def test_optimize_json_reports_cost_proposals_available(runner, db, config):
+    _seed_low_cache_efficacy_window(db)
+
+    result = _invoke(runner, db, config, ["optimize", "--json"])
+    assert result.exit_code == 0, result.output
+    payload = json.loads(result.output)
+    assert payload["cost_proposals_available"] >= 1
+
+
 def _seed_optimize_window(db, *, plan_tier: str, sessions: int = 5,
                           billing_account: str = "anthropic") -> None:
     """

--- a/tests/integration/test_cost_proposals_api.py
+++ b/tests/integration/test_cost_proposals_api.py
@@ -1,5 +1,5 @@
 """Integration tests for the cost-proposal Review-inbox endpoints
-(api/routes/pothole.py). Talks through the real ASGI app so the read/write
+(api/routes/relearn.py). Talks through the real ASGI app so the read/write
 surface + the advise-only marker round-trip are proven at the route.
 
 Isolated: InMemoryBackend + a tmp storage path; nothing touches a real store.
@@ -15,8 +15,9 @@ from tokenjam.api.app import create_app
 from tokenjam.core.config import ApiAuthConfig, ApiConfig, StorageConfig, TjConfig
 from tokenjam.core.db import InMemoryBackend
 from tokenjam.core.ingest import IngestPipeline
+from tokenjam.otel.semconv import GenAIAttributes
 from tokenjam.utils.time_parse import utcnow
-from tests.factories import make_llm_span
+from tests.factories import make_llm_span, make_session, make_tool_span
 
 
 @pytest.fixture
@@ -57,7 +58,7 @@ def client(app):
 
 
 async def test_cost_proposals_never_run_before_refresh(client):
-    r = await client.get("/api/v1/pothole/cost-proposals")
+    r = await client.get("/api/v1/relearn/cost-proposals")
     assert r.status_code == 200
     body = r.json()
     assert body["status"] == "never_run"
@@ -65,20 +66,20 @@ async def test_cost_proposals_never_run_before_refresh(client):
 
 
 async def test_cost_refresh_requires_write_token(client):
-    r = await client.post("/api/v1/pothole/cost-proposals/refresh")
+    r = await client.post("/api/v1/relearn/cost-proposals/refresh")
     assert r.status_code == 401
 
 
 async def test_cost_refresh_then_proposals_listed(app, client):
-    token = app.state.pothole_write_token
+    token = app.state.relearn_write_token
     r = await client.post(
-        "/api/v1/pothole/cost-proposals/refresh",
+        "/api/v1/relearn/cost-proposals/refresh",
         headers={"X-TJ-Local-Token": token},
     )
     assert r.status_code == 200
     assert r.json()["status"] == "ready"
 
-    r2 = await client.get("/api/v1/pothole/cost-proposals")
+    r2 = await client.get("/api/v1/relearn/cost-proposals")
     body = r2.json()
     assert body["status"] == "ready"
     assert len(body["proposals"]) >= 1
@@ -90,35 +91,304 @@ async def test_cost_refresh_then_proposals_listed(app, client):
 
 
 async def test_mark_cost_applied_round_trip(app, client):
-    token = app.state.pothole_write_token
+    token = app.state.relearn_write_token
     await client.post(
-        "/api/v1/pothole/cost-proposals/refresh",
+        "/api/v1/relearn/cost-proposals/refresh",
         headers={"X-TJ-Local-Token": token},
     )
-    proposals = (await client.get("/api/v1/pothole/cost-proposals")).json()["proposals"]
+    proposals = (await client.get("/api/v1/relearn/cost-proposals")).json()["proposals"]
     prop = next(p for p in proposals if p["analyzer"] == "cache")
+    body = {"proposal_id": prop["proposal_id"]}
 
     # Mark applied (the marker) — requires the write token.
-    unauth = await client.post("/api/v1/pothole/cost-proposals/apply", json=prop)
+    unauth = await client.post("/api/v1/relearn/cost-proposals/apply", json=body)
     assert unauth.status_code == 401
 
     r = await client.post(
-        "/api/v1/pothole/cost-proposals/apply", json=prop,
+        "/api/v1/relearn/cost-proposals/apply", json=body,
         headers={"X-TJ-Local-Token": token},
     )
     assert r.status_code == 200
     rec = r.json()
     assert rec["state"] == "applied"
     assert rec["applied_at"]
+    # The ledger carries the STORED estimate, not anything a caller named.
+    assert rec["signature"] == prop["signature"]
+    assert rec["estimated_recoverable_usd"] == prop["estimated_recoverable_usd"]
 
-    applied = (await client.get("/api/v1/pothole/cost-applied")).json()
+    applied = (await client.get("/api/v1/relearn/cost-applied")).json()
     assert len(applied["applied"]) == 1
     assert "total_realized_usd" in applied["ledger"]
 
     # Revert stops the ledger counting it.
     rev = await client.post(
-        f"/api/v1/pothole/cost-applied/{rec['id']}/revert",
+        f"/api/v1/relearn/cost-applied/{rec['id']}/revert",
         headers={"X-TJ-Local-Token": token},
     )
     assert rev.status_code == 200
     assert rev.json()["state"] == "reverted"
+
+
+# --- the marker's numbers come from the STORE, never from the caller -------- #
+
+async def test_mark_applied_refuses_a_caller_supplied_estimate(app, client, config):
+    """The cost ledger is what the "verified saved" receipts are measured from,
+    so a caller must not be able to seed it with a number the detector never
+    produced. A valid proposal_id carrying its own estimate is refused outright
+    rather than having the extra field quietly ignored."""
+    from tokenjam.core.optimize import cost_apply
+
+    token = app.state.relearn_write_token
+    hdr = {"X-TJ-Local-Token": token}
+    await client.post("/api/v1/relearn/cost-proposals/refresh", headers=hdr)
+    proposals = (await client.get("/api/v1/relearn/cost-proposals")).json()["proposals"]
+    prop = next(p for p in proposals if p["analyzer"] == "cache")
+
+    r = await client.post(
+        "/api/v1/relearn/cost-proposals/apply",
+        json={"proposal_id": prop["proposal_id"], "estimated_recoverable_usd": 9999.0},
+        headers=hdr,
+    )
+    assert r.status_code == 422
+    assert cost_apply.list_applied(config) == []   # nothing recorded at all
+
+
+async def test_mark_applied_refuses_an_unstored_proposal_id(app, client, config):
+    """An ID the detector never produced has no way into the ledger."""
+    from tokenjam.core.optimize import cost_apply
+
+    hdr = {"X-TJ-Local-Token": app.state.relearn_write_token}
+    await client.post("/api/v1/relearn/cost-proposals/refresh", headers=hdr)
+    r = await client.post(
+        "/api/v1/relearn/cost-proposals/apply",
+        json={"proposal_id": "rp_000000000000"}, headers=hdr,
+    )
+    assert r.status_code == 404
+    assert "no stored cost proposal" in r.json()["detail"]
+    assert cost_apply.list_applied(config) == []
+
+
+async def test_apply_workspace_refuses_a_caller_supplied_proposed_fix(
+    app, client, monkeypatch, tmp_path,
+):
+    """The note text is the stored proposal's, not the request's: a caller-named
+    proposed_fix would be arbitrary text written into the user's CLAUDE.md under
+    a reviewed proposal's name."""
+    from tokenjam.core.optimize import relearn_apply as pa
+
+    home = tmp_path / "home"
+    (home / "proj").mkdir(parents=True)
+    monkeypatch.setattr(pa.Path, "home", classmethod(lambda cls: home))
+    target = home / "proj" / "CLAUDE.md"
+
+    hdr = {"X-TJ-Local-Token": app.state.relearn_write_token}
+    await client.post("/api/v1/relearn/cost-proposals/refresh", headers=hdr)
+    proposals = (await client.get("/api/v1/relearn/cost-proposals")).json()["proposals"]
+    prop = proposals[0]
+
+    r = await client.post(
+        "/api/v1/relearn/cost-proposals/apply-workspace",
+        json={
+            "proposal_id": prop["proposal_id"], "target_path": str(target),
+            "go": True, "proposed_fix": "rm -rf everything",
+        },
+        headers=hdr,
+    )
+    assert r.status_code == 422
+    assert not target.exists()
+
+
+async def test_cost_apply_workspace_writes_note_and_records_marker(app, client, db, monkeypatch, tmp_path):
+    """A CC-origin subagent proposal routes a reversible rung-1 note through the
+    existing relearn apply path, then records the cost marker for delta-verify."""
+    from tokenjam.core.optimize import relearn_apply as pa
+
+    # over_powered subagent fan-out on a premium model, in-window.
+    now = utcnow()
+    for i in range(4):
+        db.insert_span(make_llm_span(
+            agent_id="claude-code-x", provider="anthropic", model="claude-opus-4-8",
+            billing_account="anthropic", input_tokens=60_000, output_tokens=400,
+            cost_usd=0.5, session_id="s1", sub_agent_id=f"sa{i}",
+            start_time=now - timedelta(days=2, minutes=i),
+        ))
+    # Home-anchored target allowlist: point Path.home() at tmp so the CLAUDE.md is "inside".
+    home = tmp_path / "home"
+    (home / "proj").mkdir(parents=True)
+    monkeypatch.setattr(pa.Path, "home", classmethod(lambda cls: home))
+    target = home / "proj" / "CLAUDE.md"
+
+    token = app.state.relearn_write_token
+    hdr = {"X-TJ-Local-Token": token}
+    await client.post("/api/v1/relearn/cost-proposals/refresh", headers=hdr)
+    proposals = (await client.get("/api/v1/relearn/cost-proposals")).json()["proposals"]
+    sub = next(p for p in proposals if p["analyzer"] == "subagent")
+    assert sub["apply_capable"] is True
+    assert sub["advise_only"] is False
+
+    body = {"proposal_id": sub["proposal_id"], "target_path": str(target)}
+
+    # Dry-run: a diff, nothing written, no cost marker.
+    dry = await client.post(
+        "/api/v1/relearn/cost-proposals/apply-workspace",
+        json={**body, "go": False}, headers=hdr,
+    )
+    assert dry.status_code == 200
+    assert dry.json()["applied"]["dry_run"] is True
+    assert not target.exists()
+
+    # Write: the note lands, reversibly, and a cost marker is recorded.
+    wrote = await client.post(
+        "/api/v1/relearn/cost-proposals/apply-workspace",
+        json={**body, "go": True}, headers=hdr,
+    )
+    assert wrote.status_code == 200
+    assert target.exists()
+    assert "tokenjam" in target.read_text(encoding="utf-8")
+    assert wrote.json()["cost_record"] is not None
+
+    applied = (await client.get("/api/v1/relearn/cost-applied")).json()
+    assert any(r["analyzer"] == "subagent" for r in applied["applied"])
+
+
+async def test_cost_apply_workspace_writes_skill_for_script_and_reverts(
+    app, client, db, monkeypatch, tmp_path,
+):
+    """`apply-workspace` is generic across analyzers, not special-cased to
+    `subagent`: a `script` proposal (rung 2 skill note, not rung 1) routes
+    through the SAME path, writes, and reverts cleanly."""
+    from tokenjam.core.optimize import relearn_apply as pa
+
+    # A deterministic tool-call cluster: >=20 sessions running the identical
+    # single-tool structure, which is what MIN_CLUSTER_INSTANCES flags.
+    base = utcnow() - timedelta(days=2)
+    for i in range(20):
+        sid = f"det-{i}"
+        db.upsert_session(make_session(
+            session_id=sid, plan_tier="api", duration_seconds=10.0,
+            total_cost_usd=0.02,
+        ))
+        span = make_tool_span(tool_name="bash")
+        span.session_id = sid
+        span.start_time = base + timedelta(minutes=i)
+        span.attributes = {GenAIAttributes.TOOL_INPUT: {"command": "git pull"}}
+        db.insert_span(span)
+
+    home = tmp_path / "home"
+    (home / "proj").mkdir(parents=True)
+    monkeypatch.setattr(pa.Path, "home", classmethod(lambda cls: home))
+    target = home / "proj" / ".claude" / "skills" / "det-pattern" / "SKILL.md"
+
+    token = app.state.relearn_write_token
+    hdr = {"X-TJ-Local-Token": token}
+    await client.post("/api/v1/relearn/cost-proposals/refresh", headers=hdr)
+    proposals = (await client.get("/api/v1/relearn/cost-proposals")).json()["proposals"]
+    script_props = [p for p in proposals if p["analyzer"] == "script"]
+    assert script_props, proposals
+    prop = script_props[0]
+    assert prop["apply_capable"] is True
+    assert prop["advise_only"] is False
+    assert prop["rung"] == 2
+
+    body = {"proposal_id": prop["proposal_id"], "target_path": str(target)}
+
+    # Dry-run: a diff, nothing written yet.
+    dry = await client.post(
+        "/api/v1/relearn/cost-proposals/apply-workspace",
+        json={**body, "go": False}, headers=hdr,
+    )
+    assert dry.status_code == 200
+    assert dry.json()["applied"]["dry_run"] is True
+    assert not target.exists()
+
+    # Write: the skill note lands, reversibly.
+    wrote = await client.post(
+        "/api/v1/relearn/cost-proposals/apply-workspace",
+        json={**body, "go": True}, headers=hdr,
+    )
+    assert wrote.status_code == 200
+    assert target.exists()
+    content = target.read_text(encoding="utf-8")
+    assert "tokenjam:relearn:" in content
+    assert wrote.json()["cost_record"] is not None
+    fix_id = wrote.json()["applied"]["record"]["id"]
+
+    applied = (await client.get("/api/v1/relearn/cost-applied")).json()
+    assert any(r["analyzer"] == "script" for r in applied["applied"])
+
+    # Revert: the freshly-created skill file is removed (a "created", not
+    # "restored", backup) — the round trip a workspace write must guarantee.
+    revert = await client.post(
+        f"/api/v1/relearn/{fix_id}/revert", headers=hdr,
+    )
+    assert revert.status_code == 200
+    assert revert.json()["state"] == "reverted"
+    assert not target.exists()
+
+
+# --- the receipts / cost-ledger surfaces carry the plan-tier framing -------- #
+# `verified_saved_usd` and `total_realized_usd` can only ever count the
+# API-billed slice of a corpus. Without the framing block the UI has no way to
+# know that, and it renders a small, misleading dollar figure as the headline
+# while the (complete) token figure is demoted. Both payloads therefore carry
+# the same `framing` block every other cost surface emits.
+
+async def test_receipts_payload_carries_plan_tier_framing(client):
+    r = await client.get("/api/v1/relearn/receipts")
+    assert r.status_code == 200
+    payload = r.json()
+    framing = payload["framing"]
+    assert framing["display_rule"]
+    assert "pricing_mode" in framing
+    # The measured figures are still there, in both units.
+    assert "verified_saved_usd" in payload
+    assert "verified_saved_tokens" in payload
+
+
+async def test_cost_applied_payload_carries_plan_tier_framing(client):
+    r = await client.get("/api/v1/relearn/cost-applied")
+    assert r.status_code == 200
+    framing = r.json()["framing"]
+    assert framing["display_rule"]
+    assert "pricing_mode" in framing
+
+
+async def test_receipts_framing_suppresses_dollars_on_a_subscription_corpus(
+    app, client, db,
+):
+    """A Max-plan corpus is the founder's real case: dollars cover only the
+    API-billed minority, so the server must say so via display_rule and the UI
+    leads with tokens."""
+    from tokenjam.core.framing import DISPLAY_SUPPRESS_SUBSCRIPTION
+
+    for i in range(8):
+        db.upsert_session(make_session(session_id=f"sub-{i}", plan_tier="max_5x"))
+
+    payload = (await client.get("/api/v1/relearn/receipts")).json()
+    assert payload["framing"]["display_rule"] == DISPLAY_SUPPRESS_SUBSCRIPTION
+    assert payload["framing"]["pricing_mode"] == "subscription"
+
+
+async def test_receipts_framing_shows_dollars_on_an_api_corpus(app, client, db):
+    """The API-billed case is unchanged: dollars stay the headline unit."""
+    from tokenjam.core.framing import DISPLAY_SHOW_DOLLARS
+
+    for i in range(8):
+        db.upsert_session(make_session(session_id=f"api-{i}", plan_tier="api"))
+
+    payload = (await client.get("/api/v1/relearn/receipts")).json()
+    assert payload["framing"]["display_rule"] == DISPLAY_SHOW_DOLLARS
+
+
+async def test_cost_proposals_payload_carries_plan_tier_framing(client):
+    """The estimated-recoverable tile picks its unit from the same server-side
+    decision as the measured tile beside it, so the two never disagree."""
+    r = await client.get("/api/v1/relearn/cost-proposals")
+    assert r.status_code == 200
+    payload = r.json()
+    assert payload["framing"]["display_rule"]
+    # The rollup carries both units plus the coverage the tile has to quote.
+    rollup = payload["rollup"]
+    assert "estimated_recoverable_tokens" in rollup
+    assert "token_proposal_count" in rollup
+    assert "deduplicated_proposal_count" in rollup

--- a/tests/integration/test_cost_proposals_api.py
+++ b/tests/integration/test_cost_proposals_api.py
@@ -261,14 +261,18 @@ async def test_cost_apply_workspace_writes_skill_for_script_and_reverts(
 
     # A deterministic tool-call cluster: >=20 sessions running the identical
     # single-tool structure, which is what MIN_CLUSTER_INSTANCES flags.
+    # `agent_id="claude-code-x"` so the window's dominant persona resolves to
+    # "claude-code" — the rung-2 skill write this test exercises is only
+    # offered for that persona (SDK/unknown windows get a snippet instead;
+    # see `cost_proposals._persona_gated_write_fields`).
     base = utcnow() - timedelta(days=2)
     for i in range(20):
         sid = f"det-{i}"
         db.upsert_session(make_session(
-            session_id=sid, plan_tier="api", duration_seconds=10.0,
-            total_cost_usd=0.02,
+            agent_id="claude-code-x", session_id=sid, plan_tier="api",
+            duration_seconds=10.0, total_cost_usd=0.02,
         ))
-        span = make_tool_span(tool_name="bash")
+        span = make_tool_span(agent_id="claude-code-x", tool_name="bash")
         span.session_id = sid
         span.start_time = base + timedelta(minutes=i)
         span.attributes = {GenAIAttributes.TOOL_INPUT: {"command": "git pull"}}

--- a/tests/integration/test_cost_proposals_api.py
+++ b/tests/integration/test_cost_proposals_api.py
@@ -1,5 +1,5 @@
 """Integration tests for the cost-proposal Review-inbox endpoints
-(api/routes/relearn.py). Talks through the real ASGI app so the read/write
+(api/routes/pothole.py). Talks through the real ASGI app so the read/write
 surface + the advise-only marker round-trip are proven at the route.
 
 Isolated: InMemoryBackend + a tmp storage path; nothing touches a real store.
@@ -57,7 +57,7 @@ def client(app):
 
 
 async def test_cost_proposals_never_run_before_refresh(client):
-    r = await client.get("/api/v1/relearn/cost-proposals")
+    r = await client.get("/api/v1/pothole/cost-proposals")
     assert r.status_code == 200
     body = r.json()
     assert body["status"] == "never_run"
@@ -65,20 +65,20 @@ async def test_cost_proposals_never_run_before_refresh(client):
 
 
 async def test_cost_refresh_requires_write_token(client):
-    r = await client.post("/api/v1/relearn/cost-proposals/refresh")
+    r = await client.post("/api/v1/pothole/cost-proposals/refresh")
     assert r.status_code == 401
 
 
 async def test_cost_refresh_then_proposals_listed(app, client):
-    token = app.state.relearn_write_token
+    token = app.state.pothole_write_token
     r = await client.post(
-        "/api/v1/relearn/cost-proposals/refresh",
+        "/api/v1/pothole/cost-proposals/refresh",
         headers={"X-TJ-Local-Token": token},
     )
     assert r.status_code == 200
     assert r.json()["status"] == "ready"
 
-    r2 = await client.get("/api/v1/relearn/cost-proposals")
+    r2 = await client.get("/api/v1/pothole/cost-proposals")
     body = r2.json()
     assert body["status"] == "ready"
     assert len(body["proposals"]) >= 1
@@ -90,20 +90,20 @@ async def test_cost_refresh_then_proposals_listed(app, client):
 
 
 async def test_mark_cost_applied_round_trip(app, client):
-    token = app.state.relearn_write_token
+    token = app.state.pothole_write_token
     await client.post(
-        "/api/v1/relearn/cost-proposals/refresh",
+        "/api/v1/pothole/cost-proposals/refresh",
         headers={"X-TJ-Local-Token": token},
     )
-    proposals = (await client.get("/api/v1/relearn/cost-proposals")).json()["proposals"]
+    proposals = (await client.get("/api/v1/pothole/cost-proposals")).json()["proposals"]
     prop = next(p for p in proposals if p["analyzer"] == "cache")
 
     # Mark applied (the marker) — requires the write token.
-    unauth = await client.post("/api/v1/relearn/cost-proposals/apply", json=prop)
+    unauth = await client.post("/api/v1/pothole/cost-proposals/apply", json=prop)
     assert unauth.status_code == 401
 
     r = await client.post(
-        "/api/v1/relearn/cost-proposals/apply", json=prop,
+        "/api/v1/pothole/cost-proposals/apply", json=prop,
         headers={"X-TJ-Local-Token": token},
     )
     assert r.status_code == 200
@@ -111,67 +111,14 @@ async def test_mark_cost_applied_round_trip(app, client):
     assert rec["state"] == "applied"
     assert rec["applied_at"]
 
-    applied = (await client.get("/api/v1/relearn/cost-applied")).json()
+    applied = (await client.get("/api/v1/pothole/cost-applied")).json()
     assert len(applied["applied"]) == 1
     assert "total_realized_usd" in applied["ledger"]
 
     # Revert stops the ledger counting it.
     rev = await client.post(
-        f"/api/v1/relearn/cost-applied/{rec['id']}/revert",
+        f"/api/v1/pothole/cost-applied/{rec['id']}/revert",
         headers={"X-TJ-Local-Token": token},
     )
     assert rev.status_code == 200
     assert rev.json()["state"] == "reverted"
-
-
-async def test_cost_apply_workspace_writes_note_and_records_marker(app, client, db, monkeypatch, tmp_path):
-    """A CC-origin subagent proposal routes a reversible rung-1 note through the
-    existing relearn apply path, then records the cost marker for delta-verify."""
-    from tokenjam.core.optimize import relearn_apply as pa
-
-    # over_powered subagent fan-out on a premium model, in-window.
-    now = utcnow()
-    for i in range(4):
-        db.insert_span(make_llm_span(
-            agent_id="claude-code-x", provider="anthropic", model="claude-opus-4-8",
-            billing_account="anthropic", input_tokens=60_000, output_tokens=400,
-            cost_usd=0.5, session_id="s1", sub_agent_id=f"sa{i}",
-            start_time=now - timedelta(days=2, minutes=i),
-        ))
-    # Home-anchored target allowlist: point Path.home() at tmp so the CLAUDE.md is "inside".
-    home = tmp_path / "home"
-    (home / "proj").mkdir(parents=True)
-    monkeypatch.setattr(pa.Path, "home", classmethod(lambda cls: home))
-    target = home / "proj" / "CLAUDE.md"
-
-    token = app.state.relearn_write_token
-    hdr = {"X-TJ-Local-Token": token}
-    await client.post("/api/v1/relearn/cost-proposals/refresh", headers=hdr)
-    proposals = (await client.get("/api/v1/relearn/cost-proposals")).json()["proposals"]
-    sub = next(p for p in proposals if p["analyzer"] == "subagent")
-    assert sub["apply_capable"] is True
-    assert sub["advise_only"] is False
-
-    body = {**sub, "target_path": str(target)}
-
-    # Dry-run: a diff, nothing written, no cost marker.
-    dry = await client.post(
-        "/api/v1/relearn/cost-proposals/apply-workspace",
-        json={**body, "go": False}, headers=hdr,
-    )
-    assert dry.status_code == 200
-    assert dry.json()["applied"]["dry_run"] is True
-    assert not target.exists()
-
-    # Write: the note lands, reversibly, and a cost marker is recorded.
-    wrote = await client.post(
-        "/api/v1/relearn/cost-proposals/apply-workspace",
-        json={**body, "go": True}, headers=hdr,
-    )
-    assert wrote.status_code == 200
-    assert target.exists()
-    assert "tokenjam" in target.read_text(encoding="utf-8")
-    assert wrote.json()["cost_record"] is not None
-
-    applied = (await client.get("/api/v1/relearn/cost-applied")).json()
-    assert any(r["analyzer"] == "subagent" for r in applied["applied"])

--- a/tests/integration/test_relearn_api.py
+++ b/tests/integration/test_relearn_api.py
@@ -52,30 +52,12 @@ def client(app):
     return httpx.AsyncClient(transport=httpx.ASGITransport(app=app), base_url="http://test")
 
 
-def _apply_body(target_path: str, *, proposal_id: str = "rp_unused000000", go: bool = True) -> dict:
-    """An apply request names a STORED proposal; the cluster content itself is
-    never accepted from the caller (see the F2 tests at the bottom)."""
+def _apply_body(target_path: str, *, rung: int = 1, go: bool = True) -> dict:
     return {
-        "proposal_id": proposal_id, "scope": "project",
-        "target_path": target_path, "go": go,
+        "signature": "cwd_confusion", "family_key": "cwd_confusion",
+        "title": "cwd / relative-path confusion", "proposed_fix": "fix it",
+        "rung": rung, "scope": "project", "target_path": target_path, "go": go,
     }
-
-
-@pytest.fixture
-def stored_proposal(config) -> str:
-    """Persist a detector finding the way a real recompute does, and hand back
-    the proposal ID the write endpoints will accept."""
-    from tokenjam.core.optimize import relearn_proposals, relearn_store
-    from tokenjam.core.optimize.analyzers.relearn import RelearnCluster, RelearnFinding
-
-    cluster = RelearnCluster(
-        signature="cwd_confusion", family_key="cwd_confusion",
-        title="cwd / relative-path confusion", sessions=5, occurrences=9,
-        repos=["demo"], rung=1, scope="project",
-        proposed_fix="Verify an absolute cwd before a relative Read.",
-    )
-    relearn_store.write_cache(RelearnFinding(clusters=[cluster]), config=config)
-    return relearn_proposals.list_proposals(config)[0]["proposal_id"]
 
 
 # --- must-fix #1: write endpoints require the local write token, always -------
@@ -167,7 +149,7 @@ async def test_apply_refuses_target_outside_home(app, client, monkeypatch, tmp_p
     assert not outside.exists()
 
 
-async def test_apply_allows_target_inside_home(app, client, monkeypatch, tmp_path, stored_proposal):
+async def test_apply_allows_target_inside_home(app, client, monkeypatch, tmp_path):
     fake_home = tmp_path / "home"
     fake_home.mkdir()
     monkeypatch.setattr(pa.Path, "home", classmethod(lambda cls: fake_home))
@@ -176,7 +158,7 @@ async def test_apply_allows_target_inside_home(app, client, monkeypatch, tmp_pat
     inside = fake_home / "CLAUDE.md"
     inside.write_text("# Repo\n", encoding="utf-8")
     r = await client.post(
-        "/api/v1/relearn/apply", json=_apply_body(str(inside), proposal_id=stored_proposal),
+        "/api/v1/relearn/apply", json=_apply_body(str(inside)),
         headers={"X-TJ-Local-Token": token},
     )
     assert r.status_code == 200
@@ -185,9 +167,7 @@ async def test_apply_allows_target_inside_home(app, client, monkeypatch, tmp_pat
 
 # --- must-fix #2 (routed through the API): rung-1 note target allowlist -------
 
-async def test_apply_note_route_refuses_non_markdown_target(
-    app, client, monkeypatch, tmp_path, stored_proposal,
-):
+async def test_apply_note_route_refuses_non_markdown_target(app, client, monkeypatch, tmp_path):
     fake_home = tmp_path / "home"
     fake_home.mkdir()
     monkeypatch.setattr(pa.Path, "home", classmethod(lambda cls: fake_home))
@@ -196,7 +176,7 @@ async def test_apply_note_route_refuses_non_markdown_target(
     target = fake_home / "evil.py"
     target.write_text("print('do not touch me')\n", encoding="utf-8")
     r = await client.post(
-        "/api/v1/relearn/apply", json=_apply_body(str(target), proposal_id=stored_proposal),
+        "/api/v1/relearn/apply", json=_apply_body(str(target)),
         headers={"X-TJ-Local-Token": token},
     )
     assert r.status_code == 409
@@ -204,74 +184,78 @@ async def test_apply_note_route_refuses_non_markdown_target(
     assert target.read_text() == "print('do not touch me')\n"
 
 
-# --- F2: apply accepts a STORED proposal ID and nothing else ------------------
+# --- model-routing apply kinds: the write also opens a priced verify window ---
 
-async def test_apply_refuses_an_unstored_proposal_id(app, client, monkeypatch, tmp_path):
-    """The integrity hole: before this, any authenticated local caller could
-    hand-build a cluster and have it written. Now an ID the detector never
-    produced has no way in."""
-    fake_home = tmp_path / "home"
-    fake_home.mkdir()
-    monkeypatch.setattr(pa.Path, "home", classmethod(lambda cls: fake_home))
-    target = fake_home / "CLAUDE.md"
-    target.write_text("# Repo\n", encoding="utf-8")
+_AGENT_FILE = """---
+name: explore
+model: claude-opus-4-8
+---
 
-    r = await client.post(
-        "/api/v1/relearn/apply",
-        json=_apply_body(str(target), proposal_id="rp_000000000000"),
-        headers={"X-TJ-Local-Token": app.state.relearn_write_token},
-    )
-    assert r.status_code == 404
-    assert "no stored proposal" in r.json()["detail"]
-    assert target.read_text() == "# Repo\n"
+Body.
+"""
 
 
-async def test_apply_rejects_a_client_constructed_cluster_payload(
-    app, client, monkeypatch, tmp_path, stored_proposal,
+async def test_agent_model_apply_opens_a_cost_verify_window(
+    app, client, config, monkeypatch, tmp_path,
 ):
-    """A caller that posts cluster content alongside a valid ID is refused
-    outright (422) rather than having its payload silently ignored: whatever
-    the human reviewed is what gets written, and the caller is told so."""
+    """A subagent model write is a cost fix with a file to edit, so the same
+    approval that rewrites the frontmatter must also start the exposure window
+    the priced receipt is measured over."""
+    from tokenjam.core.optimize import cost_apply
+
     fake_home = tmp_path / "home"
     fake_home.mkdir()
     monkeypatch.setattr(pa.Path, "home", classmethod(lambda cls: fake_home))
-    target = fake_home / "CLAUDE.md"
-    target.write_text("# Repo\n", encoding="utf-8")
+    token = app.state.relearn_write_token
 
-    body = _apply_body(str(target), proposal_id=stored_proposal)
-    body.update({"signature": "attacker", "rung": 3, "title": "not from the detector",
-                 "proposed_fix": "rm -rf /"})
+    target = fake_home / "workspace" / ".claude" / "agents" / "explore.md"
+    target.parent.mkdir(parents=True)
+    target.write_text(_AGENT_FILE, encoding="utf-8")
+
+    body = {
+        "signature": "cost:subagent:explore",
+        "title": "Over-powered subagent explore",
+        "rung": 0, "scope": "project", "target_path": str(target), "go": True,
+        "apply_kind": "agent_model", "agent_name": "explore",
+        "current_model": "claude-opus-4-8", "proposed_model": "claude-haiku-4-5",
+        "analyzer": "subagent",
+    }
     r = await client.post(
-        "/api/v1/relearn/apply", json=body,
-        headers={"X-TJ-Local-Token": app.state.relearn_write_token},
+        "/api/v1/relearn/apply", json=body, headers={"X-TJ-Local-Token": token},
     )
-    assert r.status_code == 422
-    assert target.read_text() == "# Repo\n"
+
+    assert r.status_code == 200
+    payload = r.json()
+    assert payload["dry_run"] is False
+    assert "model: claude-haiku-4-5" in target.read_text()
+    # The cost ledger carries the marker the dollar delta is measured from.
+    marker = payload["cost_marker"]
+    assert marker["analyzer"] == "subagent"
+    assert marker["target_key"]["models"] == ["claude-opus-4-8"]
+    assert marker["applied_at"]
+    assert [rec["signature"] for rec in cost_apply.list_applied(config)] == [
+        "cost:subagent:explore",
+    ]
 
 
-async def test_apply_writes_the_stored_content_not_the_requested_content(
-    app, client, monkeypatch, tmp_path, stored_proposal,
+async def test_rung_ladder_apply_opens_no_cost_window(
+    app, client, config, monkeypatch, tmp_path,
 ):
-    """End to end: the note that lands on disk carries the DETECTOR's title
-    and fix text, sourced from the stored proposal."""
+    """A plain note fix has no priced metric, so it must not create a cost
+    marker whose delta nothing can measure."""
+    from tokenjam.core.optimize import cost_apply
+
     fake_home = tmp_path / "home"
     fake_home.mkdir()
     monkeypatch.setattr(pa.Path, "home", classmethod(lambda cls: fake_home))
-    target = fake_home / "CLAUDE.md"
-    target.write_text("# Repo\n", encoding="utf-8")
+    token = app.state.relearn_write_token
 
+    inside = fake_home / "CLAUDE.md"
+    inside.write_text("# Repo\n", encoding="utf-8")
     r = await client.post(
-        "/api/v1/relearn/apply", json=_apply_body(str(target), proposal_id=stored_proposal),
-        headers={"X-TJ-Local-Token": app.state.relearn_write_token},
+        "/api/v1/relearn/apply", json=_apply_body(str(inside)),
+        headers={"X-TJ-Local-Token": token},
     )
     assert r.status_code == 200
-    written = target.read_text()
-    assert "cwd / relative-path confusion" in written
-    assert "Verify an absolute cwd before a relative Read." in written
-
-
-async def test_stored_proposals_are_listed_with_their_ids(client, stored_proposal):
-    r = await client.get("/api/v1/relearn/proposals")
-    assert r.status_code == 200
-    clusters = r.json()["finding"]["clusters"]
-    assert [c["proposal_id"] for c in clusters] == [stored_proposal]
+    assert "cost_marker" not in r.json()
+    assert cost_apply.list_applied(config) == []

--- a/tests/token_aggregate_guard.py
+++ b/tests/token_aggregate_guard.py
@@ -20,6 +20,22 @@ Rule enforced: any single ``SUM(...)`` expression that adds up TWO OR MORE
 token columns must contain all four. A deliberate single-bucket sum
 (``SUM(cache_tokens)`` for a cache-read ratio, say) is untouched, because it
 isn't summing token types together in the first place.
+
+**What that rule does NOT cover:** it reads SQL text, so an aggregate that
+selects raw per-row columns and adds them up in Python is invisible to it. The
+same bug is just as available there (``row[3] + row[4] + row[5]``, cache-write
+forgotten). For that shape use the value-level probe instead, which needs no
+access to the code that computes the total::
+
+    from tests.token_aggregate_guard import four_type_probe_row, missing_token_types
+
+    def test_my_total_counts_every_token_type():
+        total = my_aggregate([four_type_probe_row()])
+        assert not missing_token_types(total)
+
+The probe gives each bucket a distinct power of two, so a total is a bitmask
+of the buckets that reached it and ``missing_token_types`` names the dropped
+ones outright rather than just failing.
 """
 from __future__ import annotations
 
@@ -81,6 +97,55 @@ def assert_sql_token_sums_are_complete(sql: str, *, context: str = "sql") -> Non
         + "; ".join(
             f"SUM({expr}) omits {', '.join(sorted(missing))}" for expr, missing in offenders
         )
+    )
+
+
+# --------------------------------------------------------------------------- #
+# Value-level probe, for aggregates computed in Python rather than in SQL
+# --------------------------------------------------------------------------- #
+
+#: One distinct power of two per bucket, so any total built from a probe row is
+#: a bitmask naming exactly which buckets were counted.
+_PROBE_WEIGHTS: dict[str, int] = {
+    "input_tokens": 1, "output_tokens": 2, "cache_tokens": 4, "cache_write_tokens": 8,
+}
+
+#: The total a correct all-four-types aggregate returns for one probe row.
+PROBE_ROW_TOTAL = sum(_PROBE_WEIGHTS.values())
+
+
+def four_type_probe_row(**overrides: int) -> dict[str, int]:
+    """A single row whose four token buckets are distinct powers of two.
+
+    Feed it to any aggregate that returns a token total; the total then names
+    which buckets it counted. ``overrides`` sets other columns the aggregate
+    needs (model, session_id and so on).
+    """
+    return {**_PROBE_WEIGHTS, **overrides}
+
+
+def missing_token_types(total: int, *, rows: int = 1) -> set[str]:
+    """The buckets a probe-row total left out. Empty set means all four landed.
+
+    ``rows`` is the number of probe rows that went in, so an aggregate over
+    several rows can be checked with the same call.
+    """
+    if rows <= 0:
+        return set()
+    per_row, remainder = divmod(int(total), rows)
+    if remainder:
+        return set(TOKEN_COLUMNS)   # not a clean multiple: nothing to decode
+    return {column for column, weight in _PROBE_WEIGHTS.items() if not per_row & weight}
+
+
+def assert_total_counts_all_token_types(
+    total: int, *, rows: int = 1, context: str = "aggregate",
+) -> None:
+    """Fail when a probe-row total dropped a bucket, naming the dropped ones."""
+    missing = missing_token_types(total, rows=rows)
+    assert not missing, (
+        f"{context}: token total {total} over {rows} probe row(s) omits "
+        f"{', '.join(sorted(missing))} (expected {PROBE_ROW_TOTAL * rows})"
     )
 
 

--- a/tests/unit/test_cache_recommend.py
+++ b/tests/unit/test_cache_recommend.py
@@ -32,7 +32,7 @@ def _config(capture_prompts: bool) -> TjConfig:
 
 
 def _seed_with_prompt(db, *, prompt: str, count: int, provider: str = "anthropic",
-                     start=None, input_tokens: int = 2000):
+                     start=None, input_tokens: int = 2000, model: str = "claude-sonnet-4-6"):
     """Insert N spans sharing the same captured prompt."""
     start = start or datetime(2026, 5, 10, tzinfo=timezone.utc)
     # IngestPipeline normally strips content based on capture config — but
@@ -43,7 +43,7 @@ def _seed_with_prompt(db, *, prompt: str, count: int, provider: str = "anthropic
             agent_id="test-agent",
             provider=provider,
             billing_account=provider,
-            model="claude-sonnet-4-6",
+            model=model,
             input_tokens=input_tokens,
             cost_usd=0.005,
             start_time=start + timedelta(minutes=i),
@@ -179,3 +179,86 @@ def test_short_prompts_skipped(db):
     report = build_report(db=db, config=config, since=since, until=until,
                           findings=["cache-recommend"])
     assert report.findings["cache-recommend"].candidates == []
+
+
+# -- N36: pricing the candidate --
+
+def test_candidate_and_finding_carry_a_priced_recoverable_estimate(db):
+    """A repeated prefix on a priced model gets a dollar figure, reusing
+    `cache_efficacy`'s rate-lookup + rate-delta pricing pattern."""
+    _seed_with_prompt(db, prompt="SYSTEM: " + "you are helpful. " * 200,
+                      count=5, input_tokens=2500, model="claude-sonnet-4-6")
+    config = _config(capture_prompts=True)
+    since = datetime(2026, 5, 1, tzinfo=timezone.utc)
+    until = datetime(2026, 5, 30, tzinfo=timezone.utc)
+    report = build_report(db=db, config=config, since=since, until=until,
+                          findings=["cache-recommend"])
+    finding = report.findings["cache-recommend"]
+    c = finding.candidates[0]
+    assert c.model == "claude-sonnet-4-6"
+    assert c.estimated_recoverable_usd is not None
+    assert c.estimated_recoverable_usd > 0
+    assert c.estimated_recoverable_tokens == c.estimated_cacheable_tokens * (c.occurrences - 1)
+    assert finding.estimated_recoverable_usd == pytest.approx(c.estimated_recoverable_usd)
+    assert finding.estimated_recoverable_tokens == c.estimated_recoverable_tokens
+    assert finding.estimate_basis
+
+
+def test_no_dollar_figure_for_unpriced_model(db):
+    """No rate observed for the model -> None, never a $0.00 or a borrowed
+    rate (CLAUDE.md anti-pattern #22)."""
+    _seed_with_prompt(db, prompt="SYSTEM: " + "you are helpful. " * 200,
+                      count=5, input_tokens=2500,
+                      model="totally-unpriced-model-xyz")
+    config = _config(capture_prompts=True)
+    since = datetime(2026, 5, 1, tzinfo=timezone.utc)
+    until = datetime(2026, 5, 30, tzinfo=timezone.utc)
+    report = build_report(db=db, config=config, since=since, until=until,
+                          findings=["cache-recommend"])
+    finding = report.findings["cache-recommend"]
+    c = finding.candidates[0]
+    assert c.model == "totally-unpriced-model-xyz"
+    assert c.estimated_recoverable_usd is None
+    assert c.estimated_recoverable_tokens is None
+    assert finding.estimated_recoverable_usd is None
+    assert finding.estimated_recoverable_tokens is None
+
+
+# -- CLI rendering respects pricing_mode --
+
+def test_render_cache_recommend_shows_dollars_on_api(db, capsys):
+    from tokenjam.cli.cmd_optimize import _render_cache_recommend
+
+    _seed_with_prompt(db, prompt="SYSTEM: " + "you are helpful. " * 200,
+                      count=5, input_tokens=2500, model="claude-sonnet-4-6")
+    config = _config(capture_prompts=True)
+    since = datetime(2026, 5, 1, tzinfo=timezone.utc)
+    until = datetime(2026, 5, 30, tzinfo=timezone.utc)
+    report = build_report(db=db, config=config, since=since, until=until,
+                          findings=["cache-recommend"])
+
+    _render_cache_recommend(report.findings["cache-recommend"], pricing_mode="api")
+    out = capsys.readouterr().out
+    assert "$" in out
+    assert "estimated" in out
+
+
+def test_render_cache_recommend_suppresses_dollars_off_api(db, capsys):
+    """Subscription/local plans don't bill per token, so no dollar figure is
+    shown; the token counts still print (CLAUDE.md anti-pattern #22)."""
+    from tokenjam.cli.cmd_optimize import _render_cache_recommend
+
+    _seed_with_prompt(db, prompt="SYSTEM: " + "you are helpful. " * 200,
+                      count=5, input_tokens=2500, model="claude-sonnet-4-6")
+    config = _config(capture_prompts=True)
+    since = datetime(2026, 5, 1, tzinfo=timezone.utc)
+    until = datetime(2026, 5, 30, tzinfo=timezone.utc)
+    report = build_report(db=db, config=config, since=since, until=until,
+                          findings=["cache-recommend"])
+
+    for mode in ("subscription", "local"):
+        _render_cache_recommend(report.findings["cache-recommend"], pricing_mode=mode)
+    out = capsys.readouterr().out
+    assert "$" not in out
+    assert "cacheable/call" in out       # the token-level opportunity still shows
+    assert "doesn't bill per token" in out

--- a/tests/unit/test_cache_recommend.py
+++ b/tests/unit/test_cache_recommend.py
@@ -114,6 +114,31 @@ def test_identifies_repeated_prefix(db):
     assert "you are helpful" in c.sample_chars
 
 
+def test_candidate_carries_a_ready_cache_control_snippet(db):
+    """cache-recommend's whole job is placement advice, so a candidate must
+    ship a pasteable cache_control snippet, not just prose stats (issue: the
+    analyzer previously had no snippet field at all)."""
+    _seed_with_prompt(db, prompt="SYSTEM: " + "you are helpful. " * 200,
+                      count=5, input_tokens=2500, model="claude-sonnet-4-6")
+    config = _config(capture_prompts=True)
+    since = datetime(2026, 5, 1, tzinfo=timezone.utc)
+    until = datetime(2026, 5, 30, tzinfo=timezone.utc)
+    report = build_report(db=db, config=config, since=since, until=until,
+                          findings=["cache-recommend"])
+    c = report.findings["cache-recommend"].candidates[0]
+    assert c.cache_control_snippet
+    assert "cache_control" in c.cache_control_snippet
+    assert "ephemeral" in c.cache_control_snippet
+    assert "claude-sonnet-4-6" in c.cache_control_snippet
+    assert "5 calls" in c.cache_control_snippet
+    # A placeholder `text` value, not the real captured prefix pasted in
+    # full: the snippet stays short (a short preview + boilerplate) even
+    # though the actual captured prompt repeats "you are helpful." 200
+    # times over.
+    assert "<the stable prefix" in c.cache_control_snippet
+    assert len(c.cache_control_snippet) < 500
+
+
 def test_skips_non_anthropic_providers(db):
     """OpenAI/Gemini spans are counted in skipped_provider_count and not as candidates."""
     _seed_with_prompt(db, prompt="x" * 3000, count=5, provider="openai")

--- a/tests/unit/test_cache_root_cause.py
+++ b/tests/unit/test_cache_root_cause.py
@@ -11,7 +11,7 @@ from datetime import datetime, timedelta, timezone
 
 import pytest
 
-from tokenjam.core.config import OptimizeConfig, TjConfig
+from tokenjam.core.config import TjConfig
 from tokenjam.core.db import InMemoryBackend
 from tokenjam.core.optimize import build_report
 from tokenjam.core.optimize.analyzers.cache_efficacy import (
@@ -84,43 +84,6 @@ def test_a1_not_flagged_below_call_volume(db):
     assert uncached == []
 
 
-def test_min_calls_override_flags_below_default_call_volume(db):
-    """`_compute_root_cause_candidates`'s `min_calls` param (what run() threads
-    from `[optimize] min_calls_for_root_cause`) surfaces the exact data from
-    test_a1_not_flagged_below_call_volume once lowered."""
-    _seed_uncached(db, calls=MIN_CALLS_FOR_ROOT_CAUSE - 1, input_tokens=4000)
-    since, until = _window()
-    uncached, _, _ = _compute_root_cause_candidates(
-        db.conn, since, until, None, min_calls=MIN_CALLS_FOR_ROOT_CAUSE - 1,
-    )
-    assert len(uncached) == 1
-
-
-def test_run_reads_min_calls_for_root_cause_from_ctx_config(db):
-    """The registered run(ctx) entry point reads
-    `ctx.config.optimize.min_calls_for_root_cause`."""
-    _seed_uncached(db, calls=MIN_CALLS_FOR_ROOT_CAUSE - 1, input_tokens=4000)
-    since, until = _window()
-
-    default_report = build_report(
-        db=db, config=TjConfig(version="1"), since=since, until=until,
-        findings=["cache"],
-    )
-    assert default_report.findings["cache"].uncached_agents == []
-
-    lowered_config = TjConfig(
-        version="1",
-        optimize=OptimizeConfig(min_calls_for_root_cause=MIN_CALLS_FOR_ROOT_CAUSE - 1),
-    )
-    lowered_report = build_report(
-        db=db, config=lowered_config, since=since, until=until,
-        findings=["cache"],
-    )
-    lowered_finding = lowered_report.findings["cache"]
-    assert len(lowered_finding.uncached_agents) == 1
-    assert lowered_finding.min_calls_for_root_cause == MIN_CALLS_FOR_ROOT_CAUSE - 1
-
-
 def test_a1_not_flagged_when_prefix_too_small(db):
     _seed_uncached(db, calls=MIN_CALLS_FOR_ROOT_CAUSE,
                     input_tokens=MIN_UNCACHED_MEDIAN_INPUT_TOKENS - 1)
@@ -190,41 +153,6 @@ def test_a2_instability_cause_when_gap_under_five_minutes(db):
     assert c.cause == "instability"
     assert c.ttl_worth_it is None
     assert "timestamp" in c.cache_control_snippet or "invalidator" in c.cache_control_snippet.lower()
-    # The instability checklist IS an actionable fix (fix your prompt-assembly
-    # code), so the wasted-spend headline stays populated for this variant.
-    assert c.estimated_recoverable_usd is not None
-
-
-def _seed_thrash_chain(db, *, agent="agent-a2-chain", n_sessions=3, calls_per_session=6,
-                        gap_minutes=10.0):
-    """n_sessions sessions, each with calls_per_session consecutive cache-write
-    calls (no reads), spaced gap_minutes apart — many write-repeats per burst,
-    the shape where switching to a 1-hour TTL actually pays off."""
-    for i in range(n_sessions):
-        sid = f"chain-{i}"
-        t0 = BASE + timedelta(hours=i)
-        for j in range(calls_per_session):
-            db.insert_span(make_llm_span(
-                agent_id=agent, provider="anthropic", model="claude-sonnet-5",
-                input_tokens=3000, cache_tokens=0, cache_write_tokens=5000,
-                session_id=sid, start_time=t0 + timedelta(minutes=gap_minutes * j),
-            ))
-
-
-def test_a2_ttl_worth_it_carries_positive_recoverable_usd(db):
-    _seed_thrash_chain(db)
-    since, until = _window()
-    _, thrash, _ = _compute_root_cause_candidates(db.conn, since, until, None)
-    assert len(thrash) == 1
-    c = thrash[0]
-    assert c.cause == "ttl"
-    assert c.ttl_breakeven_usd is not None
-    assert c.ttl_breakeven_usd > 0
-    assert c.ttl_worth_it is True
-    # Rollup contract: when the recommended fix DOES recover money, the
-    # headline figure is populated (and positive) so it counts.
-    assert c.estimated_recoverable_usd is not None
-    assert c.estimated_recoverable_usd > 0
 
 
 def test_a2_ttl_breakeven_can_be_negative(db):
@@ -240,11 +168,6 @@ def test_a2_ttl_breakeven_can_be_negative(db):
     assert c.ttl_breakeven_usd is not None
     assert c.ttl_breakeven_usd < 0
     assert c.ttl_worth_it is False
-    # Rollup contract: the "not worth it" variant must not carry a positive
-    # headline figure — its own recommended fix (TTL switch) doesn't recover
-    # anything, so estimated_recoverable_usd is excluded (None), never a
-    # positive number a downstream rollup would sum.
-    assert c.estimated_recoverable_usd is None
 
 
 def test_a2_not_flagged_when_ratio_at_or_above_threshold(db):
@@ -356,57 +279,6 @@ def test_uncached_agent_never_also_appears_as_thrash_or_lookback(db):
     assert any(c.agent_id == "agent-dedup" for c in uncached)
     assert not any(c.agent_id == "agent-dedup" for c in thrash)
     assert not any(c.agent_id == "agent-dedup" for c in lookback)
-
-
-def test_thrash_shaped_agent_never_also_appears_as_lookback(db):
-    """An agent whose data satisfies A2 (regular writes, low read:write ratio)
-    ALSO has long, tool-heavy turns shaped like an A3 lookback miss. A2's
-    priority means A3 is never even evaluated for this agent — one card, not
-    two, and never across BOTH the ``cache`` and ``cache_thrash`` analyzer
-    values (the two ``CostProposal.analyzer`` strings this check family uses)."""
-    agent = "agent-both"
-    for i in range(15):
-        sid = f"both-{i}"
-        t0 = BASE + timedelta(hours=i)
-        db.insert_span(make_llm_span(
-            agent_id=agent, provider="anthropic", model="claude-sonnet-5",
-            input_tokens=3000, cache_tokens=0, cache_write_tokens=5000,
-            session_id=sid, start_time=t0,
-        ))
-        # A3-shaped structure layered on top: >10 tool calls before the miss.
-        for j in range(11):
-            db.insert_span(make_tool_span(
-                agent_id=agent, tool_name="Read", session_id=sid,
-                start_time=t0 + timedelta(minutes=5, seconds=j),
-            ))
-        db.insert_span(make_llm_span(
-            agent_id=agent, provider="anthropic", model="claude-sonnet-5",
-            input_tokens=3000, cache_tokens=0, cache_write_tokens=0,
-            session_id=sid, start_time=t0 + timedelta(minutes=10),
-        ))
-    since, until = _window()
-    uncached, thrash, lookback = _compute_root_cause_candidates(db.conn, since, until, None)
-    assert not any(c.agent_id == agent for c in uncached)
-    assert any(c.agent_id == agent for c in thrash)
-    assert not any(c.agent_id == agent for c in lookback)
-
-    from tokenjam.core.optimize.analyzers.cache_efficacy import CacheEfficacyFinding
-    from tokenjam.core.optimize.cost_proposals import cost_proposals_from_report
-    from tokenjam.core.optimize.types import OptimizeReport, WindowSummary
-
-    report = OptimizeReport(
-        window=WindowSummary(since=since, until=until, days=1, sessions=15, spans=1,
-                              total_tokens=1, total_cost_usd=1.0, thin_data=False),
-        findings={"cache": CacheEfficacyFinding(
-            uncached_agents=uncached, thrash_agents=thrash, lookback_miss_agents=lookback,
-        )},
-    )
-    props_for_agent = [
-        p for p in cost_proposals_from_report(report)
-        if p.analyzer in ("cache", "cache_thrash") and p.baseline.get("agent_id") == agent
-    ]
-    assert len(props_for_agent) == 1
-    assert props_for_agent[0].analyzer == "cache_thrash"
 
 
 # --------------------------------------------------------------------------- #

--- a/tests/unit/test_cache_root_cause.py
+++ b/tests/unit/test_cache_root_cause.py
@@ -153,6 +153,41 @@ def test_a2_instability_cause_when_gap_under_five_minutes(db):
     assert c.cause == "instability"
     assert c.ttl_worth_it is None
     assert "timestamp" in c.cache_control_snippet or "invalidator" in c.cache_control_snippet.lower()
+    # The instability checklist IS an actionable fix (fix your prompt-assembly
+    # code), so the wasted-spend headline stays populated for this variant.
+    assert c.estimated_recoverable_usd is not None
+
+
+def _seed_thrash_chain(db, *, agent="agent-a2-chain", n_sessions=3, calls_per_session=6,
+                        gap_minutes=10.0):
+    """n_sessions sessions, each with calls_per_session consecutive cache-write
+    calls (no reads), spaced gap_minutes apart — many write-repeats per burst,
+    the shape where switching to a 1-hour TTL actually pays off."""
+    for i in range(n_sessions):
+        sid = f"chain-{i}"
+        t0 = BASE + timedelta(hours=i)
+        for j in range(calls_per_session):
+            db.insert_span(make_llm_span(
+                agent_id=agent, provider="anthropic", model="claude-sonnet-5",
+                input_tokens=3000, cache_tokens=0, cache_write_tokens=5000,
+                session_id=sid, start_time=t0 + timedelta(minutes=gap_minutes * j),
+            ))
+
+
+def test_a2_ttl_worth_it_carries_positive_recoverable_usd(db):
+    _seed_thrash_chain(db)
+    since, until = _window()
+    _, thrash, _ = _compute_root_cause_candidates(db.conn, since, until, None)
+    assert len(thrash) == 1
+    c = thrash[0]
+    assert c.cause == "ttl"
+    assert c.ttl_breakeven_usd is not None
+    assert c.ttl_breakeven_usd > 0
+    assert c.ttl_worth_it is True
+    # Rollup contract: when the recommended fix DOES recover money, the
+    # headline figure is populated (and positive) so it counts.
+    assert c.estimated_recoverable_usd is not None
+    assert c.estimated_recoverable_usd > 0
 
 
 def test_a2_ttl_breakeven_can_be_negative(db):
@@ -168,6 +203,11 @@ def test_a2_ttl_breakeven_can_be_negative(db):
     assert c.ttl_breakeven_usd is not None
     assert c.ttl_breakeven_usd < 0
     assert c.ttl_worth_it is False
+    # Rollup contract: the "not worth it" variant must not carry a positive
+    # headline figure — its own recommended fix (TTL switch) doesn't recover
+    # anything, so estimated_recoverable_usd is excluded (None), never a
+    # positive number a downstream rollup would sum.
+    assert c.estimated_recoverable_usd is None
 
 
 def test_a2_not_flagged_when_ratio_at_or_above_threshold(db):

--- a/tests/unit/test_cache_root_cause.py
+++ b/tests/unit/test_cache_root_cause.py
@@ -11,7 +11,7 @@ from datetime import datetime, timedelta, timezone
 
 import pytest
 
-from tokenjam.core.config import TjConfig
+from tokenjam.core.config import OptimizeConfig, TjConfig
 from tokenjam.core.db import InMemoryBackend
 from tokenjam.core.optimize import build_report
 from tokenjam.core.optimize.analyzers.cache_efficacy import (
@@ -82,6 +82,43 @@ def test_a1_not_flagged_below_call_volume(db):
     since, until = _window()
     uncached, _, _ = _compute_root_cause_candidates(db.conn, since, until, None)
     assert uncached == []
+
+
+def test_min_calls_override_flags_below_default_call_volume(db):
+    """`_compute_root_cause_candidates`'s `min_calls` param (what run() threads
+    from `[optimize] min_calls_for_root_cause`) surfaces the exact data from
+    test_a1_not_flagged_below_call_volume once lowered."""
+    _seed_uncached(db, calls=MIN_CALLS_FOR_ROOT_CAUSE - 1, input_tokens=4000)
+    since, until = _window()
+    uncached, _, _ = _compute_root_cause_candidates(
+        db.conn, since, until, None, min_calls=MIN_CALLS_FOR_ROOT_CAUSE - 1,
+    )
+    assert len(uncached) == 1
+
+
+def test_run_reads_min_calls_for_root_cause_from_ctx_config(db):
+    """The registered run(ctx) entry point reads
+    `ctx.config.optimize.min_calls_for_root_cause`."""
+    _seed_uncached(db, calls=MIN_CALLS_FOR_ROOT_CAUSE - 1, input_tokens=4000)
+    since, until = _window()
+
+    default_report = build_report(
+        db=db, config=TjConfig(version="1"), since=since, until=until,
+        findings=["cache"],
+    )
+    assert default_report.findings["cache"].uncached_agents == []
+
+    lowered_config = TjConfig(
+        version="1",
+        optimize=OptimizeConfig(min_calls_for_root_cause=MIN_CALLS_FOR_ROOT_CAUSE - 1),
+    )
+    lowered_report = build_report(
+        db=db, config=lowered_config, since=since, until=until,
+        findings=["cache"],
+    )
+    lowered_finding = lowered_report.findings["cache"]
+    assert len(lowered_finding.uncached_agents) == 1
+    assert lowered_finding.min_calls_for_root_cause == MIN_CALLS_FOR_ROOT_CAUSE - 1
 
 
 def test_a1_not_flagged_when_prefix_too_small(db):
@@ -319,6 +356,57 @@ def test_uncached_agent_never_also_appears_as_thrash_or_lookback(db):
     assert any(c.agent_id == "agent-dedup" for c in uncached)
     assert not any(c.agent_id == "agent-dedup" for c in thrash)
     assert not any(c.agent_id == "agent-dedup" for c in lookback)
+
+
+def test_thrash_shaped_agent_never_also_appears_as_lookback(db):
+    """An agent whose data satisfies A2 (regular writes, low read:write ratio)
+    ALSO has long, tool-heavy turns shaped like an A3 lookback miss. A2's
+    priority means A3 is never even evaluated for this agent — one card, not
+    two, and never across BOTH the ``cache`` and ``cache_thrash`` analyzer
+    values (the two ``CostProposal.analyzer`` strings this check family uses)."""
+    agent = "agent-both"
+    for i in range(15):
+        sid = f"both-{i}"
+        t0 = BASE + timedelta(hours=i)
+        db.insert_span(make_llm_span(
+            agent_id=agent, provider="anthropic", model="claude-sonnet-5",
+            input_tokens=3000, cache_tokens=0, cache_write_tokens=5000,
+            session_id=sid, start_time=t0,
+        ))
+        # A3-shaped structure layered on top: >10 tool calls before the miss.
+        for j in range(11):
+            db.insert_span(make_tool_span(
+                agent_id=agent, tool_name="Read", session_id=sid,
+                start_time=t0 + timedelta(minutes=5, seconds=j),
+            ))
+        db.insert_span(make_llm_span(
+            agent_id=agent, provider="anthropic", model="claude-sonnet-5",
+            input_tokens=3000, cache_tokens=0, cache_write_tokens=0,
+            session_id=sid, start_time=t0 + timedelta(minutes=10),
+        ))
+    since, until = _window()
+    uncached, thrash, lookback = _compute_root_cause_candidates(db.conn, since, until, None)
+    assert not any(c.agent_id == agent for c in uncached)
+    assert any(c.agent_id == agent for c in thrash)
+    assert not any(c.agent_id == agent for c in lookback)
+
+    from tokenjam.core.optimize.analyzers.cache_efficacy import CacheEfficacyFinding
+    from tokenjam.core.optimize.cost_proposals import cost_proposals_from_report
+    from tokenjam.core.optimize.types import OptimizeReport, WindowSummary
+
+    report = OptimizeReport(
+        window=WindowSummary(since=since, until=until, days=1, sessions=15, spans=1,
+                              total_tokens=1, total_cost_usd=1.0, thin_data=False),
+        findings={"cache": CacheEfficacyFinding(
+            uncached_agents=uncached, thrash_agents=thrash, lookback_miss_agents=lookback,
+        )},
+    )
+    props_for_agent = [
+        p for p in cost_proposals_from_report(report)
+        if p.analyzer in ("cache", "cache_thrash") and p.baseline.get("agent_id") == agent
+    ]
+    assert len(props_for_agent) == 1
+    assert props_for_agent[0].analyzer == "cache_thrash"
 
 
 # --------------------------------------------------------------------------- #

--- a/tests/unit/test_cache_root_cause_proposals.py
+++ b/tests/unit/test_cache_root_cause_proposals.py
@@ -1,0 +1,198 @@
+"""Unit tests for wiring the cache analyzer's root-caused per-agent findings
+(A1 uncached / A2 thrash / A3 lookback miss) into Review-inbox proposals and
+their delta-verify receipts.
+
+Mirrors ``test_cost_proposals.py``'s fixtures/style: an ``InMemoryBackend``,
+storage under ``tmp_path``, nothing touching a real ``~/.tj``.
+"""
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+
+import pytest
+
+from tokenjam.core.db import InMemoryBackend
+from tokenjam.core.optimize import cost_verify
+from tokenjam.core.optimize.analyzers.cache_efficacy import (
+    CacheEfficacyFinding,
+    LookbackMissCandidate,
+    ThrashAgentCandidate,
+    UncachedAgentCandidate,
+)
+from tokenjam.core.optimize.cost_proposals import cost_proposals_from_report
+from tokenjam.core.optimize.types import OptimizeReport, WindowSummary
+from tests.factories import make_llm_span
+
+NOW = datetime(2026, 7, 20, 12, 0, tzinfo=timezone.utc)
+MARKER = NOW - timedelta(days=5)
+
+
+@pytest.fixture
+def db():
+    backend = InMemoryBackend()
+    yield backend
+    backend.close()
+
+
+def _window():
+    return WindowSummary(since=MARKER, until=NOW, days=5, sessions=10, spans=100,
+                          total_tokens=1, total_cost_usd=5.0, thin_data=False)
+
+
+def _uncached_candidate(agent_id="svc-uncached"):
+    return UncachedAgentCandidate(
+        agent_id=agent_id, provider="anthropic", model="claude-sonnet-5",
+        calls=25, sessions=5, assumed_prefix_tokens=4000,
+        cache_control_snippet='{"cache_control": {"type": "ephemeral"}}',
+        estimated_recoverable_usd=1.5, estimated_recoverable_tokens=90000,
+        estimate_basis="p25 prefix basis",
+    )
+
+
+def _thrash_candidate(agent_id="svc-thrash", cause="ttl", ttl_worth_it=True,
+                       ttl_breakeven_usd=0.4):
+    return ThrashAgentCandidate(
+        agent_id=agent_id, provider="anthropic", model="claude-sonnet-5",
+        calls=30, cache_write_tokens=50000, cache_read_tokens=10000,
+        read_write_ratio=0.2, cause=cause, inter_call_gap_p50_minutes=12.0,
+        ttl_worth_it=ttl_worth_it, ttl_breakeven_usd=ttl_breakeven_usd,
+        cache_control_snippet="checklist or ttl snippet",
+        estimated_recoverable_usd=0.6, estimate_basis="thrash basis",
+    )
+
+
+def _lookback_candidate(agent_id="svc-lookback"):
+    return LookbackMissCandidate(
+        agent_id=agent_id, provider="anthropic", model="claude-sonnet-5",
+        miss_count=4, avg_prior_turn_blocks=28.0,
+        cache_control_snippet="add an intermediate breakpoint",
+        estimated_recoverable_usd=0.3, estimated_recoverable_tokens=12000,
+        estimate_basis="lookback basis",
+    )
+
+
+def _report(**finding_kwargs):
+    cache = CacheEfficacyFinding(**finding_kwargs)
+    return OptimizeReport(window=_window(), findings={"cache": cache})
+
+
+# --- Adapter: A1 uncached -----------------------------------------------------
+
+def test_uncached_adapter_produces_advise_only_cost_card():
+    report = _report(uncached_agents=[_uncached_candidate()])
+    props = [p for p in cost_proposals_from_report(report) if p.analyzer == "cache"
+             and p.signature.startswith("cost:cache-uncached:")]
+    assert len(props) == 1
+    p = props[0]
+    assert p.kind == "cost"
+    assert p.advise_only is True
+    assert p.signature == "cost:cache-uncached:svc-uncached"
+    assert p.target_key == {"agent_id": "svc-uncached", "provider": "anthropic",
+                             "model": "claude-sonnet-5"}
+    assert p.agent_id == "svc-uncached"
+    assert p.estimated_recoverable_usd == 1.5
+    assert "cache_control" in p.suggestion
+    assert "25 calls" in p.evidence
+
+
+# --- Adapter: A2 thrash --------------------------------------------------------
+
+def test_thrash_adapter_ttl_worth_it_card():
+    report = _report(thrash_agents=[_thrash_candidate(cause="ttl", ttl_worth_it=True)])
+    props = [p for p in cost_proposals_from_report(report) if p.analyzer == "cache_thrash"]
+    assert len(props) == 1
+    p = props[0]
+    assert p.signature == "cost:cache-thrash:svc-thrash"
+    assert "pay off" in p.advise_text
+    assert "not worth it" not in p.advise_text
+
+
+def test_thrash_adapter_ttl_not_worth_it_card_says_so_verbatim():
+    """Acceptance criterion: when the honest break-even arithmetic is negative,
+    the card must say the fix isn't worth it, never oversell."""
+    report = _report(thrash_agents=[
+        _thrash_candidate(cause="ttl", ttl_worth_it=False, ttl_breakeven_usd=-0.2),
+    ])
+    props = [p for p in cost_proposals_from_report(report) if p.analyzer == "cache_thrash"]
+    assert len(props) == 1
+    assert "caching not worth it at this cadence" in props[0].advise_text
+
+
+def test_thrash_adapter_instability_card_lists_checklist():
+    report = _report(thrash_agents=[_thrash_candidate(cause="instability", ttl_worth_it=None)])
+    props = [p for p in cost_proposals_from_report(report) if p.analyzer == "cache_thrash"]
+    assert len(props) == 1
+    assert "timestamp" in props[0].advise_text
+    assert "UUID" in props[0].advise_text or "uuid" in props[0].advise_text.lower()
+
+
+# --- Adapter: A3 lookback ------------------------------------------------------
+
+def test_lookback_adapter_card():
+    report = _report(lookback_miss_agents=[_lookback_candidate()])
+    props = [p for p in cost_proposals_from_report(report)
+             if p.signature.startswith("cost:cache-lookback:")]
+    assert len(props) == 1
+    p = props[0]
+    assert p.analyzer == "cache"
+    assert "20" in p.evidence
+    assert "4 cache miss" in p.evidence
+    assert p.estimated_recoverable_tokens == 12000
+
+
+# --- Signatures never collide with the existing per-(provider,model) card ----
+
+def test_signatures_are_distinct_across_all_cache_check_kinds():
+    report = _report(
+        uncached_agents=[_uncached_candidate()],
+        thrash_agents=[_thrash_candidate()],
+        lookback_miss_agents=[_lookback_candidate()],
+    )
+    sigs = [p.signature for p in cost_proposals_from_report(report)]
+    assert len(sigs) == len(set(sigs))
+
+
+# --- Delta-verify: cache_thrash receipts --------------------------------------
+
+def _seed(db, *, agent, model, when, cache_write, cache_read, count=30,
+          provider="anthropic"):
+    for i in range(count):
+        db.insert_span(make_llm_span(
+            agent_id=agent, provider=provider, model=model, billing_account=provider,
+            input_tokens=1000, output_tokens=200, cache_tokens=cache_read,
+            cache_write_tokens=cache_write,
+            session_id=f"{agent}-{when.isoformat()}-{i}",
+            start_time=when + timedelta(minutes=i),
+        ))
+
+
+def _record(target_key, agent_id="svc-thrash"):
+    return {
+        "id": "rec-1", "expectation_id": "exp-1", "signature": "cost:cache-thrash:svc-thrash",
+        "analyzer": "cache_thrash", "kind": "cost", "title": "t", "target_key": target_key,
+        "agent_id": agent_id, "applied_at": MARKER.isoformat(), "baseline": {},
+        "estimated_recoverable_usd": None, "estimated_recoverable_tokens": None,
+        "estimate_basis": "", "state": "applied", "verify": {},
+    }
+
+
+def test_cache_thrash_delta_improved_when_wasted_spend_drops(db):
+    # pre: heavy write, near-zero read (thrashing). post: writes drop, reads rise.
+    _seed(db, agent="svc-thrash", model="claude-sonnet-5", cache_write=5000,
+          cache_read=0, when=MARKER - timedelta(hours=40))
+    _seed(db, agent="svc-thrash", model="claude-sonnet-5", cache_write=500,
+          cache_read=4500, when=MARKER + timedelta(hours=1))
+    rec = _record({"provider": "anthropic", "model": "claude-sonnet-5"})
+    v = cost_verify.measure_cost_delta(db.conn, rec, now=NOW)
+    assert v["verdict"] == "improved"
+    assert v["realized_usd_delta"] > 0
+
+
+def test_cache_thrash_delta_regressed_when_no_change(db):
+    _seed(db, agent="svc-thrash", model="claude-sonnet-5", cache_write=5000,
+          cache_read=0, when=MARKER - timedelta(hours=40))
+    _seed(db, agent="svc-thrash", model="claude-sonnet-5", cache_write=5000,
+          cache_read=0, when=MARKER + timedelta(hours=1))
+    rec = _record({"provider": "anthropic", "model": "claude-sonnet-5"})
+    v = cost_verify.measure_cost_delta(db.conn, rec, now=NOW)
+    assert v["verdict"] == "regressed"

--- a/tests/unit/test_cache_root_cause_proposals.py
+++ b/tests/unit/test_cache_root_cause_proposals.py
@@ -18,8 +18,12 @@ from tokenjam.core.optimize.analyzers.cache_efficacy import (
     LookbackMissCandidate,
     ThrashAgentCandidate,
     UncachedAgentCandidate,
+    _compute_root_cause_candidates,
 )
-from tokenjam.core.optimize.cost_proposals import cost_proposals_from_report
+from tokenjam.core.optimize.cost_proposals import (
+    _cache_thrash_to_proposals,
+    cost_proposals_from_report,
+)
 from tokenjam.core.optimize.types import OptimizeReport, WindowSummary
 from tests.factories import make_llm_span
 
@@ -115,6 +119,40 @@ def test_thrash_adapter_ttl_not_worth_it_card_says_so_verbatim():
     ])
     props = [p for p in cost_proposals_from_report(report) if p.analyzer == "cache_thrash"]
     assert len(props) == 1
+    assert "caching not worth it at this cadence" in props[0].advise_text
+
+
+def test_thrash_adapter_not_worth_it_excludes_recoverable_usd_end_to_end(db):
+    """Rollup contract (Component E's `estimated_recoverable_rollup` sums
+    ``CostProposal.estimated_recoverable_usd`` with no analyzer allowlist):
+    when the TTL variant's honest break-even is negative, the real analyzer ->
+    adapter pipeline must not hand the rollup a positive figure to sum."""
+    # Sparse per-burst reuse: one write per session, second call never reads
+    # back -> negative TTL break-even (see test_cache_root_cause.py's
+    # equivalent analyzer-level case for the arithmetic).
+    for i in range(15):
+        sid = f"thrash-{i}"
+        t0 = MARKER + timedelta(hours=i)
+        db.insert_span(make_llm_span(
+            agent_id="svc-thrash-negative", provider="anthropic", model="claude-sonnet-5",
+            input_tokens=3000, cache_tokens=0, cache_write_tokens=5000,
+            session_id=sid, start_time=t0,
+        ))
+        db.insert_span(make_llm_span(
+            agent_id="svc-thrash-negative", provider="anthropic", model="claude-sonnet-5",
+            input_tokens=3000, cache_tokens=0, cache_write_tokens=0,
+            session_id=sid, start_time=t0 + timedelta(minutes=10),
+        ))
+    since, until = MARKER - timedelta(hours=1), MARKER + timedelta(hours=20)
+    _, thrash, _ = _compute_root_cause_candidates(db.conn, since, until, None)
+    assert len(thrash) == 1
+    assert thrash[0].cause == "ttl"
+    assert thrash[0].ttl_worth_it is False
+
+    finding = CacheEfficacyFinding(thrash_agents=thrash)
+    props = _cache_thrash_to_proposals(finding)
+    assert len(props) == 1
+    assert props[0].estimated_recoverable_usd is None
     assert "caching not worth it at this cadence" in props[0].advise_text
 
 

--- a/tests/unit/test_cache_root_cause_proposals.py
+++ b/tests/unit/test_cache_root_cause_proposals.py
@@ -7,12 +7,14 @@ storage under ``tmp_path``, nothing touching a real ``~/.tj``.
 """
 from __future__ import annotations
 
+from dataclasses import replace
 from datetime import datetime, timedelta, timezone
 
 import pytest
 
+from tokenjam.core.config import TjConfig
 from tokenjam.core.db import InMemoryBackend
-from tokenjam.core.optimize import cost_verify
+from tokenjam.core.optimize import build_report, cost_verify
 from tokenjam.core.optimize.analyzers.cache_efficacy import (
     CacheEfficacyFinding,
     LookbackMissCandidate,
@@ -22,6 +24,8 @@ from tokenjam.core.optimize.analyzers.cache_efficacy import (
 )
 from tokenjam.core.optimize.cost_proposals import (
     _cache_thrash_to_proposals,
+    _cache_to_proposals,
+    _per_agent_cache_recoverable_by_model,
     cost_proposals_from_report,
 )
 from tokenjam.core.optimize.types import OptimizeReport, WindowSummary
@@ -188,6 +192,78 @@ def test_signatures_are_distinct_across_all_cache_check_kinds():
     )
     sigs = [p.signature for p in cost_proposals_from_report(report)]
     assert len(sigs) == len(set(sigs))
+
+
+# --- The generic per-(provider,model) card CAN overlap a per-agent card ------
+#
+# The generic ``cost:cache:<provider>:<model>`` card and the new per-agent
+# cards read the SAME underlying spans (a flagged agent's calls are part of
+# the aggregate the generic row's efficacy is computed over). This is a real
+# overlap, not a hypothetical: an agent that's the dominant (or sole) driver
+# of a model's window-wide low efficacy trips both. The generic card's dollar
+# figure must be reduced by whatever the per-agent cards already claim for
+# that model, so the rollup never counts the same spend twice.
+
+def test_per_agent_recoverable_by_model_sums_across_all_three_checks():
+    uc = _uncached_candidate(agent_id="a")
+    th = _thrash_candidate(agent_id="b")
+    lb = _lookback_candidate(agent_id="c")
+    finding = CacheEfficacyFinding(uncached_agents=[uc], thrash_agents=[th],
+                                    lookback_miss_agents=[lb])
+    totals = _per_agent_cache_recoverable_by_model(finding)
+    key = ("anthropic", "claude-sonnet-5")  # all three fixtures share this model
+    assert totals[key][0] == pytest.approx(uc.estimated_recoverable_usd
+                                            + th.estimated_recoverable_usd
+                                            + lb.estimated_recoverable_usd)
+    assert totals[key][1] == (uc.estimated_recoverable_tokens or 0) + (lb.estimated_recoverable_tokens or 0)
+
+
+def test_per_agent_recoverable_by_model_ignores_non_overlapping_models():
+    uc = _uncached_candidate(agent_id="a")
+    finding = CacheEfficacyFinding(uncached_agents=[uc])
+    totals = _per_agent_cache_recoverable_by_model(finding)
+    assert ("openai", "gpt-4o") not in totals
+
+
+def test_generic_per_model_card_is_reduced_by_overlapping_per_agent_claim(db):
+    """End-to-end: one agent is the model's ENTIRE window traffic, so it trips
+    both the generic per-model card AND its own A1 uncached card off the same
+    spans. The generic card must not still claim the full, unreduced figure."""
+    agent = "agent-solo"
+    for i in range(25):
+        db.insert_span(make_llm_span(
+            agent_id=agent, provider="anthropic", model="claude-sonnet-5",
+            input_tokens=4000, cache_tokens=0, cache_write_tokens=0,
+            session_id=f"s-{i // 5}",
+            start_time=MARKER + timedelta(minutes=i),
+        ))
+    since, until = MARKER - timedelta(hours=1), MARKER + timedelta(hours=1)
+    report = build_report(db=db, config=TjConfig(version="1"), since=since, until=until,
+                           findings=["cache"])
+    finding = report.findings["cache"]
+    assert len(finding.uncached_agents) == 1        # A1 fires
+    assert len(finding.flagged) == 1                # the generic row also fires
+
+    # What the generic card WOULD claim with no per-agent overlap subtracted.
+    unclaimed_variant = replace(finding, uncached_agents=[], thrash_agents=[],
+                                 lookback_miss_agents=[])
+    original = _cache_to_proposals(unclaimed_variant)[0].estimated_recoverable_usd
+
+    proposals = cost_proposals_from_report(report)
+    generic = next(p for p in proposals if p.signature == "cost:cache:anthropic:claude-sonnet-5")
+    agent_card = next(p for p in proposals if p.signature == "cost:cache-uncached:agent-solo")
+
+    assert generic.estimated_recoverable_usd < original
+    assert generic.estimated_recoverable_usd == pytest.approx(
+        max(0.0, original - agent_card.estimated_recoverable_usd), abs=1e-4,
+    )
+    # The two cards combined never exceed what the single generic card would
+    # have claimed alone — no inflation from counting the same spend twice.
+    assert (
+        generic.estimated_recoverable_usd + agent_card.estimated_recoverable_usd
+        <= original + 1e-6
+    )
+    assert "double-count" in generic.estimate_basis
 
 
 # --- Delta-verify: cache_thrash receipts --------------------------------------

--- a/tests/unit/test_cache_root_cause_proposals.py
+++ b/tests/unit/test_cache_root_cause_proposals.py
@@ -1,6 +1,5 @@
 """Unit tests for wiring the cache analyzer's root-caused per-agent findings
-(A1 uncached / A2 thrash / A3 lookback miss) into Review-inbox proposals and
-their delta-verify receipts.
+(A1 uncached / A2 thrash / A3 lookback miss) into Review-inbox proposals.
 
 Mirrors ``test_cost_proposals.py``'s fixtures/style: an ``InMemoryBackend``,
 storage under ``tmp_path``, nothing touching a real ``~/.tj``.
@@ -14,7 +13,7 @@ import pytest
 
 from tokenjam.core.config import TjConfig
 from tokenjam.core.db import InMemoryBackend
-from tokenjam.core.optimize import build_report, cost_verify
+from tokenjam.core.optimize import build_report
 from tokenjam.core.optimize.analyzers.cache_efficacy import (
     CacheEfficacyFinding,
     LookbackMissCandidate,
@@ -22,7 +21,13 @@ from tokenjam.core.optimize.analyzers.cache_efficacy import (
     UncachedAgentCandidate,
     _compute_root_cause_candidates,
 )
+from tokenjam.core.optimize.analyzers.cache_recommend import CachePrefixCandidate
+from tokenjam.core.optimize.analyzers.cache_recommend import (
+    CacheRecommendFinding,
+)
 from tokenjam.core.optimize.cost_proposals import (
+    CACHE_NO_LEVER_TEXT,
+    _cache_recommend_to_proposals,
     _cache_thrash_to_proposals,
     _cache_to_proposals,
     _per_agent_cache_recoverable_by_model,
@@ -266,47 +271,166 @@ def test_generic_per_model_card_is_reduced_by_overlapping_per_agent_claim(db):
     assert "double-count" in generic.estimate_basis
 
 
-# --- Delta-verify: cache_thrash receipts --------------------------------------
+# --- Persona-gated fix TEXT (cache / cache_thrash / cache-recommend) ---------
+#
+# Unlike script/reuse/verbosity there's no workspace write to gate here —
+# every cache fix is a `cache_control` edit on the raw Anthropic API request,
+# which a Claude Code session never constructs itself. A claude-code window
+# must get the honest no-lever reason instead of an instruction it can't
+# follow; every other persona is unaffected (byte-identical to before this
+# gating existed).
 
-def _seed(db, *, agent, model, when, cache_write, cache_read, count=30,
-          provider="anthropic"):
-    for i in range(count):
-        db.insert_span(make_llm_span(
-            agent_id=agent, provider=provider, model=model, billing_account=provider,
-            input_tokens=1000, output_tokens=200, cache_tokens=cache_read,
-            cache_write_tokens=cache_write,
-            session_id=f"{agent}-{when.isoformat()}-{i}",
-            start_time=when + timedelta(minutes=i),
-        ))
-
-
-def _record(target_key, agent_id="svc-thrash"):
-    return {
-        "id": "rec-1", "expectation_id": "exp-1", "signature": "cost:cache-thrash:svc-thrash",
-        "analyzer": "cache_thrash", "kind": "cost", "title": "t", "target_key": target_key,
-        "agent_id": agent_id, "applied_at": MARKER.isoformat(), "baseline": {},
-        "estimated_recoverable_usd": None, "estimated_recoverable_tokens": None,
-        "estimate_basis": "", "state": "applied", "verify": {},
-    }
+def _cache_finding_for_persona_tests():
+    return CacheEfficacyFinding(
+        flagged=[_flagged_row()],
+        uncached_agents=[_uncached_candidate()],
+        thrash_agents=[_thrash_candidate(cause="ttl", ttl_worth_it=True)],
+        lookback_miss_agents=[_lookback_candidate()],
+    )
 
 
-def test_cache_thrash_delta_improved_when_wasted_spend_drops(db):
-    # pre: heavy write, near-zero read (thrashing). post: writes drop, reads rise.
-    _seed(db, agent="svc-thrash", model="claude-sonnet-5", cache_write=5000,
-          cache_read=0, when=MARKER - timedelta(hours=40))
-    _seed(db, agent="svc-thrash", model="claude-sonnet-5", cache_write=500,
-          cache_read=4500, when=MARKER + timedelta(hours=1))
-    rec = _record({"provider": "anthropic", "model": "claude-sonnet-5"})
-    v = cost_verify.measure_cost_delta(db.conn, rec, now=NOW)
-    assert v["verdict"] == "improved"
-    assert v["realized_usd_delta"] > 0
+def _flagged_row():
+    from tokenjam.core.optimize.analyzers.cache_efficacy import CacheEfficacyRow
+    return CacheEfficacyRow(
+        provider="anthropic", model="claude-sonnet-5", input_tokens=200_000,
+        cache_tokens=1_000, efficacy=0.01, support="full", flagged=True,
+    )
 
 
-def test_cache_thrash_delta_regressed_when_no_change(db):
-    _seed(db, agent="svc-thrash", model="claude-sonnet-5", cache_write=5000,
-          cache_read=0, when=MARKER - timedelta(hours=40))
-    _seed(db, agent="svc-thrash", model="claude-sonnet-5", cache_write=5000,
-          cache_read=0, when=MARKER + timedelta(hours=1))
-    rec = _record({"provider": "anthropic", "model": "claude-sonnet-5"})
-    v = cost_verify.measure_cost_delta(db.conn, rec, now=NOW)
-    assert v["verdict"] == "regressed"
+@pytest.mark.parametrize("adapter_name", [
+    "_cache_to_proposals", "_cache_uncached_to_proposals",
+    "_cache_thrash_to_proposals", "_cache_lookback_to_proposals",
+])
+def test_claude_code_persona_gets_no_lever_text_and_no_snippet(adapter_name):
+    import tokenjam.core.optimize.cost_proposals as cp
+    adapter = getattr(cp, adapter_name)
+    props = adapter(_cache_finding_for_persona_tests(), persona="claude-code")
+    assert len(props) == 1
+    p = props[0]
+    assert p.advise_text == CACHE_NO_LEVER_TEXT
+    assert p.suggestion == ""
+    # The diagnostic stays true and useful regardless of persona.
+    assert p.evidence
+    assert p.estimated_recoverable_usd is not None or p.estimated_recoverable_tokens is not None
+
+
+@pytest.mark.parametrize("adapter_name", [
+    "_cache_to_proposals", "_cache_uncached_to_proposals",
+    "_cache_thrash_to_proposals", "_cache_lookback_to_proposals",
+])
+@pytest.mark.parametrize("persona", ["sdk", "unknown", "mixed"])
+def test_non_claude_code_personas_keep_the_instruction(adapter_name, persona):
+    import tokenjam.core.optimize.cost_proposals as cp
+    adapter = getattr(cp, adapter_name)
+    props = adapter(_cache_finding_for_persona_tests(), persona=persona)
+    assert len(props) == 1
+    p = props[0]
+    assert p.advise_text != CACHE_NO_LEVER_TEXT
+    assert "cache" in p.advise_text.lower() or "TTL" in p.advise_text
+
+    # The default (no persona kwarg) must resolve exactly like "unknown" —
+    # never silently assume claude-code.
+    default_props = adapter(_cache_finding_for_persona_tests())
+    assert default_props[0].advise_text != CACHE_NO_LEVER_TEXT
+
+
+def test_cost_proposals_from_report_gates_the_whole_cache_family_on_persona():
+    report = OptimizeReport(
+        window=_window(), findings={"cache": _cache_finding_for_persona_tests()},
+    )
+    report.persona = "claude-code"
+    by_sig = {p.signature: p for p in cost_proposals_from_report(report)}
+    generic = by_sig["cost:cache:anthropic:claude-sonnet-5"]
+    assert generic.advise_text == CACHE_NO_LEVER_TEXT
+    uncached = by_sig["cost:cache-uncached:svc-uncached"]
+    assert uncached.advise_text == CACHE_NO_LEVER_TEXT
+    assert uncached.suggestion == ""
+
+    report.persona = "sdk"
+    by_sig = {p.signature: p for p in cost_proposals_from_report(report)}
+    assert by_sig["cost:cache:anthropic:claude-sonnet-5"].advise_text != CACHE_NO_LEVER_TEXT
+    assert by_sig["cost:cache-uncached:svc-uncached"].suggestion
+
+
+# --- cache-recommend proposal: shape, snippet, persona gate, dedup ----------
+
+def _prefix_candidate(**overrides):
+    fields = dict(
+        prefix_hash="abc123def456", sample_chars="SYSTEM: you are helpful...",
+        occurrences=5, avg_input_tokens=2500.0, estimated_cacheable_tokens=1000,
+        model="claude-sonnet-5",
+        cache_control_snippet='# claude-sonnet-5: prefix seen in 5 calls\n'
+                               '{"cache_control": {"type": "ephemeral"}}',
+        estimated_recoverable_usd=0.4, estimated_recoverable_tokens=4000,
+    )
+    fields.update(overrides)
+    return CachePrefixCandidate(**fields)
+
+
+def _recommend_finding(candidates=None, **overrides):
+    candidates = candidates if candidates is not None else [_prefix_candidate()]
+    fields = dict(
+        enabled=True, candidates=candidates,
+        estimated_recoverable_usd=sum(c.estimated_recoverable_usd or 0 for c in candidates) or None,
+        estimated_recoverable_tokens=sum(c.estimated_recoverable_tokens or 0 for c in candidates) or None,
+        estimate_basis="recommend basis",
+    )
+    fields.update(overrides)
+    return CacheRecommendFinding(**fields)
+
+
+def test_cache_recommend_proposal_shape_carries_the_snippet_as_suggestion():
+    props = _cache_recommend_to_proposals(_recommend_finding(), persona="sdk")
+    assert len(props) == 1
+    p = props[0]
+    assert p.kind == "cost"
+    assert p.analyzer == "cache-recommend"
+    assert p.signature == "cost:cache-recommend:abc123def456"
+    assert p.suggestion == _prefix_candidate().cache_control_snippet
+    assert "cache_control" in p.advise_text
+    assert p.estimated_recoverable_usd == 0.4
+    assert p.estimated_recoverable_tokens == 4000
+
+
+def test_cache_recommend_proposal_empty_for_disabled_or_no_candidates():
+    assert _cache_recommend_to_proposals(None) == []
+    assert _cache_recommend_to_proposals(_recommend_finding(enabled=False)) == []
+    assert _cache_recommend_to_proposals(_recommend_finding(candidates=[])) == []
+
+
+def test_cache_recommend_claude_code_gets_no_lever_text():
+    p = _cache_recommend_to_proposals(_recommend_finding(), persona="claude-code")[0]
+    assert p.advise_text == CACHE_NO_LEVER_TEXT
+    assert p.suggestion == ""
+    assert p.evidence  # diagnostic stays
+
+
+def test_cache_recommend_is_reduced_by_overlapping_per_agent_cache_claim():
+    """A prefix candidate on the same model an A1 uncached-agent card already
+    claimed must not ALSO claim the full figure under a third signature."""
+    candidate = _prefix_candidate(model="claude-sonnet-5",
+                                   estimated_recoverable_usd=1.0,
+                                   estimated_recoverable_tokens=10_000)
+    recommend_finding = _recommend_finding(candidates=[candidate])
+    cache_finding = CacheEfficacyFinding(
+        uncached_agents=[_uncached_candidate(agent_id="svc-uncached")],
+    )
+    unreduced = _cache_recommend_to_proposals(recommend_finding)[0].estimated_recoverable_usd
+    reduced = _cache_recommend_to_proposals(recommend_finding, cache_finding)[0]
+    assert reduced.estimated_recoverable_usd < unreduced
+    assert reduced.estimated_recoverable_usd == pytest.approx(
+        max(0.0, unreduced - _uncached_candidate().estimated_recoverable_usd), abs=1e-4,
+    )
+    assert "double-count" in reduced.estimate_basis
+
+
+def test_cache_recommend_wired_into_cost_analyzers_and_report_adapter():
+    from tokenjam.core.optimize.cost_proposals import COST_ANALYZERS
+    assert "cache-recommend" in COST_ANALYZERS
+
+    report = OptimizeReport(
+        window=_window(), findings={"cache-recommend": _recommend_finding()},
+    )
+    analyzers = {p.analyzer for p in cost_proposals_from_report(report)}
+    assert "cache-recommend" in analyzers
+

--- a/tests/unit/test_cost_accounting_guards.py
+++ b/tests/unit/test_cost_accounting_guards.py
@@ -28,8 +28,11 @@ from tokenjam.core.db import InMemoryBackend
 from tokenjam.core.optimize import accounting, cost_verify
 from tokenjam.core.optimize import runner as runner_mod
 from tokenjam.core.optimize.analyzers import (
+    batch_placement,
     budget_projection,
     cache_efficacy,
+    deadweight,
+    downsize_agents,
     model_downgrade,
     output_verbosity,
     prompt_bloat,
@@ -209,9 +212,19 @@ def test_dedupe_keeps_the_last_observation():
 
 #: Every module that builds a token aggregate. Add yours here when you add an
 #: aggregate; that is the whole wiring cost of the guard.
+#:
+#: Scope caveat: this list drives the SQL-TEXT rule only. A module that adds up
+#: token types in Python is outside its reach and needs the value-level probe
+#: (``four_type_probe_row`` / ``missing_token_types``) instead — see the probe
+#: tests below. ``deadweight`` and ``downsize_agents`` are listed as no-op
+#: entries: neither builds a four-type token sum in SQL today (deadweight
+#: estimates a per-session tax from character counts; downsize_agents' one SUM
+#: is a deliberate thinking-token attribute extraction), so they are here to
+#: catch a future SQL aggregate rather than to assert one now.
 _AGGREGATE_MODULES = [
     accounting, cost_verify, runner_mod,
-    budget_projection, cache_efficacy, model_downgrade, output_verbosity,
+    batch_placement, budget_projection, cache_efficacy, deadweight,
+    downsize_agents, model_downgrade, output_verbosity,
     prompt_bloat, subagent_rightsizing, workflow_restructure,
 ]
 

--- a/tests/unit/test_cost_accounting_guards.py
+++ b/tests/unit/test_cost_accounting_guards.py
@@ -41,7 +41,10 @@ from tests.token_aggregate_guard import (
     TOKEN_COLUMNS,
     assert_module_token_sums_are_complete,
     assert_sql_token_sums_are_complete,
+    assert_total_counts_all_token_types,
     find_incomplete_token_sums,
+    four_type_probe_row,
+    missing_token_types,
 )
 
 NOW = datetime(2026, 7, 20, 12, 0, tzinfo=timezone.utc)
@@ -239,6 +242,25 @@ def test_the_guard_catches_the_bug_shape_that_shipped_three_times():
         "SELECT SUM(input_tokens + output_tokens + cache_tokens) FROM spans"
     )
     assert offenders and offenders[0][1] == {"cache_write_tokens"}
+
+
+def test_the_probe_decodes_a_python_side_aggregate_that_drops_a_bucket():
+    """The SQL guard reads query text, so an aggregate that adds columns up in
+    Python is out of its reach. The probe catches that shape and names the
+    bucket that went missing."""
+    row = four_type_probe_row(model="claude-sonnet-5")
+    dropped_cache_write = row["input_tokens"] + row["output_tokens"] + row["cache_tokens"]
+
+    assert missing_token_types(dropped_cache_write) == {"cache_write_tokens"}
+    with pytest.raises(AssertionError, match="cache_write_tokens"):
+        assert_total_counts_all_token_types(dropped_cache_write)
+
+
+def test_the_probe_passes_a_complete_python_side_aggregate():
+    rows = [four_type_probe_row(), four_type_probe_row()]
+    total = sum(accounting.four_type_token_total(r) for r in rows)
+    assert missing_token_types(total, rows=len(rows)) == set()
+    assert_total_counts_all_token_types(total, rows=len(rows))
 
 
 def test_the_guard_allows_a_deliberate_single_bucket_sum():

--- a/tests/unit/test_cost_proposal_verbs.py
+++ b/tests/unit/test_cost_proposal_verbs.py
@@ -1,0 +1,302 @@
+"""``tj relearn cost-proposals`` / ``cost-apply`` / ``cost-mark-applied`` /
+``cost-revert`` -- the CLI's first view of the cost-analyzer proposal store
+(core.optimize.cost_proposals), which before this file had a web renderer
+but no terminal one at all.
+
+Isolated: every write is routed under ``tmp_path`` via ``cfg.storage.path``
+(same standard as ``test_relearn_cli.py``); ``mark-applied`` / ``cost-apply
+--go`` use a real ``InMemoryBackend`` (an ``Expectation`` marker needs a real
+``expectations`` table) rather than touching a real ``~/.tj``.
+"""
+from __future__ import annotations
+
+import json
+import subprocess
+
+import click
+import pytest
+from click.testing import CliRunner
+
+from tokenjam.cli.cost_proposal_verbs import register_cost_proposal_verbs
+from tokenjam.core.config import ProviderBudget, StorageConfig, TjConfig
+from tokenjam.core.db import InMemoryBackend
+from tokenjam.core.optimize import cost_apply, relearn_store
+from tokenjam.core.optimize.cost_proposals import CostProposal
+
+# --- Fixtures ----------------------------------------------------------------
+
+@pytest.fixture
+def cfg(tmp_path):
+    return TjConfig(version="1", storage=StorageConfig(path=str(tmp_path / "t.duckdb")))
+
+
+@pytest.fixture
+def db():
+    backend = InMemoryBackend()
+    yield backend
+    backend.close()
+
+
+def _advise_only(**overrides) -> CostProposal:
+    """A deadweight-shaped advise-only proposal: a real copy-pasteable
+    snippet, no workspace tokenjam can write into."""
+    base = dict(
+        kind="cost", analyzer="deadweight", signature="cost:deadweight:foo",
+        title="Unused MCP server: foo",
+        target_key={"server": "foo", "scope": "user", "source": "user config"},
+        evidence="`foo` MCP server made 0 tool calls across 12 sessions.",
+        baseline={"sessions_present": 12, "invocations": 0},
+        advise_text="Remove it; it costs a standing schema-injection tax.",
+        suggestion="claude mcp remove foo --scope user",
+        estimated_recoverable_usd=12.5,
+        estimated_recoverable_tokens=50_000,
+        estimate_basis="measured over the last 90d.",
+        apply_capable=False,
+    )
+    base.update(overrides)
+    return CostProposal(**base)
+
+
+def _apply_capable(*, target_path: str, **overrides) -> CostProposal:
+    """A subagent-shaped proposal with a real workspace surface to write into."""
+    base = dict(
+        kind="cost", analyzer="subagent", signature="cost:subagent:bar",
+        title="Right-size subagent bar",
+        target_key={"agent_name": "bar"},
+        evidence="`bar` subagent averages 200 tokens output across 40 calls.",
+        baseline={"apply_sessions": 40, "apply_repos": ["demo"]},
+        advise_text="Route `bar` to a smaller model.",
+        estimated_recoverable_usd=8.0,
+        estimated_recoverable_tokens=20_000,
+        estimate_basis="measured over the last 30d.",
+        apply_capable=True,
+        rung=1,
+        scope="project",
+        proposed_fix="`bar` rarely needs deep reasoning -- size it to a smaller model.",
+        target_path=target_path,
+    )
+    base.update(overrides)
+    return CostProposal(**base)
+
+
+def _store(cfg, *proposals: CostProposal) -> list[str]:
+    """Persist cost proposals the way a real recompute would, and return the
+    stored proposal IDs."""
+    from tokenjam.core.optimize import relearn_proposals
+
+    relearn_store.write_cost_proposals(list(proposals), config=cfg)
+    return [p["proposal_id"] for p in relearn_proposals.list_cost_proposals(cfg)]
+
+
+def _git_repo(tmp_path):
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    subprocess.run(["git", "init", "-q"], cwd=repo, check=True)
+    subprocess.run(["git", "config", "user.email", "t@example.com"], cwd=repo, check=True)
+    subprocess.run(["git", "config", "user.name", "T"], cwd=repo, check=True)
+    (repo / "CLAUDE.md").write_text("# Repo\n", encoding="utf-8")
+    subprocess.run(["git", "add", "-A"], cwd=repo, check=True)
+    subprocess.run(["git", "commit", "-q", "-m", "init"], cwd=repo, check=True)
+    return repo
+
+
+def _group() -> click.Group:
+    group = click.Group("relearn")
+    return register_cost_proposal_verbs(group)
+
+
+def _run(cfg, args, *, db=None, output_json=False):
+    return CliRunner().invoke(
+        _group(), args,
+        obj={"config": cfg, "db": db, "output_json": output_json},
+    )
+
+
+# --- cost-proposals: empty states ----------------------------------------------
+
+def test_never_computed_says_so_not_a_bare_empty_state(cfg):
+    result = _run(cfg, ["cost-proposals"])
+    assert result.exit_code == 0, result.output
+    assert "never been computed" in result.output
+    assert "tj optimize" in result.output
+
+
+def test_computed_but_nothing_flagged_says_why(cfg):
+    relearn_store.write_cost_proposals([], config=cfg)
+    result = _run(cfg, ["cost-proposals"])
+    assert result.exit_code == 0, result.output
+    assert "No cost-saving fixes found" in result.output
+
+
+# --- cost-proposals: rendering --------------------------------------------------
+
+def test_list_renders_the_snippet_on_its_own_line(cfg):
+    _store(cfg, _advise_only())
+    result = _run(cfg, ["cost-proposals"])
+    assert result.exit_code == 0, result.output
+    assert "claude mcp remove foo --scope user" in result.output
+
+
+def test_list_marks_advise_only_and_states_no_apply_path(cfg):
+    _store(cfg, _advise_only())
+    result = _run(cfg, ["cost-proposals"])
+    assert "advise-only" in result.output
+    assert "no workspace" in result.output
+
+
+def test_list_marks_apply_capable_and_names_the_real_command(cfg, tmp_path):
+    [pid] = _store(cfg, _apply_capable(target_path=str(tmp_path / "CLAUDE.md")))
+    result = _run(cfg, ["cost-proposals"])
+    assert "workspace fix" in result.output
+    assert f"tj relearn cost-apply {pid}" in result.output
+
+
+def test_list_json_carries_the_full_proposal_and_framing(cfg):
+    [pid] = _store(cfg, _advise_only())
+    result = _run(cfg, ["cost-proposals"], output_json=True)
+    payload = json.loads(result.output)
+    assert payload["status"] == "ready"
+    assert payload["proposals"][0]["proposal_id"] == pid
+    assert "framing" in payload
+
+
+def test_list_shows_estimated_recoverable_rollup(cfg):
+    _store(cfg, _advise_only())
+    result = _run(cfg, ["cost-proposals"])
+    assert "estimated recoverable" in result.output
+
+
+def test_list_omits_the_advise_only_footer_when_every_proposal_is_apply_capable(cfg, tmp_path):
+    _store(cfg, _apply_capable(target_path=str(tmp_path / "CLAUDE.md")))
+    result = _run(cfg, ["cost-proposals"])
+    assert "Advise-only proposals have no apply path" not in result.output
+
+
+# --- pricing-mode honesty -------------------------------------------------------
+
+def test_subscription_plan_suppresses_the_raw_dollar_figure(tmp_path):
+    cfg = TjConfig(
+        version="1", storage=StorageConfig(path=str(tmp_path / "t.duckdb")),
+        budgets={"anthropic": ProviderBudget(plan="max_5x")},
+    )
+    _store(cfg, _advise_only())
+    result = _run(cfg, ["cost-proposals"])
+    assert "$12.50" not in result.output
+    assert "12.5" not in result.output.replace("12,500", "")  # no bare dollar amount leaks
+
+
+# --- cost-apply: the workspace-write verb ---------------------------------------
+
+def test_cost_apply_rejects_an_id_the_detector_never_produced(cfg):
+    result = _run(cfg, ["cost-apply", "rp_000000000000"])
+    assert result.exit_code != 0
+    assert "no stored cost proposal" in result.output
+
+
+def test_cost_apply_refuses_an_advise_only_proposal(cfg):
+    [pid] = _store(cfg, _advise_only())
+    result = _run(cfg, ["cost-apply", pid])
+    assert result.exit_code != 0
+    assert "advise-only" in result.output
+    assert "cost-mark-applied" in result.output
+
+
+def test_cost_apply_defaults_to_a_dry_run(cfg, tmp_path):
+    target = tmp_path / "CLAUDE.md"
+    target.write_text("# Repo\n", encoding="utf-8")
+    [pid] = _store(cfg, _apply_capable(target_path=str(target)))
+
+    result = _run(cfg, ["cost-apply", pid])
+
+    assert result.exit_code == 0, result.output
+    assert "Dry run" in result.output
+    assert target.read_text() == "# Repo\n"
+    assert not cost_apply.list_applied(cfg)
+
+
+def test_cost_apply_go_writes_and_marks_the_cost_ledger(cfg, tmp_path, db):
+    repo = _git_repo(tmp_path)
+    target = repo / "CLAUDE.md"
+    [pid] = _store(cfg, _apply_capable(target_path=str(target)))
+
+    result = _run(cfg, ["cost-apply", pid, "--go"], db=db, output_json=True)
+
+    assert result.exit_code == 0, result.output
+    payload = json.loads(result.output)
+    assert payload["applied"]["record"]["target_path"] == str(target)
+    assert payload["cost_record"] is not None
+    applied = cost_apply.list_applied(cfg)
+    assert len(applied) == 1
+    assert applied[0]["signature"] == "cost:subagent:bar"
+
+
+# --- cost-mark-applied / cost-revert --------------------------------------------
+
+def test_mark_applied_requires_a_direct_db_connection(cfg):
+    [pid] = _store(cfg, _advise_only())
+    result = _run(cfg, ["cost-mark-applied", pid])
+    assert result.exit_code != 0
+    assert "database connection" in result.output
+
+
+def test_mark_applied_records_a_ledger_entry(cfg, db):
+    [pid] = _store(cfg, _advise_only())
+    result = _run(cfg, ["cost-mark-applied", pid], db=db, output_json=True)
+    assert result.exit_code == 0, result.output
+    rec = json.loads(result.output)
+    assert rec["signature"] == "cost:deadweight:foo"
+    assert rec["state"] == "applied"
+
+
+def test_mark_applied_is_idempotent_per_signature(cfg, db):
+    [pid] = _store(cfg, _advise_only())
+    first = json.loads(_run(cfg, ["cost-mark-applied", pid], db=db, output_json=True).output)
+    second = json.loads(_run(cfg, ["cost-mark-applied", pid], db=db, output_json=True).output)
+    assert first["id"] == second["id"]
+    assert len(cost_apply.list_applied(cfg)) == 1
+
+
+def test_cost_revert_flips_the_ledger_state(cfg, db):
+    [pid] = _store(cfg, _advise_only())
+    rec = json.loads(_run(cfg, ["cost-mark-applied", pid], db=db, output_json=True).output)
+
+    result = _run(cfg, ["cost-revert", rec["id"]], output_json=True)
+
+    assert result.exit_code == 0, result.output
+    assert json.loads(result.output)["state"] == "reverted"
+
+
+def test_cost_revert_of_an_unknown_record_is_a_clean_error(cfg):
+    result = _run(cfg, ["cost-revert", "not-a-record"])
+    assert result.exit_code != 0
+    assert "not-a-record" in result.output
+
+
+# --- registration + house voice -------------------------------------------------
+
+def test_every_verb_is_registered():
+    assert sorted(_group().commands) == [
+        "cost-apply", "cost-mark-applied", "cost-proposals", "cost-revert",
+    ]
+
+
+@pytest.mark.parametrize("args", [
+    ["cost-proposals", "--help"], ["cost-apply", "--help"],
+    ["cost-mark-applied", "--help"], ["cost-revert", "--help"],
+])
+def test_help_text_avoids_em_dashes_and_the_word_quota(args):
+    out = CliRunner().invoke(_group(), args, obj={}).output
+    assert "—" not in out
+    assert "quota" not in out.lower()
+
+
+def test_human_output_avoids_em_dashes_and_the_word_quota(cfg, tmp_path):
+    target = tmp_path / "CLAUDE.md"
+    target.write_text("# Repo\n", encoding="utf-8")
+    _store(cfg, _advise_only(), _apply_capable(target_path=str(target)))
+    out = "".join(
+        _run(cfg, args).output
+        for args in (["cost-proposals"], ["cost-apply", "rp_nope"])
+    )
+    assert "—" not in out
+    assert "quota" not in out.lower()

--- a/tests/unit/test_cost_proposals.py
+++ b/tests/unit/test_cost_proposals.py
@@ -20,7 +20,10 @@ from tokenjam.core.optimize.analyzers.cache_efficacy import (
 )
 from tokenjam.core.optimize.analyzers.relearn import RelearnFinding
 from tokenjam.core.optimize.analyzers.prompt_bloat import BloatPrompt, PromptBloatFinding
-from tokenjam.core.optimize.cost_proposals import cost_proposals_from_report
+from tokenjam.core.optimize.cost_proposals import (
+    cost_proposals_from_report,
+    estimated_recoverable_rollup,
+)
 from tokenjam.core.optimize.types import (
     DowngradeFinding,
     OptimizeReport,
@@ -590,3 +593,82 @@ def test_subagent_delta_improved_when_fanout_moves_off_oversized_model(db):
     assert v["verdict"] == "improved"
     assert v["realized_usd_delta"] > 0
     assert v["post_value"] == 0.0        # no post-marker subagent spend on opus
+
+
+# --- Component E: the estimated-recoverable rollup --------------------------
+
+def test_rollup_sums_across_analyzers_and_reports_window():
+    proposals = [
+        {"signature": "cost:downsize", "analyzer": "downsize", "title": "t1",
+         "estimated_recoverable_usd": 3.0},
+        {"signature": "cost:cache:anthropic:claude-sonnet-5", "analyzer": "cache",
+         "title": "t2", "estimated_recoverable_usd": 1.2},
+    ]
+    rollup = estimated_recoverable_rollup(proposals)
+    assert rollup["estimated_recoverable_usd"] == 4.2
+    assert rollup["proposal_count"] == 2
+    assert rollup["window_days"] == 30
+    assert rollup["estimate_confidence"] == "estimated"
+    by_analyzer = {a["analyzer"]: a for a in rollup["by_analyzer"]}
+    assert by_analyzer["downsize"]["count"] == 1
+    assert by_analyzer["cache"]["usd"] == 1.2
+
+
+def test_rollup_dedupes_by_signature_never_double_counting():
+    # A stale/duplicate cache entry carrying the SAME signature twice must
+    # only contribute once — the second copy is dropped, not summed again.
+    proposals = [
+        {"signature": "cost:downsize", "analyzer": "downsize", "title": "t1",
+         "estimated_recoverable_usd": 3.0},
+        {"signature": "cost:downsize", "analyzer": "downsize", "title": "t1-stale",
+         "estimated_recoverable_usd": 3.0},
+    ]
+    rollup = estimated_recoverable_rollup(proposals)
+    assert rollup["estimated_recoverable_usd"] == 3.0
+    assert rollup["proposal_count"] == 1
+
+
+def test_rollup_empty_state():
+    rollup = estimated_recoverable_rollup([])
+    assert rollup["estimated_recoverable_usd"] == 0.0
+    assert rollup["proposal_count"] == 0
+    assert rollup["by_analyzer"] == []
+    assert rollup["contributing"] == []
+    assert "no open" in rollup["estimate_basis"]
+
+
+def test_rollup_skips_proposals_with_no_dollar_estimate():
+    # A card with an estimate of None still exists in the inbox individually;
+    # it just isn't folded into this aggregate (folding in None would
+    # silently misstate what's summed "across N proposals").
+    proposals = [
+        {"signature": "cost:trim:agentA", "analyzer": "trim", "title": "t",
+         "estimated_recoverable_usd": None},
+        {"signature": "cost:downsize", "analyzer": "downsize", "title": "t2",
+         "estimated_recoverable_usd": 2.5},
+    ]
+    rollup = estimated_recoverable_rollup(proposals)
+    assert rollup["proposal_count"] == 1
+    assert rollup["estimated_recoverable_usd"] == 2.5
+
+
+def test_rollup_is_generic_over_an_unregistered_future_analyzer():
+    # No special-casing by analyzer name — a brand-new analyzer's cards (not
+    # in cost_proposals.COST_ANALYZERS) are picked up with zero code changes
+    # here, as long as they carry the shared CostProposal fields.
+    proposals = [
+        {"signature": "cost:deadweight:some-mcp-server", "analyzer": "deadweight",
+         "title": "Unused MCP server", "estimated_recoverable_usd": 0.75},
+    ]
+    rollup = estimated_recoverable_rollup(proposals)
+    assert rollup["estimated_recoverable_usd"] == 0.75
+    assert rollup["proposal_count"] == 1
+    assert rollup["by_analyzer"][0]["analyzer"] == "deadweight"
+
+
+def test_rollup_ignores_a_proposal_with_no_signature():
+    proposals = [{"analyzer": "downsize", "title": "no sig",
+                  "estimated_recoverable_usd": 5.0}]
+    rollup = estimated_recoverable_rollup(proposals)
+    assert rollup["proposal_count"] == 0
+    assert rollup["estimated_recoverable_usd"] == 0.0

--- a/tests/unit/test_cost_proposals.py
+++ b/tests/unit/test_cost_proposals.py
@@ -567,6 +567,209 @@ def test_deadweight_finding_survives_report_dict_round_trip():
     assert finding.tax_table[0].source == "MCP schema: apollo"
 
 
+# --- script / reuse / verbosity: findings that were previously advise-only
+# with no proposal at all, now on the same apply-capable rail as `subagent`. ---
+
+def _workflow_cluster(**overrides):
+    from tokenjam.core.optimize.analyzers.workflow_restructure import WorkflowCluster
+    fields = dict(
+        signature=[{"tool": "bash", "args": ["command_string"]}], instances=25,
+        avg_cost_usd=0.02, avg_duration_seconds=1.5, example_session_id="det-0",
+        avg_tokens=500, total_cost_usd=0.5, total_tokens=12_500,
+        example_session_ids=["det-0", "det-1", "det-2"],
+    )
+    fields.update(overrides)
+    return WorkflowCluster(**fields)
+
+
+def _workflow_finding(clusters=None, **overrides):
+    from tokenjam.core.optimize.analyzers.workflow_restructure import (
+        WorkflowRestructureFinding,
+    )
+    clusters = clusters if clusters is not None else [_workflow_cluster()]
+    fields = dict(
+        clusters=clusters, sessions_examined=25, degraded=False,
+        estimated_recoverable_usd=sum(c.total_cost_usd for c in clusters) or None,
+        estimated_recoverable_tokens=sum(c.total_tokens for c in clusters) or None,
+        estimate_basis="script basis",
+    )
+    fields.update(overrides)
+    return WorkflowRestructureFinding(**fields)
+
+
+def test_script_proposal_shape_and_apply_fields():
+    from tokenjam.core.optimize.cost_proposals import _script_to_proposals
+    props = _script_to_proposals(_workflow_finding())
+    assert len(props) == 1
+    p = props[0]
+    assert p.kind == "cost"
+    assert p.analyzer == "script"
+    assert p.signature.startswith("cost:script:")
+    assert "bash" in p.evidence
+    assert p.estimated_recoverable_usd == 0.5
+    assert p.estimated_recoverable_tokens == 12_500
+    assert p.estimate_basis == "script basis"
+    # Apply-capable: a rung-2 skill note, same class of surface as `subagent`.
+    assert p.advise_only is False
+    assert p.apply_capable is True
+    assert p.rung == 2
+    assert p.scope == "project"
+    assert p.proposed_fix
+    assert p.baseline["apply_sessions"] == 25
+    assert len(p.baseline["apply_examples"]) == 3
+
+
+def test_script_proposal_notes_degraded_clustering_in_evidence():
+    from tokenjam.core.optimize.cost_proposals import _script_to_proposals
+    p = _script_to_proposals(_workflow_finding(degraded=True))[0]
+    assert "tool_inputs" in p.evidence
+
+
+def test_script_proposal_two_clusters_get_distinct_signatures_and_slugs():
+    """Two clusters must never collide on the same skill-file slug — a
+    collision would let the second cluster's apply silently overwrite the
+    first's skill note (relearn_apply's create-only guard only checks for a
+    TokenJam marker, not identity)."""
+    c1 = _workflow_cluster(signature=[{"tool": "bash"}], example_session_id="a",
+                            total_cost_usd=0.2, total_tokens=2_000)
+    c2 = _workflow_cluster(signature=[{"tool": "grep"}], example_session_id="b",
+                            total_cost_usd=0.3, total_tokens=3_000)
+    from tokenjam.core.optimize.cost_proposals import _script_to_proposals
+    from tokenjam.core.optimize.relearn_apply import slugify
+    props = _script_to_proposals(_workflow_finding(clusters=[c1, c2]))
+    assert len({p.signature for p in props}) == 2
+    assert len({slugify(p.title) for p in props}) == 2
+
+
+def test_script_proposal_empty_for_zero_cost_cluster_and_no_finding():
+    from tokenjam.core.optimize.cost_proposals import _script_to_proposals
+    zero = _workflow_cluster(avg_cost_usd=0.0, avg_tokens=0, total_cost_usd=0.0,
+                              total_tokens=0)
+    assert _script_to_proposals(_workflow_finding(clusters=[zero])) == []
+    assert _script_to_proposals(None) == []
+    assert _script_to_proposals(_workflow_finding(clusters=[])) == []
+
+
+def _reuse_cluster(**overrides):
+    from tokenjam.core.optimize.types import ReuseCluster
+    fields = dict(
+        cluster_id="abc123456789", tool_signature=("bash", "read"),
+        prompt_prefix_hash=None, repetitions=4, avg_planning_tokens=300,
+        avg_planning_cost_usd=0.01, cache_reuse_recoverable_usd=0.03,
+        script_replacement_recoverable_usd=0.04, cache_reuse_recoverable_tokens=900,
+        script_replacement_recoverable_tokens=1_200,
+        example_session_ids=["s1", "s2", "s3"], skeleton_session_id="s1",
+    )
+    fields.update(overrides)
+    return ReuseCluster(**fields)
+
+
+def _reuse_finding(clusters=None, **overrides):
+    from tokenjam.core.optimize.types import ReuseFinding
+    clusters = clusters if clusters is not None else [_reuse_cluster()]
+    fields = dict(
+        clusters=clusters,
+        estimated_recoverable_usd=sum(c.cache_reuse_recoverable_usd for c in clusters) or None,
+        estimated_recoverable_tokens=sum(c.cache_reuse_recoverable_tokens for c in clusters) or None,
+        estimate_basis="reuse basis",
+    )
+    fields.update(overrides)
+    return ReuseFinding(**fields)
+
+
+def test_reuse_proposal_shape_and_apply_fields():
+    from tokenjam.core.optimize.cost_proposals import _reuse_to_proposals
+    props = _reuse_to_proposals(_reuse_finding())
+    assert len(props) == 1
+    p = props[0]
+    assert p.kind == "cost"
+    assert p.analyzer == "reuse"
+    assert p.signature == "cost:reuse:abc123456789"
+    assert "bash, read" in p.evidence
+    # Conservative cache-reuse figure, never the script-replacement upper bound.
+    assert p.estimated_recoverable_usd == 0.03
+    assert p.estimated_recoverable_tokens == 900
+    assert p.advise_only is False
+    assert p.apply_capable is True
+    assert p.rung == 1
+    assert p.scope == "project"
+    assert p.proposed_fix
+    assert p.baseline["apply_sessions"] == 4
+    assert len(p.baseline["apply_examples"]) == 3
+
+
+def test_reuse_proposal_uses_the_analyzers_own_cluster_id_for_dedup_identity():
+    """Unlike `script`, `reuse` already carries a deterministic cluster_id
+    (plan_reuse.py computes it); the adapter must reuse it, never re-hash."""
+    from tokenjam.core.optimize.cost_proposals import _reuse_to_proposals
+    p = _reuse_to_proposals(_reuse_finding(clusters=[_reuse_cluster(cluster_id="zzz999")]))[0]
+    assert p.signature == "cost:reuse:zzz999"
+
+
+def test_reuse_proposal_empty_for_zero_recoverable_and_no_finding():
+    from tokenjam.core.optimize.cost_proposals import _reuse_to_proposals
+    zero = _reuse_cluster(cache_reuse_recoverable_usd=0.0, cache_reuse_recoverable_tokens=0)
+    assert _reuse_to_proposals(_reuse_finding(clusters=[zero])) == []
+    assert _reuse_to_proposals(None) == []
+    assert _reuse_to_proposals(_reuse_finding(clusters=[])) == []
+
+
+def _verbosity_finding(**overrides):
+    from tokenjam.core.optimize.analyzers.output_verbosity import VerbosityFinding
+    fields = dict(
+        total_candidates=6, sessions_examined=40, cohorts_examined=3,
+        estimated_recoverable_usd=0.9, estimated_recoverable_tokens=9_000,
+        estimate_basis="verbosity basis", suggested_max_tokens=800,
+    )
+    fields.update(overrides)
+    return VerbosityFinding(**fields)
+
+
+def test_verbosity_proposal_shape_and_apply_fields():
+    from tokenjam.core.optimize.cost_proposals import _verbosity_to_proposals
+    props = _verbosity_to_proposals(_verbosity_finding())
+    assert len(props) == 1
+    p = props[0]
+    assert p.kind == "cost"
+    assert p.analyzer == "verbosity"
+    assert p.signature == "cost:verbosity"
+    assert "6 session" in p.evidence
+    assert p.estimated_recoverable_usd == 0.9
+    assert p.estimated_recoverable_tokens == 9_000
+    assert p.advise_only is False
+    assert p.apply_capable is True
+    assert p.rung == 1
+    assert p.scope == "project"
+    # The remedy snippet + the concrete suggested cap both land in the note.
+    assert "concise" in p.proposed_fix.lower()
+    assert "800" in p.proposed_fix
+    # The honesty caveat (output length is not waste) rides along, never a
+    # bare "you are wasting tokens" claim.
+    assert "not waste" in p.proposed_fix
+    assert p.baseline["apply_sessions"] == 6
+
+
+def test_verbosity_proposal_empty_for_no_candidates_and_no_finding():
+    from tokenjam.core.optimize.cost_proposals import _verbosity_to_proposals
+    assert _verbosity_to_proposals(_verbosity_finding(total_candidates=0)) == []
+    assert _verbosity_to_proposals(None) == []
+
+
+def test_script_reuse_verbosity_wired_into_cost_analyzers_and_report_adapter():
+    from tokenjam.core.optimize.cost_proposals import (
+        COST_ANALYZERS,
+        cost_proposals_from_report,
+    )
+    assert {"script", "reuse", "verbosity"} <= set(COST_ANALYZERS)
+
+    rep = _report()
+    rep.findings["script"] = _workflow_finding()
+    rep.findings["reuse"] = _reuse_finding()
+    rep.findings["verbosity"] = _verbosity_finding()
+    analyzers = {p.analyzer for p in cost_proposals_from_report(rep)}
+    assert {"script", "reuse", "verbosity"} <= analyzers
+
+
 def _seed_sub(db, *, model, when, count=30, provider="anthropic"):
     for i in range(count):
         db.insert_span(make_llm_span(

--- a/tests/unit/test_cost_proposals.py
+++ b/tests/unit/test_cost_proposals.py
@@ -236,6 +236,76 @@ def test_insufficient_data_below_exposure_gate(db):
     assert v["realized_usd_delta"] is None
 
 
+# --- Delta-verify: deadweight (C1's "measured" receipt) -----------------------
+
+def _deadweight_target(tmp_path, *, still_present):
+    """A real on-disk config file the verify branch re-reads. ``still_present``
+    controls whether the ORIGINAL detected server entry is still there —
+    the exact still-configured re-check ``server_still_configured`` performs."""
+    import json
+    config_path = tmp_path / ".mcp.json"
+    servers = {"apollo": {}} if still_present else {}
+    config_path.write_text(json.dumps({"mcpServers": servers}), encoding="utf-8")
+    return {"server": "apollo", "scope": "project", "source": str(config_path)}
+
+
+def test_deadweight_delta_no_change_when_still_configured(db, tmp_path):
+    # Even with a real drop in the spans, a still-configured server must
+    # read as no_change -- the user hasn't actually removed it yet.
+    _seed(db, agent="svc-a", model="claude-opus-4-8", input_tok=10_000,
+          when=MARKER - timedelta(hours=40))
+    _seed(db, agent="svc-a", model="claude-opus-4-8", input_tok=2_000,
+          when=MARKER + timedelta(hours=1))
+    target = _deadweight_target(tmp_path, still_present=True)
+    rec = _record("deadweight", target, agent_id="svc-a")
+    v = cost_verify.measure_cost_delta(db.conn, rec, now=NOW)
+    assert v["verdict"] == "no_change"
+    assert v["realized_usd_delta"] is None
+    assert v["realized_tokens_delta"] is None
+    assert "still appears in its configured set" in v["reason"]
+
+
+def test_deadweight_delta_measured_drop_when_removed(db, tmp_path):
+    # pre: 10k input tok/session; post (server removed): 2k input tok/session.
+    _seed(db, agent="svc-a", model="claude-opus-4-8", input_tok=10_000,
+          when=MARKER - timedelta(hours=40))
+    _seed(db, agent="svc-a", model="claude-opus-4-8", input_tok=2_000,
+          when=MARKER + timedelta(hours=1))
+    target = _deadweight_target(tmp_path, still_present=False)
+    rec = _record("deadweight", target, agent_id="svc-a")
+    v = cost_verify.measure_cost_delta(db.conn, rec, now=NOW)
+    assert v["verdict"] == "improved"
+    assert v["realized_tokens_delta"] > 0
+    assert v["realized_usd_delta"] > 0
+
+
+def test_deadweight_delta_regressed_when_removed_but_no_drop(db, tmp_path):
+    # Removed from config, but per-session input tokens didn't actually
+    # fall -- must surface as regressed, never silently kept as a win.
+    _seed(db, agent="svc-a", model="claude-opus-4-8", input_tok=8_000,
+          when=MARKER - timedelta(hours=40))
+    _seed(db, agent="svc-a", model="claude-opus-4-8", input_tok=8_000,
+          when=MARKER + timedelta(hours=1))
+    target = _deadweight_target(tmp_path, still_present=False)
+    rec = _record("deadweight", target, agent_id="svc-a")
+    v = cost_verify.measure_cost_delta(db.conn, rec, now=NOW)
+    assert v["verdict"] == "regressed"
+
+
+def test_deadweight_delta_insufficient_when_removed_but_thin_exposure(db, tmp_path):
+    # Removed from config, but too few post-marker calls for a confident verdict.
+    _seed(db, agent="svc-a", model="claude-opus-4-8", input_tok=10_000,
+          when=MARKER - timedelta(hours=40))
+    _seed(db, agent="svc-a", model="claude-opus-4-8", input_tok=2_000,
+          when=MARKER + timedelta(hours=1), count=3)
+    target = _deadweight_target(tmp_path, still_present=False)
+    rec = _record("deadweight", target, agent_id="svc-a")
+    v = cost_verify.measure_cost_delta(db.conn, rec, now=NOW)
+    assert v["verdict"] == "insufficient_data"
+    assert v["realized_usd_delta"] is None
+    assert v["realized_tokens_delta"] is None
+
+
 def test_verify_record_writes_ledger_and_outcome(db, cfg):
     from tokenjam.core.loop import create_expectation, list_expectation_runs
 

--- a/tests/unit/test_cost_proposals.py
+++ b/tests/unit/test_cost_proposals.py
@@ -1,5 +1,5 @@
 """Unit tests for wiring the cost analyzers (downsize/cache/trim) into the
-self-improve loop as advise-only proposals with delta-verify receipts.
+self-improve loop as advise-only proposals.
 
 Fully isolated: the DB is an ``InMemoryBackend`` and every JSON ledger/store
 write is routed under ``tmp_path`` via ``cfg.storage.path`` — nothing here
@@ -13,7 +13,7 @@ import pytest
 
 from tokenjam.core.config import StorageConfig, TjConfig
 from tokenjam.core.db import InMemoryBackend
-from tokenjam.core.optimize import cost_apply, cost_verify, relearn_store
+from tokenjam.core.optimize import cost_apply, relearn_store
 from tokenjam.core.optimize.analyzers.cache_efficacy import (
     CacheEfficacyFinding,
     CacheEfficacyRow,
@@ -159,222 +159,6 @@ def test_mark_applied_refuses_empty_signature(db, cfg):
         cost_apply.mark_applied(db, cfg, {"signature": ""})
 
 
-# --- Delta-verify: the receipts ----------------------------------------------
-
-def _seed(db, *, agent, model, input_tok, when, count=30, provider="anthropic",
-          cache_tok=0):
-    for i in range(count):
-        db.insert_span(make_llm_span(
-            agent_id=agent, provider=provider, model=model, billing_account=provider,
-            input_tokens=input_tok, output_tokens=200, cache_tokens=cache_tok,
-            session_id=f"{agent}-{when.isoformat()}-{i}",
-            start_time=when + timedelta(minutes=i),
-        ))
-
-
-def _record(analyzer, target_key, agent_id="svc-a"):
-    return {
-        "id": "rec-1", "expectation_id": "exp-1", "signature": f"cost:{analyzer}",
-        "analyzer": analyzer, "kind": "cost", "title": "t", "target_key": target_key,
-        "agent_id": agent_id, "applied_at": MARKER.isoformat(), "baseline": {},
-        "estimated_recoverable_usd": None, "estimated_recoverable_tokens": None,
-        "estimate_basis": "", "state": "applied", "verify": {},
-    }
-
-
-def test_trim_delta_improved_when_input_per_call_drops(db):
-    # pre: 10k input/call; post: 4k input/call — a real trim.
-    _seed(db, agent="svc-a", model="claude-sonnet-5", input_tok=10_000,
-          when=MARKER - timedelta(hours=40))
-    _seed(db, agent="svc-a", model="claude-sonnet-5", input_tok=4_000,
-          when=MARKER + timedelta(hours=1))
-    v = cost_verify.measure_cost_delta(db.conn, _record("trim", {"agent_id": "svc-a"}), now=NOW)
-    assert v["verdict"] == "improved"
-    assert v["realized_tokens_delta"] > 0
-    assert v["realized_usd_delta"] > 0
-
-
-def test_trim_delta_regressed_when_no_improvement(db):
-    # pre and post identical — no movement -> regressed, not silently kept.
-    _seed(db, agent="svc-a", model="claude-sonnet-5", input_tok=8_000,
-          when=MARKER - timedelta(hours=40))
-    _seed(db, agent="svc-a", model="claude-sonnet-5", input_tok=8_000,
-          when=MARKER + timedelta(hours=1))
-    v = cost_verify.measure_cost_delta(db.conn, _record("trim", {"agent_id": "svc-a"}), now=NOW)
-    assert v["verdict"] == "regressed"
-
-
-def test_cache_delta_improved_when_efficacy_rises(db):
-    # pre: mostly fresh input; post: mostly cache reads for the flagged model.
-    _seed(db, agent="svc-a", model="claude-sonnet-5", input_tok=10_000, cache_tok=500,
-          when=MARKER - timedelta(hours=40))
-    _seed(db, agent="svc-a", model="claude-sonnet-5", input_tok=2_000, cache_tok=9_000,
-          when=MARKER + timedelta(hours=1))
-    rec = _record("cache", {"provider": "anthropic", "model": "claude-sonnet-5"})
-    v = cost_verify.measure_cost_delta(db.conn, rec, now=NOW)
-    assert v["verdict"] == "improved"
-    assert v["post_value"] > v["pre_value"]        # efficacy rose
-
-
-def test_downsize_delta_improved_when_oversized_share_drops(db):
-    # pre: all calls on the oversized model; post: moved to the cheaper one.
-    _seed(db, agent="svc-a", model="claude-opus-4-8", input_tok=8_000,
-          when=MARKER - timedelta(hours=40))
-    _seed(db, agent="svc-a", model="claude-sonnet-5", input_tok=8_000,
-          when=MARKER + timedelta(hours=1))
-    rec = _record("downsize", {"models": ["claude-opus-4-8"]})
-    v = cost_verify.measure_cost_delta(db.conn, rec, now=NOW)
-    assert v["verdict"] == "improved"
-    assert v["realized_usd_delta"] > 0
-
-
-def test_insufficient_data_below_exposure_gate(db):
-    # Only a handful of post calls — no confident verdict.
-    _seed(db, agent="svc-a", model="claude-sonnet-5", input_tok=10_000,
-          when=MARKER - timedelta(hours=40))
-    _seed(db, agent="svc-a", model="claude-sonnet-5", input_tok=4_000,
-          when=MARKER + timedelta(hours=1), count=3)
-    v = cost_verify.measure_cost_delta(db.conn, _record("trim", {"agent_id": "svc-a"}), now=NOW)
-    assert v["verdict"] == "insufficient_data"
-    assert v["realized_usd_delta"] is None
-
-
-# --- Delta-verify: deadweight (C1's "measured" receipt) -----------------------
-
-def _deadweight_target(tmp_path, *, still_present):
-    """A real on-disk config file the verify branch re-reads. ``still_present``
-    controls whether the ORIGINAL detected server entry is still there —
-    the exact still-configured re-check ``server_still_configured`` performs."""
-    import json
-    config_path = tmp_path / ".mcp.json"
-    servers = {"apollo": {}} if still_present else {}
-    config_path.write_text(json.dumps({"mcpServers": servers}), encoding="utf-8")
-    return {"server": "apollo", "scope": "project", "source": str(config_path)}
-
-
-def test_deadweight_delta_no_change_when_still_configured(db, tmp_path):
-    # Even with a real drop in the spans, a still-configured server must
-    # read as no_change -- the user hasn't actually removed it yet.
-    _seed(db, agent="svc-a", model="claude-opus-4-8", input_tok=10_000,
-          when=MARKER - timedelta(hours=40))
-    _seed(db, agent="svc-a", model="claude-opus-4-8", input_tok=2_000,
-          when=MARKER + timedelta(hours=1))
-    target = _deadweight_target(tmp_path, still_present=True)
-    rec = _record("deadweight", target, agent_id="svc-a")
-    v = cost_verify.measure_cost_delta(db.conn, rec, now=NOW)
-    assert v["verdict"] == "no_change"
-    assert v["realized_usd_delta"] is None
-    assert v["realized_tokens_delta"] is None
-    assert "still appears in its configured set" in v["reason"]
-
-
-def test_deadweight_delta_measured_drop_when_removed(db, tmp_path):
-    # pre: 10k input tok/session; post (server removed): 2k input tok/session.
-    _seed(db, agent="svc-a", model="claude-opus-4-8", input_tok=10_000,
-          when=MARKER - timedelta(hours=40))
-    _seed(db, agent="svc-a", model="claude-opus-4-8", input_tok=2_000,
-          when=MARKER + timedelta(hours=1))
-    target = _deadweight_target(tmp_path, still_present=False)
-    rec = _record("deadweight", target, agent_id="svc-a")
-    v = cost_verify.measure_cost_delta(db.conn, rec, now=NOW)
-    assert v["verdict"] == "improved"
-    assert v["realized_tokens_delta"] > 0
-    assert v["realized_usd_delta"] > 0
-
-
-def test_deadweight_delta_regressed_when_removed_but_no_drop(db, tmp_path):
-    # Removed from config, but per-session input tokens didn't actually
-    # fall -- must surface as regressed, never silently kept as a win.
-    _seed(db, agent="svc-a", model="claude-opus-4-8", input_tok=8_000,
-          when=MARKER - timedelta(hours=40))
-    _seed(db, agent="svc-a", model="claude-opus-4-8", input_tok=8_000,
-          when=MARKER + timedelta(hours=1))
-    target = _deadweight_target(tmp_path, still_present=False)
-    rec = _record("deadweight", target, agent_id="svc-a")
-    v = cost_verify.measure_cost_delta(db.conn, rec, now=NOW)
-    assert v["verdict"] == "regressed"
-
-
-def test_deadweight_delta_insufficient_when_removed_but_thin_exposure(db, tmp_path):
-    # Removed from config, but too few post-marker calls for a confident verdict.
-    _seed(db, agent="svc-a", model="claude-opus-4-8", input_tok=10_000,
-          when=MARKER - timedelta(hours=40))
-    _seed(db, agent="svc-a", model="claude-opus-4-8", input_tok=2_000,
-          when=MARKER + timedelta(hours=1), count=3)
-    target = _deadweight_target(tmp_path, still_present=False)
-    rec = _record("deadweight", target, agent_id="svc-a")
-    v = cost_verify.measure_cost_delta(db.conn, rec, now=NOW)
-    assert v["verdict"] == "insufficient_data"
-    assert v["realized_usd_delta"] is None
-    assert v["realized_tokens_delta"] is None
-
-
-def test_verify_record_writes_ledger_and_outcome(db, cfg):
-    from tokenjam.core.loop import create_expectation, list_expectation_runs
-
-    exp = create_expectation(db, name="trim svc-a", agent_id="svc-a")
-    rec = _record("trim", {"agent_id": "svc-a"})
-    rec["expectation_id"] = exp.expectation_id
-    # Persist the record so set_verify can find it.
-    from tokenjam.core.optimize.cost_apply import _write_ledger
-    _write_ledger(cfg, [rec])
-    _seed(db, agent="svc-a", model="claude-sonnet-5", input_tok=10_000,
-          when=MARKER - timedelta(hours=40))
-    _seed(db, agent="svc-a", model="claude-sonnet-5", input_tok=4_000,
-          when=MARKER + timedelta(hours=1))
-
-    v = cost_verify.verify_record(db, cfg, rec, now=NOW)
-    assert v["verdict"] == "improved"
-    # Outcome written to the loop's fix-history ledger.
-    runs = list_expectation_runs(db, exp.expectation_id)
-    assert len(runs) == 1
-    assert runs[0].outcome == "pass"
-    # And persisted onto the record.
-    stored = cost_apply.get_applied(cfg, "rec-1")
-    assert stored["verify"]["verdict"] == "improved"
-
-
-def test_cost_compound_ledger_sums_realized_dollars():
-    records = [
-        {"state": "applied", "verify": {"verdict": "improved",
-         "realized_usd_delta": 0.5, "realized_tokens_delta": 1000}},
-        {"state": "applied", "verify": {"verdict": "regressed",
-         "realized_usd_delta": 0.0}},
-        {"state": "reverted", "verify": {"verdict": "improved",
-         "realized_usd_delta": 9.9}},   # reverted never counts
-        {"state": "applied", "verify": {"verdict": "insufficient_data"}},
-    ]
-    ledger = cost_verify.cost_compound_ledger(records)
-    assert ledger["total_realized_usd"] == 0.5
-    assert ledger["improved_count"] == 1
-    assert ledger["regressed_count"] == 1
-    assert ledger["insufficient_data_count"] == 1
-    assert ledger["verified_count"] == 3
-
-
-def test_cost_compound_ledger_no_change_bucket_sums_to_verified():
-    # A no_change record (deadweight: server still configured) must land in
-    # its own named bucket, not just inflate verified_count with nowhere to
-    # go -- the named buckets must always add back up to verified_count.
-    records = [
-        {"state": "applied", "verify": {"verdict": "improved",
-         "realized_usd_delta": 0.5, "realized_tokens_delta": 1000}},
-        {"state": "applied", "verify": {"verdict": "no_change"}},
-        {"state": "applied", "verify": {"verdict": "no_change"}},
-        {"state": "applied", "verify": {"verdict": "regressed",
-         "realized_usd_delta": 0.0}},
-        {"state": "applied", "verify": {"verdict": "insufficient_data"}},
-    ]
-    ledger = cost_verify.cost_compound_ledger(records)
-    assert ledger["no_change_count"] == 2
-    assert ledger["verified_count"] == 5
-    assert (
-        ledger["improved_count"] + ledger["no_change_count"]
-        + ledger["regressed_count"] + ledger["insufficient_data_count"]
-        == ledger["verified_count"]
-    )
-
-
 # --- Store: cost proposals share the relearn cache file ----------------------
 
 def test_store_cost_and_relearn_coexist_without_clobber(tmp_path):
@@ -489,8 +273,25 @@ def test_deadweight_proposal_shape_and_fields():
     assert p.target_key == {"server": "apollo", "scope": "project", "source": "/repo/.mcp.json"}
     assert p.baseline["example_sessions"] == ["s0", "s1", "s2"]
     assert p.estimated_recoverable_tokens == 225_000
-    assert p.estimated_recoverable_usd is None  # tokens-only, never a stacked $ guess
+    # The base fixture's server carries no priced model -- the adapter must
+    # never invent a rate, so the card stays tokens-only for this server.
+    assert p.estimated_recoverable_usd is None
     assert "claude mcp remove apollo --scope project" in p.suggestion
+
+
+def test_deadweight_proposal_carries_priced_usd_from_server():
+    """When the analyzer priced the tax (a model was observed across the
+    server's sessions), the adapter must carry that $ figure straight
+    through -- never recompute or invent a rate of its own."""
+    from tokenjam.core.optimize.cost_proposals import _deadweight_to_proposals
+    server = _dead_server(
+        priced_model="claude-opus-4-8",
+        estimated_tax_usd_per_session=0.125,
+        estimated_tax_usd_90d=1.40625,
+    )
+    p = _deadweight_to_proposals(_deadweight_finding(dead_servers=[server]))[0]
+    assert p.estimated_recoverable_usd == 1.40625
+    assert p.baseline["priced_model"] == "claude-opus-4-8"
 
 
 def test_deadweight_proposal_notes_deferred_sessions_in_evidence():
@@ -599,7 +400,7 @@ def _workflow_finding(clusters=None, **overrides):
 
 def test_script_proposal_shape_and_apply_fields():
     from tokenjam.core.optimize.cost_proposals import _script_to_proposals
-    props = _script_to_proposals(_workflow_finding())
+    props = _script_to_proposals(_workflow_finding(), persona="claude-code")
     assert len(props) == 1
     p = props[0]
     assert p.kind == "cost"
@@ -679,7 +480,7 @@ def _reuse_finding(clusters=None, **overrides):
 
 def test_reuse_proposal_shape_and_apply_fields():
     from tokenjam.core.optimize.cost_proposals import _reuse_to_proposals
-    props = _reuse_to_proposals(_reuse_finding())
+    props = _reuse_to_proposals(_reuse_finding(), persona="claude-code")
     assert len(props) == 1
     p = props[0]
     assert p.kind == "cost"
@@ -727,7 +528,7 @@ def _verbosity_finding(**overrides):
 
 def test_verbosity_proposal_shape_and_apply_fields():
     from tokenjam.core.optimize.cost_proposals import _verbosity_to_proposals
-    props = _verbosity_to_proposals(_verbosity_finding())
+    props = _verbosity_to_proposals(_verbosity_finding(), persona="claude-code")
     assert len(props) == 1
     p = props[0]
     assert p.kind == "cost"
@@ -770,32 +571,150 @@ def test_script_reuse_verbosity_wired_into_cost_analyzers_and_report_adapter():
     assert {"script", "reuse", "verbosity"} <= analyzers
 
 
-def _seed_sub(db, *, model, when, count=30, provider="anthropic"):
-    for i in range(count):
-        db.insert_span(make_llm_span(
-            agent_id="claude-code-x", provider=provider, model=model,
-            billing_account=provider, input_tokens=8000, output_tokens=200,
-            session_id=f"{model}-{when.isoformat()}-{i}", sub_agent_id="sa1",
-            start_time=when + timedelta(minutes=i),
-        ))
+# --- Persona-gated fix modality (script / reuse / verbosity only) -----------
+#
+# These three analyzers' only apply path is a rung-1 CLAUDE.md note or rung-2
+# .claude/skills/<slug>/SKILL.md — an artifact nothing in an SDK service's
+# request path ever reads. An "sdk"/"unknown" persona must never see
+# apply_capable=True for them; the identical recommendation must still reach
+# them as a copy-pasteable `suggestion`. A "claude-code" window must be
+# byte-identical to before this gating existed.
+
+def _script_finding_for_persona_tests():
+    return _workflow_finding()
 
 
-def test_subagent_delta_improved_when_fanout_moves_off_oversized_model(db):
-    # pre: subagent fan-out on opus; post: moved to sonnet.
-    _seed_sub(db, model="claude-opus-4-8", when=MARKER - timedelta(hours=40))
-    _seed_sub(db, model="claude-sonnet-5", when=MARKER + timedelta(hours=1))
-    # main-thread opus post-marker must NOT count (subagent-scoped metric).
-    for i in range(10):
-        db.insert_span(make_llm_span(
-            agent_id="claude-code-x", model="claude-opus-4-8", input_tokens=8000,
-            output_tokens=200, session_id=f"main-{i}",
-            start_time=MARKER + timedelta(hours=1, minutes=i),
-        ))
-    rec = _record("subagent", {"models": ["claude-opus-4-8"], "subagent": True}, agent_id="")
-    v = cost_verify.measure_cost_delta(db.conn, rec, now=NOW)
-    assert v["verdict"] == "improved"
-    assert v["realized_usd_delta"] > 0
-    assert v["post_value"] == 0.0        # no post-marker subagent spend on opus
+def _reuse_finding_for_persona_tests():
+    return _reuse_finding()
+
+
+def _verbosity_finding_for_persona_tests():
+    return _verbosity_finding()
+
+
+@pytest.mark.parametrize("adapter_name,finder", [
+    ("_script_to_proposals", _script_finding_for_persona_tests),
+    ("_reuse_to_proposals", _reuse_finding_for_persona_tests),
+    ("_verbosity_to_proposals", _verbosity_finding_for_persona_tests),
+])
+def test_sdk_persona_gets_snippet_not_write(adapter_name, finder):
+    """An sdk-persona window: no write offered, but the exact same
+    recommendation lands in `suggestion` so the card isn't left inert."""
+    import tokenjam.core.optimize.cost_proposals as cp
+    adapter = getattr(cp, adapter_name)
+    props = adapter(finder(), persona="sdk")
+    assert len(props) == 1
+    p = props[0]
+    assert p.apply_capable is False
+    assert p.advise_only is True
+    assert p.rung == 0
+    assert p.scope == ""
+    assert p.proposed_fix == ""
+    assert p.suggestion  # the recommendation still reaches the sdk user
+    assert p.suggestion == p.advise_text
+
+
+@pytest.mark.parametrize("adapter_name,finder", [
+    ("_script_to_proposals", _script_finding_for_persona_tests),
+    ("_reuse_to_proposals", _reuse_finding_for_persona_tests),
+    ("_verbosity_to_proposals", _verbosity_finding_for_persona_tests),
+])
+def test_unknown_persona_is_gated_same_as_sdk(adapter_name, finder):
+    """"unknown" (no session in the window carries an identifiable agent_id,
+    and no declared plan settles it) is exactly the shape of a pure-SDK
+    caller who never ran `tj onboard` — the failure mode this gating exists
+    to close. Grouped with "sdk", matching
+    `cmd_optimize._render_downgrade_cta`'s CTA."""
+    import tokenjam.core.optimize.cost_proposals as cp
+    adapter = getattr(cp, adapter_name)
+    props = adapter(finder(), persona="unknown")
+    assert len(props) == 1
+    p = props[0]
+    assert p.apply_capable is False
+    assert p.advise_only is True
+    assert p.suggestion == p.advise_text
+
+    # The default persona (no explicit kwarg) must resolve exactly the same
+    # way — a caller that doesn't know the persona must never fall back to
+    # assuming claude-code.
+    default_props = adapter(finder())
+    assert default_props[0].apply_capable is False
+    assert default_props[0].advise_only is True
+
+
+@pytest.mark.parametrize("adapter_name,finder", [
+    ("_script_to_proposals", _script_finding_for_persona_tests),
+    ("_reuse_to_proposals", _reuse_finding_for_persona_tests),
+    ("_verbosity_to_proposals", _verbosity_finding_for_persona_tests),
+])
+def test_claude_code_persona_is_byte_identical_to_pre_gating_shape(adapter_name, finder):
+    """The exact fields these analyzers produced before persona gating
+    existed: apply_capable/advise_only unchanged, and no `suggestion` is
+    invented for a persona that already gets the real write."""
+    import tokenjam.core.optimize.cost_proposals as cp
+    adapter = getattr(cp, adapter_name)
+    props = adapter(finder(), persona="claude-code")
+    assert len(props) == 1
+    p = props[0]
+    assert p.advise_only is False
+    assert p.apply_capable is True
+    assert p.rung in (1, 2)
+    assert p.scope == "project"
+    assert p.proposed_fix
+    assert p.suggestion == ""  # unchanged from before this gating existed
+
+
+@pytest.mark.parametrize("adapter_name,finder", [
+    ("_script_to_proposals", _script_finding_for_persona_tests),
+    ("_reuse_to_proposals", _reuse_finding_for_persona_tests),
+    ("_verbosity_to_proposals", _verbosity_finding_for_persona_tests),
+])
+def test_mixed_persona_offers_the_write_and_the_snippet(adapter_name, finder):
+    """"mixed": both audiences are meaningfully represented and a single
+    finding isn't attributable to one side or the other, so — mirroring
+    `_render_downgrade_cta`'s "mixed shows both" precedent — the write stays
+    on offer AND the identical text is carried as `suggestion` so the sdk
+    share of the mix isn't left with a card that looks actionable for them
+    but silently isn't."""
+    import tokenjam.core.optimize.cost_proposals as cp
+    adapter = getattr(cp, adapter_name)
+    props = adapter(finder(), persona="mixed")
+    assert len(props) == 1
+    p = props[0]
+    assert p.apply_capable is True
+    assert p.advise_only is False
+    assert p.proposed_fix
+    assert p.suggestion == p.advise_text
+
+
+def test_cost_proposals_from_report_reads_persona_off_the_report():
+    """`cost_proposals_from_report` must never take the caller's word for the
+    persona out-of-band — it reads `report.persona`, the single field
+    `runner.build_report` populates once (see `AnalyzerContext.persona`)."""
+    from tokenjam.core.optimize.cost_proposals import cost_proposals_from_report
+
+    rep = _report()
+    rep.findings["script"] = _workflow_finding()
+    rep.findings["reuse"] = _reuse_finding()
+    rep.findings["verbosity"] = _verbosity_finding()
+
+    rep.persona = "sdk"
+    by_analyzer = {p.analyzer: p for p in cost_proposals_from_report(rep)}
+    for name in ("script", "reuse", "verbosity"):
+        assert by_analyzer[name].apply_capable is False
+        assert by_analyzer[name].suggestion
+
+    rep.persona = "claude-code"
+    by_analyzer = {p.analyzer: p for p in cost_proposals_from_report(rep)}
+    for name in ("script", "reuse", "verbosity"):
+        assert by_analyzer[name].apply_capable is True
+
+    # A report with no persona set at all (e.g. hand-built, pre-gating test
+    # code) defaults to "unknown" -> the fail-safe, not "claude-code".
+    rep.persona = "unknown"
+    by_analyzer = {p.analyzer: p for p in cost_proposals_from_report(rep)}
+    for name in ("script", "reuse", "verbosity"):
+        assert by_analyzer[name].apply_capable is False
 
 
 # --- Component E: the estimated-recoverable rollup --------------------------
@@ -921,3 +840,70 @@ def test_rollup_mixed_none_and_real_estimates_across_analyzers():
     assert by_analyzer["cache"]["count"] == 1     # only the real-valued cache card
     assert by_analyzer["cache"]["usd"] == 1.5
     assert "deadweight" not in by_analyzer        # its only card was None-only
+
+
+# --- Component E: the token sum and its coverage ---------------------------
+
+def test_rollup_sums_tokens_independently_of_the_dollar_estimate():
+    # The two estimates are populated by different analyzers, so a proposal can
+    # carry either alone. Folding tokens in only where a dollar figure also
+    # exists would understate the headline the suppressed-dollars path leads
+    # with — here that would report 900 instead of the true 1400.
+    proposals = [
+        {"signature": "a", "analyzer": "downsize", "title": "t1",
+         "estimated_recoverable_usd": 3.0, "estimated_recoverable_tokens": 900},
+        {"signature": "b", "analyzer": "cache", "title": "t2",
+         "estimated_recoverable_tokens": 500},
+    ]
+    rollup = estimated_recoverable_rollup(proposals)
+    assert rollup["estimated_recoverable_tokens"] == 1400
+    assert rollup["token_proposal_count"] == 2
+    assert rollup["deduplicated_proposal_count"] == 2
+    # The dollar sum still counts only the dollar-bearing proposal.
+    assert rollup["estimated_recoverable_usd"] == 3.0
+    assert rollup["proposal_count"] == 1
+
+
+def test_rollup_reports_partial_token_coverage_rather_than_implying_all():
+    # Two of three proposals carry no token estimate. The sum is a floor, and
+    # token_proposal_count vs deduplicated_proposal_count is what lets the tile
+    # say so instead of claiming coverage it does not have.
+    proposals = [
+        {"signature": "a", "analyzer": "downsize", "title": "t1",
+         "estimated_recoverable_usd": 3.0, "estimated_recoverable_tokens": 900},
+        {"signature": "b", "analyzer": "cache", "title": "t2",
+         "estimated_recoverable_usd": 1.0},
+        {"signature": "c", "analyzer": "trim", "title": "t3",
+         "estimated_recoverable_usd": 2.0},
+    ]
+    rollup = estimated_recoverable_rollup(proposals)
+    assert rollup["estimated_recoverable_tokens"] == 900
+    assert rollup["token_proposal_count"] == 1
+    assert rollup["deduplicated_proposal_count"] == 3
+    assert "1 of 3" in rollup["estimate_basis"]
+    assert "floor, not a total" in rollup["estimate_basis"]
+
+
+def test_rollup_token_sum_dedupes_by_signature_too():
+    proposals = [
+        {"signature": "a", "analyzer": "downsize", "title": "t1",
+         "estimated_recoverable_tokens": 900},
+        {"signature": "a", "analyzer": "downsize", "title": "t1-stale",
+         "estimated_recoverable_tokens": 900},
+    ]
+    rollup = estimated_recoverable_rollup(proposals)
+    assert rollup["estimated_recoverable_tokens"] == 900
+    assert rollup["token_proposal_count"] == 1
+
+
+def test_rollup_with_no_token_estimates_reports_zero_coverage():
+    # Nothing to lead with when dollars are suppressed; the tile hides rather
+    # than rendering a zero, so the counts must make that state distinguishable.
+    proposals = [
+        {"signature": "a", "analyzer": "downsize", "title": "t1",
+         "estimated_recoverable_usd": 3.0},
+    ]
+    rollup = estimated_recoverable_rollup(proposals)
+    assert rollup["estimated_recoverable_tokens"] == 0
+    assert rollup["token_proposal_count"] == 0
+    assert "floor, not a total" not in rollup["estimate_basis"]

--- a/tests/unit/test_cost_proposals.py
+++ b/tests/unit/test_cost_proposals.py
@@ -672,3 +672,49 @@ def test_rollup_ignores_a_proposal_with_no_signature():
     rollup = estimated_recoverable_rollup(proposals)
     assert rollup["proposal_count"] == 0
     assert rollup["estimated_recoverable_usd"] == 0.0
+
+
+def test_rollup_all_open_cards_carry_none_renders_empty_state():
+    # Every open card exists but none carries a dollar estimate (e.g. every
+    # cache-thrash card came back "not worth it at this cadence") — the
+    # rollup must still render the sensible empty state, not a zero that
+    # looks like a real (if tiny) measured sum.
+    proposals = [
+        {"signature": "cost:cache:thrash:agentA", "analyzer": "cache", "title": "t1",
+         "estimated_recoverable_usd": None},
+        {"signature": "cost:deadweight:mcp-x", "analyzer": "deadweight", "title": "t2",
+         "estimated_recoverable_usd": None},
+    ]
+    rollup = estimated_recoverable_rollup(proposals)
+    assert rollup["estimated_recoverable_usd"] == 0.0
+    assert rollup["proposal_count"] == 0
+    assert rollup["by_analyzer"] == []
+    assert rollup["contributing"] == []
+    assert "no open" in rollup["estimate_basis"]
+
+
+def test_rollup_mixed_none_and_real_estimates_across_analyzers():
+    # Mirrors two sibling-branch card shapes that intentionally emit None:
+    # Component A's cache-thrash card when the TTL arithmetic comes out
+    # negative ("not worth it at this cadence"), and Component C's
+    # deferred-tools deadweight card. Neither should be coerced into the sum
+    # or into "N proposals" — only the two real-valued cards contribute.
+    proposals = [
+        {"signature": "cost:cache:thrash:agentA", "analyzer": "cache", "title": "not worth it",
+         "estimated_recoverable_usd": None},
+        {"signature": "cost:deadweight:mcp-x", "analyzer": "deadweight", "title": "deferred server",
+         "estimated_recoverable_usd": None},
+        {"signature": "cost:downsize", "analyzer": "downsize", "title": "real card 1",
+         "estimated_recoverable_usd": 3.0},
+        {"signature": "cost:cache:anthropic:claude-sonnet-5", "analyzer": "cache", "title": "real card 2",
+         "estimated_recoverable_usd": 1.5},
+    ]
+    rollup = estimated_recoverable_rollup(proposals)
+    assert rollup["estimated_recoverable_usd"] == 4.5
+    assert rollup["proposal_count"] == 2   # only the two real-valued cards
+    signatures = {c["signature"] for c in rollup["contributing"]}
+    assert signatures == {"cost:downsize", "cost:cache:anthropic:claude-sonnet-5"}
+    by_analyzer = {a["analyzer"]: a for a in rollup["by_analyzer"]}
+    assert by_analyzer["cache"]["count"] == 1     # only the real-valued cache card
+    assert by_analyzer["cache"]["usd"] == 1.5
+    assert "deadweight" not in by_analyzer        # its only card was None-only

--- a/tests/unit/test_cost_proposals.py
+++ b/tests/unit/test_cost_proposals.py
@@ -3,7 +3,7 @@ self-improve loop as advise-only proposals with delta-verify receipts.
 
 Fully isolated: the DB is an ``InMemoryBackend`` and every JSON ledger/store
 write is routed under ``tmp_path`` via ``cfg.storage.path`` — nothing here
-touches a real ``~/.tj`` / ``~/.claude`` (mirrors ``test_pothole_apply``).
+touches a real ``~/.tj`` / ``~/.claude`` (mirrors ``test_relearn_apply``).
 """
 from __future__ import annotations
 
@@ -13,12 +13,12 @@ import pytest
 
 from tokenjam.core.config import StorageConfig, TjConfig
 from tokenjam.core.db import InMemoryBackend
-from tokenjam.core.optimize import cost_apply, cost_verify, pothole_store
+from tokenjam.core.optimize import cost_apply, cost_verify, relearn_store
 from tokenjam.core.optimize.analyzers.cache_efficacy import (
     CacheEfficacyFinding,
     CacheEfficacyRow,
 )
-from tokenjam.core.optimize.analyzers.pothole import PotholeFinding
+from tokenjam.core.optimize.analyzers.relearn import RelearnFinding
 from tokenjam.core.optimize.analyzers.prompt_bloat import BloatPrompt, PromptBloatFinding
 from tokenjam.core.optimize.cost_proposals import cost_proposals_from_report
 from tokenjam.core.optimize.types import (
@@ -279,23 +279,221 @@ def test_cost_compound_ledger_sums_realized_dollars():
     assert ledger["verified_count"] == 3
 
 
-# --- Store: cost proposals share the pothole cache file ----------------------
+# --- Store: cost proposals share the relearn cache file ----------------------
 
-def test_store_cost_and_pothole_coexist_without_clobber(tmp_path):
-    path = tmp_path / "pothole_cache.json"
-    # Pothole finding written first.
-    pothole_store.write_cache(PotholeFinding(sessions_scanned=7), path=path)
+def test_store_cost_and_relearn_coexist_without_clobber(tmp_path):
+    path = tmp_path / "relearn_cache.json"
+    # Relearn finding written first.
+    relearn_store.write_cache(RelearnFinding(sessions_scanned=7), path=path)
     # Cost proposals written into the SAME file must preserve the finding.
-    pothole_store.write_cost_proposals(
+    relearn_store.write_cost_proposals(
         [{"kind": "cost", "analyzer": "trim", "signature": "cost:trim:x"}], path=path,
     )
-    cost_block = pothole_store.read_cost_proposals(path=path)
+    cost_block = relearn_store.read_cost_proposals(path=path)
     assert cost_block is not None
     assert cost_block["cost_proposals"][0]["signature"] == "cost:trim:x"
-    # The pothole finding is still intact.
-    raw = pothole_store.read_cache(path=path)
+    # The relearn finding is still intact.
+    raw = relearn_store.read_cache(path=path)
     assert raw["finding"]["sessions_scanned"] == 7
-    # A later pothole recompute preserves the cost proposals.
-    pothole_store.write_cache(PotholeFinding(sessions_scanned=9), path=path)
-    assert pothole_store.read_cost_proposals(path=path)["cost_proposals"][0]["signature"] == "cost:trim:x"
-    assert pothole_store.read_cache(path=path)["finding"]["sessions_scanned"] == 9
+    # A later relearn recompute preserves the cost proposals.
+    relearn_store.write_cache(RelearnFinding(sessions_scanned=9), path=path)
+    assert relearn_store.read_cost_proposals(path=path)["cost_proposals"][0]["signature"] == "cost:trim:x"
+    assert relearn_store.read_cache(path=path)["finding"]["sessions_scanned"] == 9
+
+
+# --- Subagent right-sizing: the apply-capable 4th analyzer --------------------
+
+def _sub_finding(models=("claude-opus-4-8",)):
+    from tokenjam.core.optimize.analyzers.subagent_rightsizing import (
+        SubagentRightsizingFinding,
+        SubagentRow,
+    )
+    flagged = [
+        SubagentRow(session_id="s1", sub_agent_id=f"sa{i}", model=m, llm_calls=2,
+                    tool_calls=1, input_tokens=60000, output_tokens=500, cache_tokens=0,
+                    cache_write_tokens=0, cost_usd=1.2, provider="anthropic",
+                    flags=["over_powered"])
+        for i, m in enumerate(models)
+    ]
+    return SubagentRightsizingFinding(
+        flagged=flagged, percent_of_cost=0.66, flagged_cost_usd=1.2,
+        subagent_cost_usd=1.5, estimated_recoverable_usd=0.4,
+        estimated_recoverable_tokens=60500,
+    )
+
+
+def test_subagent_proposal_is_apply_capable_cc_origin():
+    from tokenjam.core.optimize.cost_proposals import _subagent_to_proposals
+    props = _subagent_to_proposals(_sub_finding())
+    assert len(props) == 1
+    p = props[0]
+    assert p.analyzer == "subagent"
+    assert p.apply_capable is True
+    assert p.advise_only is False        # CC-origin has a workspace surface
+    assert p.rung == 1 and p.scope == "project"
+    assert p.proposed_fix                # a sizing rubric note to write
+    assert p.target_key == {"models": ["claude-opus-4-8"], "subagent": True}
+
+
+def test_subagent_proposal_degrades_to_advise_only_without_over_powered():
+    from tokenjam.core.optimize.analyzers.subagent_rightsizing import (
+        SubagentRightsizingFinding,
+    )
+    # over_provisioned-only (no model swap) yields no proposal here.
+    assert _sub_finding.__doc__ is None  # sanity: helper unchanged
+    from tokenjam.core.optimize.cost_proposals import _subagent_to_proposals
+    assert _subagent_to_proposals(SubagentRightsizingFinding(flagged=[])) == []
+
+
+# --- deadweight (C1: MCP dead-weight servers) --------------------------------
+
+def _dead_server(**overrides):
+    from tokenjam.core.optimize.analyzers.deadweight import ServerDeadweight
+    fields = dict(
+        name="apollo", scope="project", source="/repo/.mcp.json",
+        sessions_present=10, invocations=0, deferred_sessions=0, dead=True,
+        estimated_tax_tokens_per_session=25_000, estimated_tax_tokens_90d=225_000,
+        tax_construction="25,000 tok/session (full schema injection), cited estimate.",
+        fix="Remove or project-scope the `apollo` MCP server (/repo/.mcp.json); "
+            "zero tool calls across 10 session(s) in this window.",
+        example_sessions=["s0", "s1", "s2"],
+    )
+    fields.update(overrides)
+    return ServerDeadweight(**fields)
+
+
+def _deadweight_finding(dead_servers=None, tax_table=None):
+    from tokenjam.core.optimize.analyzers.deadweight import ContextTaxRow, DeadweightFinding
+    dead_servers = dead_servers if dead_servers is not None else [_dead_server()]
+    tax_table = tax_table if tax_table is not None else [
+        ContextTaxRow(source="MCP schema: apollo", sessions=10,
+                      avg_tokens_per_session=25_000, total_tokens_window=250_000),
+    ]
+    return DeadweightFinding(
+        sessions_scanned=10, configured_servers=1,
+        servers=dead_servers, dead_servers=dead_servers, tax_table=tax_table,
+        estimated_recoverable_tokens=sum(s.estimated_tax_tokens_90d for s in dead_servers) or None,
+        estimate_basis="dead-server 90d tax sum",
+    )
+
+
+def test_deadweight_proposal_shape_and_fields():
+    from tokenjam.core.optimize.cost_proposals import _deadweight_to_proposals
+    props = _deadweight_to_proposals(_deadweight_finding())
+    assert len(props) == 1
+    p = props[0]
+    assert p.kind == "cost"
+    assert p.analyzer == "deadweight"
+    assert p.signature == "cost:deadweight:apollo"
+    assert p.advise_only is True
+    assert p.correlational is True
+    assert p.estimate_confidence == "estimated"
+    assert "apollo" in p.title
+    assert "0 tool calls" in p.evidence
+    assert p.target_key == {"server": "apollo", "scope": "project", "source": "/repo/.mcp.json"}
+    assert p.baseline["example_sessions"] == ["s0", "s1", "s2"]
+    assert p.estimated_recoverable_tokens == 225_000
+    assert p.estimated_recoverable_usd is None  # tokens-only, never a stacked $ guess
+    assert "claude mcp remove apollo --scope project" in p.suggestion
+
+
+def test_deadweight_proposal_notes_deferred_sessions_in_evidence():
+    from tokenjam.core.optimize.cost_proposals import _deadweight_to_proposals
+    server = _dead_server(deferred_sessions=4)
+    p = _deadweight_to_proposals(_deadweight_finding(dead_servers=[server]))[0]
+    assert "ToolSearch deferred" in p.evidence
+    assert "4" in p.evidence
+
+
+def test_deadweight_proposal_empty_for_no_dead_servers():
+    from tokenjam.core.optimize.cost_proposals import _deadweight_to_proposals
+    assert _deadweight_to_proposals(_deadweight_finding(dead_servers=[])) == []
+    assert _deadweight_to_proposals(None) == []
+
+
+def test_deadweight_wired_into_cost_analyzers_and_report_adapter():
+    from tokenjam.core.optimize.cost_proposals import COST_ANALYZERS, cost_proposals_from_report
+    assert "deadweight" in COST_ANALYZERS
+
+    rep = _report()
+    rep.findings["deadweight"] = _deadweight_finding()
+    props = {p.analyzer for p in cost_proposals_from_report(rep)}
+    assert "deadweight" in props
+
+
+def test_deadweight_tax_table_never_becomes_a_second_proposal():
+    """Dedup guarantee: a live (non-dead) server sits in the tax table for
+    visibility but must never itself spawn a proposal, and a dead server's
+    proposal total must equal exactly its OWN 90d tax -- never the tax
+    table's (possibly multi-row) sum."""
+    from tokenjam.core.optimize.analyzers.deadweight import ContextTaxRow
+    from tokenjam.core.optimize.cost_proposals import _deadweight_to_proposals
+
+    dead = _dead_server(name="apollo", estimated_tax_tokens_90d=225_000)
+    finding = _deadweight_finding(
+        dead_servers=[dead],
+        tax_table=[
+            ContextTaxRow(source="MCP schema: apollo", sessions=10,
+                          avg_tokens_per_session=25_000, total_tokens_window=250_000),
+            # A live server: present in the tax table, but not in dead_servers.
+            ContextTaxRow(source="MCP schema: exa", sessions=10,
+                          avg_tokens_per_session=25_000, total_tokens_window=250_000),
+            ContextTaxRow(source="CLAUDE.md", sessions=10,
+                          avg_tokens_per_session=500, total_tokens_window=5_000),
+        ],
+    )
+    props = _deadweight_to_proposals(finding)
+    assert len(props) == 1
+    assert props[0].estimated_recoverable_tokens == 225_000
+    assert finding.estimated_recoverable_tokens == 225_000  # never the tax-table's 505,000 sum
+
+
+# --- deadweight finding round-trips through report_to_dict/report_from_dict --
+
+def test_deadweight_finding_survives_report_dict_round_trip():
+    from tokenjam.core.optimize.runner import report_from_dict, report_to_dict
+    from tokenjam.core.optimize.types import OptimizeReport, WindowSummary
+
+    w = WindowSummary(since=MARKER, until=NOW, days=5, sessions=10, spans=100,
+                      total_tokens=1, total_cost_usd=5.0, thin_data=False)
+    report = OptimizeReport(window=w, findings={"deadweight": _deadweight_finding()})
+
+    payload = report_to_dict(report)
+    rebuilt = report_from_dict(payload)
+
+    finding = rebuilt.findings["deadweight"]
+    assert finding.configured_servers == 1
+    assert len(finding.dead_servers) == 1
+    assert finding.dead_servers[0].name == "apollo"
+    assert finding.dead_servers[0].example_sessions == ["s0", "s1", "s2"]
+    assert finding.estimated_recoverable_tokens == 225_000
+    assert len(finding.tax_table) == 1
+    assert finding.tax_table[0].source == "MCP schema: apollo"
+
+
+def _seed_sub(db, *, model, when, count=30, provider="anthropic"):
+    for i in range(count):
+        db.insert_span(make_llm_span(
+            agent_id="claude-code-x", provider=provider, model=model,
+            billing_account=provider, input_tokens=8000, output_tokens=200,
+            session_id=f"{model}-{when.isoformat()}-{i}", sub_agent_id="sa1",
+            start_time=when + timedelta(minutes=i),
+        ))
+
+
+def test_subagent_delta_improved_when_fanout_moves_off_oversized_model(db):
+    # pre: subagent fan-out on opus; post: moved to sonnet.
+    _seed_sub(db, model="claude-opus-4-8", when=MARKER - timedelta(hours=40))
+    _seed_sub(db, model="claude-sonnet-5", when=MARKER + timedelta(hours=1))
+    # main-thread opus post-marker must NOT count (subagent-scoped metric).
+    for i in range(10):
+        db.insert_span(make_llm_span(
+            agent_id="claude-code-x", model="claude-opus-4-8", input_tokens=8000,
+            output_tokens=200, session_id=f"main-{i}",
+            start_time=MARKER + timedelta(hours=1, minutes=i),
+        ))
+    rec = _record("subagent", {"models": ["claude-opus-4-8"], "subagent": True}, agent_id="")
+    v = cost_verify.measure_cost_delta(db.conn, rec, now=NOW)
+    assert v["verdict"] == "improved"
+    assert v["realized_usd_delta"] > 0
+    assert v["post_value"] == 0.0        # no post-marker subagent spend on opus

--- a/tests/unit/test_cost_proposals.py
+++ b/tests/unit/test_cost_proposals.py
@@ -349,6 +349,29 @@ def test_cost_compound_ledger_sums_realized_dollars():
     assert ledger["verified_count"] == 3
 
 
+def test_cost_compound_ledger_no_change_bucket_sums_to_verified():
+    # A no_change record (deadweight: server still configured) must land in
+    # its own named bucket, not just inflate verified_count with nowhere to
+    # go -- the named buckets must always add back up to verified_count.
+    records = [
+        {"state": "applied", "verify": {"verdict": "improved",
+         "realized_usd_delta": 0.5, "realized_tokens_delta": 1000}},
+        {"state": "applied", "verify": {"verdict": "no_change"}},
+        {"state": "applied", "verify": {"verdict": "no_change"}},
+        {"state": "applied", "verify": {"verdict": "regressed",
+         "realized_usd_delta": 0.0}},
+        {"state": "applied", "verify": {"verdict": "insufficient_data"}},
+    ]
+    ledger = cost_verify.cost_compound_ledger(records)
+    assert ledger["no_change_count"] == 2
+    assert ledger["verified_count"] == 5
+    assert (
+        ledger["improved_count"] + ledger["no_change_count"]
+        + ledger["regressed_count"] + ledger["insufficient_data_count"]
+        == ledger["verified_count"]
+    )
+
+
 # --- Store: cost proposals share the relearn cache file ----------------------
 
 def test_store_cost_and_relearn_coexist_without_clobber(tmp_path):

--- a/tests/unit/test_cost_proposals.py
+++ b/tests/unit/test_cost_proposals.py
@@ -3,7 +3,7 @@ self-improve loop as advise-only proposals with delta-verify receipts.
 
 Fully isolated: the DB is an ``InMemoryBackend`` and every JSON ledger/store
 write is routed under ``tmp_path`` via ``cfg.storage.path`` — nothing here
-touches a real ``~/.tj`` / ``~/.claude`` (mirrors ``test_relearn_apply``).
+touches a real ``~/.tj`` / ``~/.claude`` (mirrors ``test_pothole_apply``).
 """
 from __future__ import annotations
 
@@ -13,12 +13,12 @@ import pytest
 
 from tokenjam.core.config import StorageConfig, TjConfig
 from tokenjam.core.db import InMemoryBackend
-from tokenjam.core.optimize import cost_apply, cost_verify, relearn_store
+from tokenjam.core.optimize import cost_apply, cost_verify, pothole_store
 from tokenjam.core.optimize.analyzers.cache_efficacy import (
     CacheEfficacyFinding,
     CacheEfficacyRow,
 )
-from tokenjam.core.optimize.analyzers.relearn import RelearnFinding
+from tokenjam.core.optimize.analyzers.pothole import PotholeFinding
 from tokenjam.core.optimize.analyzers.prompt_bloat import BloatPrompt, PromptBloatFinding
 from tokenjam.core.optimize.cost_proposals import cost_proposals_from_report
 from tokenjam.core.optimize.types import (
@@ -279,238 +279,23 @@ def test_cost_compound_ledger_sums_realized_dollars():
     assert ledger["verified_count"] == 3
 
 
-# --- Store: cost proposals share the relearn cache file ----------------------
+# --- Store: cost proposals share the pothole cache file ----------------------
 
-def test_store_cost_and_relearn_coexist_without_clobber(tmp_path):
-    path = tmp_path / "relearn_cache.json"
-    # Relearn finding written first.
-    relearn_store.write_cache(RelearnFinding(sessions_scanned=7), path=path)
+def test_store_cost_and_pothole_coexist_without_clobber(tmp_path):
+    path = tmp_path / "pothole_cache.json"
+    # Pothole finding written first.
+    pothole_store.write_cache(PotholeFinding(sessions_scanned=7), path=path)
     # Cost proposals written into the SAME file must preserve the finding.
-    relearn_store.write_cost_proposals(
+    pothole_store.write_cost_proposals(
         [{"kind": "cost", "analyzer": "trim", "signature": "cost:trim:x"}], path=path,
     )
-    cost_block = relearn_store.read_cost_proposals(path=path)
+    cost_block = pothole_store.read_cost_proposals(path=path)
     assert cost_block is not None
     assert cost_block["cost_proposals"][0]["signature"] == "cost:trim:x"
-    # The relearn finding is still intact.
-    raw = relearn_store.read_cache(path=path)
+    # The pothole finding is still intact.
+    raw = pothole_store.read_cache(path=path)
     assert raw["finding"]["sessions_scanned"] == 7
-    # A later relearn recompute preserves the cost proposals.
-    relearn_store.write_cache(RelearnFinding(sessions_scanned=9), path=path)
-    assert relearn_store.read_cost_proposals(path=path)["cost_proposals"][0]["signature"] == "cost:trim:x"
-    assert relearn_store.read_cache(path=path)["finding"]["sessions_scanned"] == 9
-
-
-# --- Subagent right-sizing: the apply-capable 4th analyzer --------------------
-
-def _sub_finding(models=("claude-opus-4-8",)):
-    from tokenjam.core.optimize.analyzers.subagent_rightsizing import (
-        SubagentRightsizingFinding,
-        SubagentRow,
-    )
-    flagged = [
-        SubagentRow(session_id="s1", sub_agent_id=f"sa{i}", model=m, llm_calls=2,
-                    tool_calls=1, input_tokens=60000, output_tokens=500, cache_tokens=0,
-                    cache_write_tokens=0, cost_usd=1.2, provider="anthropic",
-                    flags=["over_powered"])
-        for i, m in enumerate(models)
-    ]
-    return SubagentRightsizingFinding(
-        flagged=flagged, percent_of_cost=0.66, flagged_cost_usd=1.2,
-        subagent_cost_usd=1.5, estimated_recoverable_usd=0.4,
-        estimated_recoverable_tokens=60500,
-    )
-
-
-def test_subagent_proposal_is_apply_capable_cc_origin():
-    from tokenjam.core.optimize.cost_proposals import _subagent_to_proposals
-    props = _subagent_to_proposals(_sub_finding())
-    assert len(props) == 1
-    p = props[0]
-    assert p.analyzer == "subagent"
-    assert p.apply_capable is True
-    assert p.advise_only is False        # CC-origin has a workspace surface
-    assert p.rung == 1 and p.scope == "project"
-    assert p.proposed_fix                # a sizing rubric note to write
-    assert p.target_key == {"models": ["claude-opus-4-8"], "subagent": True}
-
-
-def test_subagent_proposal_degrades_to_advise_only_without_over_powered():
-    from tokenjam.core.optimize.analyzers.subagent_rightsizing import (
-        SubagentRightsizingFinding,
-    )
-    # over_provisioned-only (no model swap) yields no proposal here.
-    assert _sub_finding.__doc__ is None  # sanity: helper unchanged
-    from tokenjam.core.optimize.cost_proposals import _subagent_to_proposals
-    assert _subagent_to_proposals(SubagentRightsizingFinding(flagged=[])) == []
-
-
-# --- deadweight (C1: MCP dead-weight servers) --------------------------------
-
-def _dead_server(**overrides):
-    from tokenjam.core.optimize.analyzers.deadweight import ServerDeadweight
-    fields = dict(
-        name="apollo", scope="project", source="/repo/.mcp.json",
-        sessions_present=10, invocations=0, deferred_sessions=0, dead=True,
-        estimated_tax_tokens_per_session=25_000, estimated_tax_tokens_90d=225_000,
-        tax_construction="25,000 tok/session (full schema injection), cited estimate.",
-        fix="Remove or project-scope the `apollo` MCP server (/repo/.mcp.json); "
-            "zero tool calls across 10 session(s) in this window.",
-        example_sessions=["s0", "s1", "s2"],
-    )
-    fields.update(overrides)
-    return ServerDeadweight(**fields)
-
-
-def _deadweight_finding(dead_servers=None, tax_table=None):
-    from tokenjam.core.optimize.analyzers.deadweight import ContextTaxRow, DeadweightFinding
-    dead_servers = dead_servers if dead_servers is not None else [_dead_server()]
-    tax_table = tax_table if tax_table is not None else [
-        ContextTaxRow(source="MCP schema: apollo", sessions=10,
-                      avg_tokens_per_session=25_000, total_tokens_window=250_000),
-    ]
-    return DeadweightFinding(
-        sessions_scanned=10, configured_servers=1,
-        servers=dead_servers, dead_servers=dead_servers, tax_table=tax_table,
-        estimated_recoverable_tokens=sum(s.estimated_tax_tokens_90d for s in dead_servers) or None,
-        estimate_basis="dead-server 90d tax sum",
-    )
-
-
-def test_deadweight_proposal_shape_and_fields():
-    from tokenjam.core.optimize.cost_proposals import _deadweight_to_proposals
-    props = _deadweight_to_proposals(_deadweight_finding())
-    assert len(props) == 1
-    p = props[0]
-    assert p.kind == "cost"
-    assert p.analyzer == "deadweight"
-    assert p.signature == "cost:deadweight:apollo"
-    assert p.advise_only is True
-    assert p.correlational is True
-    assert p.estimate_confidence == "estimated"
-    assert "apollo" in p.title
-    assert "0 tool calls" in p.evidence
-    assert p.target_key == {"server": "apollo", "scope": "project", "source": "/repo/.mcp.json"}
-    assert p.baseline["example_sessions"] == ["s0", "s1", "s2"]
-    assert p.estimated_recoverable_tokens == 225_000
-    # The base fixture's server carries no priced model -- the adapter must
-    # never invent a rate, so the card stays tokens-only for this server.
-    assert p.estimated_recoverable_usd is None
-    assert "claude mcp remove apollo --scope project" in p.suggestion
-
-
-def test_deadweight_proposal_carries_priced_usd_from_server():
-    """When the analyzer priced the tax (a model was observed across the
-    server's sessions), the adapter must carry that $ figure straight
-    through -- never recompute or invent a rate of its own."""
-    from tokenjam.core.optimize.cost_proposals import _deadweight_to_proposals
-    server = _dead_server(
-        priced_model="claude-opus-4-8",
-        estimated_tax_usd_per_session=0.125,
-        estimated_tax_usd_90d=1.40625,
-    )
-    p = _deadweight_to_proposals(_deadweight_finding(dead_servers=[server]))[0]
-    assert p.estimated_recoverable_usd == 1.40625
-    assert p.baseline["priced_model"] == "claude-opus-4-8"
-
-
-def test_deadweight_proposal_notes_deferred_sessions_in_evidence():
-    from tokenjam.core.optimize.cost_proposals import _deadweight_to_proposals
-    server = _dead_server(deferred_sessions=4)
-    p = _deadweight_to_proposals(_deadweight_finding(dead_servers=[server]))[0]
-    assert "ToolSearch deferred" in p.evidence
-    assert "4" in p.evidence
-
-
-def test_deadweight_proposal_empty_for_no_dead_servers():
-    from tokenjam.core.optimize.cost_proposals import _deadweight_to_proposals
-    assert _deadweight_to_proposals(_deadweight_finding(dead_servers=[])) == []
-    assert _deadweight_to_proposals(None) == []
-
-
-def test_deadweight_wired_into_cost_analyzers_and_report_adapter():
-    from tokenjam.core.optimize.cost_proposals import COST_ANALYZERS, cost_proposals_from_report
-    assert "deadweight" in COST_ANALYZERS
-
-    rep = _report()
-    rep.findings["deadweight"] = _deadweight_finding()
-    props = {p.analyzer for p in cost_proposals_from_report(rep)}
-    assert "deadweight" in props
-
-
-def test_deadweight_tax_table_never_becomes_a_second_proposal():
-    """Dedup guarantee: a live (non-dead) server sits in the tax table for
-    visibility but must never itself spawn a proposal, and a dead server's
-    proposal total must equal exactly its OWN 90d tax -- never the tax
-    table's (possibly multi-row) sum."""
-    from tokenjam.core.optimize.analyzers.deadweight import ContextTaxRow
-    from tokenjam.core.optimize.cost_proposals import _deadweight_to_proposals
-
-    dead = _dead_server(name="apollo", estimated_tax_tokens_90d=225_000)
-    finding = _deadweight_finding(
-        dead_servers=[dead],
-        tax_table=[
-            ContextTaxRow(source="MCP schema: apollo", sessions=10,
-                          avg_tokens_per_session=25_000, total_tokens_window=250_000),
-            # A live server: present in the tax table, but not in dead_servers.
-            ContextTaxRow(source="MCP schema: exa", sessions=10,
-                          avg_tokens_per_session=25_000, total_tokens_window=250_000),
-            ContextTaxRow(source="CLAUDE.md", sessions=10,
-                          avg_tokens_per_session=500, total_tokens_window=5_000),
-        ],
-    )
-    props = _deadweight_to_proposals(finding)
-    assert len(props) == 1
-    assert props[0].estimated_recoverable_tokens == 225_000
-    assert finding.estimated_recoverable_tokens == 225_000  # never the tax-table's 505,000 sum
-
-
-# --- deadweight finding round-trips through report_to_dict/report_from_dict --
-
-def test_deadweight_finding_survives_report_dict_round_trip():
-    from tokenjam.core.optimize.runner import report_from_dict, report_to_dict
-    from tokenjam.core.optimize.types import OptimizeReport, WindowSummary
-
-    w = WindowSummary(since=MARKER, until=NOW, days=5, sessions=10, spans=100,
-                      total_tokens=1, total_cost_usd=5.0, thin_data=False)
-    report = OptimizeReport(window=w, findings={"deadweight": _deadweight_finding()})
-
-    payload = report_to_dict(report)
-    rebuilt = report_from_dict(payload)
-
-    finding = rebuilt.findings["deadweight"]
-    assert finding.configured_servers == 1
-    assert len(finding.dead_servers) == 1
-    assert finding.dead_servers[0].name == "apollo"
-    assert finding.dead_servers[0].example_sessions == ["s0", "s1", "s2"]
-    assert finding.estimated_recoverable_tokens == 225_000
-    assert len(finding.tax_table) == 1
-    assert finding.tax_table[0].source == "MCP schema: apollo"
-
-
-def _seed_sub(db, *, model, when, count=30, provider="anthropic"):
-    for i in range(count):
-        db.insert_span(make_llm_span(
-            agent_id="claude-code-x", provider=provider, model=model,
-            billing_account=provider, input_tokens=8000, output_tokens=200,
-            session_id=f"{model}-{when.isoformat()}-{i}", sub_agent_id="sa1",
-            start_time=when + timedelta(minutes=i),
-        ))
-
-
-def test_subagent_delta_improved_when_fanout_moves_off_oversized_model(db):
-    # pre: subagent fan-out on opus; post: moved to sonnet.
-    _seed_sub(db, model="claude-opus-4-8", when=MARKER - timedelta(hours=40))
-    _seed_sub(db, model="claude-sonnet-5", when=MARKER + timedelta(hours=1))
-    # main-thread opus post-marker must NOT count (subagent-scoped metric).
-    for i in range(10):
-        db.insert_span(make_llm_span(
-            agent_id="claude-code-x", model="claude-opus-4-8", input_tokens=8000,
-            output_tokens=200, session_id=f"main-{i}",
-            start_time=MARKER + timedelta(hours=1, minutes=i),
-        ))
-    rec = _record("subagent", {"models": ["claude-opus-4-8"], "subagent": True}, agent_id="")
-    v = cost_verify.measure_cost_delta(db.conn, rec, now=NOW)
-    assert v["verdict"] == "improved"
-    assert v["realized_usd_delta"] > 0
-    assert v["post_value"] == 0.0        # no post-marker subagent spend on opus
+    # A later pothole recompute preserves the cost proposals.
+    pothole_store.write_cache(PotholeFinding(sessions_scanned=9), path=path)
+    assert pothole_store.read_cost_proposals(path=path)["cost_proposals"][0]["signature"] == "cost:trim:x"
+    assert pothole_store.read_cache(path=path)["finding"]["sessions_scanned"] == 9

--- a/tests/unit/test_cost_proposals_model.py
+++ b/tests/unit/test_cost_proposals_model.py
@@ -360,6 +360,71 @@ def test_no_placement_finding_means_no_placement_card(tmp_path):
     assert [p for p in props if p.analyzer == "placement"] == []
 
 
+def test_placement_card_suppresses_dollars_on_subscription(tmp_path):
+    """N42: the Batch API discount is an api-billed lever. Matches the CLI's
+    `_render_placement`, which already suppresses this dollar figure on
+    non-api plans (CLAUDE.md anti-pattern #22)."""
+    card = [
+        p for p in cp.cost_proposals_from_report(
+            _report(placement=_placement_finding()), config=_cfg(tmp_path),
+            pricing_mode="subscription",
+        )
+        if p.analyzer == "placement"
+    ][0]
+    assert card.estimated_recoverable_usd is None
+    assert "no dollar figure is shown for this plan" in card.advise_text
+    assert "$3.00" not in card.advise_text
+    # Token-level evidence (the workload shape) is still shown either way.
+    assert "no human turn" in card.evidence
+
+
+def test_placement_card_suppresses_dollars_on_local(tmp_path):
+    card = [
+        p for p in cp.cost_proposals_from_report(
+            _report(placement=_placement_finding()), config=_cfg(tmp_path),
+            pricing_mode="local",
+        )
+        if p.analyzer == "placement"
+    ][0]
+    assert card.estimated_recoverable_usd is None
+
+
+def test_recompute_cost_proposals_resolves_pricing_mode_from_sessions(tmp_path):
+    """N42 end to end: `recompute_cost_proposals` reads the window's dominant
+    plan tier off the `sessions` table and threads it through, so a
+    subscription install's Review inbox suppresses the same placement dollar
+    figure the CLI does — it isn't only reachable by passing the kwarg by
+    hand."""
+    from tokenjam.core.db import InMemoryBackend
+    from tokenjam.utils.time_parse import utcnow
+    from tests.factories import make_llm_span, make_session
+
+    db = InMemoryBackend()
+    try:
+        base = utcnow() - timedelta(days=10)
+        for i in range(6):
+            start = base + timedelta(hours=6 * i)
+            session_id = f"nightly-{i}"
+            db.insert_span(make_llm_span(
+                agent_id="nightly", model="claude-sonnet-4-6", provider="anthropic",
+                input_tokens=2_000, output_tokens=500, cache_tokens=100,
+                cache_write_tokens=50, cost_usd=1.0,
+                session_id=session_id, start_time=start,
+            ))
+            db.upsert_session(make_session(
+                agent_id="nightly", session_id=session_id, plan_tier="pro",
+                started_at=start, ended_at=start + timedelta(minutes=1),
+            ))
+
+        proposals = cp.recompute_cost_proposals(db, _cfg(tmp_path), window_days=30)
+        placement = [p for p in proposals if p.analyzer == "placement"]
+        assert placement, "expected a placement card from the cadence-regular sessions"
+        assert placement[0].estimated_recoverable_usd is None
+        assert "no dollar figure is shown for this plan" in placement[0].advise_text
+    finally:
+        db.close()
+
+
 # --------------------------------------------------------------------------- #
 # House rules on every string these cards can print
 # --------------------------------------------------------------------------- #

--- a/tests/unit/test_cost_proposals_model.py
+++ b/tests/unit/test_cost_proposals_model.py
@@ -254,6 +254,42 @@ def test_missing_agent_file_falls_back_to_the_guidance_block(tmp_path, monkeypat
     assert card.signature == "cost:subagent"
 
 
+def test_subagent_verify_receipt_is_a_priced_dollar_delta(db_backend):
+    # The measured receipt for a subagent model write has to be dollars priced
+    # per model over the fan-out spans, not a token count: the fix changes the
+    # rate, not the volume.
+    from tokenjam.core.optimize import cost_verify
+    from tests.factories import make_llm_span
+
+    marker = NOW - timedelta(days=5)
+    for label, when, model in (
+        ("pre", marker - timedelta(hours=40), "claude-opus-4-8"),
+        ("post", marker + timedelta(hours=1), "claude-haiku-4-5"),
+    ):
+        for i in range(30):
+            db_backend.insert_span(make_llm_span(
+                agent_id="orchestrator", provider="anthropic", model=model,
+                input_tokens=30_000, output_tokens=800,
+                cache_tokens=5_000, cache_write_tokens=1_000,
+                session_id=f"sess-{label}-{i}", sub_agent_id="explore",
+                start_time=when + timedelta(minutes=i),
+            ))
+
+    record = {
+        "id": "rec-1", "expectation_id": "exp-1",
+        "signature": "cost:subagent:explore", "analyzer": "subagent",
+        "kind": "cost", "title": "t",
+        "target_key": {"models": ["claude-opus-4-8"], "subagent": True,
+                       "agent_name": "explore"},
+        "agent_id": "", "applied_at": marker.isoformat(), "baseline": {},
+        "estimated_recoverable_usd": None, "estimated_recoverable_tokens": None,
+        "estimate_basis": "", "state": "applied", "verify": {},
+    }
+    verdict = cost_verify.measure_cost_delta(db_backend.conn, record, now=NOW)
+    assert verdict["verdict"] == "improved"
+    assert verdict["realized_usd_delta"] > 0
+
+
 # --------------------------------------------------------------------------- #
 # D1: the batch placement card
 # --------------------------------------------------------------------------- #
@@ -348,6 +384,28 @@ def test_card_copy_has_no_em_dash_and_never_says_quota(tmp_path, field):
         text = getattr(card, field) or ""
         assert "—" not in text, f"em dash in {card.signature}.{field}"
         assert "quota" not in text.lower(), f"'quota' in {card.signature}.{field}"
+
+
+def test_cards_carry_the_fields_the_rollup_sums(tmp_path):
+    # The rollup reads signature, analyzer, title and estimated_recoverable_usd
+    # generically, with no analyzer allowlist, so each card must fill all four
+    # and no two may share a signature.
+    cards = _all_cards(tmp_path)
+    signatures = [c.signature for c in cards]
+    assert len(signatures) == len(set(signatures))
+    for card in cards:
+        assert card.signature and card.analyzer and card.title
+        assert card.estimated_recoverable_usd is not None
+        assert card.estimated_recoverable_usd > 0
+
+
+def test_an_agent_the_swap_would_not_save_on_gets_no_card(tmp_path):
+    finding = _downsize_finding()
+    finding.per_agent[0].delta_usd = -0.5
+    props = cp.cost_proposals_from_report(_report(downgrade=finding), config=_cfg(tmp_path))
+    # No per-agent card claiming a negative recovery; the window-wide card,
+    # whose own estimate is finding-level, takes over.
+    assert [p.signature for p in props if p.analyzer == "downsize"] == ["cost:downsize"]
 
 
 def test_every_dollar_figure_is_tagged_and_has_a_construction_footnote(tmp_path):

--- a/tests/unit/test_lens_ui_regression.py
+++ b/tests/unit/test_lens_ui_regression.py
@@ -2102,21 +2102,11 @@ def test_cost_proposals_wired_into_review_inbox(html):
     assert "function CostProposalCard" in html
     assert "function CostAppliedRow" in html
     assert "function CostVerifyLine" in html
-    assert "api('/relearn/cost-proposals')" in html
-    assert "api('/relearn/cost-applied')" in html
-    assert "'/relearn/cost-proposals/apply'" in html
+    assert "api('/pothole/cost-proposals')" in html
+    assert "api('/pothole/cost-applied')" in html
+    assert "'/pothole/cost-proposals/apply'" in html
     # The card is advise-only: a marker button, never an apply-to-code write.
     assert "Mark applied" in html
     assert "Cost advisories" in html
     # Honesty discipline (Rule 14): the realized delta is estimated / correlational.
     assert "realized_usd_delta" in html
-
-
-def test_subagent_cost_card_has_workspace_apply_flow(html):
-    # The subagent (4th) analyzer is apply-capable: its CC-origin card routes a
-    # reversible rung-1 note through the apply-workspace endpoint (dry-run diff
-    # then write), unlike the three advise-only analyzers.
-    assert "'/relearn/cost-proposals/apply-workspace'" in html
-    assert "apply_capable" in html
-    assert "Apply note" in html
-    assert "subagent: 'subagent'" in html

--- a/tests/unit/test_optimize.py
+++ b/tests/unit/test_optimize.py
@@ -307,6 +307,56 @@ def test_build_report_returns_caveat_in_dict(db):
     assert report.downgrade.caveat == MODEL_DOWNGRADE_CAVEAT
 
 
+# --- Persona threading (AnalyzerContext.persona / OptimizeReport.persona) ---
+#
+# `build_report` used to leave persona classification entirely to callers
+# (the CLI recomputed it standalone after the fact) — nothing an analyzer or
+# `cost_proposals` ran during `build_report` itself could see it. These prove
+# it's computed exactly once, from the same `agent_persona_mix` /
+# `dominant_persona` functions the CLI's own CTA uses, and lands on the built
+# report.
+
+def test_build_report_persona_is_claude_code_when_sessions_are_cc(db):
+    from tests.factories import make_session
+
+    since = utcnow() - timedelta(days=30)
+    until = utcnow() + timedelta(hours=1)
+    for i in range(3):
+        db.upsert_session(make_session(
+            agent_id="claude-code-x", session_id=f"cc-{i}",
+            started_at=until - timedelta(hours=1),
+        ))
+    cfg = TjConfig(version="1")
+    report = build_report(db=db, config=cfg, since=since, until=until)
+    assert report.persona == "claude-code"
+
+
+def test_build_report_persona_is_sdk_when_sessions_are_not_cc(db):
+    from tests.factories import make_session
+
+    since = utcnow() - timedelta(days=30)
+    until = utcnow() + timedelta(hours=1)
+    for i in range(3):
+        db.upsert_session(make_session(
+            agent_id="my-production-service", session_id=f"svc-{i}",
+            started_at=until - timedelta(hours=1),
+        ))
+    cfg = TjConfig(version="1")
+    report = build_report(db=db, config=cfg, since=since, until=until)
+    assert report.persona == "sdk"
+
+
+def test_build_report_persona_defaults_to_unknown_with_no_session_rows(db):
+    """No `sessions` rows in the window and no declared plan on the config —
+    the fail-safe default, never a silent "claude-code" assumption."""
+    _insert_small_opus_session(db, session_id="a")  # spans only, no session row
+    cfg = TjConfig(version="1")
+    since = utcnow() - timedelta(days=30)
+    until = utcnow() + timedelta(hours=1)
+    report = build_report(db=db, config=cfg, since=since, until=until)
+    assert report.persona == "unknown"
+
+
 def test_cycle_bounds_handles_mid_month():
     from datetime import datetime, timezone
     now = datetime(2026, 5, 15, tzinfo=timezone.utc)

--- a/tests/unit/test_receipts.py
+++ b/tests/unit/test_receipts.py
@@ -1,0 +1,120 @@
+"""Unit tests for Component G1's combined "verified saved" receipts
+(`core.optimize.receipts.verified_saved_summary`) — the measured twin of
+Component E's estimated-recoverable rollup.
+
+Pure: both source ledgers (`relearn_verify.compound_ledger` /
+`cost_verify.cost_compound_ledger`) already operate on plain dicts, so these
+tests build minimal applied-fix records by hand rather than round-tripping
+through a real apply flow (mirrors `test_cost_compound_ledger_sums_realized_
+dollars` in `test_cost_proposals.py`).
+"""
+from __future__ import annotations
+
+from tokenjam.core.optimize import cost_proposals, receipts
+
+
+def _relearn_rec(verdict, tokens=0, state="applied"):
+    return {"state": state, "rung": 1, "verify": {"verdict": verdict, "realized_tokens_saved": tokens}}
+
+
+def _cost_rec(verdict, usd=0.0, tokens=0, state="applied"):
+    return {"state": state, "verify": {
+        "verdict": verdict, "realized_usd_delta": usd, "realized_tokens_delta": tokens,
+    }}
+
+
+def test_summary_combines_both_ledgers_tokens_and_dollars():
+    relearn_records = [_relearn_rec("improved", tokens=1500)]
+    cost_records = [_cost_rec("improved", usd=0.5, tokens=1000)]
+
+    summary = receipts.verified_saved_summary(relearn_records, cost_records)
+
+    # Dollars come ONLY from the cost-verify ledger — relearn tokens are
+    # never force-converted to a $ figure (no per-model rate to price them at).
+    assert summary["verified_saved_usd"] == 0.5
+    assert summary["cost_usd_saved"] == 0.5
+    # Tokens are additive across both ledgers — both are real token counts.
+    assert summary["verified_saved_tokens"] == 2500
+    assert summary["relearn_tokens_saved"] == 1500
+    assert summary["cost_tokens_saved"] == 1000
+    assert summary["improved_count"] == 2
+    assert summary["verified_count"] == 2
+
+
+def test_summary_empty_state_when_nothing_verified_yet():
+    summary = receipts.verified_saved_summary([], [])
+    assert summary["verified_saved_usd"] == 0.0
+    assert summary["verified_saved_tokens"] == 0
+    assert summary["verified_count"] == 0
+    assert summary["improved_count"] == 0
+
+
+def test_summary_shows_regressed_and_no_change_not_hidden():
+    # A regressed relearn fix, a regressed cost fix, and a no_change relearn
+    # fix must all be COUNTED in the breakdown — never dropped from the
+    # figure just because they didn't pay off. "The honesty is the feature."
+    relearn_records = [
+        _relearn_rec("improved", tokens=500),
+        _relearn_rec("regressed"),
+        _relearn_rec("no_change"),
+        _relearn_rec("insufficient_data"),
+    ]
+    cost_records = [
+        _cost_rec("improved", usd=1.0, tokens=200),
+        _cost_rec("regressed"),
+    ]
+    summary = receipts.verified_saved_summary(relearn_records, cost_records)
+
+    assert summary["improved_count"] == 2
+    assert summary["regressed_count"] == 2          # one from each ledger
+    assert summary["no_change_count"] == 1           # relearn-only concept
+    assert summary["insufficient_data_count"] == 1
+    # The realized total only reflects the IMPROVED fixes — regressed/no-change
+    # never inflate the headline figure, they just aren't silently dropped
+    # from the verified_count/regressed_count breakdown above.
+    assert summary["verified_saved_usd"] == 1.0
+    assert summary["verified_saved_tokens"] == 700
+
+
+def test_summary_ignores_reverted_records():
+    relearn_records = [_relearn_rec("improved", tokens=999, state="reverted")]
+    cost_records = [_cost_rec("improved", usd=9.9, state="reverted")]
+    summary = receipts.verified_saved_summary(relearn_records, cost_records)
+    assert summary["verified_count"] == 0
+    assert summary["verified_saved_usd"] == 0.0
+    assert summary["verified_saved_tokens"] == 0
+
+
+def test_summary_is_tagged_measured():
+    summary = receipts.verified_saved_summary([_relearn_rec("improved", tokens=1)], [])
+    assert summary["estimate_confidence"] == "measured"
+
+
+# --- Estimated vs measured: the two never merge into one figure -------------
+
+def test_estimated_rollup_and_measured_receipts_stay_structurally_separate():
+    """Regression guard for the spec's hard rule (Component E's docstring /
+    G1's spec text): an estimate and a measurement must never be summed into
+    one number. We can't inspect the UI from here, so this asserts the two
+    Python payloads themselves keep disjoint vocabularies — no shared numeric
+    key that a future change could accidentally add together — and carry
+    distinct confidence tags.
+    """
+    rollup = cost_proposals.estimated_recoverable_rollup(
+        [{"signature": "cost:downsize", "analyzer": "downsize", "title": "t",
+          "estimated_recoverable_usd": 3.0}],
+    )
+    summary = receipts.verified_saved_summary(
+        [_relearn_rec("improved", tokens=500)],
+        [_cost_rec("improved", usd=1.0, tokens=200)],
+    )
+
+    assert rollup["estimate_confidence"] == "estimated"
+    assert summary["estimate_confidence"] == "measured"
+    assert rollup["estimate_confidence"] != summary["estimate_confidence"]
+
+    # No dollar-figure key overlaps between the two payloads — nothing here
+    # could be naively `+`-ed together into one blended number.
+    dollar_keys_rollup = {k for k in rollup if "usd" in k}
+    dollar_keys_summary = {k for k in summary if "usd" in k}
+    assert dollar_keys_rollup.isdisjoint(dollar_keys_summary)

--- a/tests/unit/test_workflow_restructure.py
+++ b/tests/unit/test_workflow_restructure.py
@@ -332,3 +332,76 @@ def test_cache_write_tokens_included_in_recoverable_total(db):
     # avg_tokens should be input+output only (per-instance UI framing),
     # not affected by the bug fix
     assert c.avg_tokens == 1200
+
+
+def test_cluster_carries_cluster_level_totals_and_examples(db):
+    """Each cluster carries its OWN total_cost_usd/total_tokens (the sum across
+    every member session, not the per-instance avg_cost_usd/avg_tokens above)
+    plus up to 3 example session ids — the denominator + evidence a cost-
+    proposal adapter needs without re-deriving them from the per-instance
+    means (avg_cost_usd * instances only approximates the real cluster sum
+    once rounding is involved)."""
+    base = datetime(2026, 5, 10, tzinfo=timezone.utc)
+    for i in range(MIN_CLUSTER_INSTANCES):
+        sid = f"totals-{i}"
+        sess = make_session(session_id=sid, plan_tier="api", duration_seconds=30.0,
+                            input_tokens=1000, output_tokens=200, total_cost_usd=0.05)
+        db.upsert_session(sess)
+        span = make_tool_span(tool_name="bash")
+        span.session_id = sid
+        span.start_time = base + timedelta(minutes=i)
+        span.attributes = {GenAIAttributes.TOOL_INPUT: {"command": "git pull"}}
+        db.insert_span(span)
+
+    config = _config(tool_inputs=True)
+    since = datetime(2026, 5, 1, tzinfo=timezone.utc)
+    until = datetime(2026, 5, 30, tzinfo=timezone.utc)
+    report = build_report(db=db, config=config, since=since, until=until,
+                          findings=["script"])
+    c = report.findings["script"].clusters[0]
+    assert c.total_cost_usd == pytest.approx(0.05 * MIN_CLUSTER_INSTANCES)
+    assert c.total_tokens == 1200 * MIN_CLUSTER_INSTANCES
+    assert len(c.example_session_ids) == 3
+    assert c.example_session_id in c.example_session_ids
+
+
+def test_cluster_totals_and_examples_survive_report_dict_round_trip():
+    """WorkflowCluster(**c) (runner.report_from_dict) must round-trip the new
+    fields, and default them for an OLDER serialized report missing the keys
+    entirely (the pre-existing avg_tokens round-trip guarantee, extended)."""
+    from tokenjam.core.optimize.analyzers.workflow_restructure import WorkflowCluster
+    from tokenjam.core.optimize.runner import report_from_dict, report_to_dict
+    from tokenjam.core.optimize.types import OptimizeReport, WindowSummary
+
+    w = WindowSummary(since=datetime(2026, 5, 1, tzinfo=timezone.utc),
+                      until=datetime(2026, 5, 30, tzinfo=timezone.utc), days=29,
+                      sessions=20, spans=20, total_tokens=24000, total_cost_usd=1.0,
+                      thin_data=False)
+    cluster = WorkflowCluster(
+        signature=[{"tool": "bash", "args": ["command_string"]}], instances=20,
+        avg_cost_usd=0.05, avg_duration_seconds=1.5, example_session_id="det-0",
+        avg_tokens=1200, total_cost_usd=1.0, total_tokens=24000,
+        example_session_ids=["det-0", "det-1", "det-2"],
+    )
+    from tokenjam.core.optimize.analyzers.workflow_restructure import (
+        WorkflowRestructureFinding,
+    )
+    report = OptimizeReport(window=w, findings={
+        "script": WorkflowRestructureFinding(clusters=[cluster], sessions_examined=20),
+    })
+
+    rebuilt = report_from_dict(report_to_dict(report))
+    rc = rebuilt.findings["script"].clusters[0]
+    assert rc.total_cost_usd == 1.0
+    assert rc.total_tokens == 24000
+    assert rc.example_session_ids == ["det-0", "det-1", "det-2"]
+
+    # An older payload with neither key present still round-trips: defaults.
+    old_payload = {
+        "signature": [{"tool": "bash"}], "instances": 5, "avg_cost_usd": 0.01,
+        "avg_duration_seconds": None, "example_session_id": "old-0",
+    }
+    old_cluster = WorkflowCluster(**old_payload)
+    assert old_cluster.total_cost_usd == 0.0
+    assert old_cluster.total_tokens == 0
+    assert old_cluster.example_session_ids == []

--- a/tokenjam/api/routes/relearn.py
+++ b/tokenjam/api/routes/relearn.py
@@ -155,6 +155,16 @@ class ApplyRelearnRequest(BaseModel):
     target_path:    str
     go:             bool = False
     force:          bool = False   # bypass the active-session warning
+    # Model-routing apply kinds (``core.optimize.model_apply``): setting an
+    # agent file's `model:` key, or swapping one exact model id in a repo the
+    # user registered. Empty on every rung-ladder fix, which is every other
+    # proposal. The model ids travel with the request for the same reason the
+    # cluster does: the human approved THESE values on the card.
+    apply_kind:     str = ""
+    agent_name:     str = ""
+    current_model:  str = ""
+    proposed_model: str = ""
+    source_path:    str = ""
 
 
 @router.post("/relearn/apply", dependencies=_WRITE_AUTH)

--- a/tokenjam/api/routes/relearn.py
+++ b/tokenjam/api/routes/relearn.py
@@ -13,7 +13,9 @@ Phase 1 (detect + surface) was read-only. Phase 2 (this module's ``/apply``,
 Approve stage: writes route through ``core.optimize.relearn_apply`` for every
 rung-routing / backup / git-commit / fail-open guarantee — this route only
 translates HTTP <-> that module's ``RelearnApplyRefused`` (-> 409) contract,
-it never hand-rolls a parallel write path.
+it never hand-rolls a parallel write path. ``/apply`` names a STORED proposal
+(``core.optimize.relearn_proposals``) and never accepts cluster content from
+the caller, so what gets written is always something the detector produced.
 
 Phase 3 (Verify + Compound, ``core.optimize.relearn_verify``) rides the SAME
 ``/refresh`` cadence: every background/manual recompute also re-measures each
@@ -28,15 +30,21 @@ from pathlib import Path
 from typing import Any
 
 from fastapi import APIRouter, Depends, HTTPException, Request
-from pydantic import BaseModel
+from pydantic import BaseModel, ConfigDict
 
 from tokenjam.api.deps import require_api_key, require_relearn_write_auth
+from tokenjam.core.framing import (
+    WindowSummary,
+    compute_framing,
+    plan_determination_mix,
+)
 from tokenjam.core.optimize import (
     cost_apply,
     cost_proposals as cost_proposals_mod,
     cost_verify,
     receipts,
     relearn_apply,
+    relearn_proposals,
     relearn_store,
     relearn_verify,
 )
@@ -79,9 +87,87 @@ def _config(request: Request):
     return config
 
 
+def _framing(request: Request) -> dict[str, Any]:
+    """Plan-tier framing block for this module's dollar-bearing payloads.
+
+    Same single compute path every other cost surface uses
+    (``core.framing.compute_framing``) so the UI never re-derives the
+    suppress-dollars-for-subscription rule in JS. The mix is
+    window-INDEPENDENT (``plan_determination_mix``, as on /status): the
+    receipts and the cost ledger are cumulative-to-date figures, not scoped
+    to a window. Degrades to the config-declared plan when the daemon has no
+    direct DB connection (e.g. a proxy), exactly as ``compute_framing``
+    already handles an empty mix.
+    """
+    db = getattr(request.app.state, "db", None)
+    conn = getattr(db, "conn", None) if db is not None else None
+    mix = plan_determination_mix(conn) if conn is not None else {}
+    framing = compute_framing(
+        _config(request),
+        WindowSummary(plan_tier_mix=mix, sessions=sum(mix.values())),
+    )
+    return framing.to_dict()
+
+
 def _conn(request: Request) -> Any | None:
     db = getattr(request.app.state, "db", None)
     return getattr(db, "conn", None) if db is not None else None
+
+
+def _resolvable_session_ids(conn: Any | None, session_ids: list[str]) -> set[str]:
+    """Subset of `session_ids` that exist as rows in the sessions table."""
+    if conn is None or not session_ids:
+        return set()
+    placeholders = ", ".join(f"${i}" for i in range(1, len(session_ids) + 1))
+    try:
+        rows = conn.execute(
+            f"SELECT session_id FROM sessions WHERE session_id IN ({placeholders})",
+            session_ids,
+        ).fetchall()
+    except Exception:
+        return set()
+    return {str(r[0]) for r in rows}
+
+
+def _with_example_resolvability(finding: Any, conn: Any | None) -> Any:
+    """Copy of `finding` with each cluster example stamped `session_resolvable`.
+
+    The detector sources example session ids from Claude Code transcript files
+    on disk (`<projects_root>/**/<session_id>.jsonl`), so an example can name a
+    session that was never ingested into the sessions table. Resolvability is
+    computed at read time rather than baked into the cached finding, so it also
+    covers findings stored before this field existed and stays correct as more
+    sessions get ingested. The Review inbox links only resolvable examples and
+    renders the rest as plain evidence text instead of a link to a dead page.
+    """
+    if not isinstance(finding, dict):
+        return finding
+    clusters = finding.get("clusters")
+    if not isinstance(clusters, list):
+        return finding
+    ids = sorted({
+        str(ex["session_id"])
+        for c in clusters if isinstance(c, dict)
+        for ex in (c.get("examples") or [])
+        if isinstance(ex, dict) and ex.get("session_id")
+    })
+    resolvable = _resolvable_session_ids(conn, ids)
+    return {
+        **finding,
+        "clusters": [
+            c if not isinstance(c, dict) else {
+                **c,
+                "examples": [
+                    ex if not isinstance(ex, dict) else {
+                        **ex,
+                        "session_resolvable": str(ex.get("session_id")) in resolvable,
+                    }
+                    for ex in (c.get("examples") or [])
+                ],
+            }
+            for c in clusters
+        ],
+    }
 
 
 @router.get("/relearn/proposals", dependencies=[Depends(require_api_key)])
@@ -104,10 +190,16 @@ def get_relearn_proposals(request: Request) -> dict[str, Any]:
             "computed_at": None,
             "finding": None,
         }
+    finding = cached.get("finding")
+    if isinstance(finding, dict):
+        # Re-stamp on read as well as on write, so a cache written before the
+        # proposal id or the advise-only reason existed still resolves without
+        # waiting for a recompute. Idempotent.
+        finding = relearn_proposals.stamp_proposal_ids(finding)
     return {
         "status": "computing" if computing else "ready",
         "computed_at": cached.get("computed_at"),
-        "finding": cached.get("finding"),
+        "finding": _with_example_resolvability(finding, _conn(request)),
     }
 
 
@@ -135,57 +227,70 @@ def refresh_relearn_proposals(request: Request) -> dict[str, Any]:
 # --------------------------------------------------------------------------- #
 
 class ApplyRelearnRequest(BaseModel):
-    # The full cluster the client already has from GET /relearn/proposals —
-    # re-posted rather than re-looked-up server-side so a stale cache can't
-    # silently apply a DIFFERENT cluster than the one the human reviewed.
-    signature:      str
-    family_key:     str | None = None
-    title:          str
-    proposed_fix:   str = ""
-    rung:           int
-    sessions:       int = 0
-    occurrences:    int = 0
-    repos:          list[str] = []
-    examples:       list[dict[str, Any]] = []
+    """A named STORED proposal plus the human's confirmed write target.
+
+    The cluster content itself is never accepted from the client: it is looked
+    up server-side from the detector's own stored proposals
+    (``core.optimize.relearn_proposals``). ``extra="forbid"`` makes that
+    explicit rather than silent, so a caller still posting a hand-built
+    cluster gets a 422 telling it what changed instead of having its payload
+    quietly ignored.
+    """
+    model_config = ConfigDict(extra="forbid")
+
+    proposal_id:    str
     # Scope override (§7 — "repo-identity is noisy"): the human confirms both
     # before Approve, never inferred silently.
     scope:          str
     target_path:    str
     go:             bool = False
     force:          bool = False   # bypass the active-session warning
-    # Model-routing apply kinds (``core.optimize.model_apply``): setting an
-    # agent file's `model:` key, or swapping one exact model id in a repo the
-    # user registered. Empty on every rung-ladder fix, which is every other
-    # proposal. The model ids travel with the request for the same reason the
-    # cluster does: the human approved THESE values on the card.
-    apply_kind:     str = ""
-    agent_name:     str = ""
-    current_model:  str = ""
-    proposed_model: str = ""
-    source_path:    str = ""
-    # Which cost analyzer's card this write came from, so the same apply also
-    # opens a cost-verify exposure window and the realized delta lands in the
-    # ledger the receipts surface reads dollars from. Empty for rung-ladder
-    # fixes, whose receipts are recurrence-based rather than priced.
-    analyzer:       str = ""
-    agent_id:       str = ""
+
+    # Nothing else. The model-routing values (apply_kind / agent_name /
+    # current_model / proposed_model / source_path) and the cost-verify routing
+    # (analyzer / agent_id) all come off the stored proposal, because the card
+    # the human approved was rendered FROM that stored proposal. Reading them
+    # back out of the request would be trusting the caller to echo faithfully
+    # something the server already knows — and would let any holder of a valid
+    # proposal_id aim source_path at an unregistered repo, which is the exact
+    # precondition the model_swap safety case rests on.
 
 
 @router.post("/relearn/apply", dependencies=_WRITE_AUTH)
 def post_relearn_apply(request: Request, body: ApplyRelearnRequest) -> dict[str, Any]:
     """Dry-run (default) or write (``go=true``) an approved fix at its rung.
 
-    409s (via ``RelearnApplyRefused``) on: an unknown rung, a create-only
-    target (skill/hook) that already holds a non-TokenJam file, or — unless
-    ``force=true`` — a live session just seen in the target repo (§7: never
-    apply mid-session). The UI's re-send-with-force is the explicit
-    "apply anyway" the spec calls for. 403s when ``target_path`` resolves
-    outside the user's home directory (defense-in-depth allowlist).
+    Takes a ``proposal_id`` from ``GET /relearn/proposals``. 404s when no
+    stored proposal carries that ID: a client-constructed cluster has no way
+    into the write machinery, which is what makes "human-gated" a property of
+    the server rather than of the UI flow.
+
+    409s (via ``RelearnApplyRefused``) on: an unknown rung, a family with no
+    matcher at an enforcement rung, a create-only target (skill/hook) that
+    already holds a non-TokenJam file, or (unless ``force=true``) a live
+    session just seen in the target repo (§7: never apply mid-session). The
+    UI's re-send-with-force is the explicit "apply anyway" the spec calls for.
+    403s when ``target_path`` resolves outside the user's home directory
+    (defense-in-depth allowlist).
     """
     _reject_target_outside_home(body.target_path)
-    cluster = body.model_dump(
-        exclude={"scope", "target_path", "go", "force", "analyzer", "agent_id"},
-    )
+    stored = relearn_proposals.get_proposal(body.proposal_id, config=_config(request))
+    if stored is None:
+        raise HTTPException(
+            status_code=404,
+            detail=f"no stored proposal {body.proposal_id}. Refresh the proposals "
+                   f"and apply one the detector actually produced.",
+        )
+    cluster = relearn_proposals.cluster_for_apply(stored)
+    missing = relearn_proposals.missing_apply_fields(cluster)
+    if missing:
+        raise HTTPException(
+            status_code=409,
+            detail=f"stored proposal {body.proposal_id} is missing "
+                   f"{', '.join(missing)}, which its "
+                   f"{cluster.get('apply_kind')} apply cannot be built without. "
+                   f"Recompute the proposals and retry.",
+        )
     try:
         result = relearn_apply.apply_relearn_fix(
             _config(request), cluster,
@@ -194,12 +299,14 @@ def post_relearn_apply(request: Request, body: ApplyRelearnRequest) -> dict[str,
         )
     except relearn_apply.RelearnApplyRefused as exc:
         raise HTTPException(status_code=409, detail=str(exc)) from exc
-    if body.go and body.apply_kind and body.analyzer:
-        result["cost_marker"] = _open_cost_verify_window(request, body)
+    if body.go and cluster.get("apply_kind") and stored.get("analyzer"):
+        result["cost_marker"] = _open_cost_verify_window(request, stored, cluster)
     return result
 
 
-def _open_cost_verify_window(request: Request, body: ApplyRelearnRequest) -> dict[str, Any] | None:
+def _open_cost_verify_window(
+    request: Request, stored: dict[str, Any], cluster: dict[str, Any],
+) -> dict[str, Any] | None:
     """Start the priced exposure window for a model-routing write.
 
     A model swap is a cost fix that happens to have a file to edit, so its
@@ -207,21 +314,27 @@ def _open_cost_verify_window(request: Request, body: ApplyRelearnRequest) -> dic
     That measurement hangs off the cost-applied ledger, so the same approval
     that wrote the file also opens the window. Best-effort: a marker that cannot
     be created must never fail an apply that already succeeded on disk.
+
+    Every value here comes from the STORED proposal, never the request body,
+    for the same reason the write itself does: the ledger must record what the
+    detector produced and the human reviewed, not what a caller asserts.
     """
     from tokenjam.core.optimize import cost_apply
 
+    analyzer = str(stored.get("analyzer") or "")
+    current_model = str(cluster.get("current_model") or "")
     proposal = {
-        "signature": body.signature,
-        "analyzer": body.analyzer,
-        "title": body.title,
-        "agent_id": body.agent_id,
-        "advise_text": body.proposed_fix,
+        "signature": str(cluster.get("signature", "")),
+        "analyzer": analyzer,
+        "title": str(cluster.get("title", "")),
+        "agent_id": str(stored.get("agent_id") or ""),
+        "advise_text": str(cluster.get("proposed_fix", "")),
         "target_key": {
-            "models": [body.current_model] if body.current_model else [],
-            "subagent": body.analyzer == "subagent",
-            "agent_name": body.agent_name,
+            "models": [current_model] if current_model else [],
+            "subagent": analyzer == "subagent",
+            "agent_name": str(cluster.get("agent_name") or ""),
         },
-        "baseline": {"proposed_model": body.proposed_model},
+        "baseline": {"proposed_model": str(cluster.get("proposed_model") or "")},
         "estimated_recoverable_usd": None,
         "estimated_recoverable_tokens": None,
         "estimate_basis": "",
@@ -301,20 +414,32 @@ def get_cost_proposals(request: Request) -> dict[str, Any]:
     change what's actually still outstanding)."""
     config = _config(request)
     block = relearn_store.read_cost_proposals(config=config)
-    proposals = list(block.get("cost_proposals") or []) if block is not None else []
+    # Listed WITH their proposal_ids: a model-routing card's Approve names an
+    # ID and nothing else, so the ID has to travel with the card it belongs to.
+    proposals: list[dict[str, Any]] = (
+        relearn_proposals.list_cost_proposals(config) if block is not None else []
+    )
     applied_sigs = {
         rec.get("signature") for rec in cost_apply.list_applied(config)
         if rec.get("state") != "reverted"
     }
     open_proposals = [p for p in proposals if p.get("signature") not in applied_sigs]
     rollup = cost_proposals_mod.estimated_recoverable_rollup(open_proposals)
+    # Same plan-tier framing the receipts / cost-ledger payloads carry, so the
+    # estimated-recoverable headline picks the same unit as its measured twin
+    # sitting next to it rather than always leading with dollars.
+    framing = _framing(request)
     if block is None:
-        return {"status": "never_run", "computed_at": None, "proposals": [], "rollup": rollup}
+        return {
+            "status": "never_run", "computed_at": None, "proposals": [],
+            "rollup": rollup, "framing": framing,
+        }
     return {
         "status": "ready",
         "computed_at": block.get("cost_computed_at"),
         "proposals": proposals,
         "rollup": rollup,
+        "framing": framing,
     }
 
 
@@ -324,11 +449,16 @@ def get_relearn_receipts(request: Request) -> dict[str, Any]:
     twin of the ``rollup`` field above (Component E). Combines the relearn
     ledger and the cost-verify ledger (``core.optimize.receipts``);
     read-only, no recompute triggered here — it rides the same ``/refresh``
-    cadence the two source ledgers already recompute on."""
+    cadence the two source ledgers already recompute on.
+
+    Carries the plan-tier ``framing`` block: ``verified_saved_usd`` can only
+    ever count the API-billed slice, so on a subscription-dominant corpus the
+    UI must lead with the (complete) token figure rather than the dollars."""
     config = _config(request)
     relearn_records = relearn_apply.list_applied(config)
     cost_records = cost_apply.list_applied(config)
-    return receipts.verified_saved_summary(relearn_records, cost_records)
+    summary = receipts.verified_saved_summary(relearn_records, cost_records)
+    return {**summary, "framing": _framing(request)}
 
 
 @router.post("/relearn/cost-proposals/refresh", dependencies=_WRITE_AUTH)
@@ -346,53 +476,70 @@ def refresh_cost_proposals(request: Request) -> dict[str, Any]:
     return {"status": "ready", "proposals": len(proposals), "verified": verify}
 
 
+def _stored_cost_proposal(request: Request, proposal_id: str) -> dict[str, Any]:
+    """The stored cost proposal with this ID, or a 404.
+
+    Resolved from the detector's own stored proposals
+    (``relearn_proposals.list_cost_proposals``) rather than from the request
+    body, so the ledger records what the detector produced and the human
+    reviewed. The cost ledger feeds the "verified saved" receipts, and a
+    receipt is only worth anything if its numbers were earned.
+    """
+    for proposal in relearn_proposals.list_cost_proposals(_config(request)):
+        if proposal.get("proposal_id") == proposal_id:
+            return proposal
+    raise HTTPException(
+        status_code=404,
+        detail=f"no stored cost proposal {proposal_id}. Refresh the cost "
+               f"proposals and apply one the detector actually produced.",
+    )
+
+
 class MarkCostAppliedRequest(BaseModel):
-    # The full proposal the client already holds from GET /relearn/cost-proposals
-    # — re-posted so a stale cache can't mark a DIFFERENT proposal than the one
-    # the human reviewed (same guard as ApplyRelearnRequest).
-    signature:   str
-    analyzer:    str = ""
-    title:       str = ""
-    target_key:  dict[str, Any] = {}
-    baseline:    dict[str, Any] = {}
-    advise_text: str = ""
-    agent_id:    str = ""
-    estimated_recoverable_usd:    float | None = None
-    estimated_recoverable_tokens: int | None = None
-    estimate_basis: str = ""
+    """A named STORED cost proposal, and nothing else.
+
+    The proposal's content (signature, analyzer, target_key, baseline, the
+    estimate and its basis) is looked up server-side from the detector's own
+    stored cost proposals, never accepted from the client — the same guard
+    ``ApplyRelearnRequest`` uses. ``extra="forbid"`` makes that explicit rather
+    than silent, so a caller still posting a hand-built proposal gets a 422
+    telling it what changed instead of having its numbers quietly ignored.
+    """
+    model_config = ConfigDict(extra="forbid")
+
+    proposal_id: str
 
 
 @router.post("/relearn/cost-proposals/apply", dependencies=_WRITE_AUTH)
 def post_cost_mark_applied(request: Request, body: MarkCostAppliedRequest) -> dict[str, Any]:
     """Mark a cost proposal applied: create the fix marker (an Expectation) and
     a ledger record the delta-verify pass measures against. There is NO code
-    write — cost proposals are advise-only. 409 on a malformed proposal or when
+    write — cost proposals are advise-only.
+
+    Takes a ``proposal_id`` from ``GET /relearn/cost-proposals``. 404s when no
+    stored cost proposal carries that ID. 409 on a malformed proposal or when
     the marker can't be created (no writable DB)."""
     db = getattr(request.app.state, "db", None)
     if db is None:
         raise HTTPException(status_code=503, detail="Server not fully initialised (db missing).")
+    stored = _stored_cost_proposal(request, body.proposal_id)
     try:
-        return cost_apply.mark_applied(db, _config(request), body.model_dump())
+        return cost_apply.mark_applied(db, _config(request), stored)
     except cost_apply.CostApplyRefused as exc:
         raise HTTPException(status_code=409, detail=str(exc)) from exc
 
 
 class ApplyWorkspaceCostRequest(BaseModel):
-    # The subagent (CC-origin) proposal the client holds, plus the confirmed
-    # write target. Re-posted so a stale cache can't apply a DIFFERENT proposal.
-    signature:    str
-    analyzer:     str = ""
-    title:        str = ""
-    target_key:   dict[str, Any] = {}
-    baseline:     dict[str, Any] = {}
-    advise_text:  str = ""
-    agent_id:     str = ""
-    estimated_recoverable_usd:    float | None = None
-    estimated_recoverable_tokens: int | None = None
-    estimate_basis: str = ""
-    # Apply plumbing (adapter-supplied). rung is 1 for the sizing-rubric note.
-    proposed_fix: str = ""
-    rung:         int = 1
+    """A named STORED cost proposal plus the human's confirmed write target.
+
+    Same split as ``ApplyRelearnRequest``: the proposal's content and its apply
+    plumbing (``proposed_fix``, ``rung``) come off the store, because the card
+    the human approved was rendered FROM that stored proposal; only the write
+    target and the go/force confirmations are the caller's to choose.
+    """
+    model_config = ConfigDict(extra="forbid")
+
+    proposal_id:  str
     scope:        str = "project"
     target_path:  str = ""
     go:           bool = False
@@ -401,30 +548,44 @@ class ApplyWorkspaceCostRequest(BaseModel):
 
 @router.post("/relearn/cost-proposals/apply-workspace", dependencies=_WRITE_AUTH)
 def post_cost_apply_workspace(request: Request, body: ApplyWorkspaceCostRequest) -> dict[str, Any]:
-    """Apply a CC-origin subagent proposal's sizing-rubric note to the workspace.
+    """Apply an ``apply_capable`` cost proposal's workspace note/skill.
 
-    Unlike the three advise-only analyzers, a subagent right-sizing finding has a
-    writable surface (a rung-1 CLAUDE.md sizing rubric the orchestrating agent
-    reads before spawning subagents). This routes the actual write through the
-    EXISTING relearn apply path (``relearn_apply.apply_relearn_fix``) — same
-    reversible, git-committed, human-gated (dry-run first) discipline — then
-    records the cost marker so the delta-verify pass measures the fan-out
-    model-mix cost delta after it. ``go=false`` returns the dry-run diff; a
-    second call with ``go=true`` writes. 403 outside home; 409 on a refusal.
+    Covers every analyzer whose fix is a workspace surface an orchestrating
+    agent (or the model itself) reads before acting, rather than a file this
+    proposal can edit outright: ``subagent`` (rung-1 sizing rubric),
+    ``script`` (rung-2 deterministic-workflow skill), ``reuse`` (rung-1
+    planning-skeleton note), ``verbosity`` (rung-1 output-brevity note). This
+    routes the actual write through the EXISTING relearn apply path
+    (``relearn_apply.apply_relearn_fix``) — same reversible, git-committed,
+    human-gated (dry-run first) discipline — then records the cost marker so
+    the delta-verify pass measures the realized delta after it. ``go=false``
+    returns the dry-run diff; a second call with ``go=true`` writes. 404 on an
+    unknown ``proposal_id``; 403 outside home; 409 on a refusal.
     """
     _reject_target_outside_home(body.target_path)
     config = _config(request)
     db = getattr(request.app.state, "db", None)
-    # The cluster shape relearn_apply renders a rung-1 note from.
+    stored = _stored_cost_proposal(request, body.proposal_id)
+    signature = str(stored.get("signature") or "")
+    analyzer = str(stored.get("analyzer") or "")
+    baseline = dict(stored.get("baseline") or {})
+    # The cluster shape relearn_apply renders a rung-1/2 note/skill from,
+    # projected from the STORE: a caller-supplied proposed_fix would be
+    # arbitrary text written into the user's workspace under a reviewed
+    # proposal's name. `apply_sessions` falls back to the subagent analyzer's
+    # own baseline key (`flagged_subagents`) so this generalization doesn't
+    # change that analyzer's existing behavior.
     cluster = {
-        "signature": body.signature,
-        "family_key": "subagent_rightsizing",
-        "title": body.title or body.signature,
-        "proposed_fix": body.proposed_fix,
-        "rung": body.rung,
-        "sessions": int(body.baseline.get("flagged_subagents", 0) or 0),
-        "repos": [],
-        "examples": [],
+        "signature": signature,
+        "family_key": f"cost_{analyzer}" if analyzer else "cost_proposal",
+        "title": str(stored.get("title") or "") or signature,
+        "proposed_fix": str(stored.get("proposed_fix") or ""),
+        "rung": int(stored.get("rung") or 1),
+        "sessions": int(
+            baseline.get("apply_sessions", baseline.get("flagged_subagents", 0)) or 0
+        ),
+        "repos": list(baseline.get("apply_repos") or []),
+        "examples": list(baseline.get("apply_examples") or []),
     }
     try:
         applied = relearn_apply.apply_relearn_fix(
@@ -443,11 +604,7 @@ def post_cost_apply_workspace(request: Request, body: ApplyWorkspaceCostRequest)
     cost_record = None
     if db is not None:
         try:
-            cost_record = cost_apply.mark_applied(
-                db, config, body.model_dump(exclude={
-                    "proposed_fix", "rung", "scope", "target_path", "go", "force",
-                }),
-            )
+            cost_record = cost_apply.mark_applied(db, config, stored)
         except cost_apply.CostApplyRefused:
             cost_record = None
     return {"applied": applied, "cost_record": cost_record}
@@ -456,9 +613,15 @@ def post_cost_apply_workspace(request: Request, body: ApplyWorkspaceCostRequest)
 @router.get("/relearn/cost-applied", dependencies=[Depends(require_api_key)])
 def get_cost_applied(request: Request) -> dict[str, Any]:
     """Every applied (and reverted) cost fix, plus the realized-dollars ledger
-    summary (``cost_verify.cost_compound_ledger``)."""
+    summary (``cost_verify.cost_compound_ledger``), plus the plan-tier
+    ``framing`` block so the ledger's realized dollars are suppressed /
+    reframed for subscription users like every other cost surface."""
     applied = cost_apply.list_applied(_config(request))
-    return {"applied": applied, "ledger": cost_verify.cost_compound_ledger(applied)}
+    return {
+        "applied": applied,
+        "ledger": cost_verify.cost_compound_ledger(applied),
+        "framing": _framing(request),
+    }
 
 
 @router.post("/relearn/cost-applied/{record_id}/revert", dependencies=_WRITE_AUTH)

--- a/tokenjam/api/routes/relearn.py
+++ b/tokenjam/api/routes/relearn.py
@@ -13,9 +13,7 @@ Phase 1 (detect + surface) was read-only. Phase 2 (this module's ``/apply``,
 Approve stage: writes route through ``core.optimize.relearn_apply`` for every
 rung-routing / backup / git-commit / fail-open guarantee — this route only
 translates HTTP <-> that module's ``RelearnApplyRefused`` (-> 409) contract,
-it never hand-rolls a parallel write path. ``/apply`` names a STORED proposal
-(``core.optimize.relearn_proposals``) and never accepts cluster content from
-the caller, so what gets written is always something the detector produced.
+it never hand-rolls a parallel write path.
 
 Phase 3 (Verify + Compound, ``core.optimize.relearn_verify``) rides the SAME
 ``/refresh`` cadence: every background/manual recompute also re-measures each
@@ -30,7 +28,7 @@ from pathlib import Path
 from typing import Any
 
 from fastapi import APIRouter, Depends, HTTPException, Request
-from pydantic import BaseModel, ConfigDict
+from pydantic import BaseModel
 
 from tokenjam.api.deps import require_api_key, require_relearn_write_auth
 from tokenjam.core.optimize import (
@@ -38,7 +36,6 @@ from tokenjam.core.optimize import (
     cost_proposals as cost_proposals_mod,
     cost_verify,
     relearn_apply,
-    relearn_proposals,
     relearn_store,
     relearn_verify,
 )
@@ -137,18 +134,18 @@ def refresh_relearn_proposals(request: Request) -> dict[str, Any]:
 # --------------------------------------------------------------------------- #
 
 class ApplyRelearnRequest(BaseModel):
-    """A named STORED proposal plus the human's confirmed write target.
-
-    The cluster content itself is never accepted from the client: it is looked
-    up server-side from the detector's own stored proposals
-    (``core.optimize.relearn_proposals``). ``extra="forbid"`` makes that
-    explicit rather than silent, so a caller still posting a hand-built
-    cluster gets a 422 telling it what changed instead of having its payload
-    quietly ignored.
-    """
-    model_config = ConfigDict(extra="forbid")
-
-    proposal_id:    str
+    # The full cluster the client already has from GET /relearn/proposals —
+    # re-posted rather than re-looked-up server-side so a stale cache can't
+    # silently apply a DIFFERENT cluster than the one the human reviewed.
+    signature:      str
+    family_key:     str | None = None
+    title:          str
+    proposed_fix:   str = ""
+    rung:           int
+    sessions:       int = 0
+    occurrences:    int = 0
+    repos:          list[str] = []
+    examples:       list[dict[str, Any]] = []
     # Scope override (§7 — "repo-identity is noisy"): the human confirms both
     # before Approve, never inferred silently.
     scope:          str
@@ -165,42 +162,73 @@ class ApplyRelearnRequest(BaseModel):
     current_model:  str = ""
     proposed_model: str = ""
     source_path:    str = ""
+    # Which cost analyzer's card this write came from, so the same apply also
+    # opens a cost-verify exposure window and the realized delta lands in the
+    # ledger the receipts surface reads dollars from. Empty for rung-ladder
+    # fixes, whose receipts are recurrence-based rather than priced.
+    analyzer:       str = ""
+    agent_id:       str = ""
 
 
 @router.post("/relearn/apply", dependencies=_WRITE_AUTH)
 def post_relearn_apply(request: Request, body: ApplyRelearnRequest) -> dict[str, Any]:
     """Dry-run (default) or write (``go=true``) an approved fix at its rung.
 
-    Takes a ``proposal_id`` from ``GET /relearn/proposals``. 404s when no
-    stored proposal carries that ID: a client-constructed cluster has no way
-    into the write machinery, which is what makes "human-gated" a property of
-    the server rather than of the UI flow.
-
-    409s (via ``RelearnApplyRefused``) on: an unknown rung, a family with no
-    matcher at an enforcement rung, a create-only target (skill/hook) that
-    already holds a non-TokenJam file, or (unless ``force=true``) a live
-    session just seen in the target repo (§7: never apply mid-session). The
-    UI's re-send-with-force is the explicit "apply anyway" the spec calls for.
-    403s when ``target_path`` resolves outside the user's home directory
-    (defense-in-depth allowlist).
+    409s (via ``RelearnApplyRefused``) on: an unknown rung, a create-only
+    target (skill/hook) that already holds a non-TokenJam file, or — unless
+    ``force=true`` — a live session just seen in the target repo (§7: never
+    apply mid-session). The UI's re-send-with-force is the explicit
+    "apply anyway" the spec calls for. 403s when ``target_path`` resolves
+    outside the user's home directory (defense-in-depth allowlist).
     """
     _reject_target_outside_home(body.target_path)
-    stored = relearn_proposals.get_proposal(body.proposal_id, config=_config(request))
-    if stored is None:
-        raise HTTPException(
-            status_code=404,
-            detail=f"no stored proposal {body.proposal_id}. Refresh the proposals "
-                   f"and apply one the detector actually produced.",
-        )
-    cluster = relearn_proposals.cluster_for_apply(stored)
+    cluster = body.model_dump(
+        exclude={"scope", "target_path", "go", "force", "analyzer", "agent_id"},
+    )
     try:
-        return relearn_apply.apply_relearn_fix(
+        result = relearn_apply.apply_relearn_fix(
             _config(request), cluster,
             target_path=body.target_path, scope=body.scope,
             go=body.go, conn=_conn(request), force=body.force,
         )
     except relearn_apply.RelearnApplyRefused as exc:
         raise HTTPException(status_code=409, detail=str(exc)) from exc
+    if body.go and body.apply_kind and body.analyzer:
+        result["cost_marker"] = _open_cost_verify_window(request, body)
+    return result
+
+
+def _open_cost_verify_window(request: Request, body: ApplyRelearnRequest) -> dict[str, Any] | None:
+    """Start the priced exposure window for a model-routing write.
+
+    A model swap is a cost fix that happens to have a file to edit, so its
+    receipt has to be a measured dollar delta on spans, not a recurrence count.
+    That measurement hangs off the cost-applied ledger, so the same approval
+    that wrote the file also opens the window. Best-effort: a marker that cannot
+    be created must never fail an apply that already succeeded on disk.
+    """
+    from tokenjam.core.optimize import cost_apply
+
+    proposal = {
+        "signature": body.signature,
+        "analyzer": body.analyzer,
+        "title": body.title,
+        "agent_id": body.agent_id,
+        "advise_text": body.proposed_fix,
+        "target_key": {
+            "models": [body.current_model] if body.current_model else [],
+            "subagent": body.analyzer == "subagent",
+            "agent_name": body.agent_name,
+        },
+        "baseline": {"proposed_model": body.proposed_model},
+        "estimated_recoverable_usd": None,
+        "estimated_recoverable_tokens": None,
+        "estimate_basis": "",
+    }
+    try:
+        return cost_apply.mark_applied(_conn(request), _config(request), proposal)
+    except Exception:
+        return None
 
 
 @router.get("/relearn/applied", dependencies=[Depends(require_api_key)])

--- a/tokenjam/api/routes/relearn.py
+++ b/tokenjam/api/routes/relearn.py
@@ -35,6 +35,7 @@ from tokenjam.core.optimize import (
     cost_apply,
     cost_proposals as cost_proposals_mod,
     cost_verify,
+    receipts,
     relearn_apply,
     relearn_store,
     relearn_verify,
@@ -286,17 +287,48 @@ def get_cost_proposals(request: Request) -> dict[str, Any]:
     """Cost proposals for the Review inbox, listed beside relearn proposals.
 
     Returns ``{"status": "ready"|"never_run", "computed_at": iso|null,
-    "proposals": [dict, ...]}``. A fresh install (no cost recompute has run)
-    reports ``never_run`` with an empty list — the inbox renders its empty
-    state, not an error."""
-    block = relearn_store.read_cost_proposals(config=_config(request))
+    "proposals": [dict, ...], "rollup": dict}``. A fresh install (no cost
+    recompute has run) reports ``never_run`` with an empty list — the inbox
+    renders its empty state, not an error.
+
+    ``rollup`` is Component E's single "estimated recoverable" headline
+    (``cost_proposals.estimated_recoverable_rollup``): the sum of
+    ``estimated_recoverable_usd`` across the OPEN proposals only — every
+    proposal whose signature isn't already in the (non-reverted) cost-applied
+    ledger. Computed here, not client-side, so the headline reflects every
+    viewer's state consistently (a browser's local "dismiss" never affects
+    this figure — dismissing hides a card from one person's view, it doesn't
+    change what's actually still outstanding)."""
+    config = _config(request)
+    block = relearn_store.read_cost_proposals(config=config)
+    proposals = list(block.get("cost_proposals") or []) if block is not None else []
+    applied_sigs = {
+        rec.get("signature") for rec in cost_apply.list_applied(config)
+        if rec.get("state") != "reverted"
+    }
+    open_proposals = [p for p in proposals if p.get("signature") not in applied_sigs]
+    rollup = cost_proposals_mod.estimated_recoverable_rollup(open_proposals)
     if block is None:
-        return {"status": "never_run", "computed_at": None, "proposals": []}
+        return {"status": "never_run", "computed_at": None, "proposals": [], "rollup": rollup}
     return {
         "status": "ready",
         "computed_at": block.get("cost_computed_at"),
-        "proposals": block.get("cost_proposals") or [],
+        "proposals": proposals,
+        "rollup": rollup,
     }
+
+
+@router.get("/relearn/receipts", dependencies=[Depends(require_api_key)])
+def get_relearn_receipts(request: Request) -> dict[str, Any]:
+    """Component G1: the cumulative "verified saved" receipts — the measured
+    twin of the ``rollup`` field above (Component E). Combines the relearn
+    ledger and the cost-verify ledger (``core.optimize.receipts``);
+    read-only, no recompute triggered here — it rides the same ``/refresh``
+    cadence the two source ledgers already recompute on."""
+    config = _config(request)
+    relearn_records = relearn_apply.list_applied(config)
+    cost_records = cost_apply.list_applied(config)
+    return receipts.verified_saved_summary(relearn_records, cost_records)
 
 
 @router.post("/relearn/cost-proposals/refresh", dependencies=_WRITE_AUTH)

--- a/tokenjam/cli/cmd_optimize.py
+++ b/tokenjam/cli/cmd_optimize.py
@@ -249,6 +249,23 @@ def cmd_optimize(
         except Exception:
             pass
 
+        # Opportunistic cost-proposal refresh: until now the ONLY producer of
+        # the cost-proposal store (core.optimize.cost_proposals
+        # .recompute_cost_proposals) was the web Review inbox's manual
+        # refresh button — a pure-CLI user who never runs `tj serve` plus the
+        # web UI would never have a cost proposal computed at all, so `tj
+        # relearn cost-proposals` would sit permanently empty regardless of
+        # how good its renderer is. Piggyback the same recompute here so a
+        # plain `tj optimize` run keeps that store warm too.
+        # `recompute_cost_proposals` already never raises (it returns [] on
+        # failure), so a broken window here degrades to a stale/empty
+        # cost-proposals list, never a broken `tj optimize`.
+        try:
+            from tokenjam.core.optimize.cost_proposals import recompute_cost_proposals
+            recompute_cost_proposals(db, config, agent_id=agent)
+        except Exception:
+            pass
+
     dominant = dominant_plan(plan_mix)
     pricing_mode = pricing_mode_for(dominant)
     declared_plan = config_declared_plan(config)
@@ -305,6 +322,13 @@ def cmd_optimize(
             except ValueError as exc:
                 raise click.BadParameter(str(exc), param_hint="'--compare'") from exc
 
+    # Cost-proposal count (downsize/cache/trim/subagent/... fixes, each with a
+    # copy-pasteable snippet) — read regardless of output mode so both the
+    # JSON payload and the human footer below can point at `tj relearn
+    # cost-proposals` instead of leaving findings with nowhere to go.
+    from tokenjam.core.optimize import relearn_proposals
+    cost_proposal_count = len(relearn_proposals.list_cost_proposals(config))
+
     if output_json:
         payload = report_to_dict(report)
         payload["plan_tier_mix"] = plan_mix
@@ -312,6 +336,7 @@ def cmd_optimize(
         payload["pricing_mode"] = pricing_mode
         payload["agent_persona_mix"] = agent_mix
         payload["persona"] = persona
+        payload["cost_proposals_available"] = cost_proposal_count
         if cost_diff is not None:
             from tokenjam.cli.cmd_cost import _diff_to_dict
             payload["compare"] = _diff_to_dict(cost_diff)
@@ -347,6 +372,18 @@ def cmd_optimize(
         from tokenjam.cli.cmd_cost import _render_diff_dict
         console.print("\n[bold]Window comparison[/bold]")
         _render_diff_dict(cost_diff_dict)
+
+    # Findings above are diagnoses; this is where they go. Until now nothing
+    # in `tj optimize`'s output pointed anywhere — the fix for e.g. a `cache`
+    # or `deadweight` finding lived only in the web Review inbox's cost-proposal
+    # cards (core.optimize.cost_proposals), never named from the terminal.
+    if cost_proposal_count:
+        console.print(
+            f"[dim]{cost_proposal_count} cost fix"
+            f"{'es' if cost_proposal_count != 1 else ''} available, each with "
+            f"a copy-pasteable snippet: run [bold]tj relearn "
+            f"cost-proposals[/bold].[/dim]"
+        )
 
 
 # ---------------------------------------------------------------------------

--- a/tokenjam/cli/cmd_optimize.py
+++ b/tokenjam/cli/cmd_optimize.py
@@ -1275,7 +1275,39 @@ def _render_cache_recommend(
             f"~{format_tokens(c.estimated_cacheable_tokens)} cacheable/call  "
             f"[dim]({format_tokens(int(c.avg_input_tokens))} avg input)[/dim]"
         )
+        # Subscription/local plans don't pay per token — no dollar lever to
+        # show. On api, a candidate can still have no priced rate for its
+        # model, in which case we say why rather than print a $0.00.
+        if pricing_mode == "api":
+            if c.estimated_recoverable_usd is not None:
+                console.print(
+                    f"           [dim]≈[/dim] [green]{format_cost(c.estimated_recoverable_usd)}[/green] "
+                    f"estimated over this window [dim](model {c.model})[/dim]"
+                )
+            else:
+                console.print(
+                    f"           [dim]no dollar figure: no priced rate observed "
+                    f"for {c.model or 'this model'}[/dim]"
+                )
         console.print(f"           [dim italic]{sample}[/dim italic]")
+
+    if pricing_mode == "api" and finding.estimated_recoverable_usd is not None:
+        console.print(
+            f"     • [green]~{format_cost(finding.estimated_recoverable_usd)}[/green] "
+            f"estimated recoverable across these candidates [dim](reads after "
+            f"the first occurrence, minus one cache write per prefix)[/dim]"
+        )
+    elif pricing_mode != "api":
+        console.print(
+            "     [dim]This plan doesn't bill per token, so no dollar figure "
+            "is shown; the token counts above still show the caching "
+            "opportunity.[/dim]"
+        )
+    else:
+        console.print(
+            "     [dim]No dollar figure: no priced Anthropic model rate was "
+            "observed for these candidates.[/dim]"
+        )
 
     if finding.skipped_provider_count:
         console.print(

--- a/tokenjam/cli/cmd_relearn.py
+++ b/tokenjam/cli/cmd_relearn.py
@@ -1,0 +1,76 @@
+"""`tj relearn` — the self-improve loop's CLI surface.
+
+The group's write verbs (``list`` / ``apply <proposal-id> [--go]`` / ``enable``
+/ ``revert``) live in ``cli/relearn_write_verbs.py`` and are attached at the
+bottom of this file; this file owns the group itself plus the read-only
+``eval-case`` command.
+"""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import click
+
+from tokenjam.core.config import TjConfig
+from tokenjam.utils.formatting import console
+
+
+@click.group("relearn", invoke_without_command=False)
+def cmd_relearn() -> None:
+    """Self-improve loop: review and apply recurring-mistake fixes."""
+
+
+@cmd_relearn.command("eval-case")
+@click.argument("proposal_id")
+@click.option("--out", "out_path", default=None,
+              help="Write the JSON here instead of printing it.")
+@click.pass_context
+def cmd_relearn_eval_case(ctx: click.Context, proposal_id: str, out_path: str | None) -> None:
+    """Emit the eval-case JSON artifact for a stored PROPOSAL_ID.
+
+    The advise lane's hand-off. tokenjam cannot apply a fix into an agent it
+    has no workspace for, so an advise-only proposal has no apply path at all;
+    this hands back the same clustered evidence in a plain JSON shape you can
+    feed your own eval tooling as a regression case. Read-only: it writes
+    nothing but the file you name.
+    """
+    from tokenjam.core.optimize import relearn_proposals
+    from tokenjam.core.optimize.relearn_otel import to_eval_case
+
+    config: TjConfig = ctx.obj["config"]
+    stored = relearn_proposals.get_proposal(proposal_id, config=config)
+    if stored is None:
+        raise click.ClickException(
+            f"no stored proposal {proposal_id}. Run `tj relearn list` for the "
+            f"IDs the detector actually produced."
+        )
+    case = to_eval_case(relearn_proposals.relearn_cluster_from(stored))
+    payload = json.dumps(case, indent=2, default=str)
+
+    if out_path:
+        Path(out_path).write_text(payload + "\n", encoding="utf-8")
+        console.print(f"[green]wrote[/] {out_path}")
+        return
+    click.echo(payload)
+
+
+# --------------------------------------------------------------------------- #
+# Write verbs (list / apply / enable / revert) — defined in their own module,
+# attached here so `tj relearn` exposes the whole group.
+# --------------------------------------------------------------------------- #
+
+from tokenjam.cli.relearn_write_verbs import register_write_verbs  # noqa: E402
+
+register_write_verbs(cmd_relearn)
+
+# --------------------------------------------------------------------------- #
+# Cost-proposal verbs (cost-proposals / cost-apply / cost-mark-applied /
+# cost-revert) — the terminal view of the cost analyzers' proposals
+# (core.optimize.cost_proposals), a distinct `kind` from the relearn
+# proposals above but stored in the same cache and reviewed the same way.
+# --------------------------------------------------------------------------- #
+
+from tokenjam.cli.cost_proposal_verbs import register_cost_proposal_verbs  # noqa: E402
+
+register_cost_proposal_verbs(cmd_relearn)

--- a/tokenjam/cli/cost_proposal_verbs.py
+++ b/tokenjam/cli/cost_proposal_verbs.py
@@ -1,0 +1,418 @@
+"""``tj relearn cost-proposals`` (+ ``cost-apply`` / ``cost-mark-applied`` /
+``cost-revert``) -- the terminal view of the cost-analyzer proposals
+(downsize/cache/trim/subagent/deadweight/script/reuse/verbosity) that,
+before this file, had no CLI renderer at all.
+
+``cmd_optimize.py`` renders each analyzer's raw FINDING (a different, older
+shape); it never touches the proposal layer at all. The proposal layer
+(``core.optimize.cost_proposals`` -> ``core.optimize.relearn_proposals
+.list_cost_proposals``) is what the web Review inbox's cards are built from
+-- evidence, a recommendation, and (for most analyzers) a copy-pasteable
+``suggestion`` snippet that is the actual fix. A terminal user got the
+diagnosis and never saw the fix. These verbs close that gap by reading the
+SAME store the API route (``GET /api/v1/relearn/cost-proposals``) serves,
+never duplicating its logic.
+
+Flat verbs, siblings of ``tj relearn list`` / ``apply`` / ``enable`` /
+``revert`` in the same group -- not a nested subgroup, matching this
+codebase's existing "one level deep" CLI shape. Thin by construction: every
+write here is a wrapper over ``core.optimize.cost_apply`` (mark/revert) or
+``core.optimize.relearn_apply`` (the same workspace-write machinery
+``tj relearn apply`` uses), never a second copy of that logic.
+
+Two kinds of cost proposal, rendered honestly as two different things:
+
+  * ``apply_capable`` (subagent / script / reuse / verbosity, some of the
+    time) -- tokenjam CAN write the fix into a workspace file. ``cost-apply``
+    does that, dry-run by default, exactly like ``tj relearn apply``.
+  * advise-only (most cards: downsize, cache, trim, deadweight) -- the fix
+    lives in the user's OWN application code. There is no apply path; the
+    ``suggestion`` snippet printed with the card IS the fix. Presenting it as
+    a consolation ("sorry, no auto-apply") would misstate what happened here
+    -- for these analyzers a hand-edit was always the intended fix.
+    ``cost-mark-applied`` just records that the user made the change, so the
+    delta-verify pass has a "changed at T" marker to measure against.
+"""
+from __future__ import annotations
+
+import json
+
+import click
+
+from tokenjam.core.framing import (
+    Framing,
+    WindowSummary,
+    compute_framing,
+    plan_determination_mix,
+    render_savings,
+)
+from tokenjam.core.optimize import cost_apply, relearn_apply, relearn_proposals, relearn_store
+from tokenjam.utils.formatting import console
+
+
+def _config(ctx: click.Context):
+    config = ctx.obj.get("config")
+    if config is None:
+        raise click.ClickException("no config loaded.")
+    return config
+
+
+def _conn(ctx: click.Context):
+    """The live DuckDB connection, or None when the daemon holds the lock and
+    the CLI fell back to the HTTP backend."""
+    db = ctx.obj.get("db")
+    return getattr(db, "conn", None) if db is not None else None
+
+
+def _emit(ctx: click.Context, payload: dict) -> bool:
+    if ctx.obj.get("output_json"):
+        click.echo(json.dumps(payload, default=str))
+        return True
+    return False
+
+
+def _framing_for(ctx: click.Context) -> Framing:
+    """The same plan-tier framing chain ``GET /relearn/cost-proposals`` uses
+    (``core.framing.compute_framing`` off a window-INDEPENDENT plan mix,
+    since cost-proposal figures are cumulative-to-date, not scoped to a
+    --since window) -- so a dollar figure rendered here never disagrees with
+    the web Review inbox's card for the same proposal. Degrades to the
+    config-declared plan when there is no direct DB connection, exactly as
+    ``compute_framing`` already handles an empty mix."""
+    config = _config(ctx)
+    conn = _conn(ctx)
+    mix = plan_determination_mix(conn) if conn is not None else {}
+    return compute_framing(config, WindowSummary(plan_tier_mix=mix, sessions=sum(mix.values())))
+
+
+def _stored_cost_proposal(config, proposal_id: str) -> dict | None:
+    """The stored cost proposal with this ID, scoped to the cost-proposal
+    store only -- never a relearn cluster ID accepted here by accident.
+    Mirrors ``api/routes/relearn.py``'s ``_stored_cost_proposal`` without
+    importing across the CLI/API boundary (the two are kept in sync only by
+    both reading ``relearn_proposals.list_cost_proposals``)."""
+    for proposal in relearn_proposals.list_cost_proposals(config):
+        if proposal.get("proposal_id") == proposal_id:
+            return proposal
+    return None
+
+
+# --------------------------------------------------------------------------- #
+# cost-proposals: the list/render verb.
+# --------------------------------------------------------------------------- #
+
+@click.command("cost-proposals")
+@click.pass_context
+def cost_proposals_cmd(ctx: click.Context) -> None:
+    """List cost-saving fixes (downsize/cache/trim/subagent/deadweight/
+    script/reuse/verbosity), each with the evidence and the copy-pasteable
+    snippet or workspace-apply path it carries."""
+    config = _config(ctx)
+    block = relearn_store.read_cost_proposals(config=config)
+    proposals = relearn_proposals.list_cost_proposals(config)
+    framing = _framing_for(ctx)
+
+    if _emit(ctx, {
+        "status": "ready" if block is not None else "never_run",
+        "computed_at": (block or {}).get("cost_computed_at"),
+        "proposals": proposals,
+        "framing": framing.to_dict(),
+    }):
+        return
+
+    if block is None:
+        console.print(
+            "[dim]Cost proposals have never been computed. Run "
+            "[bold]tj optimize[/bold] to compute them.[/dim]"
+        )
+        return
+
+    if not proposals:
+        computed_at = str(block.get("cost_computed_at") or "")[:16].replace("T", " ")
+        console.print(
+            f"[dim]No cost-saving fixes found as of {computed_at or 'the last pass'}. "
+            f"Either usage doesn't match any analyzer's pattern yet, or there "
+            f"isn't enough history. Run [bold]tj optimize[/bold] again after "
+            f"more usage accrues.[/dim]"
+        )
+        return
+
+    applied_sigs = {
+        rec.get("signature") for rec in cost_apply.list_applied(config)
+        if rec.get("state") != "reverted"
+    }
+    open_proposals = [p for p in proposals if p.get("signature") not in applied_sigs]
+
+    if open_proposals:
+        from tokenjam.core.optimize.cost_proposals import estimated_recoverable_rollup
+        rollup = estimated_recoverable_rollup(open_proposals)
+        headline = render_savings(
+            rollup.get("estimated_recoverable_usd"),
+            rollup.get("estimated_recoverable_tokens"),
+            framing,
+        )
+        if headline != "—":
+            console.print(
+                f"[bold green]~{headline}[/bold green] estimated recoverable across "
+                f"{rollup.get('proposal_count', 0)} of "
+                f"{rollup.get('deduplicated_proposal_count', 0)} open proposal(s) "
+                f"[dim](estimated, correlational)[/dim]\n"
+            )
+
+    for i, p in enumerate(proposals, start=1):
+        _render_cost_proposal(p, framing, i, applied=p.get("signature") in applied_sigs)
+        console.print()
+
+    if any(not p.get("apply_capable") for p in proposals):
+        console.print(
+            "[dim]Advise-only proposals have no apply path: the fix lives in "
+            "your own application code, which tokenjam has no workspace to "
+            "write into. The snippet above IS the fix -- copy it in, then "
+            "[bold]tj relearn cost-mark-applied <id>[/bold] to record "
+            "it.[/dim]"
+        )
+
+
+def _render_cost_proposal(
+    p: dict, framing: Framing, index: int, *, applied: bool = False,
+) -> None:
+    pid = p.get("proposal_id") or ""
+    title = p.get("title") or p.get("signature") or pid
+    analyzer = p.get("analyzer") or ""
+    if applied:
+        badge = "applied"
+    elif p.get("apply_capable"):
+        badge = "workspace fix"
+    else:
+        badge = "advise-only"
+
+    console.print(
+        f"[bold]{index}.[/bold] [bold]{title}[/bold] "
+        f"[dim]({analyzer} · {badge})[/dim]  [dim]{pid}[/dim]"
+    )
+    if p.get("evidence"):
+        console.print(f"     {p['evidence']}")
+
+    savings = render_savings(
+        p.get("estimated_recoverable_usd"), p.get("estimated_recoverable_tokens"), framing,
+    )
+    if savings != "—":
+        console.print(
+            f"     [green]~{savings}[/green] estimated recoverable "
+            f"[dim](estimate: {p.get('estimate_basis') or 'correlational'})[/dim]"
+        )
+
+    if p.get("advise_text"):
+        console.print(f"     [dim]Recommendation:[/dim] {p['advise_text']}")
+
+    # The copy-pasteable fix: its own line, no markup/highlighting applied and
+    # no wrapping, so a command like `claude mcp remove foo --scope user` can
+    # be selected cleanly out of the terminal.
+    snippet = p.get("suggestion") or p.get("one_paste_fix") or ""
+    if snippet:
+        console.print("     [dim]Fix:[/dim]")
+        console.print(snippet, markup=False, highlight=False, soft_wrap=True)
+
+    if applied:
+        pass
+    elif p.get("apply_capable"):
+        console.print(
+            f"     [yellow]→[/yellow] workspace fix available: "
+            f"[bold]tj relearn cost-apply {pid}[/bold] "
+            f"[dim](dry run; add --go to write)[/dim]"
+        )
+    else:
+        reason = p.get("apply_blocked_reason") or (
+            "no workspace tokenjam can write this fix into -- apply the "
+            "snippet above yourself"
+        )
+        console.print(f"     [dim]{reason}[/dim]")
+
+    if p.get("caveat"):
+        console.print(f"     [yellow]![/yellow] [italic]{p['caveat']}[/italic]")
+
+
+# --------------------------------------------------------------------------- #
+# cost-apply: the workspace-write verb, apply_capable proposals only.
+# --------------------------------------------------------------------------- #
+
+@click.command("cost-apply")
+@click.argument("proposal_id")
+@click.option("--go", is_flag=True, help="Actually write the fix (default is a dry run).")
+@click.option("--target", "target_path", default=None,
+              help="Where to write it. Defaults to the proposal's target path.")
+@click.option("--scope", type=click.Choice(["project", "user-global"]), default=None,
+              help="Override the proposal's scope.")
+@click.option("--force", is_flag=True,
+              help="Apply even though a session looks live in the target repo.")
+@click.pass_context
+def cost_apply_cmd(
+    ctx: click.Context, proposal_id: str, go: bool,
+    target_path: str | None, scope: str | None, force: bool,
+) -> None:
+    """Preview (default) or write the workspace fix for an apply-capable
+    stored cost PROPOSAL_ID (subagent / script / reuse / verbosity).
+
+    Most cost proposals (downsize, cache, trim, deadweight) are advise-only
+    and have no workspace fix for this command to write -- their fix is the
+    snippet `tj relearn cost-proposals` prints; apply it yourself, then
+    record it with `tj relearn cost-mark-applied`.
+    """
+    config = _config(ctx)
+    stored = _stored_cost_proposal(config, proposal_id)
+    if stored is None:
+        raise click.ClickException(
+            f"no stored cost proposal {proposal_id}. Run "
+            f"`tj relearn cost-proposals` for the IDs the detector actually produced."
+        )
+    if not stored.get("apply_capable"):
+        raise click.ClickException(
+            stored.get("apply_blocked_reason")
+            or "this proposal is advise-only: it has no workspace tokenjam "
+               "can write into. Apply its snippet yourself, then run "
+               f"`tj relearn cost-mark-applied {proposal_id}`."
+        )
+    target = (target_path or stored.get("target_path") or "").strip()
+    if not target:
+        raise click.ClickException(
+            "this proposal has no suggested target path. Pass one with --target."
+        )
+
+    analyzer = str(stored.get("analyzer") or "")
+    baseline = dict(stored.get("baseline") or {})
+    # The cluster shape `relearn_apply.apply_relearn_fix` renders a rung-1/2
+    # note/skill from, built the same way `POST
+    # /relearn/cost-proposals/apply-workspace` builds it
+    # (api/routes/relearn.py) -- duplicated here rather than imported,
+    # because the CLI must not import across into the API layer.
+    cluster = {
+        "signature": str(stored.get("signature") or ""),
+        "family_key": f"cost_{analyzer}" if analyzer else "cost_proposal",
+        "title": str(stored.get("title") or "") or str(stored.get("signature") or ""),
+        "proposed_fix": str(stored.get("proposed_fix") or ""),
+        "rung": int(stored.get("rung") or 1),
+        "sessions": int(
+            baseline.get("apply_sessions", baseline.get("flagged_subagents", 0)) or 0
+        ),
+        "repos": list(baseline.get("apply_repos") or []),
+        "examples": list(baseline.get("apply_examples") or []),
+    }
+    try:
+        result = relearn_apply.apply_relearn_fix(
+            config, cluster, target_path=target,
+            scope=scope or stored.get("scope") or "project",
+            go=go, conn=_conn(ctx), force=force,
+        )
+    except relearn_apply.RelearnApplyRefused as exc:
+        raise click.ClickException(str(exc)) from exc
+
+    # Real write happened: drop the cost marker so the realized delta is
+    # measured against this moment, mirroring the API route's
+    # apply-then-mark sequencing.
+    cost_record = None
+    if go and not result.get("dry_run"):
+        db = ctx.obj.get("db")
+        if db is not None:
+            try:
+                cost_record = cost_apply.mark_applied(db, config, stored)
+            except cost_apply.CostApplyRefused:
+                cost_record = None
+
+    if _emit(ctx, {"applied": result, "cost_record": cost_record}):
+        return
+    if result.get("dry_run"):
+        console.print(f"[bold]{stored.get('title') or proposal_id}[/]")
+        console.print(f"[dim]would write {result['kind']} to {result['target_path']}[/dim]")
+        if result.get("diff"):
+            console.print(result["diff"])
+        console.print("[dim]Dry run. Nothing was written; re-run with --go to apply.[/dim]")
+        return
+    rec = result["record"]
+    console.print(
+        f"[green]applied[/] {rec['kind']} to {rec['target_path']} "
+        f"[dim](fix {rec['id']})[/dim]"
+    )
+    if cost_record:
+        console.print(
+            f"[dim]cost proposal marked applied (record {cost_record['id']}); "
+            f"undo with `tj relearn cost-revert {cost_record['id']}`.[/dim]"
+        )
+    console.print(f"[dim]Undo the workspace write with `tj relearn revert {rec['id']}`.[/dim]")
+
+
+# --------------------------------------------------------------------------- #
+# cost-mark-applied / cost-revert: the advise-only bookkeeping verbs.
+# --------------------------------------------------------------------------- #
+
+@click.command("cost-mark-applied")
+@click.argument("proposal_id")
+@click.pass_context
+def cost_mark_applied_cmd(ctx: click.Context, proposal_id: str) -> None:
+    """Record that you applied an advise-only cost PROPOSAL_ID yourself.
+
+    No code write -- cost proposals are advise-only by default; this only
+    creates the fix marker the delta-verify pass measures the realized
+    change against.
+    """
+    config = _config(ctx)
+    stored = _stored_cost_proposal(config, proposal_id)
+    if stored is None:
+        raise click.ClickException(
+            f"no stored cost proposal {proposal_id}. Run "
+            f"`tj relearn cost-proposals` for the IDs the detector actually produced."
+        )
+    db = ctx.obj.get("db")
+    if db is None or _conn(ctx) is None:
+        raise click.ClickException(
+            "cost-mark-applied requires a direct database connection "
+            "(stop `tj serve` first, or mark it from the web Review inbox instead)."
+        )
+    try:
+        rec = cost_apply.mark_applied(db, config, stored)
+    except cost_apply.CostApplyRefused as exc:
+        raise click.ClickException(str(exc)) from exc
+    if _emit(ctx, rec):
+        return
+    console.print(
+        f"[green]marked applied[/] {rec.get('title') or proposal_id} "
+        f"[dim](record {rec['id']})[/dim]"
+    )
+    console.print(f"[dim]Undo with `tj relearn cost-revert {rec['id']}`.[/dim]")
+
+
+@click.command("cost-revert")
+@click.argument("record_id")
+@click.pass_context
+def cost_revert_cmd(ctx: click.Context, record_id: str) -> None:
+    """Undo a marked/applied cost fix RECORD_ID.
+
+    Ledger-only for advise-only proposals (there's no file to restore); a
+    workspace fix written by `cost-apply` should be undone with
+    `tj relearn revert` instead, which restores the actual file.
+    """
+    config = _config(ctx)
+    try:
+        rec = cost_apply.revert_applied(config, record_id)
+    except cost_apply.CostApplyRefused as exc:
+        raise click.ClickException(str(exc)) from exc
+    if _emit(ctx, rec):
+        return
+    console.print(f"[green]reverted[/] {rec.get('title') or record_id}")
+
+
+# --------------------------------------------------------------------------- #
+# Registration
+# --------------------------------------------------------------------------- #
+
+#: Every verb this module contributes to the ``tj relearn`` group, in the
+#: order they should appear.
+COST_PROPOSAL_VERBS = (
+    cost_proposals_cmd, cost_apply_cmd, cost_mark_applied_cmd, cost_revert_cmd,
+)
+
+
+def register_cost_proposal_verbs(group: click.Group) -> click.Group:
+    """Attach this module's verbs to the ``tj relearn`` group and return it."""
+    for command in COST_PROPOSAL_VERBS:
+        group.add_command(command)
+    return group

--- a/tokenjam/core/config.py
+++ b/tokenjam/core/config.py
@@ -46,6 +46,13 @@ class AgentConfig:
     # project without restarting the agent — the mapping is applied by tj, so
     # no service.namespace needs to arrive on the wire.
     project:          str | None           = None
+    # Local checkout this agent's code lives in, registered BY THE USER
+    # ([agents.<id>] source_path). Opt-in and never inferred: tokenjam does not
+    # scan the filesystem looking for an agent's source. Its only consumer is
+    # the gated model-id swap in `core.optimize.relearn_apply` (a deterministic
+    # string substitution in a clean git repo); with no source_path a downsize
+    # card stays advise-only and just prints the one-paste fix.
+    source_path:      str | None           = None
 
 
 @dataclass
@@ -432,6 +439,7 @@ def _parse(raw: dict) -> TjConfig:
             output_schema=agent_raw.get("output_schema"),
             drift=drift,
             project=agent_raw.get("project"),
+            source_path=agent_raw.get("source_path"),
         )
 
     storage_raw = raw.get("storage", {})

--- a/tokenjam/core/optimize/analyzers/cache_efficacy.py
+++ b/tokenjam/core/optimize/analyzers/cache_efficacy.py
@@ -38,6 +38,11 @@ MIN_INPUT_TOKENS = 100_000
 # the model is still leaving substantial caching savings on the table.
 EFFICACY_THRESHOLD = 0.30
 
+# A1 root-cause minimum call volume (moved up from the A1/A2/A3 block below so
+# CacheEfficacyFinding's default can reference it) — minimum call volume before
+# the absolute waste is worth a card.
+MIN_CALLS_FOR_ROOT_CAUSE = 20
+
 # Per-provider support level. Used by the renderer to qualify the finding.
 PROVIDER_SUPPORT: dict[str, str] = {
     "anthropic":     "full",
@@ -88,6 +93,13 @@ class CacheEfficacyFinding:
     uncached_agents:      list["UncachedAgentCandidate"] = field(default_factory=list)
     thrash_agents:        list["ThrashAgentCandidate"]   = field(default_factory=list)
     lookback_miss_agents: list["LookbackMissCandidate"]  = field(default_factory=list)
+    # Effective thresholds this run applied (config-overridable, see
+    # core.config.OptimizeConfig) — carried on the finding so a renderer's
+    # flagged-state message never hardcodes a number that could be stale
+    # against the user's own config.
+    min_input_tokens:        int   = MIN_INPUT_TOKENS
+    efficacy_threshold:      float = EFFICACY_THRESHOLD
+    min_calls_for_root_cause: int  = MIN_CALLS_FOR_ROOT_CAUSE
 
 
 def estimate_cache_recoverable(
@@ -128,7 +140,11 @@ def estimate_cache_recoverable(
     return round(total_usd, 6), total_tokens
 
 
-def _compute_rows(conn, since, until, agent_id: str | None) -> list[CacheEfficacyRow]:
+def _compute_rows(
+    conn, since, until, agent_id: str | None,
+    *, min_input_tokens: int = MIN_INPUT_TOKENS,
+    efficacy_threshold: float = EFFICACY_THRESHOLD,
+) -> list[CacheEfficacyRow]:
     """Aggregate input_tokens and cache_tokens per (provider, model) in window."""
     clauses = [
         "start_time >= $1", "start_time < $2",
@@ -161,8 +177,8 @@ def _compute_rows(conn, since, until, agent_id: str | None) -> list[CacheEfficac
         support = PROVIDER_SUPPORT.get(str(provider).lower(), "unsupported")
         flagged = (
             support in {"full", "best_effort"}
-            and in_tok >= MIN_INPUT_TOKENS
-            and efficacy < EFFICACY_THRESHOLD
+            and in_tok >= min_input_tokens
+            and efficacy < efficacy_threshold
         )
         result.append(CacheEfficacyRow(
             provider=str(provider),
@@ -183,10 +199,10 @@ def _compute_rows(conn, since, until, agent_id: str | None) -> list[CacheEfficac
 # never produces two cards (uncached beats thrash beats lookback).
 # --------------------------------------------------------------------------- #
 
-# A1 — minimum call volume before the absolute waste is worth a card, and the
-# minimum median per-call input size below which even a perfectly cached
-# prefix wouldn't save much.
-MIN_CALLS_FOR_ROOT_CAUSE = 20
+# A1 — minimum median per-call input size below which even a perfectly cached
+# prefix wouldn't save much. (MIN_CALLS_FOR_ROOT_CAUSE, the other A1 gate,
+# moved up near MIN_INPUT_TOKENS/EFFICACY_THRESHOLD so CacheEfficacyFinding's
+# default can reference it.)
 MIN_UNCACHED_MEDIAN_INPUT_TOKENS = 2048
 
 # A2 — below this read:write ratio, more was spent WRITING the prefix than was
@@ -426,10 +442,13 @@ def _lookback_snippet(model: str) -> str:
     )
 
 
-def _classify_a1(agent_id: str, calls: list[_AgentCallRow]) -> UncachedAgentCandidate | None:
-    """Uncached agent: >=20 calls, never caches, and the prefix is large
-    enough that caching it would actually matter."""
-    if len(calls) < MIN_CALLS_FOR_ROOT_CAUSE:
+def _classify_a1(
+    agent_id: str, calls: list[_AgentCallRow],
+    *, min_calls: int = MIN_CALLS_FOR_ROOT_CAUSE,
+) -> UncachedAgentCandidate | None:
+    """Uncached agent: >=min_calls calls, never caches, and the prefix is
+    large enough that caching it would actually matter."""
+    if len(calls) < min_calls:
         return None
     if any(c.cache_tokens > 0 or c.cache_write_tokens > 0 for c in calls):
         return None
@@ -525,6 +544,17 @@ def _classify_a2(agent_id: str, calls: list[_AgentCallRow]) -> ThrashAgentCandid
     else:
         snippet = SILENT_INVALIDATOR_CHECKLIST
 
+    # Rollup contract: `estimated_recoverable_usd` feeds a generic cross-card
+    # dollar rollup, so it must only ever be populated when THIS card's own
+    # recommended fix actually recovers it. The "instability" checklist and
+    # the ttl_worth_it==True variant both recommend a fix that closes the
+    # wasted-spend gap, so `wasted_usd` stands as the headline. When the TTL
+    # break-even comes out negative, the card explicitly says "not worth it"
+    # — recommending against the only fix on offer — so the headline must NOT
+    # carry a positive number nobody should act on; excluded (None), not zero
+    # coerced to a false-looking "no waste" claim.
+    recoverable_usd = None if (cause == "ttl" and ttl_worth_it is False) else wasted_usd
+
     return ThrashAgentCandidate(
         agent_id=agent_id, provider=provider, model=model, calls=len(calls),
         cache_write_tokens=total_write, cache_read_tokens=total_read,
@@ -532,13 +562,13 @@ def _classify_a2(agent_id: str, calls: list[_AgentCallRow]) -> ThrashAgentCandid
         inter_call_gap_p50_minutes=round(gap_p50, 2),
         ttl_worth_it=ttl_worth_it, ttl_breakeven_usd=ttl_breakeven_usd,
         cache_control_snippet=snippet,
-        estimated_recoverable_usd=wasted_usd,
+        estimated_recoverable_usd=recoverable_usd,
         estimate_basis=(
             "wasted = cache-write tokens x (write rate - cache-read rate); "
             "what was paid to write the prefix versus what the same tokens "
-            "would have cost read from a stable cache. The TTL variant's "
-            "break-even (ttl_breakeven_usd) is a separate, honest projection "
-            "that can come out negative — see cause=='ttl' ? ttl_worth_it."
+            "would have cost read from a stable cache. Excluded (None) when "
+            "the TTL variant's break-even is negative, since the card's own "
+            "recommended fix (switching TTL) would not recover it."
         ),
     )
 
@@ -603,6 +633,7 @@ def _classify_a3(
 
 def _compute_root_cause_candidates(
     conn, since, until, agent_id: str | None,
+    *, min_calls: int = MIN_CALLS_FOR_ROOT_CAUSE,
 ) -> tuple[
     list[UncachedAgentCandidate], list[ThrashAgentCandidate], list[LookbackMissCandidate],
 ]:
@@ -616,7 +647,7 @@ def _compute_root_cause_candidates(
     thrash: list[ThrashAgentCandidate] = []
     lookback: list[LookbackMissCandidate] = []
     for aid, calls in by_agent.items():
-        a1 = _classify_a1(aid, calls)
+        a1 = _classify_a1(aid, calls, min_calls=min_calls)
         if a1 is not None:
             uncached.append(a1)
             continue
@@ -633,9 +664,17 @@ def _compute_root_cause_candidates(
 @register("cache")
 def run(ctx: AnalyzerContext) -> None:
     """Registry entry point. Attaches the finding to ctx.report.findings."""
-    rows = _compute_rows(ctx.conn, ctx.since, ctx.until, ctx.agent_id)
-    uncached, thrash, lookback = _compute_root_cause_candidates(
+    optimize_cfg = getattr(ctx.config, "optimize", None)
+    min_input_tokens = getattr(optimize_cfg, "min_cache_input_tokens", MIN_INPUT_TOKENS)
+    efficacy_threshold = getattr(optimize_cfg, "cache_efficacy_threshold", EFFICACY_THRESHOLD)
+    min_calls = getattr(optimize_cfg, "min_calls_for_root_cause", MIN_CALLS_FOR_ROOT_CAUSE)
+
+    rows = _compute_rows(
         ctx.conn, ctx.since, ctx.until, ctx.agent_id,
+        min_input_tokens=min_input_tokens, efficacy_threshold=efficacy_threshold,
+    )
+    uncached, thrash, lookback = _compute_root_cause_candidates(
+        ctx.conn, ctx.since, ctx.until, ctx.agent_id, min_calls=min_calls,
     )
     if not rows and not uncached and not thrash and not lookback:
         return
@@ -645,6 +684,9 @@ def run(ctx: AnalyzerContext) -> None:
         flagged=[r for r in rows if r.flagged],
         estimated_recoverable_usd=rec_usd,
         estimated_recoverable_tokens=rec_tokens,
+        min_input_tokens=min_input_tokens,
+        efficacy_threshold=efficacy_threshold,
+        min_calls_for_root_cause=min_calls,
         estimate_basis=(
             "gap between current cache-read efficacy and 80% ceiling at the "
             "input-vs-cache rate delta"

--- a/tokenjam/core/optimize/analyzers/cache_efficacy.py
+++ b/tokenjam/core/optimize/analyzers/cache_efficacy.py
@@ -38,11 +38,6 @@ MIN_INPUT_TOKENS = 100_000
 # the model is still leaving substantial caching savings on the table.
 EFFICACY_THRESHOLD = 0.30
 
-# A1 root-cause minimum call volume (moved up from the A1/A2/A3 block below so
-# CacheEfficacyFinding's default can reference it) — minimum call volume before
-# the absolute waste is worth a card.
-MIN_CALLS_FOR_ROOT_CAUSE = 20
-
 # Per-provider support level. Used by the renderer to qualify the finding.
 PROVIDER_SUPPORT: dict[str, str] = {
     "anthropic":     "full",
@@ -93,13 +88,6 @@ class CacheEfficacyFinding:
     uncached_agents:      list["UncachedAgentCandidate"] = field(default_factory=list)
     thrash_agents:        list["ThrashAgentCandidate"]   = field(default_factory=list)
     lookback_miss_agents: list["LookbackMissCandidate"]  = field(default_factory=list)
-    # Effective thresholds this run applied (config-overridable, see
-    # core.config.OptimizeConfig) — carried on the finding so a renderer's
-    # flagged-state message never hardcodes a number that could be stale
-    # against the user's own config.
-    min_input_tokens:        int   = MIN_INPUT_TOKENS
-    efficacy_threshold:      float = EFFICACY_THRESHOLD
-    min_calls_for_root_cause: int  = MIN_CALLS_FOR_ROOT_CAUSE
 
 
 def estimate_cache_recoverable(
@@ -140,11 +128,7 @@ def estimate_cache_recoverable(
     return round(total_usd, 6), total_tokens
 
 
-def _compute_rows(
-    conn, since, until, agent_id: str | None,
-    *, min_input_tokens: int = MIN_INPUT_TOKENS,
-    efficacy_threshold: float = EFFICACY_THRESHOLD,
-) -> list[CacheEfficacyRow]:
+def _compute_rows(conn, since, until, agent_id: str | None) -> list[CacheEfficacyRow]:
     """Aggregate input_tokens and cache_tokens per (provider, model) in window."""
     clauses = [
         "start_time >= $1", "start_time < $2",
@@ -177,8 +161,8 @@ def _compute_rows(
         support = PROVIDER_SUPPORT.get(str(provider).lower(), "unsupported")
         flagged = (
             support in {"full", "best_effort"}
-            and in_tok >= min_input_tokens
-            and efficacy < efficacy_threshold
+            and in_tok >= MIN_INPUT_TOKENS
+            and efficacy < EFFICACY_THRESHOLD
         )
         result.append(CacheEfficacyRow(
             provider=str(provider),
@@ -199,10 +183,10 @@ def _compute_rows(
 # never produces two cards (uncached beats thrash beats lookback).
 # --------------------------------------------------------------------------- #
 
-# A1 — minimum median per-call input size below which even a perfectly cached
-# prefix wouldn't save much. (MIN_CALLS_FOR_ROOT_CAUSE, the other A1 gate,
-# moved up near MIN_INPUT_TOKENS/EFFICACY_THRESHOLD so CacheEfficacyFinding's
-# default can reference it.)
+# A1 — minimum call volume before the absolute waste is worth a card, and the
+# minimum median per-call input size below which even a perfectly cached
+# prefix wouldn't save much.
+MIN_CALLS_FOR_ROOT_CAUSE = 20
 MIN_UNCACHED_MEDIAN_INPUT_TOKENS = 2048
 
 # A2 — below this read:write ratio, more was spent WRITING the prefix than was
@@ -442,13 +426,10 @@ def _lookback_snippet(model: str) -> str:
     )
 
 
-def _classify_a1(
-    agent_id: str, calls: list[_AgentCallRow],
-    *, min_calls: int = MIN_CALLS_FOR_ROOT_CAUSE,
-) -> UncachedAgentCandidate | None:
-    """Uncached agent: >=min_calls calls, never caches, and the prefix is
-    large enough that caching it would actually matter."""
-    if len(calls) < min_calls:
+def _classify_a1(agent_id: str, calls: list[_AgentCallRow]) -> UncachedAgentCandidate | None:
+    """Uncached agent: >=20 calls, never caches, and the prefix is large
+    enough that caching it would actually matter."""
+    if len(calls) < MIN_CALLS_FOR_ROOT_CAUSE:
         return None
     if any(c.cache_tokens > 0 or c.cache_write_tokens > 0 for c in calls):
         return None
@@ -544,17 +525,6 @@ def _classify_a2(agent_id: str, calls: list[_AgentCallRow]) -> ThrashAgentCandid
     else:
         snippet = SILENT_INVALIDATOR_CHECKLIST
 
-    # Rollup contract: `estimated_recoverable_usd` feeds a generic cross-card
-    # dollar rollup, so it must only ever be populated when THIS card's own
-    # recommended fix actually recovers it. The "instability" checklist and
-    # the ttl_worth_it==True variant both recommend a fix that closes the
-    # wasted-spend gap, so `wasted_usd` stands as the headline. When the TTL
-    # break-even comes out negative, the card explicitly says "not worth it"
-    # — recommending against the only fix on offer — so the headline must NOT
-    # carry a positive number nobody should act on; excluded (None), not zero
-    # coerced to a false-looking "no waste" claim.
-    recoverable_usd = None if (cause == "ttl" and ttl_worth_it is False) else wasted_usd
-
     return ThrashAgentCandidate(
         agent_id=agent_id, provider=provider, model=model, calls=len(calls),
         cache_write_tokens=total_write, cache_read_tokens=total_read,
@@ -562,13 +532,13 @@ def _classify_a2(agent_id: str, calls: list[_AgentCallRow]) -> ThrashAgentCandid
         inter_call_gap_p50_minutes=round(gap_p50, 2),
         ttl_worth_it=ttl_worth_it, ttl_breakeven_usd=ttl_breakeven_usd,
         cache_control_snippet=snippet,
-        estimated_recoverable_usd=recoverable_usd,
+        estimated_recoverable_usd=wasted_usd,
         estimate_basis=(
             "wasted = cache-write tokens x (write rate - cache-read rate); "
             "what was paid to write the prefix versus what the same tokens "
-            "would have cost read from a stable cache. Excluded (None) when "
-            "the TTL variant's break-even is negative, since the card's own "
-            "recommended fix (switching TTL) would not recover it."
+            "would have cost read from a stable cache. The TTL variant's "
+            "break-even (ttl_breakeven_usd) is a separate, honest projection "
+            "that can come out negative — see cause=='ttl' ? ttl_worth_it."
         ),
     )
 
@@ -633,7 +603,6 @@ def _classify_a3(
 
 def _compute_root_cause_candidates(
     conn, since, until, agent_id: str | None,
-    *, min_calls: int = MIN_CALLS_FOR_ROOT_CAUSE,
 ) -> tuple[
     list[UncachedAgentCandidate], list[ThrashAgentCandidate], list[LookbackMissCandidate],
 ]:
@@ -647,7 +616,7 @@ def _compute_root_cause_candidates(
     thrash: list[ThrashAgentCandidate] = []
     lookback: list[LookbackMissCandidate] = []
     for aid, calls in by_agent.items():
-        a1 = _classify_a1(aid, calls, min_calls=min_calls)
+        a1 = _classify_a1(aid, calls)
         if a1 is not None:
             uncached.append(a1)
             continue
@@ -664,17 +633,9 @@ def _compute_root_cause_candidates(
 @register("cache")
 def run(ctx: AnalyzerContext) -> None:
     """Registry entry point. Attaches the finding to ctx.report.findings."""
-    optimize_cfg = getattr(ctx.config, "optimize", None)
-    min_input_tokens = getattr(optimize_cfg, "min_cache_input_tokens", MIN_INPUT_TOKENS)
-    efficacy_threshold = getattr(optimize_cfg, "cache_efficacy_threshold", EFFICACY_THRESHOLD)
-    min_calls = getattr(optimize_cfg, "min_calls_for_root_cause", MIN_CALLS_FOR_ROOT_CAUSE)
-
-    rows = _compute_rows(
-        ctx.conn, ctx.since, ctx.until, ctx.agent_id,
-        min_input_tokens=min_input_tokens, efficacy_threshold=efficacy_threshold,
-    )
+    rows = _compute_rows(ctx.conn, ctx.since, ctx.until, ctx.agent_id)
     uncached, thrash, lookback = _compute_root_cause_candidates(
-        ctx.conn, ctx.since, ctx.until, ctx.agent_id, min_calls=min_calls,
+        ctx.conn, ctx.since, ctx.until, ctx.agent_id,
     )
     if not rows and not uncached and not thrash and not lookback:
         return
@@ -684,9 +645,6 @@ def run(ctx: AnalyzerContext) -> None:
         flagged=[r for r in rows if r.flagged],
         estimated_recoverable_usd=rec_usd,
         estimated_recoverable_tokens=rec_tokens,
-        min_input_tokens=min_input_tokens,
-        efficacy_threshold=efficacy_threshold,
-        min_calls_for_root_cause=min_calls,
         estimate_basis=(
             "gap between current cache-read efficacy and 80% ceiling at the "
             "input-vs-cache rate delta"

--- a/tokenjam/core/optimize/analyzers/cache_recommend.py
+++ b/tokenjam/core/optimize/analyzers/cache_recommend.py
@@ -16,6 +16,7 @@ mislead. Multi-provider support is a future research project.
 from __future__ import annotations
 
 import hashlib
+import json
 from dataclasses import dataclass, field
 from typing import Any
 
@@ -44,6 +45,13 @@ class CachePrefixCandidate:
     avg_input_tokens: float        # average input_tokens on calls that share this prefix
     estimated_cacheable_tokens: int
     model:          str = ""       # this prefix's dominant model, for pricing
+    # The one-paste fix (#128): a ready cache_control placement for this
+    # exact prefix, built by `_prefix_cache_control_snippet` below. This
+    # analyzer's whole job is WHERE to place a breakpoint, so leaving this
+    # empty and only printing prose stats (as v1 did) meant the one analyzer
+    # whose purpose is placement advice was the one that gave no placement
+    # code, while `cache`'s own A3 lookback-miss path already built one.
+    cache_control_snippet: str = ""
     # Recoverable-savings contract (#111), same field names as every other
     # analyzer. None when no priced rate was observed for `model` — never a
     # zero or a borrowed rate (CLAUDE.md anti-pattern #22).
@@ -64,6 +72,11 @@ class CacheRecommendFinding:
     estimated_recoverable_usd:    float | None = None
     estimated_recoverable_tokens: int | None   = None
     estimate_basis:               str          = ""
+    # The effective occurrence bar this run applied (config-overridable, see
+    # core.config.OptimizeConfig.min_prefix_occurrences) — carried on the
+    # finding so a renderer's empty-state message never hardcodes a number
+    # that could be stale against the user's own config.
+    min_prefix_occurrences:       int          = MIN_PREFIX_OCCURRENCES
 
 
 def _stringify_prompt(value: Any) -> str:
@@ -108,6 +121,33 @@ def _prefix_hash(text: str) -> str:
     return hashlib.sha256(head).hexdigest()[:16]
 
 
+def _prefix_cache_control_snippet(
+    model: str, sample: str, occurrences: int, cacheable_tokens: int,
+) -> str:
+    """The one-paste fix for a recurring prefix. Modelled on
+    `cache_efficacy._uncached_snippet`: a comment identifying which prefix
+    (from the truncated preview already captured, never the full text) plus
+    a placeholder `text` block carrying the `cache_control` breakpoint.
+
+    A placeholder, not the real captured content: `sample` is only the first
+    ~120 characters kept for the UI preview, not the full prefix, and
+    pasting a partial prefix into a "snippet" would silently truncate the
+    user's actual boundary if copied as-is. The preview is enough to let the
+    user recognise WHICH of their own prefixes this is.
+    """
+    preview = sample[:80].replace("\n", " ").replace("\r", " ").strip()
+    model_label = model or "this model"
+    return (
+        f"# {model_label}: prefix seen in {occurrences} calls, starting "
+        f'"{preview}..."; ~{cacheable_tokens:,} tokens estimated cacheable\n'
+        + json.dumps({
+            "type": "text",
+            "text": "<the stable prefix that starts this way, same content every call>",
+            "cache_control": {"type": "ephemeral"},
+        }, indent=2)
+    )
+
+
 def _estimate_candidate_recoverable(
     model: str, cacheable_tokens_per_call: int, occurrences: int,
 ) -> tuple[float | None, int | None]:
@@ -140,10 +180,16 @@ def _estimate_candidate_recoverable(
 @register("cache-recommend")
 def run(ctx: AnalyzerContext) -> None:
     """Registry entry point. Attaches a CacheRecommendFinding to ctx.report.findings."""
+    optimize_cfg = getattr(ctx.config, "optimize", None)
+    min_prefix_occurrences = getattr(
+        optimize_cfg, "min_prefix_occurrences", MIN_PREFIX_OCCURRENCES,
+    )
+
     capture = getattr(ctx.config, "capture", None)
     if capture is None or not getattr(capture, "prompts", False):
         ctx.report.findings["cache-recommend"] = CacheRecommendFinding(
             enabled=False,
+            min_prefix_occurrences=min_prefix_occurrences,
             hint=(
                 "Enable `[capture] prompts = true` in tj.toml and let the "
                 "daemon collect a window of data before re-running this "
@@ -205,7 +251,7 @@ def run(ctx: AnalyzerContext) -> None:
 
     candidates: list[CachePrefixCandidate] = []
     for h, entry in prefix_counts.items():
-        if entry["count"] < MIN_PREFIX_OCCURRENCES:
+        if entry["count"] < min_prefix_occurrences:
             continue
         avg_in = entry["tokens_sum"] / entry["count"] if entry["count"] else 0.0
         # Rough estimate of cacheable tokens per call. A 2000-char prefix
@@ -230,6 +276,9 @@ def run(ctx: AnalyzerContext) -> None:
             avg_input_tokens=round(avg_in, 1),
             estimated_cacheable_tokens=estimated_cacheable,
             model=dominant_model,
+            cache_control_snippet=_prefix_cache_control_snippet(
+                dominant_model, str(entry["sample"]), int(entry["count"]), estimated_cacheable,
+            ),
             estimated_recoverable_usd=usd,
             estimated_recoverable_tokens=tokens,
         ))
@@ -258,4 +307,5 @@ def run(ctx: AnalyzerContext) -> None:
         estimated_recoverable_usd=finding_usd,
         estimated_recoverable_tokens=finding_tokens,
         estimate_basis=basis,
+        min_prefix_occurrences=min_prefix_occurrences,
     )

--- a/tokenjam/core/optimize/analyzers/cache_recommend.py
+++ b/tokenjam/core/optimize/analyzers/cache_recommend.py
@@ -64,11 +64,6 @@ class CacheRecommendFinding:
     estimated_recoverable_usd:    float | None = None
     estimated_recoverable_tokens: int | None   = None
     estimate_basis:               str          = ""
-    # The effective occurrence bar this run applied (config-overridable, see
-    # core.config.OptimizeConfig.min_prefix_occurrences) — carried on the
-    # finding so a renderer's empty-state message never hardcodes a number
-    # that could be stale against the user's own config.
-    min_prefix_occurrences:       int          = MIN_PREFIX_OCCURRENCES
 
 
 def _stringify_prompt(value: Any) -> str:
@@ -145,16 +140,10 @@ def _estimate_candidate_recoverable(
 @register("cache-recommend")
 def run(ctx: AnalyzerContext) -> None:
     """Registry entry point. Attaches a CacheRecommendFinding to ctx.report.findings."""
-    optimize_cfg = getattr(ctx.config, "optimize", None)
-    min_prefix_occurrences = getattr(
-        optimize_cfg, "min_prefix_occurrences", MIN_PREFIX_OCCURRENCES,
-    )
-
     capture = getattr(ctx.config, "capture", None)
     if capture is None or not getattr(capture, "prompts", False):
         ctx.report.findings["cache-recommend"] = CacheRecommendFinding(
             enabled=False,
-            min_prefix_occurrences=min_prefix_occurrences,
             hint=(
                 "Enable `[capture] prompts = true` in tj.toml and let the "
                 "daemon collect a window of data before re-running this "
@@ -216,7 +205,7 @@ def run(ctx: AnalyzerContext) -> None:
 
     candidates: list[CachePrefixCandidate] = []
     for h, entry in prefix_counts.items():
-        if entry["count"] < min_prefix_occurrences:
+        if entry["count"] < MIN_PREFIX_OCCURRENCES:
             continue
         avg_in = entry["tokens_sum"] / entry["count"] if entry["count"] else 0.0
         # Rough estimate of cacheable tokens per call. A 2000-char prefix
@@ -269,5 +258,4 @@ def run(ctx: AnalyzerContext) -> None:
         estimated_recoverable_usd=finding_usd,
         estimated_recoverable_tokens=finding_tokens,
         estimate_basis=basis,
-        min_prefix_occurrences=min_prefix_occurrences,
     )

--- a/tokenjam/core/optimize/analyzers/deadweight.py
+++ b/tokenjam/core/optimize/analyzers/deadweight.py
@@ -168,6 +168,26 @@ def enumerate_configured_servers(repo_cwds: set[str]) -> dict[str, ConfiguredSer
     return servers
 
 
+def server_still_configured(name: str, source: str) -> bool:
+    """Read-only re-check: does ``name`` still appear in the ``mcpServers``
+    block of its ORIGINAL detected config file (``source``)?
+
+    Used by ``cost_verify``'s deadweight branch after a mark-applied to tell
+    "still configured, nothing to measure yet" apart from "actually removed
+    or project-scoped, measure the token drop". A missing file and a
+    present-but-empty-of-this-entry file both read as "no longer
+    configured" — either way the tax stopped. Missing ``name``/``source``
+    can't be verified at all, so this conservatively reports "still
+    configured" rather than falsely claiming a removal.
+    """
+    if not name or not source:
+        return True
+    path = Path(source)
+    if not path.is_file():
+        return False
+    return name in _mcp_server_names(path)
+
+
 # --- Transcript scanning ---------------------------------------------------
 
 #: ``mcp__<server>__<tool>`` — server names may contain single underscores

--- a/tokenjam/core/optimize/analyzers/deadweight.py
+++ b/tokenjam/core/optimize/analyzers/deadweight.py
@@ -45,7 +45,6 @@ import json
 import re
 from dataclasses import dataclass, field
 from datetime import datetime, timezone
-from json.decoder import scanstring
 from pathlib import Path
 from typing import Any
 
@@ -57,24 +56,8 @@ from tokenjam.core.transcript import _SYSTEM_REMINDER_RE, read_records, resolve_
 
 #: A server must be configured-present in at least this many DISTINCT
 #: sessions, with zero invocations across all of them, before it's flagged
-#: dead weight. Originally 10 (spec: "start N=10"); lowered to 5 after an
-#: audit of all twelve analyzers found this the single biggest one-shot fix
-#: for analyzers that rarely fire on a normal user's window — a server
-#: configured-but-never-called is unlikely to be a fluke even at a much
-#: lower bar. False-positive shape (modeling each session as an independent
-#: Bernoulli trial with per-session use probability p): a server actually
-#: needed 1-in-4 sessions has a (1-p)^N ~= 42% chance of a spurious
-#: zero-invocation read at N=3, vs ~24% at N=5, vs ~6% at N=10 -- N=5 keeps
-#: that chance in the same order of magnitude as the old default while
-#: needing HALF the silent evidence to surface, materially increasing how
-#: often this analyzer fires. N=3 was considered and rejected: it nearly
-#: doubles the false-positive rate over N=5 for the same occasional-use
-#: server, and this finding is apply-capable (see the removal machinery
-#: below), so a wrongly-flagged server costs a real (user-approved, but
-#: still avoidable) config edit, not just a noisy card. The module's own
-#: DEADWEIGHT_HONESTY_CAVEAT and review-before-apply gate remain the
-#: backstop for whatever residual false-positive risk N=5 still carries.
-MIN_SESSIONS_DEADWEIGHT = 5
+#: dead weight (spec: "start N=10").
+MIN_SESSIONS_DEADWEIGHT = 10
 
 #: How many example session ids a dead server's card carries as evidence
 #: (mirrors relearn.py's MAX_EXAMPLE_SESSIONS convention).
@@ -185,234 +168,6 @@ def enumerate_configured_servers(repo_cwds: set[str]) -> dict[str, ConfiguredSer
     return servers
 
 
-def server_still_configured(name: str, source: str) -> bool:
-    """Read-only re-check: does ``name`` still appear in the ``mcpServers``
-    block of its ORIGINAL detected config file (``source``)?
-
-    Distinguishes "still configured" from "actually removed or
-    project-scoped". A missing file and a present-but-empty-of-this-entry
-    file both read as "no longer configured" — either way the tax stopped.
-    Missing ``name``/``source`` can't be verified at all, so this
-    conservatively reports "still configured" rather than falsely claiming a
-    removal.
-    """
-    if not name or not source:
-        return True
-    path = Path(source)
-    if not path.is_file():
-        return False
-    return name in _mcp_server_names(path)
-
-
-# --- Deterministic apply: remove one server's entry from its config file --
-#
-# A dead server's fix is machine-editable — ``ConfiguredServer`` already
-# resolved the exact config file, so there is no search step the way
-# ``model_apply.model_swap`` needs one. The removal is a TARGETED TEXT SPLICE,
-# never a ``json.loads`` -> mutate -> ``json.dumps`` round trip: re-serializing
-# the whole document would reformat every byte (key order, indentation,
-# spacing), turning a one-entry diff into a wholesale rewrite of the user's
-# config. The functions below locate the exact character span of one server's
-# entry inside its ``mcpServers`` block by walking the raw text — using
-# ``json.decoder.scanstring`` only to skip string literals correctly
-# (including escapes), never to reformat anything — and delete only that
-# span. Every other byte in the file is untouched.
-
-#: Apply-kind discriminator for this write, carried on the proposal and the
-#: ledger record (mirrors ``model_apply.APPLY_KIND_*``).
-APPLY_KIND_MCP_REMOVE = "mcp_remove"
-
-_WS_CHARS = " \t\r\n"
-
-
-def _skip_ws(text: str, i: int) -> int:
-    n = len(text)
-    while i < n and text[i] in _WS_CHARS:
-        i += 1
-    return i
-
-
-def _skip_json_value(text: str, i: int) -> int:
-    """Index just past the JSON value starting at ``text[i]`` (already past
-    leading whitespace). Handles strings, objects, arrays and bare scalars
-    (numbers / true / false / null) — enough to walk any value a ``.mcp.json``
-    /``settings.json`` server entry can hold, without needing to know its
-    shape ahead of time."""
-    ch = text[i]
-    if ch == '"':
-        _, end = scanstring(text, i + 1)
-        return end
-    if ch in "{[":
-        depth = 1
-        i += 1
-        n = len(text)
-        while depth > 0 and i < n:
-            c = text[i]
-            if c == '"':
-                _, i = scanstring(text, i + 1)
-                continue
-            if c in "{[":
-                depth += 1
-            elif c in "}]":
-                depth -= 1
-            i += 1
-        return i
-    j = i
-    n = len(text)
-    while j < n and text[j] not in ",}] \t\r\n":
-        j += 1
-    return j
-
-
-def _object_entries(text: str, obj_open: int) -> list[tuple[str, int, int, int]]:
-    """Every TOP-LEVEL entry of the object opening at ``text[obj_open] ==
-    '{'``, as ``(key, key_start, value_start, value_end)``. Nested keys (a
-    server's own ``env``/``args`` block, say) never surface here — depth
-    tracking inside ``_skip_json_value`` is what keeps this to one level."""
-    entries: list[tuple[str, int, int, int]] = []
-    i = _skip_ws(text, obj_open + 1)
-    while i < len(text) and text[i] != "}":
-        key_start = i
-        _key, i = scanstring(text, i + 1)
-        i = _skip_ws(text, i)
-        i += 1  # the colon
-        i = _skip_ws(text, i)
-        value_start = i
-        value_end = _skip_json_value(text, i)
-        entries.append((_key, key_start, value_start, value_end))
-        i = _skip_ws(text, value_end)
-        if i < len(text) and text[i] == ",":
-            i = _skip_ws(text, i + 1)
-    return entries
-
-
-def _mcp_servers_object_open(text: str) -> int | None:
-    """Index of the ``{`` opening the top-level ``mcpServers`` object, or
-    ``None`` when the document doesn't open with an object or carries no such
-    key — the caller falls back to a refusal rather than a guess."""
-    root_open = _skip_ws(text, 0)
-    if root_open >= len(text) or text[root_open] != "{":
-        return None
-    for key, _key_start, value_start, _value_end in _object_entries(text, root_open):
-        if key == "mcpServers" and value_start < len(text) and text[value_start] == "{":
-            return value_start
-    return None
-
-
-def _mcp_server_entry_span(text: str, server_name: str) -> tuple[int, int] | None:
-    """The ``(start, end)`` character span to delete from ``text`` to remove
-    ``server_name``'s entry from the ``mcpServers`` block, or ``None`` when it
-    can't be located this way (no ``mcpServers`` object, or no such key).
-
-    The span always reuses an ADJACENT separator rather than inventing new
-    whitespace: removing a first/middle entry keeps the punctuation that sat
-    between the PRECEDING entry and this one (which becomes the new
-    connector to whatever follows); removing the last (or only) entry instead
-    deletes the separator that sat between the entry before it and this one,
-    so no dangling trailing comma is left before the closing ``}``.
-    """
-    obj_open = _mcp_servers_object_open(text)
-    if obj_open is None:
-        return None
-    entries = _object_entries(text, obj_open)
-    idx = next((i for i, e in enumerate(entries) if e[0] == server_name), None)
-    if idx is None:
-        return None
-    _key, key_start, _value_start, value_end = entries[idx]
-    is_last = idx == len(entries) - 1
-    if is_last:
-        prev_end = entries[idx - 1][3] if idx > 0 else obj_open + 1
-        return prev_end, value_end
-    next_key_start = entries[idx + 1][1]
-    return key_start, next_key_start
-
-
-def render_mcp_remove(pre_image: str | None, server_name: str) -> tuple[str | None, str]:
-    """The config file's new content with ``server_name``'s entry removed
-    from its ``mcpServers`` block.
-
-    Returns ``(content, "")`` on success and ``(None, reason)`` when the
-    removal cannot be made deterministically: no file, invalid JSON, no
-    ``mcpServers`` block, or the server no longer named there (already
-    removed by hand, or by a concurrent edit).
-    """
-    if not server_name:
-        return None, "no server name given for the MCP removal."
-    if pre_image is None:
-        return None, "no config file at that path to edit."
-    try:
-        doc = json.loads(pre_image)
-    except ValueError as exc:
-        return None, f"that file is not valid JSON ({exc}) — refusing to edit it."
-    servers = doc.get("mcpServers") if isinstance(doc, dict) else None
-    if not isinstance(servers, dict) or server_name not in servers:
-        return None, f"`{server_name}` is not in that file's mcpServers block any more."
-    span = _mcp_server_entry_span(pre_image, server_name)
-    if span is None:
-        return None, (
-            f"could not locate `{server_name}`'s entry precisely in the file "
-            f"text — refusing a risky edit."
-        )
-    start, end = span
-    return pre_image[:start] + pre_image[end:], ""
-
-
-def mcp_remove_precheck(source_path: str, server_name: str) -> dict:
-    """Whether ``server_name``'s entry may be removed from ``source_path``,
-    re-checked at apply time — the repo can have moved, the file can have
-    gone missing, or a human can have already hand-removed the entry between
-    the moment the card was built and the moment it is approved.
-
-    Every precondition must hold; any failure returns ``{"ok": False,
-    "reason": ...}`` and the caller falls back to the one-paste ``claude mcp
-    remove`` command, saying why on the card.
-    """
-    if not source_path or not server_name:
-        return {"ok": False, "reason": (
-            "no source config path or server name given for this MCP removal."
-        )}
-    path = Path(source_path).expanduser()
-    if not path.is_file():
-        return {"ok": False, "reason": f"{path} no longer exists on disk — nothing to edit."}
-    try:
-        json.loads(path.read_text(encoding="utf-8"))
-    except (OSError, ValueError) as exc:
-        return {"ok": False, "reason": f"{path} is not valid JSON ({exc}) — refusing to edit it."}
-    if not server_still_configured(server_name, str(path)):
-        return {"ok": False, "reason": (
-            f"`{server_name}` is no longer in {path}'s mcpServers block — it may "
-            f"already have been removed by hand."
-        )}
-    return {"ok": True, "reason": "", "target_path": str(path)}
-
-
-def build_mcp_remove_plan(cluster: dict, target: Path, pre_image: str | None) -> str:
-    """New content for an ``mcp_remove`` apply: ``cluster``'s server entry
-    deleted from its ``mcpServers`` block, every other byte untouched.
-
-    Raises ``RelearnApplyRefused`` with the refusal reason, which the API
-    layer surfaces as a 409 and the card renders as the fallback explanation
-    — mirrors ``model_apply.build_model_plan``'s contract so the two slot
-    into the same ``relearn_apply._build_write_plan`` dispatch.
-    """
-    from tokenjam.core.optimize.relearn_apply import RelearnApplyRefused
-
-    server_name = str(cluster.get("agent_name") or "")
-    source_path = str(cluster.get("source_path") or "")
-    check = mcp_remove_precheck(source_path, server_name)
-    if not check["ok"]:
-        raise RelearnApplyRefused(check["reason"])
-    if Path(check["target_path"]) != target:
-        raise RelearnApplyRefused(
-            f"the MCP config now lives at {check['target_path']}, not {target}. "
-            f"Refusing to write the stale target."
-        )
-    content, reason = render_mcp_remove(pre_image, server_name)
-    if content is None:
-        raise RelearnApplyRefused(reason)
-    return content
-
-
 # --- Transcript scanning ---------------------------------------------------
 
 #: ``mcp__<server>__<tool>`` — server names may contain single underscores
@@ -486,18 +241,14 @@ class _SessionSignal:
     mcp_invocations: dict[str, int] = field(default_factory=dict)
     deferred_servers: set[str] = field(default_factory=set)
     reminder_chars_by_source: dict[str, int] = field(default_factory=dict)
-    #: assistant-turn model -> turn count, for pricing the token tax at a
-    #: representative model's input rate (see ``_dominant_model``).
-    models: dict[str, int] = field(default_factory=dict)
 
 
 def _analyze_session(records: list[dict[str, Any]]) -> _SessionSignal:
     """One pass over a session's raw records: MCP invocation counts, which
-    servers appeared in a deferred-tools listing, the C2 tax-table source
-    buckets (measured off the FIRST system-reminder blob only — Claude Code
-    injects it once at session start; later turns don't repeat it, so
-    summing across turns would overcount), and the assistant model(s) used
-    (for pricing the token tax)."""
+    servers appeared in a deferred-tools listing, and the C2 tax-table
+    source buckets (measured off the FIRST system-reminder blob only —
+    Claude Code injects it once at session start; later turns don't repeat
+    it, so summing across turns would overcount)."""
     signal = _SessionSignal()
     reminder_measured = False
 
@@ -525,11 +276,6 @@ def _analyze_session(records: list[dict[str, Any]]) -> _SessionSignal:
                     signal.reminder_chars_by_source = _split_reminder_sources(reminder_blobs[0])
                     reminder_measured = True
 
-        if role == "assistant":
-            model = message.get("model")
-            if isinstance(model, str) and model:
-                signal.models[model] = signal.models.get(model, 0) + 1
-
         for block in blocks:
             if isinstance(block, dict) and block.get("type") == "tool_use":
                 server = _mcp_server_from_tool_name(str(block.get("name") or ""))
@@ -539,56 +285,26 @@ def _analyze_session(records: list[dict[str, Any]]) -> _SessionSignal:
     return signal
 
 
-def _dominant_model(model_counts: dict[str, int]) -> str:
-    """The most-frequent assistant model across the counted turns, or "" when
-    none were observed. Ties broken by first-seen (dict insertion order)."""
-    if not model_counts:
-        return ""
-    return max(model_counts.items(), key=lambda kv: kv[1])[0]
-
-
-def _tax_construction_note(
-    non_deferred: int, deferred_sessions: int, sessions_present: int,
-    *, model: str = "", input_per_mtok: float | None = None,
-    usd_per_session: float | None = None,
-) -> str:
+def _tax_construction_note(non_deferred: int, deferred_sessions: int, sessions_present: int) -> str:
     if sessions_present == 0:
         return ""
     if deferred_sessions == 0:
-        note = (
+        return (
             f"{FULL_SCHEMA_TAX_TOKENS:,} tok/session (full schema injection), "
             f"cited estimate, not a live per-call measurement."
         )
-    elif non_deferred == 0:
-        note = (
+    if non_deferred == 0:
+        return (
             f"{DEFERRED_SCHEMA_TAX_TOKENS:,} tok/session; ToolSearch deferred "
             f"this server's schemas in every observed session (name and "
             f"description line only, never the full schema tax)."
         )
-    else:
-        note = (
-            f"{FULL_SCHEMA_TAX_TOKENS:,} tok/session when fully loaded "
-            f"({non_deferred} of {sessions_present} sessions) blended with "
-            f"{DEFERRED_SCHEMA_TAX_TOKENS:,} tok/session when ToolSearch defers "
-            f"this server's schemas ({deferred_sessions} of {sessions_present} "
-            f"sessions); never claims the full tax for a deferred session."
-        )
-    return note + " " + _pricing_note(model, input_per_mtok, usd_per_session)
-
-
-def _pricing_note(model: str, input_per_mtok: float | None, usd_per_session: float | None) -> str:
-    """The dollar-conversion clause appended to a server's construction
-    footnote. Never fabricates a rate: when no priced model was observed
-    across the server's sessions, states that plainly and stays tokens-only.
-    """
-    if not model or input_per_mtok is None or usd_per_session is None:
-        return (
-            "No dollar estimate: no priced model observed across these "
-            "sessions (core/pricing.py has no rate for it); tokens only."
-        )
     return (
-        f"Priced at {model}'s input rate (${input_per_mtok:.2f}/MTok via "
-        f"core/pricing.py) -> ${usd_per_session:,.4f}/session estimated."
+        f"{FULL_SCHEMA_TAX_TOKENS:,} tok/session when fully loaded "
+        f"({non_deferred} of {sessions_present} sessions) blended with "
+        f"{DEFERRED_SCHEMA_TAX_TOKENS:,} tok/session when ToolSearch defers "
+        f"this server's schemas ({deferred_sessions} of {sessions_present} "
+        f"sessions); never claims the full tax for a deferred session."
     )
 
 
@@ -609,12 +325,6 @@ class ServerDeadweight:
     tax_construction:                 str
     fix:                              str
     example_sessions:                 list[str] = field(default_factory=list)
-    #: Dollar conversion of the token tax, priced through core/pricing.py at
-    #: the dominant model observed across this server's present sessions.
-    #: ``None`` when no priced model was observed (never a fabricated rate).
-    priced_model:                     str = ""
-    estimated_tax_usd_per_session:    float | None = None
-    estimated_tax_usd_90d:            float | None = None
 
 
 @dataclass
@@ -636,7 +346,6 @@ class DeadweightFinding:
     dead_servers:                 list[ServerDeadweight] = field(default_factory=list)
     tax_table:                    list[ContextTaxRow] = field(default_factory=list)
     estimated_recoverable_tokens: int | None = None
-    estimated_recoverable_usd:    float | None = None
     estimate_basis:                str = ""
     estimate_confidence:            str = "estimated"
     caveat:                          str = DEADWEIGHT_HONESTY_CAVEAT
@@ -696,8 +405,6 @@ def compute_deadweight_finding(
     )
     projection_factor = 90.0 / days
 
-    from tokenjam.core.pricing import get_rates, provider_for_model
-
     tax_rows: list[ContextTaxRow] = []
     reminder_bucket_totals: dict[str, list[int]] = {}
 
@@ -706,7 +413,6 @@ def compute_deadweight_finding(
         invocations = 0
         deferred_sessions = 0
         example_sessions: list[str] = []
-        model_counts: dict[str, int] = {}
         for session_id, signal in per_session.items():
             deferred_here = server.name in signal.deferred_servers
             present = deferred_here or server.scope == "user" or (
@@ -720,8 +426,6 @@ def compute_deadweight_finding(
                 deferred_sessions += 1
             if len(example_sessions) < MAX_EXAMPLE_SESSIONS:
                 example_sessions.append(session_id)
-            for model, count in signal.models.items():
-                model_counts[model] = model_counts.get(model, 0) + count
 
         dead = sessions_present >= MIN_SESSIONS_DEADWEIGHT and invocations == 0
         non_deferred = max(sessions_present - deferred_sessions, 0)
@@ -734,23 +438,6 @@ def compute_deadweight_finding(
         )
         tax_90d = round(tax_per_session * sessions_present * projection_factor)
 
-        # Price the token tax through core/pricing.py at the dominant model
-        # observed across this server's present sessions -- never a
-        # hardcoded rate. usd stays None when no priced model was seen.
-        priced_model = _dominant_model(model_counts)
-        input_per_mtok: float | None = None
-        usd_per_session: float | None = None
-        usd_90d: float | None = None
-        if priced_model:
-            provider = provider_for_model(priced_model) or "unknown"
-            rates = get_rates(provider, priced_model)
-            if rates is not None and rates.input_per_mtok > 0:
-                input_per_mtok = rates.input_per_mtok
-                usd_per_session = round(tax_per_session / 1_000_000 * input_per_mtok, 6)
-                usd_90d = round(tax_90d / 1_000_000 * input_per_mtok, 6)
-            else:
-                priced_model = ""  # no rate available -- don't claim a model we can't price
-
         row = ServerDeadweight(
             name=server.name,
             scope=server.scope,
@@ -761,20 +448,13 @@ def compute_deadweight_finding(
             dead=dead,
             estimated_tax_tokens_per_session=tax_per_session,
             estimated_tax_tokens_90d=tax_90d,
-            tax_construction=_tax_construction_note(
-                non_deferred, deferred_sessions, sessions_present,
-                model=priced_model, input_per_mtok=input_per_mtok,
-                usd_per_session=usd_per_session,
-            ),
+            tax_construction=_tax_construction_note(non_deferred, deferred_sessions, sessions_present),
             fix=(
                 f"Remove or project-scope the `{server.name}` MCP server "
                 f"({server.source}); zero tool calls across {sessions_present} "
                 f"session(s) in this window."
             ),
             example_sessions=example_sessions,
-            priced_model=priced_model,
-            estimated_tax_usd_per_session=usd_per_session,
-            estimated_tax_usd_90d=usd_90d,
         )
         finding.servers.append(row)
         if sessions_present > 0:
@@ -828,32 +508,13 @@ def compute_deadweight_finding(
         finding.estimated_recoverable_tokens = sum(
             s.estimated_tax_tokens_90d for s in finding.dead_servers
         )
-        priced = [
-            s.estimated_tax_usd_90d for s in finding.dead_servers
-            if s.estimated_tax_usd_90d is not None
-        ]
-        basis = (
+        finding.estimate_basis = (
             f"sum of each dead server's projected 90-day schema-injection tax "
             f"({FULL_SCHEMA_TAX_TOKENS:,} tok/session full, "
             f"{DEFERRED_SCHEMA_TAX_TOKENS:,} tok/session when deferred); the "
             f"tax table's own MCP-schema rows are informational only and "
             f"never double-count into this total."
         )
-        if priced:
-            finding.estimated_recoverable_usd = round(sum(priced), 6)
-            basis += (
-                " Dollar figure priced per server through core/pricing.py "
-                "at the dominant model observed in that server's sessions "
-                "(never a hardcoded rate)."
-            )
-            if len(priced) < len(finding.dead_servers):
-                basis += (
-                    f" {len(finding.dead_servers) - len(priced)} of "
-                    f"{len(finding.dead_servers)} dead server(s) had no "
-                    f"priced model observed and are excluded from the "
-                    f"dollar sum (token figure still includes them)."
-                )
-        finding.estimate_basis = basis
     elif configured:
         finding.notes.append(
             f"No configured MCP server cleared the dead-weight bar "

--- a/tokenjam/core/optimize/analyzers/subagent_rightsizing.py
+++ b/tokenjam/core/optimize/analyzers/subagent_rightsizing.py
@@ -68,7 +68,7 @@ SUBAGENT_HONESTY_CAVEAT = (
 # reduction we can't size honestly, so it never inflates this number.
 SUBAGENT_ESTIMATE_BASIS = (
     "over_powered subagents priced at their cheaper same-family model over the "
-    "same tokens — a model-swap delta, structural fit only, no quality "
+    "same tokens: a model-swap delta, structural fit only, no quality "
     "validation; review before re-dispatching. over_provisioned spend is "
     "flagged but not counted here (its recoverable prompt-size cut isn't "
     "quantifiable). No guaranteed saving."

--- a/tokenjam/core/optimize/analyzers/workflow_restructure.py
+++ b/tokenjam/core/optimize/analyzers/workflow_restructure.py
@@ -99,6 +99,16 @@ class WorkflowCluster:
     # server-side (single compute path). Defaulted so older serialized reports
     # round-trip through WorkflowCluster(**c).
     avg_tokens:    int = 0
+    # Cluster-level totals (sum across every member session, not the per-
+    # instance mean above) — the denominator a cost-proposal adapter needs to
+    # price ONE cluster's recoverable amount without re-deriving it from
+    # avg_cost_usd * instances. Defaulted for the same round-trip reason.
+    total_cost_usd: float = 0.0
+    total_tokens:    int   = 0
+    # Up to 3 example session ids for this cluster (beyond the single
+    # `example_session_id` above), so a downstream apply artifact (a rung-2
+    # skill note) can cite more than one instance. Defaulted for round-trip.
+    example_session_ids: list[str] = field(default_factory=list)
 
 
 @dataclass
@@ -231,6 +241,9 @@ def run(ctx: AnalyzerContext) -> None:
             avg_duration_seconds=round(avg_duration, 2) if avg_duration > 0 else None,
             example_session_id=members[0],
             avg_tokens=avg_tokens,
+            total_cost_usd=round(cluster_cost, 6),
+            total_tokens=cluster_tokens,
+            example_session_ids=list(members[:3]),
         ))
 
     # Sort by instance count desc — the most common deterministic patterns

--- a/tokenjam/core/optimize/cost_apply.py
+++ b/tokenjam/core/optimize/cost_apply.py
@@ -2,19 +2,19 @@
 
 A cost proposal is advise-only (see ``cost_proposals``): its fix lives in the
 user's own application code, which tokenjam has no workspace to write into. So
-unlike ``relearn_apply`` there is NO file write, no rung routing, no git commit
+unlike ``pothole_apply`` there is NO file write, no rung routing, no git commit
 here. "Apply" means exactly one thing: the user tells tokenjam "I made this
 change" so the loop can start measuring whether it moved the cost needle.
 
 That "I changed something at time T, watch whether it holds" is the loop
 primitive ``core.loop.Expectation`` already models (the same one the OTel
-relearn lane keys on — ``relearn_otel_verify``). Marking a cost proposal
+pothole lane keys on — ``pothole_otel_verify``). Marking a cost proposal
 applied therefore:
 
   1. creates an ``Expectation`` whose ``created_at`` is the "applied at T"
      marker and whose ``agent_id`` scopes the later measurement, and
   2. appends a record to a small ``cost_applied.json`` ledger (mirroring
-     ``relearn_apply``'s ``applied_fixes.json``) carrying the proposal snapshot
+     ``pothole_apply``'s ``applied_fixes.json``) carrying the proposal snapshot
      + the ``target_key`` the delta-verify pass re-measures against.
 
 The realized dollar delta lands back in that record's ``verify`` sub-dict (see
@@ -29,17 +29,17 @@ from dataclasses import asdict, dataclass, field
 from pathlib import Path
 from typing import Any
 
-from tokenjam.core.optimize.relearn_apply import _storage_base_dir
+from tokenjam.core.optimize.pothole_apply import _storage_base_dir
 
 
 class CostApplyRefused(Exception):
     """Raised when a mark-applied request can't be honored (bad payload, no DB).
-    The API layer translates this to a 409, mirroring RelearnApplyRefused."""
+    The API layer translates this to a 409, mirroring PotholeApplyRefused."""
 
 
 def cost_applied_path(config: Any) -> Path:
     """``<storage-parent>/cost_applied.json`` — honors --config / storage.path
-    exactly like ``relearn_apply.applied_fixes_path`` (never the real ~/.tj for
+    exactly like ``pothole_apply.applied_fixes_path`` (never the real ~/.tj for
     a :memory: / "" storage.path)."""
     return _storage_base_dir(config) / "cost_applied.json"
 
@@ -124,8 +124,8 @@ def mark_applied(
     """Record that the user applied a cost proposal.
 
     ``proposal`` is the CostProposal dict the client already holds from
-    ``GET /relearn/cost-proposals`` (re-posted, never re-looked-up server-side,
-    so a stale cache can't mark a DIFFERENT proposal — same guard the relearn
+    ``GET /pothole/cost-proposals`` (re-posted, never re-looked-up server-side,
+    so a stale cache can't mark a DIFFERENT proposal — same guard the pothole
     apply path uses). Creates the Expectation marker + appends the ledger
     record. Idempotent per signature: an existing non-reverted record for the
     same signature is returned unchanged rather than duplicated.

--- a/tokenjam/core/optimize/cost_proposals.py
+++ b/tokenjam/core/optimize/cost_proposals.py
@@ -30,7 +30,7 @@ proposals. It never touches the DB, the store, or the network.
 """
 from __future__ import annotations
 
-from dataclasses import dataclass
+from dataclasses import asdict, dataclass, is_dataclass
 from typing import Any
 
 # House-style label strings. Kept verbatim on every cost proposal so no channel
@@ -474,3 +474,93 @@ def cost_proposals_from_report(report: Any) -> list[CostProposal]:
         except Exception:
             continue
     return proposals
+
+
+# --------------------------------------------------------------------------- #
+# Component E — the Review inbox's single "estimated recoverable" headline.
+# Pure arithmetic over whatever proposals the caller hands it (the API route
+# is what narrows that set to "open" — not yet applied — before calling
+# this); kept separate so the sum/dedup logic is unit-testable on its own and
+# never entangled with the applied-ledger lookup.
+# --------------------------------------------------------------------------- #
+
+def estimated_recoverable_rollup(
+    proposals: list[Any],
+    *,
+    window_days: int = DEFAULT_COST_WINDOW_DAYS,
+) -> dict[str, Any]:
+    """Sum ``estimated_recoverable_usd`` across ``proposals``, deduplicated by
+    ``signature`` (a proposal's stable identity — see the ``CostProposal``
+    docstring) so a stale or duplicate cache entry is never double-counted.
+
+    Generic over ``analyzer``: reads only the shared ``CostProposal`` fields,
+    so a new analyzer's cards are picked up automatically with no changes
+    here (§3's dedup rule already lives one layer down, in each analyzer's
+    adapter — one underlying waste source becomes one card before it ever
+    reaches this function).
+
+    Only a proposal carrying a numeric estimate contributes to the sum AND to
+    ``proposal_count`` — a card with no estimate yet still renders
+    individually in the inbox, it just isn't folded into this aggregate
+    (counting it in "N proposals" without a dollar contribution would
+    silently understate the average the headline implies).
+
+    Tagged ``estimated`` — see ``receipts.verified_saved_summary`` for the
+    measured twin (Component G1). The two figures are NEVER added together;
+    every caller must keep them as two clearly labeled numbers.
+    """
+    seen: dict[str, dict[str, Any]] = {}
+    for p in proposals:
+        row = asdict(p) if is_dataclass(p) else dict(p)
+        sig = str(row.get("signature") or "")
+        if not sig or sig in seen:
+            continue  # empty/duplicate signature never counts twice
+        seen[sig] = row
+
+    contributing: list[dict[str, Any]] = []
+    by_analyzer: dict[str, dict[str, Any]] = {}
+    total_usd = 0.0
+    for row in seen.values():
+        usd = row.get("estimated_recoverable_usd")
+        if usd is None:
+            continue
+        usd = float(usd)
+        total_usd += usd
+        analyzer = str(row.get("analyzer") or "unknown")
+        entry = by_analyzer.setdefault(analyzer, {"analyzer": analyzer, "count": 0, "usd": 0.0})
+        entry["count"] += 1
+        entry["usd"] = round(entry["usd"] + usd, 6)
+        contributing.append({
+            "signature": row.get("signature"), "analyzer": analyzer,
+            "title": row.get("title"), "usd": round(usd, 6),
+        })
+
+    proposal_count = len(contributing)
+    if proposal_count == 0:
+        basis = (
+            "no open (not yet applied) cost proposal currently carries a "
+            "dollar estimate. Estimated, correlational; never mixed with "
+            "the measured verified-saved figure."
+        )
+    else:
+        breakdown = "; ".join(
+            f"{a['analyzer']} ({a['count']})"
+            for a in sorted(by_analyzer.values(), key=lambda x: x["analyzer"])
+        )
+        basis = (
+            f"sum of estimated_recoverable_usd across {proposal_count} open "
+            f"(not yet applied), deduplicated-by-signature cost proposal(s) "
+            f"over the last {window_days}d; contributing analyzers: {breakdown}. "
+            "Estimated, correlational; never mixed with the measured "
+            "verified-saved figure."
+        )
+
+    return {
+        "estimated_recoverable_usd": round(total_usd, 6),
+        "proposal_count": proposal_count,
+        "window_days": window_days,
+        "by_analyzer": sorted(by_analyzer.values(), key=lambda x: x["analyzer"]),
+        "contributing": contributing,
+        "estimate_confidence": COST_ESTIMATE_CONFIDENCE,
+        "estimate_basis": basis,
+    }

--- a/tokenjam/core/optimize/cost_proposals.py
+++ b/tokenjam/core/optimize/cost_proposals.py
@@ -1,15 +1,15 @@
-"""Adapt cost-analyzer findings into Review-inbox proposals ("advisories with
-receipts").
+"""Adapt cost-analyzer findings into Review-inbox proposals ("advisories").
 
 The self-improve loop's relearn detector already produces
 ``RelearnCluster`` proposals that the Lens Improve inbox renders and that a
-user can mark, apply, and verify. The *cost* analyzers (``downsize`` model
-over-sizing, ``cache`` efficacy, ``trim`` prompt bloat, ``subagent``
-right-sizing, ``deadweight`` dead MCP servers, ``script`` deterministic
-workflows, ``reuse`` repeated planning skeletons, ``verbosity`` high-output
-outliers) produce findings of a different shape. This module adapts each
-finding into a ``CostProposal`` so the inbox can list them BESIDE the relearn
-proposals, typed by a distinct ``kind`` field.
+user can mark and apply. The *cost* analyzers (``downsize`` model
+over-sizing, ``cache`` efficacy, ``cache-recommend`` breakpoint placement,
+``trim`` prompt bloat, ``subagent`` right-sizing, ``deadweight`` dead MCP
+servers, ``script`` deterministic workflows, ``reuse`` repeated planning
+skeletons, ``verbosity`` high-output outliers) produce findings of a
+different shape. This module adapts each finding into a ``CostProposal`` so
+the inbox can list them BESIDE the relearn proposals, typed by a distinct
+``kind`` field.
 
 Two structural facts carry over from the relearn ``advise_only`` lane and are
 NOT optional here:
@@ -27,12 +27,10 @@ NOT optional here:
     (``apply_capable=True``, ``rung``, ``scope``, ``proposed_fix``). Every
     other card carries a recommendation and, where sensible, a copyable
     config/code suggestion; the user applies it themselves.
-  * **Estimated / correlational, never causal.** Every saving figure a cost
-    finding carries is a heuristic ESTIMATE (house style, CLAUDE.md Rule 14).
-    The adapter preserves the finding's own ``estimate_basis`` and labels the
-    figure ``estimated``; the later realized delta (see ``cost_verify``) is
-    correlational with the user's change, never proof tokenjam's advice caused
-    it.
+  * **Estimated, never causal.** Every saving figure a cost finding carries is
+    a heuristic ESTIMATE (house style, CLAUDE.md Rule 14). The adapter
+    preserves the finding's own ``estimate_basis`` and labels the figure
+    ``estimated`` — never proof tokenjam's advice caused a savings change.
 
 The adapter is pure: it reads an already-built ``OptimizeReport`` and returns
 proposals. It never touches the DB, the store, or the network.
@@ -55,10 +53,14 @@ COST_CORRELATIONAL_CAVEAT = (
     "before changing anything."
 )
 
-#: The analyzers this wiring covers, by registration name.
+#: The analyzers this wiring covers, by registration name. ``cache-recommend``
+#: requires ``[capture] prompts = true``; when that's off the analyzer itself
+#: returns an ``enabled=False`` finding with no candidates (same shape as
+#: ``trim``'s own disabled-state guard), so including it here unconditionally
+#: costs nothing when capture is off.
 COST_ANALYZERS = (
-    "downsize", "cache", "trim", "subagent", "deadweight", "script", "reuse",
-    "verbosity",
+    "downsize", "cache", "cache-recommend", "trim", "subagent", "deadweight",
+    "script", "reuse", "verbosity",
 )
 
 # The rung-1/rung-2 apply notes below all route through the SAME workspace-note
@@ -106,17 +108,15 @@ class CostProposal:
     """One cost analyzer's finding, shaped for the Review inbox.
 
     Mirrors the fields the inbox already reads off a ``RelearnCluster`` (title,
-    evidence, an estimate with its basis, ``advise_only``) plus the cost-
-    specific ``target_key`` the delta-verify pass re-measures against.
+    evidence, an estimate with its basis, ``advise_only``) plus a cost-specific
+    ``target_key``.
     """
     kind:      str                     # always "cost" — the inbox discriminator
     analyzer:  str                     # "downsize" | "cache" | "trim" | "subagent"
-    signature: str                     # stable identity for dedup + verify keying
+    signature: str                     # stable identity for dedup
     title:     str
-    # WHICH thing is flagged, machine-readable — the key ``cost_verify`` uses to
-    # re-measure a delta over spans after the user marks the proposal applied
-    # (downsize: the oversized model(s); cache: a provider/model; trim: an
-    # agent/step).
+    # WHICH thing is flagged, machine-readable (downsize: the oversized
+    # model(s); cache: a provider/model; trim: an agent/step).
     target_key: dict[str, Any]
     # Human-readable evidence line: which model/step/cache + the measured
     # baseline number.
@@ -508,13 +508,63 @@ def _placement_to_proposals(
     )]
 
 
-def _cache_to_proposals(finding: Any) -> list[CostProposal]:
+# --------------------------------------------------------------------------- #
+# Persona-gated fix TEXT — the `cache` family (`cache` / `cache_thrash` /
+# `cache-recommend`) only. Unrelated to `_persona_gated_write_fields` below:
+# that helper picks between a workspace WRITE and a snippet fallback for
+# script/reuse/verbosity. No cache proposal has a write to offer in the
+# first place — every cache fix is an edit to a `cache_control` (or TTL)
+# field on the raw Anthropic API request, code a Claude Code session never
+# constructs itself (the harness builds that request on the user's behalf).
+# There's no workspace surface to fall back to for that persona; the
+# instruction itself is the thing they can't act on, so the only honest
+# move is to say why instead of stating it as their fix (CLAUDE.md
+# anti-pattern #22 — never hand out an instruction the reader can't
+# follow). The measured finding underneath (efficacy percentage, token
+# counts, evidence) is unaffected — it's true and useful regardless of who
+# can act on the fix, so only `advise_text`/`suggestion` are ever gated,
+# never `evidence`/`baseline`/the estimate fields.
+#
+# "unknown" stays on the actionable branch (unlike
+# `_persona_gated_write_fields`, which groups "unknown" with "sdk" to keep a
+# WRITE off by default): here the safe default is the opposite direction,
+# since withholding is the risky move (a real fix denied) rather than
+# over-offering one (an unusable write silently succeeding). "mixed" keeps
+# the instruction too — the sdk share of a mixed window can act on it, and
+# suppressing it would cost that share a real fix for no benefit to the
+# claude-code share.
+# --------------------------------------------------------------------------- #
+
+CACHE_NO_LEVER_TEXT = (
+    "Prompt caching is controlled by cache_control fields on the raw "
+    "Anthropic API request. A Claude Code session doesn't construct that "
+    "request itself; the harness does. There's no code here for you to "
+    "edit, so no fix is shown for it."
+)
+
+
+def _persona_gated_cache_fields(
+    persona: str, advise_text: str, suggestion: str = "",
+) -> dict[str, Any]:
+    """Decide, from the window's dominant persona, whether the cache_control
+    instruction (and any snippet) is shown at all. See the module-section
+    comment above for the reasoning."""
+    if persona == "claude-code":
+        return {"advise_text": CACHE_NO_LEVER_TEXT, "suggestion": ""}
+    return {"advise_text": advise_text, "suggestion": suggestion}
+
+
+def _cache_to_proposals(finding: Any, persona: str = "unknown") -> list[CostProposal]:
     """One proposal per flagged (provider, model) cache-efficacy row.
 
     Reduced by whatever the more specific per-agent root-cause cards (A1/A2/
     A3) already claim for that same (provider, model) — see
     ``_per_agent_cache_recoverable_by_model`` — so the rollup never sums the
     same underlying waste twice under two different signatures.
+
+    The instruction is gated by ``persona`` — see
+    ``_persona_gated_cache_fields``; a ``"claude-code"`` window gets the
+    honest no-lever reason instead of a cache_control edit it can't make.
     """
     if finding is None:
         return []
@@ -558,24 +608,28 @@ def _cache_to_proposals(finding: Any) -> list[CostProposal]:
                 "efficacy": float(row.efficacy),
                 "efficacy_ceiling": float(getattr(finding, "efficacy_ceiling", 0.80)),
             },
-            advise_text=(
-                "Add a stable cache prefix / enable prompt caching for this model "
-                "so repeated context is served from cache instead of re-billed as "
-                "fresh input."
-            ),
             estimated_recoverable_usd=usd,
             estimated_recoverable_tokens=tokens,
             estimate_basis=basis,
+            **_persona_gated_cache_fields(
+                persona,
+                "Add a stable cache prefix / enable prompt caching for this model "
+                "so repeated context is served from cache instead of re-billed as "
+                "fresh input.",
+            ),
         ))
     return proposals
 
 
-def _cache_uncached_to_proposals(finding: Any) -> list[CostProposal]:
+def _cache_uncached_to_proposals(finding: Any, persona: str = "unknown") -> list[CostProposal]:
     """One proposal per A1 uncached-agent candidate (see
     ``analyzers.cache_efficacy``): an agent group making cacheable calls with
-    prompt caching never attempted. Verified through the same efficacy metric
-    as ``_cache_to_proposals`` (agent-scoped), so no ``cost_verify`` change
-    is needed for this check."""
+    prompt caching never attempted. Scored through the same efficacy metric
+    as ``_cache_to_proposals`` (agent-scoped).
+
+    Persona-gated the same way as ``_cache_to_proposals`` — see
+    ``_persona_gated_cache_fields``.
+    """
     if finding is None:
         return []
     proposals: list[CostProposal] = []
@@ -598,24 +652,32 @@ def _cache_uncached_to_proposals(finding: Any) -> list[CostProposal]:
                 "calls": c.calls, "sessions": c.sessions,
                 "assumed_prefix_tokens": c.assumed_prefix_tokens,
             },
-            advise_text=(
-                "Add a cache_control breakpoint on this agent's stable prefix "
-                "(system prompt / tool definitions) so repeated calls read "
-                "from cache instead of paying full input price every time."
-            ),
-            suggestion=c.cache_control_snippet,
             estimated_recoverable_usd=c.estimated_recoverable_usd,
             estimated_recoverable_tokens=c.estimated_recoverable_tokens,
             estimate_basis=c.estimate_basis,
             agent_id=c.agent_id,
+            **_persona_gated_cache_fields(
+                persona,
+                "Add a cache_control breakpoint on this agent's stable prefix "
+                "(system prompt / tool definitions) so repeated calls read "
+                "from cache instead of paying full input price every time.",
+                c.cache_control_snippet,
+            ),
         ))
     return proposals
 
 
-def _cache_thrash_to_proposals(finding: Any) -> list[CostProposal]:
+def _cache_thrash_to_proposals(finding: Any, persona: str = "unknown") -> list[CostProposal]:
     """One proposal per A2 cache-thrash candidate. Card text branches on the
     detected root cause: a TTL-cadence card (honest break-even, which may say
-    the switch isn't worth it) versus an instability checklist card."""
+    the switch isn't worth it) versus an instability checklist card.
+
+    Persona-gated the same way as ``_cache_to_proposals`` — see
+    ``_persona_gated_cache_fields``. The instability checklist is written for
+    someone reading their own prompt-assembly code, so it's gated exactly
+    like the TTL branch's cache_control edit — neither is something a Claude
+    Code session can act on.
+    """
     if finding is None:
         return []
     from tokenjam.core.optimize.analyzers.cache_efficacy import (
@@ -668,20 +730,23 @@ def _cache_thrash_to_proposals(finding: Any) -> list[CostProposal]:
                 "ttl_worth_it": c.ttl_worth_it,
                 "ttl_breakeven_usd": c.ttl_breakeven_usd,
             },
-            advise_text=advise,
-            suggestion=c.cache_control_snippet,
             estimated_recoverable_usd=c.estimated_recoverable_usd,
             estimated_recoverable_tokens=c.estimated_recoverable_tokens,
             estimate_basis=c.estimate_basis,
             agent_id=c.agent_id,
+            **_persona_gated_cache_fields(persona, advise, c.cache_control_snippet),
         ))
     return proposals
 
 
-def _cache_lookback_to_proposals(finding: Any) -> list[CostProposal]:
+def _cache_lookback_to_proposals(finding: Any, persona: str = "unknown") -> list[CostProposal]:
     """One proposal per A3 20-block-lookback-miss candidate. Weakest-
     confidence check of the three; the analyzer only classifies an agent here
-    when A1/A2 don't already explain its cache waste."""
+    when A1/A2 don't already explain its cache waste.
+
+    Persona-gated the same way as ``_cache_to_proposals`` — see
+    ``_persona_gated_cache_fields``.
+    """
     if finding is None:
         return []
     from tokenjam.core.optimize.analyzers.cache_efficacy import LOOKBACK_BLOCK_LIMIT
@@ -706,18 +771,104 @@ def _cache_lookback_to_proposals(finding: Any) -> list[CostProposal]:
                 "miss_count": c.miss_count,
                 "avg_prior_turn_blocks": c.avg_prior_turn_blocks,
             },
-            advise_text=(
-                "Anthropic's cache breakpoint search looks back at most "
-                f"{LOOKBACK_BLOCK_LIMIT} content blocks. Long tool-heavy "
-                "turns push the prior breakpoint out of range; add an "
-                "intermediate cache_control breakpoint every ~15 blocks in "
-                "long tool-use turns."
-            ),
-            suggestion=c.cache_control_snippet,
             estimated_recoverable_usd=c.estimated_recoverable_usd,
             estimated_recoverable_tokens=c.estimated_recoverable_tokens,
             estimate_basis=c.estimate_basis,
             agent_id=c.agent_id,
+            **_persona_gated_cache_fields(
+                persona,
+                "Anthropic's cache breakpoint search looks back at most "
+                f"{LOOKBACK_BLOCK_LIMIT} content blocks. Long tool-heavy "
+                "turns push the prior breakpoint out of range; add an "
+                "intermediate cache_control breakpoint every ~15 blocks in "
+                "long tool-use turns.",
+                c.cache_control_snippet,
+            ),
+        ))
+    return proposals
+
+
+def _cache_recommend_to_proposals(
+    finding: Any, cache_finding: Any = None, persona: str = "unknown",
+) -> list[CostProposal]:
+    """One proposal per Anthropic prefix candidate ``cache-recommend`` flags —
+    a placement recommendation for a `cache_control` breakpoint, carrying a
+    ready-to-paste snippet (``CachePrefixCandidate.cache_control_snippet``,
+    built in the analyzer, modelled on ``cache_efficacy``'s own snippet
+    builders).
+
+    Same class of finding as ``_cache_to_proposals``'s A1/A2/A3 root causes —
+    an edit to a raw Anthropic API request a Claude Code session never
+    constructs itself — so it's gated by the same rule; see
+    ``_persona_gated_cache_fields``.
+
+    Reduced by whatever ``cache``'s own per-agent root-cause cards (A1/A2/A3)
+    already claim for the same model — the same dedup rule ``_cache_to_
+    proposals`` applies against its own generic row, via the same
+    ``_per_agent_cache_recoverable_by_model`` helper — so a prefix already
+    counted as an uncached-agent / thrash / lookback-miss recovery doesn't
+    also get counted here under a third signature. ``cache_finding`` is
+    optional (the two analyzers are wired independently and either can be
+    absent from a report); with none supplied, nothing is subtracted.
+    """
+    if finding is None or not getattr(finding, "enabled", False):
+        return []
+    candidates = list(getattr(finding, "candidates", []) or [])
+    if not candidates:
+        return []
+
+    already_claimed = (
+        _per_agent_cache_recoverable_by_model(cache_finding)
+        if cache_finding is not None else {}
+    )
+
+    proposals: list[CostProposal] = []
+    for c in candidates:
+        usd = c.estimated_recoverable_usd
+        tokens = c.estimated_recoverable_tokens
+        basis = str(getattr(finding, "estimate_basis", "") or "")
+        claimed_usd, claimed_tokens = already_claimed.get(("anthropic", c.model), (0.0, 0))
+        if claimed_usd > 0 or claimed_tokens > 0:
+            usd = round(max(0.0, (usd or 0.0) - claimed_usd), 6)
+            tokens = max(0, (tokens or 0) - claimed_tokens)
+            basis = (
+                basis + (" " if basis else "")
+                + f"Reduced by ${claimed_usd:.4f} already attributed to "
+                "per-agent cache proposals for this model, so the rollup "
+                "does not double-count the same spend."
+            )
+        preview = c.sample_chars[:60].replace("\n", " ").strip()
+        evidence = (
+            f'A stable prompt prefix (starting "{preview}...") recurred '
+            f"across {c.occurrences} calls on {c.model or 'an unrecorded model'}, "
+            f"averaging {c.avg_input_tokens:,.0f} input tokens per call; "
+            f"~{c.estimated_cacheable_tokens:,} tokens of that prefix estimated "
+            "cacheable."
+        )
+        proposals.append(CostProposal(
+            kind="cost",
+            analyzer="cache-recommend",
+            signature=f"cost:cache-recommend:{c.prefix_hash}",
+            title=f"Repeated prompt prefix on {c.model or 'unrecorded model'}",
+            target_key={"prefix_hash": c.prefix_hash, "model": c.model},
+            evidence=evidence,
+            baseline={
+                "prefix_hash": c.prefix_hash,
+                "model": c.model,
+                "occurrences": c.occurrences,
+                "avg_input_tokens": c.avg_input_tokens,
+                "estimated_cacheable_tokens": c.estimated_cacheable_tokens,
+            },
+            estimated_recoverable_usd=usd,
+            estimated_recoverable_tokens=tokens,
+            estimate_basis=basis,
+            **_persona_gated_cache_fields(
+                persona,
+                "Add a cache_control breakpoint right after this prefix so "
+                f"repeat calls on {c.model or 'this model'} read it from cache "
+                "instead of paying full input price again.",
+                c.cache_control_snippet,
+            ),
         ))
     return proposals
 
@@ -986,6 +1137,32 @@ def _subagent_to_proposals(finding: Any, config: Any = None) -> list[CostProposa
     )]
 
 
+def _mcp_remove_plumbing(server: Any) -> dict[str, Any]:
+    """Whether ``server``'s config entry can be removed directly, and where.
+
+    Unlike ``model_swap`` there is no search step: ``ConfiguredServer``
+    already resolved the exact config file at detection time. This just
+    re-verifies that still holds (the file can have moved, or a human can
+    have already removed the entry by hand) at proposal-build time, so the
+    card's pre-filled target is current, not stale analyzer-time data.
+    """
+    from tokenjam.core.optimize.analyzers.deadweight import (
+        APPLY_KIND_MCP_REMOVE,
+        mcp_remove_precheck,
+    )
+
+    check = mcp_remove_precheck(server.source, server.name)
+    if not check["ok"]:
+        return {"apply_capable": False, "apply_blocked_reason": check["reason"]}
+    return {
+        "apply_capable": True,
+        "apply_kind": APPLY_KIND_MCP_REMOVE,
+        "source_path": check["target_path"],
+        "target_path": check["target_path"],
+        "apply_blocked_reason": "",
+    }
+
+
 def _deadweight_to_proposals(finding: Any) -> list[CostProposal]:
     """One proposal per dead-weight MCP server (Component C1).
 
@@ -1002,6 +1179,15 @@ def _deadweight_to_proposals(finding: Any) -> list[CostProposal]:
     in that server's sessions (never a hardcoded rate; see
     ``deadweight._pricing_note``). Stays ``None`` when no priced model was
     observed for that server — this adapter never invents a rate itself.
+
+    Apply-capable, like ``downsize``'s ``model_swap`` cards: the fix is a
+    deterministic edit of a value already written down (the server's own
+    ``mcpServers`` entry), so it routes through the same
+    ``relearn_apply.apply_relearn_fix`` machinery under
+    ``APPLY_KIND_MCP_REMOVE`` — reversible, git-committed where the config
+    lives in a repo, one-step revert. Falls back to the one-paste ``claude
+    mcp remove`` command, with the reason stated, when the precondition
+    doesn't hold (file missing, malformed, or the entry already gone).
     """
     if finding is None:
         return []
@@ -1018,6 +1204,20 @@ def _deadweight_to_proposals(finding: Any) -> list[CostProposal]:
                 f"of those session(s)."
             )
         scope_flag = "user" if server.scope == "user" else "project"
+        plumbing = _mcp_remove_plumbing(server)
+        advise = (
+            server.fix + " Removing (or project-scoping) it is reversible "
+            "and loses no data; it only stops the standing schema-injection "
+            "tax on future sessions."
+        )
+        if plumbing.get("apply_capable"):
+            advise += (
+                f" tokenjam can remove this exact entry from "
+                f"{plumbing['target_path']}, with the change committed and "
+                f"revertable in one call."
+            )
+        elif plumbing.get("apply_blocked_reason"):
+            advise += f" Applying it here is not on offer: {plumbing['apply_blocked_reason']}"
         proposals.append(CostProposal(
             kind="cost",
             analyzer="deadweight",
@@ -1036,11 +1236,7 @@ def _deadweight_to_proposals(finding: Any) -> list[CostProposal]:
                 "example_sessions": list(server.example_sessions),
                 "priced_model": server.priced_model,
             },
-            advise_text=(
-                server.fix + " Removing (or project-scoping) it is reversible "
-                "and loses no data; it only stops the standing schema-injection "
-                "tax on future sessions."
-            ),
+            advise_text=advise,
             suggestion=f"claude mcp remove {server.name} --scope {scope_flag}",
             estimated_recoverable_tokens=server.estimated_tax_tokens_90d or None,
             estimated_recoverable_usd=server.estimated_tax_usd_90d,
@@ -1048,6 +1244,14 @@ def _deadweight_to_proposals(finding: Any) -> list[CostProposal]:
                 server.tax_construction
                 + " Projected over a 90-day window from the sessions observed."
             ),
+            advise_only=not plumbing.get("apply_capable", False),
+            apply_capable=bool(plumbing.get("apply_capable")),
+            apply_kind=str(plumbing.get("apply_kind", "")),
+            agent_name=server.name,
+            source_path=str(plumbing.get("source_path", "")),
+            target_path=str(plumbing.get("target_path", "")),
+            scope=server.scope,
+            apply_blocked_reason=str(plumbing.get("apply_blocked_reason", "")),
         ))
     return proposals
 
@@ -1380,11 +1584,11 @@ def cost_proposals_from_report(
     """Every cost proposal derivable from an already-built ``OptimizeReport``.
 
     Reads the ``downsize`` finding off the typed ``report.downgrade`` slot and
-    the ``cache`` / ``trim`` / ``subagent`` / ``placement`` / ``deadweight`` /
-    ``script`` / ``reuse`` / ``verbosity`` findings off ``report.findings``.
-    Missing findings (analyzer not run, no candidates) contribute nothing.
-    Never raises — a malformed finding is skipped so one bad analyzer can't
-    sink the inbox.
+    the ``cache`` / ``cache-recommend`` / ``trim`` / ``subagent`` /
+    ``placement`` / ``deadweight`` / ``script`` / ``reuse`` / ``verbosity``
+    findings off ``report.findings``. Missing findings (analyzer not run, no
+    candidates) contribute nothing. Never raises — a malformed finding is
+    skipped so one bad analyzer can't sink the inbox.
 
     ``config`` is optional and used for one thing: looking up the local source
     path a user registered for an agent, which decides whether the downsize card
@@ -1400,19 +1604,30 @@ def cost_proposals_from_report(
     ``script`` / ``reuse`` / ``verbosity`` read ``report.persona`` (set once
     by ``runner.build_report`` — see ``AnalyzerContext.persona``) to decide
     whether their rung-1/rung-2 workspace write is offered at all — see
-    ``_persona_gated_write_fields``. A report built without that field (e.g.
-    hand-constructed in a test) defaults to ``"unknown"``, which keeps the
-    write off rather than assuming ``"claude-code"``.
+    ``_persona_gated_write_fields``. The whole ``cache`` family (``cache`` /
+    ``cache_thrash`` / ``cache-recommend``) reads the same ``persona`` to
+    decide whether their cache_control instruction is shown at all — see
+    ``_persona_gated_cache_fields``; unlike script/reuse/verbosity there is no
+    write to gate, only the instruction text. A report built without a
+    ``persona`` field (e.g. hand-constructed in a test) defaults to
+    ``"unknown"``, which keeps the script/reuse/verbosity write off (that
+    helper's conservative default) while leaving the cache family's
+    instruction on (that helper's conservative default runs the other way —
+    see its own docstring) — neither ever assumes ``"claude-code"``.
     """
     findings = getattr(report, "findings", {}) or {}
     persona = str(getattr(report, "persona", "") or "unknown")
     proposals: list[CostProposal] = []
     adapters = (
         (lambda f: _downsize_to_proposal(f, config), getattr(report, "downgrade", None)),
-        (_cache_to_proposals, findings.get("cache")),
-        (_cache_uncached_to_proposals, findings.get("cache")),
-        (_cache_thrash_to_proposals, findings.get("cache")),
-        (_cache_lookback_to_proposals, findings.get("cache")),
+        (lambda f: _cache_to_proposals(f, persona=persona), findings.get("cache")),
+        (lambda f: _cache_uncached_to_proposals(f, persona=persona), findings.get("cache")),
+        (lambda f: _cache_thrash_to_proposals(f, persona=persona), findings.get("cache")),
+        (lambda f: _cache_lookback_to_proposals(f, persona=persona), findings.get("cache")),
+        (
+            lambda f: _cache_recommend_to_proposals(f, findings.get("cache"), persona=persona),
+            findings.get("cache-recommend"),
+        ),
         (_trim_to_proposals, findings.get("trim")),
         (lambda f: _subagent_to_proposals(f, config), findings.get("subagent")),
         (lambda f: _placement_to_proposals(f, pricing_mode=pricing_mode), findings.get("placement")),
@@ -1466,9 +1681,7 @@ def estimated_recoverable_rollup(
     ``proposal_count``, and say so against ``deduplicated_proposal_count`` when
     coverage is partial: the token sum is a floor, not a total.
 
-    Tagged ``estimated`` — see ``receipts.verified_saved_summary`` for the
-    measured twin (Component G1). The two figures are NEVER added together;
-    every caller must keep them as two clearly labeled numbers.
+    Tagged ``estimated`` — this is a heuristic figure, never a measured one.
     """
     seen: dict[str, dict[str, Any]] = {}
     for p in proposals:

--- a/tokenjam/core/optimize/cost_proposals.py
+++ b/tokenjam/core/optimize/cost_proposals.py
@@ -165,17 +165,68 @@ def _downsize_to_proposal(finding: Any) -> list[CostProposal]:
     )]
 
 
+def _per_agent_cache_recoverable_by_model(finding: Any) -> dict[tuple[str, str], tuple[float, int]]:
+    """Sum of ``estimated_recoverable_usd``/``estimated_recoverable_tokens``
+    already claimed by the root-caused per-agent cards (A1 uncached / A2
+    thrash / A3 lookback), keyed by (provider, model).
+
+    The generic per-(provider, model) efficacy row and these per-agent checks
+    both read from the SAME underlying spans — a flagged agent's own calls
+    are part of the aggregate the generic row's efficacy is computed over. So
+    the dollars a per-agent card claims must be subtracted from the generic
+    row's figure before it's surfaced, or the Review-inbox rollup (which sums
+    every open card's ``estimated_recoverable_usd`` with no analyzer
+    allowlist) double-counts the same waste under two signatures. See
+    ``_cache_to_proposals``.
+    """
+    totals: dict[tuple[str, str], tuple[float, int]] = {}
+    groups = (
+        getattr(finding, "uncached_agents", []) or [],
+        getattr(finding, "thrash_agents", []) or [],
+        getattr(finding, "lookback_miss_agents", []) or [],
+    )
+    for group in groups:
+        for c in group:
+            usd = getattr(c, "estimated_recoverable_usd", None) or 0.0
+            tokens = getattr(c, "estimated_recoverable_tokens", None) or 0
+            if usd <= 0 and tokens <= 0:
+                continue
+            key = (c.provider, c.model)
+            prev_usd, prev_tokens = totals.get(key, (0.0, 0))
+            totals[key] = (prev_usd + usd, prev_tokens + tokens)
+    return totals
+
+
 def _cache_to_proposals(finding: Any) -> list[CostProposal]:
-    """One proposal per flagged (provider, model) cache-efficacy row."""
+    """One proposal per flagged (provider, model) cache-efficacy row.
+
+    Reduced by whatever the more specific per-agent root-cause cards (A1/A2/
+    A3) already claim for that same (provider, model) — see
+    ``_per_agent_cache_recoverable_by_model`` — so the rollup never sums the
+    same underlying waste twice under two different signatures.
+    """
     if finding is None:
         return []
     from tokenjam.core.optimize.analyzers.cache_efficacy import (
         estimate_cache_recoverable,
     )
 
+    already_claimed = _per_agent_cache_recoverable_by_model(finding)
+
     proposals: list[CostProposal] = []
     for row in getattr(finding, "flagged", []) or []:
         usd, tokens = estimate_cache_recoverable([row])
+        claimed_usd, claimed_tokens = already_claimed.get((row.provider, row.model), (0.0, 0))
+        basis = str(getattr(finding, "estimate_basis", "") or "")
+        if claimed_usd > 0 or claimed_tokens > 0:
+            usd = round(max(0.0, (usd or 0.0) - claimed_usd), 6)
+            tokens = max(0, (tokens or 0) - claimed_tokens)
+            basis = (
+                basis + (" " if basis else "")
+                + f"Reduced by ${claimed_usd:.4f} already attributed to more "
+                "specific per-agent cache proposals for this model, so the "
+                "rollup does not double-count the same spend."
+            )
         evidence = (
             f"{row.provider}/{row.model}: {row.efficacy * 100:.0f}% of input "
             f"tokens served from cache over {row.input_tokens:,} input tokens "
@@ -203,7 +254,7 @@ def _cache_to_proposals(finding: Any) -> list[CostProposal]:
             ),
             estimated_recoverable_usd=usd,
             estimated_recoverable_tokens=tokens,
-            estimate_basis=str(getattr(finding, "estimate_basis", "") or ""),
+            estimate_basis=basis,
         ))
     return proposals
 

--- a/tokenjam/core/optimize/cost_proposals.py
+++ b/tokenjam/core/optimize/cost_proposals.py
@@ -1,21 +1,21 @@
 """Adapt cost-analyzer findings into Review-inbox proposals ("advisories with
 receipts").
 
-The self-improve loop's pothole detector already produces
-``PotholeCluster`` proposals that the Lens Improve inbox renders and that a
+The self-improve loop's relearn detector already produces
+``RelearnCluster`` proposals that the Lens Improve inbox renders and that a
 user can mark, apply, and verify. Three *cost* analyzers — ``downsize``
 (model over-sizing), ``cache`` (cache efficacy), ``trim`` (prompt bloat) —
 produce findings of a different shape. This module adapts each finding into a
-``CostProposal`` so the inbox can list them BESIDE the pothole proposals, typed
+``CostProposal`` so the inbox can list them BESIDE the relearn proposals, typed
 by a distinct ``kind`` field.
 
-Two structural facts carry over from the pothole ``advise_only`` lane and are
+Two structural facts carry over from the relearn ``advise_only`` lane and are
 NOT optional here:
 
   * **Advise-only everywhere.** A cost fix lives in the user's own application
     code (a model-routing decision, a cache-prefix change, a prompt edit), not
     a workspace tokenjam may write into. So a cost proposal has NO apply path —
-    exactly like an ``advise_only`` ``PotholeCluster`` (empty
+    exactly like an ``advise_only`` ``RelearnCluster`` (empty
     ``suggested_target``). The card carries a recommendation and, where
     sensible, a copyable config/code suggestion; the user applies it themselves.
   * **Estimated / correlational, never causal.** Every saving figure a cost
@@ -43,19 +43,30 @@ COST_CORRELATIONAL_CAVEAT = (
 )
 
 #: The three analyzers this wiring covers, by registration name.
-COST_ANALYZERS = ("downsize", "cache", "trim")
+COST_ANALYZERS = ("downsize", "cache", "trim", "subagent")
+
+# The rung-1 sizing-rubric note a CC-origin subagent proposal writes into the
+# workspace CLAUDE.md when applied. A shape-based default, not a per-subagent
+# edit — it names the observed oversized dispatches and states the routing rule.
+SUBAGENT_RUBRIC_INTRO = (
+    "Right-size Task-dispatched subagents: default a subagent to the cheapest "
+    "same-family model that fits its shape, and only reach for a premium-tier "
+    "model (Opus / Fable) when the subtask genuinely needs deep reasoning. A "
+    "subagent that does little tool work and returns a short result rarely needs "
+    "the premium tier."
+)
 
 
 @dataclass
 class CostProposal:
     """One cost analyzer's finding, shaped for the Review inbox.
 
-    Mirrors the fields the inbox already reads off a ``PotholeCluster`` (title,
+    Mirrors the fields the inbox already reads off a ``RelearnCluster`` (title,
     evidence, an estimate with its basis, ``advise_only``) plus the cost-
     specific ``target_key`` the delta-verify pass re-measures against.
     """
     kind:      str                     # always "cost" — the inbox discriminator
-    analyzer:  str                     # "downsize" | "cache" | "trim"
+    analyzer:  str                     # "downsize" | "cache" | "trim" | "subagent"
     signature: str                     # stable identity for dedup + verify keying
     title:     str
     # WHICH thing is flagged, machine-readable — the key ``cost_verify`` uses to
@@ -85,6 +96,18 @@ class CostProposal:
     # Best-effort service scope for the marker/expectation the user creates on
     # "mark applied" (Expectation.agent_id). "" when the finding spans agents.
     agent_id:             str = ""
+    # Workspace-apply plumbing (subagent right-sizing only). Unlike the three
+    # advise-only analyzers, a CC-origin subagent finding HAS a writable surface
+    # — a rung-1 sizing rubric note in the workspace's CLAUDE.md — so its card
+    # can route an actual, reversible, human-gated write through the existing
+    # relearn apply path (``relearn_apply.apply_relearn_fix``). The adapter (not
+    # the analyzer) supplies these; ``apply_capable`` gates the apply action, and
+    # a proposal with no clean workspace surface degrades to advise-only like the
+    # other three (``apply_capable=False``, ``advise_only=True``).
+    apply_capable:        bool = False
+    rung:                 int  = 0
+    scope:                str  = ""
+    proposed_fix:         str  = ""
 
 
 # --------------------------------------------------------------------------- #
@@ -185,6 +208,158 @@ def _cache_to_proposals(finding: Any) -> list[CostProposal]:
     return proposals
 
 
+def _cache_uncached_to_proposals(finding: Any) -> list[CostProposal]:
+    """One proposal per A1 uncached-agent candidate (see
+    ``analyzers.cache_efficacy``): an agent group making cacheable calls with
+    prompt caching never attempted. Verified through the same efficacy metric
+    as ``_cache_to_proposals`` (agent-scoped), so no ``cost_verify`` change
+    is needed for this check."""
+    if finding is None:
+        return []
+    proposals: list[CostProposal] = []
+    for c in getattr(finding, "uncached_agents", []) or []:
+        evidence = (
+            f"{c.agent_id}: {c.calls} calls on {c.model} with zero prompt "
+            f"caching attempted (no cache reads, no cache writes) across "
+            f"{c.sessions} session(s); assumed stable prefix "
+            f"~{c.assumed_prefix_tokens:,} tokens (this agent's own p25 input size)."
+        )
+        proposals.append(CostProposal(
+            kind="cost",
+            analyzer="cache",
+            signature=f"cost:cache-uncached:{c.agent_id}",
+            title=f"Uncached agent: {c.agent_id}",
+            target_key={"agent_id": c.agent_id, "provider": c.provider, "model": c.model},
+            evidence=evidence,
+            baseline={
+                "agent_id": c.agent_id, "provider": c.provider, "model": c.model,
+                "calls": c.calls, "sessions": c.sessions,
+                "assumed_prefix_tokens": c.assumed_prefix_tokens,
+            },
+            advise_text=(
+                "Add a cache_control breakpoint on this agent's stable prefix "
+                "(system prompt / tool definitions) so repeated calls read "
+                "from cache instead of paying full input price every time."
+            ),
+            suggestion=c.cache_control_snippet,
+            estimated_recoverable_usd=c.estimated_recoverable_usd,
+            estimated_recoverable_tokens=c.estimated_recoverable_tokens,
+            estimate_basis=c.estimate_basis,
+            agent_id=c.agent_id,
+        ))
+    return proposals
+
+
+def _cache_thrash_to_proposals(finding: Any) -> list[CostProposal]:
+    """One proposal per A2 cache-thrash candidate. Card text branches on the
+    detected root cause: a TTL-cadence card (honest break-even, which may say
+    the switch isn't worth it) versus an instability checklist card."""
+    if finding is None:
+        return []
+    from tokenjam.core.optimize.analyzers.cache_efficacy import (
+        SILENT_INVALIDATOR_CHECKLIST,
+    )
+
+    proposals: list[CostProposal] = []
+    for c in getattr(finding, "thrash_agents", []) or []:
+        evidence = (
+            f"{c.agent_id}: caching attempted on {c.model} but read:write "
+            f"ratio is {c.read_write_ratio:.2f} over {c.calls} calls "
+            f"({c.cache_read_tokens:,} cache-read tokens vs "
+            f"{c.cache_write_tokens:,} cache-write tokens); median inter-call "
+            f"gap {c.inter_call_gap_p50_minutes:.1f} min."
+        )
+        if c.cause == "ttl":
+            if c.ttl_worth_it:
+                advise = (
+                    "Calls land more than 5 minutes apart, so the default "
+                    "5-minute cache write is expiring before it's reused. "
+                    "Switching to the 1-hour cache TTL is estimated to pay "
+                    "off at this cadence."
+                )
+            else:
+                advise = (
+                    "Calls land more than 5 minutes apart, so the default "
+                    "5-minute cache write is expiring before it's reused. "
+                    "The 1-hour TTL's write premium doesn't clear at this "
+                    "cadence: caching not worth it at this cadence."
+                )
+        else:
+            advise = (
+                "Calls land close enough together that a TTL expiry doesn't "
+                "explain the miss rate; the prefix itself is likely changing "
+                "between calls. " + SILENT_INVALIDATOR_CHECKLIST
+            )
+        proposals.append(CostProposal(
+            kind="cost",
+            analyzer="cache_thrash",
+            signature=f"cost:cache-thrash:{c.agent_id}",
+            title=f"Cache thrash: {c.agent_id}",
+            target_key={"agent_id": c.agent_id, "provider": c.provider, "model": c.model},
+            evidence=evidence,
+            baseline={
+                "agent_id": c.agent_id, "provider": c.provider, "model": c.model,
+                "calls": c.calls, "cache_write_tokens": c.cache_write_tokens,
+                "cache_read_tokens": c.cache_read_tokens,
+                "read_write_ratio": c.read_write_ratio, "cause": c.cause,
+                "inter_call_gap_p50_minutes": c.inter_call_gap_p50_minutes,
+                "ttl_worth_it": c.ttl_worth_it,
+                "ttl_breakeven_usd": c.ttl_breakeven_usd,
+            },
+            advise_text=advise,
+            suggestion=c.cache_control_snippet,
+            estimated_recoverable_usd=c.estimated_recoverable_usd,
+            estimated_recoverable_tokens=c.estimated_recoverable_tokens,
+            estimate_basis=c.estimate_basis,
+            agent_id=c.agent_id,
+        ))
+    return proposals
+
+
+def _cache_lookback_to_proposals(finding: Any) -> list[CostProposal]:
+    """One proposal per A3 20-block-lookback-miss candidate. Weakest-
+    confidence check of the three; the analyzer only classifies an agent here
+    when A1/A2 don't already explain its cache waste."""
+    if finding is None:
+        return []
+    from tokenjam.core.optimize.analyzers.cache_efficacy import LOOKBACK_BLOCK_LIMIT
+
+    proposals: list[CostProposal] = []
+    for c in getattr(finding, "lookback_miss_agents", []) or []:
+        evidence = (
+            f"{c.agent_id}: {c.miss_count} cache miss(es) on {c.model}, each "
+            f"directly following a turn with an estimated "
+            f"{c.avg_prior_turn_blocks:.0f} content blocks (lookback limit: "
+            f"{LOOKBACK_BLOCK_LIMIT})."
+        )
+        proposals.append(CostProposal(
+            kind="cost",
+            analyzer="cache",
+            signature=f"cost:cache-lookback:{c.agent_id}",
+            title=f"20-block lookback miss: {c.agent_id}",
+            target_key={"agent_id": c.agent_id, "provider": c.provider, "model": c.model},
+            evidence=evidence,
+            baseline={
+                "agent_id": c.agent_id, "provider": c.provider, "model": c.model,
+                "miss_count": c.miss_count,
+                "avg_prior_turn_blocks": c.avg_prior_turn_blocks,
+            },
+            advise_text=(
+                "Anthropic's cache breakpoint search looks back at most "
+                f"{LOOKBACK_BLOCK_LIMIT} content blocks. Long tool-heavy "
+                "turns push the prior breakpoint out of range; add an "
+                "intermediate cache_control breakpoint every ~15 blocks in "
+                "long tool-use turns."
+            ),
+            suggestion=c.cache_control_snippet,
+            estimated_recoverable_usd=c.estimated_recoverable_usd,
+            estimated_recoverable_tokens=c.estimated_recoverable_tokens,
+            estimate_basis=c.estimate_basis,
+            agent_id=c.agent_id,
+        ))
+    return proposals
+
+
 def _trim_to_proposals(finding: Any) -> list[CostProposal]:
     """One proposal per flagged agent/step (grouped from ``per_prompt``)."""
     if finding is None or not getattr(finding, "enabled", False):
@@ -248,6 +423,76 @@ def _trim_to_proposals(finding: Any) -> list[CostProposal]:
     return proposals
 
 
+def _subagent_to_proposals(finding: Any) -> list[CostProposal]:
+    """One proposal covering the subagent right-sizing finding.
+
+    Unlike the three advise-only analyzers, this one is workspace-appliable for
+    the common (CC-origin) case: the fan-out model choice is made by the
+    orchestrating agent, which reads the workspace's CLAUDE.md — so a rung-1
+    sizing rubric note IS a legitimate, reversible workspace fix. The subagent
+    analyzer runs only over Claude Code data (``sub_agent_id`` is populated by
+    the CC backfill; other runtimes carry NULL and are ignored), so a finding
+    here is CC-origin, hence ``apply_capable``. If no oversized model is priced
+    (nothing to key a delta on), the proposal degrades to advise-only.
+
+    The delta-verify pass measures the fan-out model-mix cost delta across the
+    over-powered models, so a single proposal listing them keeps the finding-
+    level estimate coherent (mirrors the downsize adapter).
+    """
+    if finding is None:
+        return []
+    flagged = list(getattr(finding, "flagged", []) or [])
+    over_powered = [r for r in flagged if "over_powered" in (getattr(r, "flags", []) or [])]
+    if not over_powered:
+        return []
+
+    models = sorted({str(r.model) for r in over_powered})
+    subagents = len({(r.session_id, r.sub_agent_id) for r in over_powered})
+    pct = float(getattr(finding, "percent_of_cost", 0.0) or 0.0) * 100
+    model_list = ", ".join(models)
+    evidence = (
+        f"{subagents} subagent dispatch(es) ran on a premium-tier model "
+        f"({model_list}) but did little work (small output, few tool calls). "
+        f"Subagents are {pct:.0f}% of the window's cost."
+    )
+    proposed_fix = (
+        SUBAGENT_RUBRIC_INTRO
+        + f"\n\nObserved oversized dispatches ran on: {model_list}. Route that "
+        "shape to the cheaper same-family model next time."
+    )
+    # Apply-capable when we have a concrete model to name in the rubric; else
+    # degrade to advise-only (no clean workspace surface to write).
+    apply_capable = bool(models)
+    return [CostProposal(
+        kind="cost",
+        analyzer="subagent",
+        signature="cost:subagent",
+        title="Over-powered subagent dispatches (route the fan-out to a cheaper model)",
+        target_key={"models": models, "subagent": True},
+        evidence=evidence,
+        baseline={
+            "flagged_subagents": subagents,
+            "flagged_cost_usd": float(getattr(finding, "flagged_cost_usd", 0.0) or 0.0),
+            "subagent_cost_usd": float(getattr(finding, "subagent_cost_usd", 0.0) or 0.0),
+            "percent_of_cost": float(getattr(finding, "percent_of_cost", 0.0) or 0.0),
+        },
+        advise_text=(
+            "Lower the model tier for the flagged Task dispatches. On Claude Code "
+            "this is a sizing rubric in your CLAUDE.md (apply it below) that the "
+            "orchestrating agent reads before it spawns subagents. "
+            + str(getattr(finding, "caveat", "") or "")
+        ).strip(),
+        estimated_recoverable_usd=getattr(finding, "estimated_recoverable_usd", None),
+        estimated_recoverable_tokens=getattr(finding, "estimated_recoverable_tokens", None),
+        estimate_basis=str(getattr(finding, "estimate_basis", "") or ""),
+        advise_only=not apply_capable,
+        apply_capable=apply_capable,
+        rung=1 if apply_capable else 0,
+        scope="project" if apply_capable else "",
+        proposed_fix=proposed_fix if apply_capable else "",
+    )]
+
+
 #: Default look-back for the daemon/CLI cost-proposal recompute. Matches the
 #: monthly framing the cost analyzers project against.
 DEFAULT_COST_WINDOW_DAYS = 30
@@ -271,7 +516,7 @@ def recompute_cost_proposals(
     """
     from datetime import timedelta
 
-    from tokenjam.core.optimize import pothole_store
+    from tokenjam.core.optimize import relearn_store
     from tokenjam.core.optimize.runner import build_report
     from tokenjam.utils.time_parse import utcnow
 
@@ -287,7 +532,7 @@ def recompute_cost_proposals(
         return []
 
     try:
-        pothole_store.write_cost_proposals(proposals, config=config)
+        relearn_store.write_cost_proposals(proposals, config=config)
     except Exception:
         pass
     return proposals
@@ -297,15 +542,21 @@ def cost_proposals_from_report(report: Any) -> list[CostProposal]:
     """Every cost proposal derivable from an already-built ``OptimizeReport``.
 
     Reads the ``downsize`` finding off the typed ``report.downgrade`` slot and
-    the ``cache`` / ``trim`` findings off ``report.findings``. Missing findings
-    (analyzer not run, no candidates) contribute nothing. Never raises — a
-    malformed finding is skipped so one bad analyzer can't sink the inbox.
+    the ``cache`` / ``trim`` / ``subagent`` findings off ``report.findings``.
+    Missing findings (analyzer not run, no candidates) contribute nothing. Never
+    raises — a malformed finding is skipped so one bad analyzer can't sink the
+    inbox.
     """
+    findings = getattr(report, "findings", {}) or {}
     proposals: list[CostProposal] = []
     adapters = (
         (_downsize_to_proposal, getattr(report, "downgrade", None)),
-        (_cache_to_proposals, (getattr(report, "findings", {}) or {}).get("cache")),
-        (_trim_to_proposals, (getattr(report, "findings", {}) or {}).get("trim")),
+        (_cache_to_proposals, findings.get("cache")),
+        (_cache_uncached_to_proposals, findings.get("cache")),
+        (_cache_thrash_to_proposals, findings.get("cache")),
+        (_cache_lookback_to_proposals, findings.get("cache")),
+        (_trim_to_proposals, findings.get("trim")),
+        (_subagent_to_proposals, findings.get("subagent")),
     )
     for adapter, finding in adapters:
         try:

--- a/tokenjam/core/optimize/cost_proposals.py
+++ b/tokenjam/core/optimize/cost_proposals.py
@@ -268,6 +268,11 @@ def _downsize_agent_proposals(finding: Any, config: Any) -> list[CostProposal]:
     """
     proposals: list[CostProposal] = []
     for row in getattr(finding, "per_agent", []) or []:
+        if row.delta_usd <= 0:
+            # The proposed model is not actually cheaper for this agent's token
+            # mix. There is nothing to recover, so there is no card: a rollup
+            # that summed this would be summing a loss.
+            continue
         plumbing = _model_swap_plumbing(row, config) if config is not None else {
             "apply_capable": False,
             "apply_blocked_reason": (

--- a/tokenjam/core/optimize/cost_proposals.py
+++ b/tokenjam/core/optimize/cost_proposals.py
@@ -422,12 +422,21 @@ def _downsize_agent_proposals(finding: Any, config: Any) -> list[CostProposal]:
     return proposals
 
 
-def _placement_to_proposals(finding: Any) -> list[CostProposal]:
+def _placement_to_proposals(
+    finding: Any, *, pricing_mode: str = "api",
+) -> list[CostProposal]:
     """One card for the batch-placement candidates (advise-only).
 
     Advise-only is not a formality here: moving a workload to the batch lane is
     an architectural change in the user's own application, and the card says so
     beside the number.
+
+    The Batch API's flat discount is an api-billed price lever — a
+    subscription or local plan can't pull it, so ``pricing_mode`` gates the
+    dollar figure exactly like the CLI's ``_render_placement`` already does
+    (CLAUDE.md anti-pattern #22: never show a figure the reader can't act
+    on). Without this the web Review inbox showed a batch-placement dollar
+    figure the CLI deliberately suppresses for the same finding.
     """
     if finding is None:
         return []
@@ -448,12 +457,22 @@ def _placement_to_proposals(finding: Any) -> list[CostProposal]:
         f"turn after the first model call ({cadence}). They are "
         f"{percent:.0f}% of the window's spend, {_money(total)} (measured)."
     )
-    advise = (
-        f"The Batch API bills a flat 50% of standard prices, so the same work "
-        f"on the batch lane is {_money(saving)} less over this window "
-        f"(estimated). {getattr(finding, 'friction', '')} Nothing here is "
-        f"applied for you; the change lives in your own application code."
-    )
+    if pricing_mode == "api":
+        advise = (
+            f"The Batch API bills a flat 50% of standard prices, so the same work "
+            f"on the batch lane is {_money(saving)} less over this window "
+            f"(estimated). {getattr(finding, 'friction', '')} Nothing here is "
+            f"applied for you; the change lives in your own application code."
+        )
+        recoverable_usd: float | None = saving
+    else:
+        advise = (
+            f"The Batch API's flat discount is an api-billed price lever, so no "
+            f"dollar figure is shown for this plan. "
+            f"{getattr(finding, 'friction', '')} Nothing here is "
+            f"applied for you; the change lives in your own application code."
+        )
+        recoverable_usd = None
     return [CostProposal(
         kind="cost",
         analyzer="placement",
@@ -482,7 +501,7 @@ def _placement_to_proposals(finding: Any) -> list[CostProposal]:
             "synchronous endpoint:\n"
             + "\n".join(f"#   {c.agent_id}" for c in candidates)
         ),
-        estimated_recoverable_usd=saving,
+        estimated_recoverable_usd=recoverable_usd,
         estimated_recoverable_tokens=getattr(finding, "estimated_recoverable_tokens", None),
         estimate_basis=str(getattr(finding, "estimate_basis", "") or ""),
         agent_id=candidates[0].agent_id if len(candidates) == 1 else "",
@@ -1262,6 +1281,7 @@ def recompute_cost_proposals(
     """
     from datetime import timedelta
 
+    from tokenjam.core.framing import dominant_plan, plan_tier_mix, pricing_mode_for
     from tokenjam.core.optimize import relearn_store
     from tokenjam.core.optimize.runner import build_report
     from tokenjam.utils.time_parse import utcnow
@@ -1273,7 +1293,16 @@ def recompute_cost_proposals(
             db, config, since, until, agent_id=agent_id,
             findings=list(COST_ANALYZERS),
         )
-        proposals = cost_proposals_from_report(report, config=config)
+        # Same plan-tier -> pricing-mode resolution `tj optimize` uses, so the
+        # web Review inbox suppresses the same dollar figures the CLI does
+        # (placement's batch-lever dollars, currently the only card this
+        # gates — see `_placement_to_proposals`).
+        conn = getattr(db, "conn", None)
+        plan_mix = plan_tier_mix(conn, since, until, agent_id) if conn is not None else {}
+        pricing_mode = pricing_mode_for(dominant_plan(plan_mix))
+        proposals = cost_proposals_from_report(
+            report, config=config, pricing_mode=pricing_mode,
+        )
     except Exception:
         return []
 
@@ -1284,7 +1313,9 @@ def recompute_cost_proposals(
     return proposals
 
 
-def cost_proposals_from_report(report: Any, config: Any = None) -> list[CostProposal]:
+def cost_proposals_from_report(
+    report: Any, config: Any = None, *, pricing_mode: str = "api",
+) -> list[CostProposal]:
     """Every cost proposal derivable from an already-built ``OptimizeReport``.
 
     Reads the ``downsize`` finding off the typed ``report.downgrade`` slot and
@@ -1298,6 +1329,12 @@ def cost_proposals_from_report(report: Any, config: Any = None) -> list[CostProp
     path a user registered for an agent, which decides whether the downsize card
     can offer the gated model-id swap or falls back to its one-paste artifact.
     Without it every card is advise-only.
+
+    ``pricing_mode`` gates the ``placement`` card's dollar figure — the Batch
+    API discount is an api-billed lever, so a subscription/local caller gets
+    the advise text without a number, same as the CLI. Defaults to ``"api"``
+    so existing callers that don't know their caller's plan keep today's
+    behaviour.
     """
     findings = getattr(report, "findings", {}) or {}
     proposals: list[CostProposal] = []
@@ -1309,7 +1346,7 @@ def cost_proposals_from_report(report: Any, config: Any = None) -> list[CostProp
         (_cache_lookback_to_proposals, findings.get("cache")),
         (_trim_to_proposals, findings.get("trim")),
         (lambda f: _subagent_to_proposals(f, config), findings.get("subagent")),
-        (_placement_to_proposals, findings.get("placement")),
+        (lambda f: _placement_to_proposals(f, pricing_mode=pricing_mode), findings.get("placement")),
         (_deadweight_to_proposals, findings.get("deadweight")),
         (_script_to_proposals, findings.get("script")),
         (_reuse_to_proposals, findings.get("reuse")),

--- a/tokenjam/core/optimize/cost_proposals.py
+++ b/tokenjam/core/optimize/cost_proposals.py
@@ -3,21 +3,30 @@ receipts").
 
 The self-improve loop's relearn detector already produces
 ``RelearnCluster`` proposals that the Lens Improve inbox renders and that a
-user can mark, apply, and verify. Three *cost* analyzers — ``downsize``
-(model over-sizing), ``cache`` (cache efficacy), ``trim`` (prompt bloat) —
-produce findings of a different shape. This module adapts each finding into a
-``CostProposal`` so the inbox can list them BESIDE the relearn proposals, typed
-by a distinct ``kind`` field.
+user can mark, apply, and verify. The *cost* analyzers (``downsize`` model
+over-sizing, ``cache`` efficacy, ``trim`` prompt bloat, ``subagent``
+right-sizing, ``deadweight`` dead MCP servers, ``script`` deterministic
+workflows, ``reuse`` repeated planning skeletons, ``verbosity`` high-output
+outliers) produce findings of a different shape. This module adapts each
+finding into a ``CostProposal`` so the inbox can list them BESIDE the relearn
+proposals, typed by a distinct ``kind`` field.
 
 Two structural facts carry over from the relearn ``advise_only`` lane and are
 NOT optional here:
 
-  * **Advise-only everywhere.** A cost fix lives in the user's own application
-    code (a model-routing decision, a cache-prefix change, a prompt edit), not
-    a workspace tokenjam may write into. So a cost proposal has NO apply path —
-    exactly like an ``advise_only`` ``RelearnCluster`` (empty
-    ``suggested_target``). The card carries a recommendation and, where
-    sensible, a copyable config/code suggestion; the user applies it themselves.
+  * **Advise-only by default, apply-capable where a real workspace surface
+    exists.** Most cost fixes live in the user's own application code (a
+    model-routing decision, a cache-prefix change, a prompt edit) that
+    tokenjam cannot write into — those cards have NO apply path, exactly like
+    an ``advise_only`` ``RelearnCluster`` (empty ``suggested_target``). A
+    minority (``subagent``, the per-agent slice of ``downsize``, ``script``,
+    ``reuse``, ``verbosity``) DO have a workspace surface an orchestrating
+    agent reads before acting (a CLAUDE.md rubric, a model-id key, a new
+    skill note) and route through the same rung-gated
+    ``relearn_apply.apply_relearn_fix`` machinery the relearn lane uses
+    (``apply_capable=True``, ``rung``, ``scope``, ``proposed_fix``). Every
+    other card carries a recommendation and, where sensible, a copyable
+    config/code suggestion; the user applies it themselves.
   * **Estimated / correlational, never causal.** Every saving figure a cost
     finding carries is a heuristic ESTIMATE (house style, CLAUDE.md Rule 14).
     The adapter preserves the finding's own ``estimate_basis`` and labels the
@@ -30,7 +39,11 @@ proposals. It never touches the DB, the store, or the network.
 """
 from __future__ import annotations
 
+import hashlib
+import json
+import re
 from dataclasses import asdict, dataclass, is_dataclass
+from pathlib import Path
 from typing import Any
 
 # House-style label strings. Kept verbatim on every cost proposal so no channel
@@ -43,7 +56,38 @@ COST_CORRELATIONAL_CAVEAT = (
 )
 
 #: The analyzers this wiring covers, by registration name.
-COST_ANALYZERS = ("downsize", "cache", "trim", "subagent", "deadweight")
+COST_ANALYZERS = (
+    "downsize", "cache", "trim", "subagent", "deadweight", "script", "reuse",
+    "verbosity",
+)
+
+# The rung-1/rung-2 apply notes below all route through the SAME workspace-note
+# machinery `subagent` already uses (`relearn_apply.apply_relearn_fix`, rung 1
+# = CLAUDE.md note, rung 2 = a new .claude/skills/<slug>/SKILL.md). None of
+# these three analyzers has a workspace file it can edit outright the way a
+# model-routing swap does — the fix is behavioral (an orchestrator or the model
+# itself reading guidance), same class of surface as the subagent rubric.
+
+# The rung-2 skill note a `script` proposal writes: the observed tool-call
+# pattern is deterministic enough that a script could run it directly instead
+# of dispatching a full agent turn.
+_SCRIPT_SKILL_INTRO = (
+    "This tool-call pattern repeated across many sessions with the same "
+    "structural shape (same tools, same argument types, different values). "
+    "Consider replacing it with a deterministic script that runs these calls "
+    "directly, and reserve the agent turn for the parts that actually need a "
+    "model's judgment."
+)
+
+# The rung-1 note a `reuse` proposal writes: the planning skeleton recurs.
+_REUSE_NOTE_INTRO = (
+    "This class of task shares a planning skeleton: the same tool sequence "
+    "follows the first planning call, session after session, with only the "
+    "argument values differing (dates, versions, paths). Consider templating "
+    "the plan for this shape instead of re-planning it from scratch each "
+    "time. Review before reusing: a skeleton match is a candidate, not proof "
+    "the plan is identical."
+)
 
 # The rung-1 sizing-rubric note a CC-origin subagent proposal writes into the
 # workspace CLAUDE.md when applied. A shape-based default, not a per-subagent
@@ -108,6 +152,23 @@ class CostProposal:
     rung:                 int  = 0
     scope:                str  = ""
     proposed_fix:         str  = ""
+    # Model-routing apply kinds (``core.optimize.model_apply``). Set only where
+    # the edit is a deterministic rewrite of a value already written down: an
+    # agent file's ``model:`` key, or one exact model-id string in a repo the
+    # user registered. Empty everywhere else, which leaves the card advise-only
+    # with its one-paste artifact.
+    apply_kind:           str  = ""
+    agent_name:           str  = ""
+    current_model:        str  = ""
+    proposed_model:       str  = ""
+    source_path:          str  = ""
+    target_path:          str  = ""
+    # Why the direct apply is not on offer, when it is not. Rendered on the card
+    # next to the one-paste fix so a fallback is never silent.
+    apply_blocked_reason: str  = ""
+    # The exact fix, with this agent's own measured values already substituted
+    # in. Every advise-only card carries one.
+    one_paste_fix:        str  = ""
 
 
 # --------------------------------------------------------------------------- #
@@ -115,16 +176,26 @@ class CostProposal:
 # proposals. All tolerate a None/empty finding (returns []).
 # --------------------------------------------------------------------------- #
 
-def _downsize_to_proposal(finding: Any) -> list[CostProposal]:
-    """One proposal covering the model-over-sizing finding.
+def _downsize_to_proposal(finding: Any, config: Any = None) -> list[CostProposal]:
+    """The model-over-sizing card(s).
 
-    ``DowngradeFinding.suggestions`` maps each oversized model to its cheaper
-    same-family alternative. The delta-verify pass later measures the model-mix
-    cost delta across ALL flagged models, so a single proposal (listing them)
-    keeps the estimate — which is a finding-level aggregate — coherent.
+    When the finding carries per-agent price rows, each agent gets its own card
+    with its own arithmetic (and, where the preconditions hold, the gated model-
+    id swap). Those rows partition the same candidate sessions, so the window-
+    wide card is NOT emitted alongside them: one source of over-sized spend,
+    one card.
+
+    Without those rows (no pricing data for a model on either side) the finding
+    falls back to the single window-wide card. ``DowngradeFinding.suggestions``
+    maps each oversized model to its cheaper same-family alternative, and the
+    delta-verify pass measures the model-mix cost delta across ALL flagged
+    models, so one proposal listing them keeps that aggregate estimate coherent.
     """
     if finding is None or getattr(finding, "candidate_sessions", 0) <= 0:
         return []
+    per_agent = _downsize_agent_proposals(finding, config)
+    if per_agent:
+        return per_agent
     suggestions: dict[str, str] = dict(getattr(finding, "suggestions", {}) or {})
     if not suggestions:
         return []
@@ -159,23 +230,295 @@ def _downsize_to_proposal(finding: Any) -> list[CostProposal]:
         },
         advise_text=advise,
         suggestion=suggestion,
+        one_paste_fix=suggestion,
         estimated_recoverable_usd=getattr(finding, "estimated_recoverable_usd", None),
         estimated_recoverable_tokens=getattr(finding, "estimated_recoverable_tokens", None),
         estimate_basis=str(getattr(finding, "estimate_basis", "") or ""),
     )]
 
 
+def _per_agent_cache_recoverable_by_model(finding: Any) -> dict[tuple[str, str], tuple[float, int]]:
+    """Sum of ``estimated_recoverable_usd``/``estimated_recoverable_tokens``
+    already claimed by the root-caused per-agent cards (A1 uncached / A2
+    thrash / A3 lookback), keyed by (provider, model).
+
+    The generic per-(provider, model) efficacy row and these per-agent checks
+    both read from the SAME underlying spans — a flagged agent's own calls
+    are part of the aggregate the generic row's efficacy is computed over. So
+    the dollars a per-agent card claims must be subtracted from the generic
+    row's figure before it's surfaced, or the Review-inbox rollup (which sums
+    every open card's ``estimated_recoverable_usd`` with no analyzer
+    allowlist) double-counts the same waste under two signatures. See
+    ``_cache_to_proposals``.
+    """
+    totals: dict[tuple[str, str], tuple[float, int]] = {}
+    groups = (
+        getattr(finding, "uncached_agents", []) or [],
+        getattr(finding, "thrash_agents", []) or [],
+        getattr(finding, "lookback_miss_agents", []) or [],
+    )
+    for group in groups:
+        for c in group:
+            usd = getattr(c, "estimated_recoverable_usd", None) or 0.0
+            tokens = getattr(c, "estimated_recoverable_tokens", None) or 0
+            if usd <= 0 and tokens <= 0:
+                continue
+            key = (c.provider, c.model)
+            prev_usd, prev_tokens = totals.get(key, (0.0, 0))
+            totals[key] = (prev_usd + usd, prev_tokens + tokens)
+    return totals
+
+
+def _money(value: float) -> str:
+    """A dollar figure with enough precision to stay honest at small values.
+
+    Never rendered bare: every call site pairs it with an estimated/measured tag
+    and the construction footnote.
+    """
+    if abs(value) >= 1.0:
+        return f"${value:,.2f}"
+    return f"${value:.4f}"
+
+
+def _agent_arithmetic_line(row: Any) -> str:
+    """The card's arithmetic, spelled out with both sides of the comparison."""
+    window = (
+        f"{row.sessions} session(s) over {row.window_days:.0f} day(s): "
+        f"{row.input_tokens:,} input, {row.output_tokens:,} output, "
+        f"{row.cache_tokens:,} cache read and {row.cache_write_tokens:,} cache "
+        f"write tokens. At {row.model} rates that is "
+        f"{_money(row.current_cost_usd)}; the same tokens at {row.alt_model} "
+        f"rates are {_money(row.alternative_cost_usd)}. Difference: "
+        f"{_money(row.delta_usd)} over the window, up to "
+        f"{_money(row.projected_30d_delta_usd)} per 30 days at this rate "
+        f"(estimated)."
+    )
+    if row.thinking_share_of_output is not None:
+        window += (
+            f" Thinking tokens were {row.thinking_share_of_output * 100:.0f}% of "
+            f"this agent's output tokens over the same sessions "
+            f"({row.thinking_tokens:,} of {row.output_tokens:,}, measured); "
+            f"they bill as output on both models."
+        )
+    return window
+
+
+def _model_swap_plumbing(row: Any, config: Any) -> dict[str, Any]:
+    """Whether this agent's swap can be written directly, and where.
+
+    The direct write is offered only when the user registered a local source
+    path for the agent and every precondition in
+    ``model_apply.model_swap_precheck`` holds. Otherwise the card keeps its
+    one-paste artifact and states the reason.
+    """
+    from tokenjam.core.optimize.model_apply import (
+        APPLY_KIND_MODEL_SWAP,
+        model_swap_precheck,
+    )
+
+    agents = getattr(config, "agents", None) or {}
+    agent_cfg = agents.get(row.agent_id) if hasattr(agents, "get") else None
+    source_path = str(getattr(agent_cfg, "source_path", "") or "")
+    check = model_swap_precheck(source_path, row.model)
+    if not check["ok"]:
+        return {"apply_capable": False, "apply_blocked_reason": check["reason"]}
+    return {
+        "apply_capable": True,
+        "apply_kind": APPLY_KIND_MODEL_SWAP,
+        "source_path": source_path,
+        "target_path": check["target_path"],
+        "current_model": row.model,
+        "proposed_model": row.alt_model,
+        "apply_blocked_reason": "",
+    }
+
+
+def _downsize_agent_proposals(finding: Any, config: Any) -> list[CostProposal]:
+    """One card per agent, carrying that agent's own price arithmetic.
+
+    Replaces the window-wide card when per-agent rows exist, so one source of
+    over-sized spend produces exactly one card rather than an aggregate plus its
+    own parts.
+    """
+    proposals: list[CostProposal] = []
+    for row in getattr(finding, "per_agent", []) or []:
+        if row.delta_usd <= 0:
+            # The proposed model is not actually cheaper for this agent's token
+            # mix. There is nothing to recover, so there is no card: a rollup
+            # that summed this would be summing a loss.
+            continue
+        plumbing = _model_swap_plumbing(row, config) if config is not None else {
+            "apply_capable": False,
+            "apply_blocked_reason": (
+                "no tj config was available to look up a registered source path."
+            ),
+        }
+        one_paste = (
+            f"{row.model} -> {row.alt_model}\n"
+            f"# Set this agent's model id to {row.alt_model} where it is "
+            f"configured, then redeploy or restart the agent."
+        )
+        advise = (
+            f"Route {row.agent_id}'s flagged structural-shaped work from "
+            f"{row.model} to {row.alt_model}. The price difference above is "
+            f"arithmetic on this agent's measured tokens, given the switch; "
+            f"whether the cheaper model answers as well is not measured here, "
+            f"so review the example sessions first."
+        )
+        if plumbing.get("apply_capable"):
+            advise += (
+                f" tokenjam can make this exact substitution in "
+                f"{plumbing['target_path']}, with the change committed and "
+                f"revertable in one call. After it is applied you must redeploy "
+                f"or restart the agent: measurement starts at the first call "
+                f"that runs on {row.alt_model}, not at the moment of the write."
+            )
+        elif plumbing.get("apply_blocked_reason"):
+            advise += f" Applying it here is not on offer: {plumbing['apply_blocked_reason']}"
+        proposals.append(CostProposal(
+            kind="cost",
+            analyzer="downsize",
+            signature=f"cost:downsize:{row.agent_id}",
+            title=f"Model over-sizing in {row.agent_id} ({row.model} to {row.alt_model})",
+            target_key={
+                "agent_id": row.agent_id,
+                "models": [row.model],
+                "suggestions": {row.model: row.alt_model},
+            },
+            evidence=_agent_arithmetic_line(row),
+            baseline={
+                "agent_id": row.agent_id,
+                "provider": row.provider,
+                "model": row.model,
+                "alt_model": row.alt_model,
+                "sessions": row.sessions,
+                "input_tokens": row.input_tokens,
+                "output_tokens": row.output_tokens,
+                "cache_tokens": row.cache_tokens,
+                "cache_write_tokens": row.cache_write_tokens,
+                "current_cost_usd": row.current_cost_usd,
+                "alternative_cost_usd": row.alternative_cost_usd,
+                "delta_usd": row.delta_usd,
+                "projected_30d_delta_usd": row.projected_30d_delta_usd,
+                "thinking_tokens": row.thinking_tokens,
+                "thinking_share_of_output": row.thinking_share_of_output,
+            },
+            advise_text=advise,
+            suggestion=one_paste,
+            one_paste_fix=one_paste,
+            estimated_recoverable_usd=row.delta_usd,
+            estimated_recoverable_tokens=row.total_tokens,
+            estimate_basis=row.estimate_basis,
+            agent_id=row.agent_id if row.agent_id != "unknown" else "",
+            advise_only=not plumbing.get("apply_capable", False),
+            apply_capable=bool(plumbing.get("apply_capable")),
+            apply_kind=str(plumbing.get("apply_kind", "")),
+            source_path=str(plumbing.get("source_path", "")),
+            target_path=str(plumbing.get("target_path", "")),
+            current_model=str(plumbing.get("current_model", "")),
+            proposed_model=str(plumbing.get("proposed_model", "")),
+            apply_blocked_reason=str(plumbing.get("apply_blocked_reason", "")),
+        ))
+    return proposals
+
+
+def _placement_to_proposals(finding: Any) -> list[CostProposal]:
+    """One card for the batch-placement candidates (advise-only).
+
+    Advise-only is not a formality here: moving a workload to the batch lane is
+    an architectural change in the user's own application, and the card says so
+    beside the number.
+    """
+    if finding is None:
+        return []
+    candidates = list(getattr(finding, "candidates", []) or [])
+    if not candidates:
+        return []
+    agents = ", ".join(c.agent_id for c in candidates[:5])
+    total = float(getattr(finding, "candidate_cost_usd", 0.0) or 0.0)
+    saving = float(getattr(finding, "estimated_recoverable_usd", 0.0) or 0.0)
+    percent = float(getattr(finding, "percent_of_window_cost", 0.0) or 0.0)
+    cadence = ", ".join(
+        f"{c.agent_id} every {c.median_gap_seconds / 3600:.1f}h across "
+        f"{c.sessions} runs"
+        for c in candidates[:5]
+    )
+    evidence = (
+        f"{len(candidates)} workload(s) ran on a regular cadence with no human "
+        f"turn after the first model call ({cadence}). They are "
+        f"{percent:.0f}% of the window's spend, {_money(total)} (measured)."
+    )
+    advise = (
+        f"The Batch API bills a flat 50% of standard prices, so the same work "
+        f"on the batch lane is {_money(saving)} less over this window "
+        f"(estimated). {getattr(finding, 'friction', '')} Nothing here is "
+        f"applied for you; the change lives in your own application code."
+    )
+    return [CostProposal(
+        kind="cost",
+        analyzer="placement",
+        signature="cost:placement:batch",
+        title="Batch API candidates (unattended, cadence-regular workloads)",
+        target_key={"agents": [c.agent_id for c in candidates], "placement": "batch"},
+        evidence=evidence,
+        baseline={
+            "candidates": [
+                {
+                    "agent_id": c.agent_id, "sessions": c.sessions,
+                    "median_gap_seconds": c.median_gap_seconds, "gap_cv": c.gap_cv,
+                    "cost_usd": c.cost_usd, "tokens": c.tokens,
+                    "estimated_batch_saving_usd": c.estimated_batch_saving_usd,
+                }
+                for c in candidates
+            ],
+            "candidate_cost_usd": total,
+            "window_cost_usd": float(getattr(finding, "window_cost_usd", 0.0) or 0.0),
+            "percent_of_window_cost": percent,
+        },
+        advise_text=advise,
+        suggestion=agents,
+        one_paste_fix=(
+            "# Submit these workloads through the Batch API instead of the "
+            "synchronous endpoint:\n"
+            + "\n".join(f"#   {c.agent_id}" for c in candidates)
+        ),
+        estimated_recoverable_usd=saving,
+        estimated_recoverable_tokens=getattr(finding, "estimated_recoverable_tokens", None),
+        estimate_basis=str(getattr(finding, "estimate_basis", "") or ""),
+        agent_id=candidates[0].agent_id if len(candidates) == 1 else "",
+    )]
+
+
 def _cache_to_proposals(finding: Any) -> list[CostProposal]:
-    """One proposal per flagged (provider, model) cache-efficacy row."""
+    """One proposal per flagged (provider, model) cache-efficacy row.
+
+    Reduced by whatever the more specific per-agent root-cause cards (A1/A2/
+    A3) already claim for that same (provider, model) — see
+    ``_per_agent_cache_recoverable_by_model`` — so the rollup never sums the
+    same underlying waste twice under two different signatures.
+    """
     if finding is None:
         return []
     from tokenjam.core.optimize.analyzers.cache_efficacy import (
         estimate_cache_recoverable,
     )
 
+    already_claimed = _per_agent_cache_recoverable_by_model(finding)
+
     proposals: list[CostProposal] = []
     for row in getattr(finding, "flagged", []) or []:
         usd, tokens = estimate_cache_recoverable([row])
+        claimed_usd, claimed_tokens = already_claimed.get((row.provider, row.model), (0.0, 0))
+        basis = str(getattr(finding, "estimate_basis", "") or "")
+        if claimed_usd > 0 or claimed_tokens > 0:
+            usd = round(max(0.0, (usd or 0.0) - claimed_usd), 6)
+            tokens = max(0, (tokens or 0) - claimed_tokens)
+            basis = (
+                basis + (" " if basis else "")
+                + f"Reduced by ${claimed_usd:.4f} already attributed to more "
+                "specific per-agent cache proposals for this model, so the "
+                "rollup does not double-count the same spend."
+            )
         evidence = (
             f"{row.provider}/{row.model}: {row.efficacy * 100:.0f}% of input "
             f"tokens served from cache over {row.input_tokens:,} input tokens "
@@ -203,7 +546,159 @@ def _cache_to_proposals(finding: Any) -> list[CostProposal]:
             ),
             estimated_recoverable_usd=usd,
             estimated_recoverable_tokens=tokens,
-            estimate_basis=str(getattr(finding, "estimate_basis", "") or ""),
+            estimate_basis=basis,
+        ))
+    return proposals
+
+
+def _cache_uncached_to_proposals(finding: Any) -> list[CostProposal]:
+    """One proposal per A1 uncached-agent candidate (see
+    ``analyzers.cache_efficacy``): an agent group making cacheable calls with
+    prompt caching never attempted. Verified through the same efficacy metric
+    as ``_cache_to_proposals`` (agent-scoped), so no ``cost_verify`` change
+    is needed for this check."""
+    if finding is None:
+        return []
+    proposals: list[CostProposal] = []
+    for c in getattr(finding, "uncached_agents", []) or []:
+        evidence = (
+            f"{c.agent_id}: {c.calls} calls on {c.model} with zero prompt "
+            f"caching attempted (no cache reads, no cache writes) across "
+            f"{c.sessions} session(s); assumed stable prefix "
+            f"~{c.assumed_prefix_tokens:,} tokens (this agent's own p25 input size)."
+        )
+        proposals.append(CostProposal(
+            kind="cost",
+            analyzer="cache",
+            signature=f"cost:cache-uncached:{c.agent_id}",
+            title=f"Uncached agent: {c.agent_id}",
+            target_key={"agent_id": c.agent_id, "provider": c.provider, "model": c.model},
+            evidence=evidence,
+            baseline={
+                "agent_id": c.agent_id, "provider": c.provider, "model": c.model,
+                "calls": c.calls, "sessions": c.sessions,
+                "assumed_prefix_tokens": c.assumed_prefix_tokens,
+            },
+            advise_text=(
+                "Add a cache_control breakpoint on this agent's stable prefix "
+                "(system prompt / tool definitions) so repeated calls read "
+                "from cache instead of paying full input price every time."
+            ),
+            suggestion=c.cache_control_snippet,
+            estimated_recoverable_usd=c.estimated_recoverable_usd,
+            estimated_recoverable_tokens=c.estimated_recoverable_tokens,
+            estimate_basis=c.estimate_basis,
+            agent_id=c.agent_id,
+        ))
+    return proposals
+
+
+def _cache_thrash_to_proposals(finding: Any) -> list[CostProposal]:
+    """One proposal per A2 cache-thrash candidate. Card text branches on the
+    detected root cause: a TTL-cadence card (honest break-even, which may say
+    the switch isn't worth it) versus an instability checklist card."""
+    if finding is None:
+        return []
+    from tokenjam.core.optimize.analyzers.cache_efficacy import (
+        SILENT_INVALIDATOR_CHECKLIST,
+    )
+
+    proposals: list[CostProposal] = []
+    for c in getattr(finding, "thrash_agents", []) or []:
+        evidence = (
+            f"{c.agent_id}: caching attempted on {c.model} but read:write "
+            f"ratio is {c.read_write_ratio:.2f} over {c.calls} calls "
+            f"({c.cache_read_tokens:,} cache-read tokens vs "
+            f"{c.cache_write_tokens:,} cache-write tokens); median inter-call "
+            f"gap {c.inter_call_gap_p50_minutes:.1f} min."
+        )
+        if c.cause == "ttl":
+            if c.ttl_worth_it:
+                advise = (
+                    "Calls land more than 5 minutes apart, so the default "
+                    "5-minute cache write is expiring before it's reused. "
+                    "Switching to the 1-hour cache TTL is estimated to pay "
+                    "off at this cadence."
+                )
+            else:
+                advise = (
+                    "Calls land more than 5 minutes apart, so the default "
+                    "5-minute cache write is expiring before it's reused. "
+                    "The 1-hour TTL's write premium doesn't clear at this "
+                    "cadence: caching not worth it at this cadence."
+                )
+        else:
+            advise = (
+                "Calls land close enough together that a TTL expiry doesn't "
+                "explain the miss rate; the prefix itself is likely changing "
+                "between calls. " + SILENT_INVALIDATOR_CHECKLIST
+            )
+        proposals.append(CostProposal(
+            kind="cost",
+            analyzer="cache_thrash",
+            signature=f"cost:cache-thrash:{c.agent_id}",
+            title=f"Cache thrash: {c.agent_id}",
+            target_key={"agent_id": c.agent_id, "provider": c.provider, "model": c.model},
+            evidence=evidence,
+            baseline={
+                "agent_id": c.agent_id, "provider": c.provider, "model": c.model,
+                "calls": c.calls, "cache_write_tokens": c.cache_write_tokens,
+                "cache_read_tokens": c.cache_read_tokens,
+                "read_write_ratio": c.read_write_ratio, "cause": c.cause,
+                "inter_call_gap_p50_minutes": c.inter_call_gap_p50_minutes,
+                "ttl_worth_it": c.ttl_worth_it,
+                "ttl_breakeven_usd": c.ttl_breakeven_usd,
+            },
+            advise_text=advise,
+            suggestion=c.cache_control_snippet,
+            estimated_recoverable_usd=c.estimated_recoverable_usd,
+            estimated_recoverable_tokens=c.estimated_recoverable_tokens,
+            estimate_basis=c.estimate_basis,
+            agent_id=c.agent_id,
+        ))
+    return proposals
+
+
+def _cache_lookback_to_proposals(finding: Any) -> list[CostProposal]:
+    """One proposal per A3 20-block-lookback-miss candidate. Weakest-
+    confidence check of the three; the analyzer only classifies an agent here
+    when A1/A2 don't already explain its cache waste."""
+    if finding is None:
+        return []
+    from tokenjam.core.optimize.analyzers.cache_efficacy import LOOKBACK_BLOCK_LIMIT
+
+    proposals: list[CostProposal] = []
+    for c in getattr(finding, "lookback_miss_agents", []) or []:
+        evidence = (
+            f"{c.agent_id}: {c.miss_count} cache miss(es) on {c.model}, each "
+            f"directly following a turn with an estimated "
+            f"{c.avg_prior_turn_blocks:.0f} content blocks (lookback limit: "
+            f"{LOOKBACK_BLOCK_LIMIT})."
+        )
+        proposals.append(CostProposal(
+            kind="cost",
+            analyzer="cache",
+            signature=f"cost:cache-lookback:{c.agent_id}",
+            title=f"20-block lookback miss: {c.agent_id}",
+            target_key={"agent_id": c.agent_id, "provider": c.provider, "model": c.model},
+            evidence=evidence,
+            baseline={
+                "agent_id": c.agent_id, "provider": c.provider, "model": c.model,
+                "miss_count": c.miss_count,
+                "avg_prior_turn_blocks": c.avg_prior_turn_blocks,
+            },
+            advise_text=(
+                "Anthropic's cache breakpoint search looks back at most "
+                f"{LOOKBACK_BLOCK_LIMIT} content blocks. Long tool-heavy "
+                "turns push the prior breakpoint out of range; add an "
+                "intermediate cache_control breakpoint every ~15 blocks in "
+                "long tool-use turns."
+            ),
+            suggestion=c.cache_control_snippet,
+            estimated_recoverable_usd=c.estimated_recoverable_usd,
+            estimated_recoverable_tokens=c.estimated_recoverable_tokens,
+            estimate_basis=c.estimate_basis,
+            agent_id=c.agent_id,
         ))
     return proposals
 
@@ -271,7 +766,80 @@ def _trim_to_proposals(finding: Any) -> list[CostProposal]:
     return proposals
 
 
-def _subagent_to_proposals(finding: Any) -> list[CostProposal]:
+#: A ``sub_agent_id`` only names an agent definition when it is a plain slug.
+#: Claude Code stamps a UUID for inline Task dispatches, and there is no file to
+#: edit for those: that is the guidance-block fallback case, not a lookup to
+#: guess at.
+_AGENT_NAME_RE = re.compile(r"^[a-z][a-z0-9]*(?:-[a-z0-9]+)*$")
+
+#: Cap on transcripts read to locate the repos a finding's sessions ran in.
+_MAX_SCOPE_SESSIONS = 20
+
+
+def _session_cwds(session_ids: list[str], config: Any) -> dict[str, str]:
+    """``session_id -> repo cwd``, read from the sessions' own transcripts.
+
+    Reuses the relearn detector's resolver rather than re-deriving a cwd from
+    the encoded project directory name, which is unreliable. Best-effort: an
+    unreadable transcript simply contributes no cwd.
+    """
+    from tokenjam.core.optimize.analyzers.relearn import _repo_cwd_map_for
+    from tokenjam.core.transcript import resolve_projects_root
+
+    override = getattr(getattr(config, "loop", None), "transcript_path", None)
+    root = resolve_projects_root(override)
+    pairs = [(sid, sid) for sid in session_ids[:_MAX_SCOPE_SESSIONS]]
+    return _repo_cwd_map_for(pairs, root)
+
+
+def _agent_model_plumbing(over_powered: list[Any], config: Any) -> dict[str, Any]:
+    """Whether a flagged subagent has a definition file whose model can be set.
+
+    Scope routing is relearn's: sessions concentrated in one repo write into
+    that repo's ``.claude/agents/``, sessions spanning repos write into the
+    user-global one. The flagged rows are cost-ordered, so the first subagent
+    with a real definition file is the most expensive one that can be fixed
+    outright. No file means the guidance block stays the fix, which is the
+    inline Task-tool case.
+    """
+    from tokenjam.core.optimize.analyzers.model_downgrade import lookup_downgrade
+    from tokenjam.core.optimize.analyzers.relearn import _scope_for
+    from tokenjam.core.optimize.model_apply import (
+        APPLY_KIND_AGENT_MODEL,
+        default_agent_file_path,
+    )
+
+    named = [
+        r for r in over_powered
+        if _AGENT_NAME_RE.match(str(getattr(r, "sub_agent_id", "") or ""))
+    ]
+    if not named or config is None:
+        return {}
+    cwds = _session_cwds([str(r.session_id) for r in over_powered], config)
+    repos = {Path(cwd).name for cwd in cwds.values() if cwd}
+    scope = _scope_for(repos)
+    repo_cwd = next(iter(cwds.values()), "") if len(repos) == 1 else ""
+
+    for row in named:
+        proposed = lookup_downgrade(str(row.provider), str(row.model))
+        if not proposed:
+            continue
+        name = str(row.sub_agent_id)
+        path = default_agent_file_path(scope, repo_cwd, name)
+        if not path or not Path(path).is_file():
+            continue
+        return {
+            "apply_kind": APPLY_KIND_AGENT_MODEL,
+            "agent_name": name,
+            "target_path": path,
+            "scope": scope,
+            "current_model": str(row.model),
+            "proposed_model": proposed,
+        }
+    return {}
+
+
+def _subagent_to_proposals(finding: Any, config: Any = None) -> list[CostProposal]:
     """One proposal covering the subagent right-sizing finding.
 
     Unlike the three advise-only analyzers, this one is workspace-appliable for
@@ -311,6 +879,64 @@ def _subagent_to_proposals(finding: Any) -> list[CostProposal]:
     # Apply-capable when we have a concrete model to name in the rubric; else
     # degrade to advise-only (no clean workspace surface to write).
     apply_capable = bool(models)
+    # The stronger surface, when the flagged subagent has a definition file: set
+    # its `model:` key outright instead of writing a rubric the orchestrator has
+    # to read and honor. Falls back to that rubric when there is no file.
+    try:
+        agent_apply = _agent_model_plumbing(over_powered, config)
+    except Exception:
+        agent_apply = {}
+    if agent_apply:
+        advise_extra = (
+            f" {agent_apply['agent_name']} has its own definition file, so "
+            f"tokenjam can set its model key to "
+            f"{agent_apply['proposed_model']} directly. The change is committed "
+            f"where the file is in a repo and reverts in one call. Its next "
+            f"dispatch runs on the new model, which is where measurement starts."
+        )
+        return [CostProposal(
+            kind="cost",
+            analyzer="subagent",
+            signature=f"cost:subagent:{agent_apply['agent_name']}",
+            title=(
+                f"Over-powered subagent {agent_apply['agent_name']} "
+                f"({agent_apply['current_model']} to {agent_apply['proposed_model']})"
+            ),
+            target_key={
+                "models": models, "subagent": True,
+                "agent_name": agent_apply["agent_name"],
+            },
+            evidence=evidence,
+            baseline={
+                "flagged_subagents": subagents,
+                "flagged_cost_usd": float(getattr(finding, "flagged_cost_usd", 0.0) or 0.0),
+                "subagent_cost_usd": float(getattr(finding, "subagent_cost_usd", 0.0) or 0.0),
+                "percent_of_cost": float(getattr(finding, "percent_of_cost", 0.0) or 0.0),
+                "agent_name": agent_apply["agent_name"],
+                "current_model": agent_apply["current_model"],
+                "proposed_model": agent_apply["proposed_model"],
+            },
+            advise_text=(
+                "Lower the model tier for the flagged Task dispatches. "
+                + str(getattr(finding, "caveat", "") or "") + advise_extra
+            ).strip(),
+            suggestion=f"model: {agent_apply['proposed_model']}",
+            one_paste_fix=(
+                f"# In {agent_apply['target_path']}, frontmatter:\n"
+                f"model: {agent_apply['proposed_model']}"
+            ),
+            estimated_recoverable_usd=getattr(finding, "estimated_recoverable_usd", None),
+            estimated_recoverable_tokens=getattr(finding, "estimated_recoverable_tokens", None),
+            estimate_basis=str(getattr(finding, "estimate_basis", "") or ""),
+            advise_only=False,
+            apply_capable=True,
+            scope=agent_apply["scope"],
+            apply_kind=agent_apply["apply_kind"],
+            agent_name=agent_apply["agent_name"],
+            target_path=agent_apply["target_path"],
+            current_model=agent_apply["current_model"],
+            proposed_model=agent_apply["proposed_model"],
+        )]
     return [CostProposal(
         kind="cost",
         analyzer="subagent",
@@ -349,14 +975,14 @@ def _deadweight_to_proposals(finding: Any) -> list[CostProposal]:
     visibility) never feeds a proposal here, so a server's schema-injection
     tax is never counted both in the tax table AND a proposal (the same
     dedup guarantee ``compute_deadweight_finding`` itself enforces on
-    ``estimated_recoverable_tokens``).
+    ``estimated_recoverable_tokens`` / ``estimated_recoverable_usd``).
 
-    Dollar figures are deliberately left ``None``: the tax is a token
-    estimate (a cited per-server constant, not priced against any one
-    session's actual model), and stacking an unknown model rate onto an
-    already-``estimated`` token figure would compound uncertainty rather
-    than inform it — so this card is tokens-only, like the analyzer's own
-    finding.
+    ``estimated_recoverable_usd`` is carried straight off the analyzer's own
+    ``ServerDeadweight.estimated_tax_usd_90d`` — the analyzer already prices
+    the token tax through ``core/pricing.py`` at the dominant model observed
+    in that server's sessions (never a hardcoded rate; see
+    ``deadweight._pricing_note``). Stays ``None`` when no priced model was
+    observed for that server — this adapter never invents a rate itself.
     """
     if finding is None:
         return []
@@ -389,6 +1015,7 @@ def _deadweight_to_proposals(finding: Any) -> list[CostProposal]:
                 "scope": server.scope,
                 "source": server.source,
                 "example_sessions": list(server.example_sessions),
+                "priced_model": server.priced_model,
             },
             advise_text=(
                 server.fix + " Removing (or project-scoping) it is reversible "
@@ -397,12 +1024,219 @@ def _deadweight_to_proposals(finding: Any) -> list[CostProposal]:
             ),
             suggestion=f"claude mcp remove {server.name} --scope {scope_flag}",
             estimated_recoverable_tokens=server.estimated_tax_tokens_90d or None,
+            estimated_recoverable_usd=server.estimated_tax_usd_90d,
             estimate_basis=(
                 server.tax_construction
                 + " Projected over a 90-day window from the sessions observed."
             ),
         ))
     return proposals
+
+
+def _cluster_hash(value: Any) -> str:
+    """Stable 12-hex-char identity for a cluster's structural key. Deterministic
+    across runs over the same underlying signature (a JSON-serialisable
+    structure), used only where the analyzer itself doesn't already hand back
+    a cluster id (contrast ``ReuseCluster.cluster_id``, which does)."""
+    encoded = json.dumps(value, sort_keys=False, default=str)
+    return hashlib.sha256(encoded.encode("utf-8")).hexdigest()[:12]
+
+
+def _script_to_proposals(finding: Any) -> list[CostProposal]:
+    """One proposal per flagged deterministic-tool-call cluster.
+
+    Apply-capable at rung 2: a skill note naming the repeated call pattern and
+    recommending a script in its place. No agent-file/model-swap surface
+    exists here (this isn't a model-routing finding), so unlike ``subagent``
+    there is only the one apply shape. The skill's slug is derived from the
+    title, which embeds the cluster's own hash so two clusters never collide
+    on the same skill file (`relearn_apply`'s create-only guard would otherwise
+    let a second cluster's apply silently overwrite the first's skill note).
+    """
+    if finding is None:
+        return []
+    clusters = list(getattr(finding, "clusters", []) or [])
+    if not clusters:
+        return []
+    degraded = bool(getattr(finding, "degraded", False))
+    caveat = str(getattr(finding, "caveat", "") or "")
+
+    proposals: list[CostProposal] = []
+    for cluster in clusters:
+        if cluster.total_cost_usd <= 0 and cluster.total_tokens <= 0:
+            continue
+        cluster_hash = _cluster_hash(cluster.signature)
+        tool_names = [step.get("tool", "?") for step in cluster.signature]
+        tool_list = " -> ".join(tool_names) or "(no tools recorded)"
+        title = f"Deterministic tool pattern: {tool_list} ({cluster_hash})"
+        evidence = (
+            f"{cluster.instances} sessions ran the same tool-call structure "
+            f"({tool_list}), averaging {cluster.avg_tokens:,} input+output "
+            f"tokens and {_money(cluster.avg_cost_usd)} per session."
+        )
+        if degraded:
+            evidence += (
+                " Clustered on tool names only (enable [capture] tool_inputs "
+                "in tj.toml for the finer argument-shape signature)."
+            )
+        advise = (
+            _SCRIPT_SKILL_INTRO + " " + caveat
+        ).strip()
+        proposals.append(CostProposal(
+            kind="cost",
+            analyzer="script",
+            signature=f"cost:script:{cluster_hash}",
+            title=title,
+            target_key={"signature": cluster.signature, "instances": cluster.instances},
+            evidence=evidence,
+            baseline={
+                "instances": cluster.instances,
+                "avg_cost_usd": cluster.avg_cost_usd,
+                "avg_tokens": cluster.avg_tokens,
+                "avg_duration_seconds": cluster.avg_duration_seconds,
+                "example_session_id": cluster.example_session_id,
+                "degraded": degraded,
+                "apply_sessions": cluster.instances,
+                "apply_examples": [
+                    {"session_id": sid, "repo": "", "snippet": tool_list[:160]}
+                    for sid in (cluster.example_session_ids or [])
+                ],
+            },
+            advise_text=advise,
+            estimated_recoverable_usd=cluster.total_cost_usd or None,
+            estimated_recoverable_tokens=cluster.total_tokens or None,
+            estimate_basis=str(getattr(finding, "estimate_basis", "") or ""),
+            advise_only=False,
+            apply_capable=True,
+            rung=2,
+            scope="project",
+            proposed_fix=advise,
+        ))
+    return proposals
+
+
+def _reuse_to_proposals(finding: Any) -> list[CostProposal]:
+    """One proposal per repeated planning-skeleton cluster.
+
+    Apply-capable at rung 1: a CLAUDE.md note naming the recurring skeleton.
+    Uses the finding's conservative ``cache_reuse_recoverable_*`` figure (you
+    already paid for the plan once), not the ``script_replacement_*`` upper
+    bound, matching ``ReuseFinding``'s own aggregate.
+    """
+    if finding is None:
+        return []
+    clusters = list(getattr(finding, "clusters", []) or [])
+    if not clusters:
+        return []
+
+    proposals: list[CostProposal] = []
+    for cluster in clusters:
+        if cluster.cache_reuse_recoverable_usd <= 0 and cluster.cache_reuse_recoverable_tokens <= 0:
+            continue
+        tool_list = ", ".join(cluster.tool_signature) or "(no tool calls after the plan)"
+        title = f"Repeated planning skeleton: {tool_list} ({cluster.cluster_id})"
+        evidence = (
+            f"{cluster.repetitions} sessions shared a planning-call skeleton "
+            f"(tool sequence after the plan: {tool_list}), averaging "
+            f"{cluster.avg_planning_tokens:,} planning tokens "
+            f"({_money(cluster.avg_planning_cost_usd)} per call)."
+        )
+        advise = (
+            _REUSE_NOTE_INTRO + " " + str(cluster.caveat or "")
+        ).strip()
+        proposals.append(CostProposal(
+            kind="cost",
+            analyzer="reuse",
+            signature=f"cost:reuse:{cluster.cluster_id}",
+            title=title,
+            target_key={
+                "cluster_id": cluster.cluster_id,
+                "tool_signature": list(cluster.tool_signature),
+            },
+            evidence=evidence,
+            baseline={
+                "repetitions": cluster.repetitions,
+                "avg_planning_tokens": cluster.avg_planning_tokens,
+                "avg_planning_cost_usd": cluster.avg_planning_cost_usd,
+                "skeleton_session_id": cluster.skeleton_session_id,
+                "apply_sessions": cluster.repetitions,
+                "apply_examples": [
+                    {"session_id": sid, "repo": "", "snippet": tool_list[:160]}
+                    for sid in (cluster.example_session_ids or [])
+                ],
+            },
+            advise_text=advise,
+            estimated_recoverable_usd=cluster.cache_reuse_recoverable_usd or None,
+            estimated_recoverable_tokens=cluster.cache_reuse_recoverable_tokens or None,
+            estimate_basis=str(getattr(finding, "estimate_basis", "") or ""),
+            advise_only=False,
+            apply_capable=True,
+            rung=1,
+            scope="project",
+            proposed_fix=advise,
+        ))
+    return proposals
+
+
+def _verbosity_to_proposals(finding: Any) -> list[CostProposal]:
+    """One proposal for the whole verbosity finding (unlike ``script``/
+    ``reuse``, this is a single window-wide signal, not per-cluster).
+
+    Apply-capable at rung 1: a CLAUDE.md note carrying the finding's own
+    ``remedy_snippet`` plus its suggested ``max_tokens`` cap. This is the
+    least-grounded of the three analyzers by design (output length is not
+    waste), so the note leans on the finding's own honesty caveat rather than
+    asserting a saving. Left un-degraded to advise-only would strand the one
+    lever this analyzer already computes (the remedy snippet) with nowhere to
+    go; a workspace note is the same class of soft, orchestrator-read surface
+    the ``subagent`` rubric already uses, so this reuses that precedent
+    rather than inventing a new one.
+    """
+    if finding is None:
+        return []
+    total_candidates = int(getattr(finding, "total_candidates", 0) or 0)
+    if total_candidates <= 0:
+        return []
+    remedy = str(getattr(finding, "remedy_snippet", "") or "")
+    max_tokens = getattr(finding, "suggested_max_tokens", None)
+    caveat = str(getattr(finding, "caveat", "") or "")
+    evidence = (
+        f"{total_candidates} session(s) across "
+        f"{int(getattr(finding, 'cohorts_examined', 0) or 0)} task-shape "
+        f"cohort(s) ran output well above their cohort's median."
+    )
+    advise = remedy
+    if max_tokens:
+        advise += (
+            f" Suggested cap for this shape of task: keep responses under "
+            f"about {max_tokens:,} output tokens (the cohort baseline most "
+            f"sessions already sit under)."
+        )
+    advise = (advise + " " + caveat).strip()
+    return [CostProposal(
+        kind="cost",
+        analyzer="verbosity",
+        signature="cost:verbosity",
+        title="High-verbosity output vs cohort baseline",
+        target_key={"total_candidates": total_candidates},
+        evidence=evidence,
+        baseline={
+            "total_candidates": total_candidates,
+            "sessions_examined": int(getattr(finding, "sessions_examined", 0) or 0),
+            "cohorts_examined": int(getattr(finding, "cohorts_examined", 0) or 0),
+            "suggested_max_tokens": max_tokens,
+            "apply_sessions": total_candidates,
+        },
+        advise_text=advise,
+        estimated_recoverable_usd=getattr(finding, "estimated_recoverable_usd", None),
+        estimated_recoverable_tokens=getattr(finding, "estimated_recoverable_tokens", None),
+        estimate_basis=str(getattr(finding, "estimate_basis", "") or ""),
+        advise_only=False,
+        apply_capable=True,
+        rung=1,
+        scope="project",
+        proposed_fix=advise,
+    )]
 
 
 #: Default look-back for the daemon/CLI cost-proposal recompute. Matches the
@@ -439,7 +1273,7 @@ def recompute_cost_proposals(
             db, config, since, until, agent_id=agent_id,
             findings=list(COST_ANALYZERS),
         )
-        proposals = cost_proposals_from_report(report)
+        proposals = cost_proposals_from_report(report, config=config)
     except Exception:
         return []
 
@@ -450,23 +1284,36 @@ def recompute_cost_proposals(
     return proposals
 
 
-def cost_proposals_from_report(report: Any) -> list[CostProposal]:
+def cost_proposals_from_report(report: Any, config: Any = None) -> list[CostProposal]:
     """Every cost proposal derivable from an already-built ``OptimizeReport``.
 
     Reads the ``downsize`` finding off the typed ``report.downgrade`` slot and
-    the ``cache`` / ``trim`` / ``subagent`` / ``deadweight`` findings off
-    ``report.findings``. Missing findings (analyzer not run, no candidates)
-    contribute nothing. Never raises — a malformed finding is skipped so one
-    bad analyzer can't sink the inbox.
+    the ``cache`` / ``trim`` / ``subagent`` / ``placement`` / ``deadweight`` /
+    ``script`` / ``reuse`` / ``verbosity`` findings off ``report.findings``.
+    Missing findings (analyzer not run, no candidates) contribute nothing.
+    Never raises — a malformed finding is skipped so one bad analyzer can't
+    sink the inbox.
+
+    ``config`` is optional and used for one thing: looking up the local source
+    path a user registered for an agent, which decides whether the downsize card
+    can offer the gated model-id swap or falls back to its one-paste artifact.
+    Without it every card is advise-only.
     """
     findings = getattr(report, "findings", {}) or {}
     proposals: list[CostProposal] = []
     adapters = (
-        (_downsize_to_proposal, getattr(report, "downgrade", None)),
+        (lambda f: _downsize_to_proposal(f, config), getattr(report, "downgrade", None)),
         (_cache_to_proposals, findings.get("cache")),
+        (_cache_uncached_to_proposals, findings.get("cache")),
+        (_cache_thrash_to_proposals, findings.get("cache")),
+        (_cache_lookback_to_proposals, findings.get("cache")),
         (_trim_to_proposals, findings.get("trim")),
-        (_subagent_to_proposals, findings.get("subagent")),
+        (lambda f: _subagent_to_proposals(f, config), findings.get("subagent")),
+        (_placement_to_proposals, findings.get("placement")),
         (_deadweight_to_proposals, findings.get("deadweight")),
+        (_script_to_proposals, findings.get("script")),
+        (_reuse_to_proposals, findings.get("reuse")),
+        (_verbosity_to_proposals, findings.get("verbosity")),
     )
     for adapter, finding in adapters:
         try:
@@ -505,6 +1352,14 @@ def estimated_recoverable_rollup(
     (counting it in "N proposals" without a dollar contribution would
     silently understate the average the headline implies).
 
+    ``estimated_recoverable_tokens`` is summed independently, over whichever
+    proposals carry a token estimate — a different (often overlapping but never
+    identical) set from the dollar-bearing ones. Renderers that lead with the
+    token figure (subscription users, where dollars cover only the API-billed
+    slice) must therefore quote ``token_proposal_count`` rather than
+    ``proposal_count``, and say so against ``deduplicated_proposal_count`` when
+    coverage is partial: the token sum is a floor, not a total.
+
     Tagged ``estimated`` — see ``receipts.verified_saved_summary`` for the
     measured twin (Component G1). The two figures are NEVER added together;
     every caller must keep them as two clearly labeled numbers.
@@ -520,7 +1375,19 @@ def estimated_recoverable_rollup(
     contributing: list[dict[str, Any]] = []
     by_analyzer: dict[str, dict[str, Any]] = {}
     total_usd = 0.0
+    total_tokens = 0
+    token_proposal_count = 0
     for row in seen.values():
+        # The token sum is counted INDEPENDENTLY of the dollar sum: the two
+        # estimates are populated by different analyzers and a proposal can
+        # carry either one alone. Folding tokens in only where a dollar
+        # estimate also exists would silently understate the token headline
+        # the suppressed-dollars rendering path leads with.
+        tokens = row.get("estimated_recoverable_tokens")
+        if tokens is not None:
+            total_tokens += int(tokens)
+            token_proposal_count += 1
+
         usd = row.get("estimated_recoverable_usd")
         if usd is None:
             continue
@@ -536,6 +1403,10 @@ def estimated_recoverable_rollup(
         })
 
     proposal_count = len(contributing)
+    # Denominator for BOTH coverage claims: every open, deduplicated proposal,
+    # including the ones carrying neither estimate. A renderer that says "across
+    # N proposals" without this can't tell the reader its figure is partial.
+    deduplicated_proposal_count = len(seen)
     if proposal_count == 0:
         basis = (
             "no open (not yet applied) cost proposal currently carries a "
@@ -548,16 +1419,27 @@ def estimated_recoverable_rollup(
             for a in sorted(by_analyzer.values(), key=lambda x: x["analyzer"])
         )
         basis = (
-            f"sum of estimated_recoverable_usd across {proposal_count} open "
-            f"(not yet applied), deduplicated-by-signature cost proposal(s) "
-            f"over the last {window_days}d; contributing analyzers: {breakdown}. "
+            f"sum of estimated_recoverable_usd across {proposal_count} of "
+            f"{deduplicated_proposal_count} open (not yet applied), "
+            f"deduplicated-by-signature cost proposal(s) over the last "
+            f"{window_days}d; contributing analyzers: {breakdown}. "
             "Estimated, correlational; never mixed with the measured "
             "verified-saved figure."
+        )
+    if token_proposal_count:
+        basis += (
+            f" Token figure: sum of estimated_recoverable_tokens across "
+            f"{token_proposal_count} of {deduplicated_proposal_count} "
+            f"proposal(s); the rest carry no token estimate, so it is a "
+            f"floor, not a total."
         )
 
     return {
         "estimated_recoverable_usd": round(total_usd, 6),
+        "estimated_recoverable_tokens": total_tokens,
         "proposal_count": proposal_count,
+        "token_proposal_count": token_proposal_count,
+        "deduplicated_proposal_count": deduplicated_proposal_count,
         "window_days": window_days,
         "by_analyzer": sorted(by_analyzer.values(), key=lambda x: x["analyzer"]),
         "contributing": contributing,

--- a/tokenjam/core/optimize/cost_proposals.py
+++ b/tokenjam/core/optimize/cost_proposals.py
@@ -30,9 +30,7 @@ proposals. It never touches the DB, the store, or the network.
 """
 from __future__ import annotations
 
-import re
 from dataclasses import dataclass
-from pathlib import Path
 from typing import Any
 
 # House-style label strings. Kept verbatim on every cost proposal so no channel
@@ -44,8 +42,8 @@ COST_CORRELATIONAL_CAVEAT = (
     "before changing anything."
 )
 
-#: The three analyzers this wiring covers, by registration name.
-COST_ANALYZERS = ("downsize", "cache", "trim", "subagent")
+#: The analyzers this wiring covers, by registration name.
+COST_ANALYZERS = ("downsize", "cache", "trim", "subagent", "deadweight")
 
 # The rung-1 sizing-rubric note a CC-origin subagent proposal writes into the
 # workspace CLAUDE.md when applied. A shape-based default, not a per-subagent
@@ -110,23 +108,6 @@ class CostProposal:
     rung:                 int  = 0
     scope:                str  = ""
     proposed_fix:         str  = ""
-    # Model-routing apply kinds (``core.optimize.model_apply``). Set only where
-    # the edit is a deterministic rewrite of a value already written down: an
-    # agent file's ``model:`` key, or one exact model-id string in a repo the
-    # user registered. Empty everywhere else, which leaves the card advise-only
-    # with its one-paste artifact.
-    apply_kind:           str  = ""
-    agent_name:           str  = ""
-    current_model:        str  = ""
-    proposed_model:       str  = ""
-    source_path:          str  = ""
-    target_path:          str  = ""
-    # Why the direct apply is not on offer, when it is not. Rendered on the card
-    # next to the one-paste fix so a fallback is never silent.
-    apply_blocked_reason: str  = ""
-    # The exact fix, with this agent's own measured values already substituted
-    # in. Every advise-only card carries one.
-    one_paste_fix:        str  = ""
 
 
 # --------------------------------------------------------------------------- #
@@ -134,26 +115,16 @@ class CostProposal:
 # proposals. All tolerate a None/empty finding (returns []).
 # --------------------------------------------------------------------------- #
 
-def _downsize_to_proposal(finding: Any, config: Any = None) -> list[CostProposal]:
-    """The model-over-sizing card(s).
+def _downsize_to_proposal(finding: Any) -> list[CostProposal]:
+    """One proposal covering the model-over-sizing finding.
 
-    When the finding carries per-agent price rows, each agent gets its own card
-    with its own arithmetic (and, where the preconditions hold, the gated model-
-    id swap). Those rows partition the same candidate sessions, so the window-
-    wide card is NOT emitted alongside them: one source of over-sized spend,
-    one card.
-
-    Without those rows (no pricing data for a model on either side) the finding
-    falls back to the single window-wide card. ``DowngradeFinding.suggestions``
-    maps each oversized model to its cheaper same-family alternative, and the
-    delta-verify pass measures the model-mix cost delta across ALL flagged
-    models, so one proposal listing them keeps that aggregate estimate coherent.
+    ``DowngradeFinding.suggestions`` maps each oversized model to its cheaper
+    same-family alternative. The delta-verify pass later measures the model-mix
+    cost delta across ALL flagged models, so a single proposal (listing them)
+    keeps the estimate — which is a finding-level aggregate — coherent.
     """
     if finding is None or getattr(finding, "candidate_sessions", 0) <= 0:
         return []
-    per_agent = _downsize_agent_proposals(finding, config)
-    if per_agent:
-        return per_agent
     suggestions: dict[str, str] = dict(getattr(finding, "suggestions", {}) or {})
     if not suggestions:
         return []
@@ -188,230 +159,9 @@ def _downsize_to_proposal(finding: Any, config: Any = None) -> list[CostProposal
         },
         advise_text=advise,
         suggestion=suggestion,
-        one_paste_fix=suggestion,
         estimated_recoverable_usd=getattr(finding, "estimated_recoverable_usd", None),
         estimated_recoverable_tokens=getattr(finding, "estimated_recoverable_tokens", None),
         estimate_basis=str(getattr(finding, "estimate_basis", "") or ""),
-    )]
-
-
-def _money(value: float) -> str:
-    """A dollar figure with enough precision to stay honest at small values.
-
-    Never rendered bare: every call site pairs it with an estimated/measured tag
-    and the construction footnote.
-    """
-    if abs(value) >= 1.0:
-        return f"${value:,.2f}"
-    return f"${value:.4f}"
-
-
-def _agent_arithmetic_line(row: Any) -> str:
-    """The card's arithmetic, spelled out with both sides of the comparison."""
-    window = (
-        f"{row.sessions} session(s) over {row.window_days:.0f} day(s): "
-        f"{row.input_tokens:,} input, {row.output_tokens:,} output, "
-        f"{row.cache_tokens:,} cache read and {row.cache_write_tokens:,} cache "
-        f"write tokens. At {row.model} rates that is "
-        f"{_money(row.current_cost_usd)}; the same tokens at {row.alt_model} "
-        f"rates are {_money(row.alternative_cost_usd)}. Difference: "
-        f"{_money(row.delta_usd)} over the window, up to "
-        f"{_money(row.projected_30d_delta_usd)} per 30 days at this rate "
-        f"(estimated)."
-    )
-    if row.thinking_share_of_output is not None:
-        window += (
-            f" Thinking tokens were {row.thinking_share_of_output * 100:.0f}% of "
-            f"this agent's output tokens over the same sessions "
-            f"({row.thinking_tokens:,} of {row.output_tokens:,}, measured); "
-            f"they bill as output on both models."
-        )
-    return window
-
-
-def _model_swap_plumbing(row: Any, config: Any) -> dict[str, Any]:
-    """Whether this agent's swap can be written directly, and where.
-
-    The direct write is offered only when the user registered a local source
-    path for the agent and every precondition in
-    ``model_apply.model_swap_precheck`` holds. Otherwise the card keeps its
-    one-paste artifact and states the reason.
-    """
-    from tokenjam.core.optimize.model_apply import (
-        APPLY_KIND_MODEL_SWAP,
-        model_swap_precheck,
-    )
-
-    agents = getattr(config, "agents", None) or {}
-    agent_cfg = agents.get(row.agent_id) if hasattr(agents, "get") else None
-    source_path = str(getattr(agent_cfg, "source_path", "") or "")
-    check = model_swap_precheck(source_path, row.model)
-    if not check["ok"]:
-        return {"apply_capable": False, "apply_blocked_reason": check["reason"]}
-    return {
-        "apply_capable": True,
-        "apply_kind": APPLY_KIND_MODEL_SWAP,
-        "source_path": source_path,
-        "target_path": check["target_path"],
-        "current_model": row.model,
-        "proposed_model": row.alt_model,
-        "apply_blocked_reason": "",
-    }
-
-
-def _downsize_agent_proposals(finding: Any, config: Any) -> list[CostProposal]:
-    """One card per agent, carrying that agent's own price arithmetic.
-
-    Replaces the window-wide card when per-agent rows exist, so one source of
-    over-sized spend produces exactly one card rather than an aggregate plus its
-    own parts.
-    """
-    proposals: list[CostProposal] = []
-    for row in getattr(finding, "per_agent", []) or []:
-        if row.delta_usd <= 0:
-            # The proposed model is not actually cheaper for this agent's token
-            # mix. There is nothing to recover, so there is no card: a rollup
-            # that summed this would be summing a loss.
-            continue
-        plumbing = _model_swap_plumbing(row, config) if config is not None else {
-            "apply_capable": False,
-            "apply_blocked_reason": (
-                "no tj config was available to look up a registered source path."
-            ),
-        }
-        one_paste = (
-            f"{row.model} -> {row.alt_model}\n"
-            f"# Set this agent's model id to {row.alt_model} where it is "
-            f"configured, then redeploy or restart the agent."
-        )
-        advise = (
-            f"Route {row.agent_id}'s flagged structural-shaped work from "
-            f"{row.model} to {row.alt_model}. The price difference above is "
-            f"arithmetic on this agent's measured tokens, given the switch; "
-            f"whether the cheaper model answers as well is not measured here, "
-            f"so review the example sessions first."
-        )
-        if plumbing.get("apply_capable"):
-            advise += (
-                f" tokenjam can make this exact substitution in "
-                f"{plumbing['target_path']}, with the change committed and "
-                f"revertable in one call. After it is applied you must redeploy "
-                f"or restart the agent: measurement starts at the first call "
-                f"that runs on {row.alt_model}, not at the moment of the write."
-            )
-        elif plumbing.get("apply_blocked_reason"):
-            advise += f" Applying it here is not on offer: {plumbing['apply_blocked_reason']}"
-        proposals.append(CostProposal(
-            kind="cost",
-            analyzer="downsize",
-            signature=f"cost:downsize:{row.agent_id}",
-            title=f"Model over-sizing in {row.agent_id} ({row.model} to {row.alt_model})",
-            target_key={
-                "agent_id": row.agent_id,
-                "models": [row.model],
-                "suggestions": {row.model: row.alt_model},
-            },
-            evidence=_agent_arithmetic_line(row),
-            baseline={
-                "agent_id": row.agent_id,
-                "provider": row.provider,
-                "model": row.model,
-                "alt_model": row.alt_model,
-                "sessions": row.sessions,
-                "input_tokens": row.input_tokens,
-                "output_tokens": row.output_tokens,
-                "cache_tokens": row.cache_tokens,
-                "cache_write_tokens": row.cache_write_tokens,
-                "current_cost_usd": row.current_cost_usd,
-                "alternative_cost_usd": row.alternative_cost_usd,
-                "delta_usd": row.delta_usd,
-                "projected_30d_delta_usd": row.projected_30d_delta_usd,
-                "thinking_tokens": row.thinking_tokens,
-                "thinking_share_of_output": row.thinking_share_of_output,
-            },
-            advise_text=advise,
-            suggestion=one_paste,
-            one_paste_fix=one_paste,
-            estimated_recoverable_usd=row.delta_usd,
-            estimated_recoverable_tokens=row.total_tokens,
-            estimate_basis=row.estimate_basis,
-            agent_id=row.agent_id if row.agent_id != "unknown" else "",
-            advise_only=not plumbing.get("apply_capable", False),
-            apply_capable=bool(plumbing.get("apply_capable")),
-            apply_kind=str(plumbing.get("apply_kind", "")),
-            source_path=str(plumbing.get("source_path", "")),
-            target_path=str(plumbing.get("target_path", "")),
-            current_model=str(plumbing.get("current_model", "")),
-            proposed_model=str(plumbing.get("proposed_model", "")),
-            apply_blocked_reason=str(plumbing.get("apply_blocked_reason", "")),
-        ))
-    return proposals
-
-
-def _placement_to_proposals(finding: Any) -> list[CostProposal]:
-    """One card for the batch-placement candidates (advise-only).
-
-    Advise-only is not a formality here: moving a workload to the batch lane is
-    an architectural change in the user's own application, and the card says so
-    beside the number.
-    """
-    if finding is None:
-        return []
-    candidates = list(getattr(finding, "candidates", []) or [])
-    if not candidates:
-        return []
-    agents = ", ".join(c.agent_id for c in candidates[:5])
-    total = float(getattr(finding, "candidate_cost_usd", 0.0) or 0.0)
-    saving = float(getattr(finding, "estimated_recoverable_usd", 0.0) or 0.0)
-    percent = float(getattr(finding, "percent_of_window_cost", 0.0) or 0.0)
-    cadence = ", ".join(
-        f"{c.agent_id} every {c.median_gap_seconds / 3600:.1f}h across "
-        f"{c.sessions} runs"
-        for c in candidates[:5]
-    )
-    evidence = (
-        f"{len(candidates)} workload(s) ran on a regular cadence with no human "
-        f"turn after the first model call ({cadence}). They are "
-        f"{percent:.0f}% of the window's spend, {_money(total)} (measured)."
-    )
-    advise = (
-        f"The Batch API bills a flat 50% of standard prices, so the same work "
-        f"on the batch lane is {_money(saving)} less over this window "
-        f"(estimated). {getattr(finding, 'friction', '')} Nothing here is "
-        f"applied for you; the change lives in your own application code."
-    )
-    return [CostProposal(
-        kind="cost",
-        analyzer="placement",
-        signature="cost:placement:batch",
-        title="Batch API candidates (unattended, cadence-regular workloads)",
-        target_key={"agents": [c.agent_id for c in candidates], "placement": "batch"},
-        evidence=evidence,
-        baseline={
-            "candidates": [
-                {
-                    "agent_id": c.agent_id, "sessions": c.sessions,
-                    "median_gap_seconds": c.median_gap_seconds, "gap_cv": c.gap_cv,
-                    "cost_usd": c.cost_usd, "tokens": c.tokens,
-                    "estimated_batch_saving_usd": c.estimated_batch_saving_usd,
-                }
-                for c in candidates
-            ],
-            "candidate_cost_usd": total,
-            "window_cost_usd": float(getattr(finding, "window_cost_usd", 0.0) or 0.0),
-            "percent_of_window_cost": percent,
-        },
-        advise_text=advise,
-        suggestion=agents,
-        one_paste_fix=(
-            "# Submit these workloads through the Batch API instead of the "
-            "synchronous endpoint:\n"
-            + "\n".join(f"#   {c.agent_id}" for c in candidates)
-        ),
-        estimated_recoverable_usd=saving,
-        estimated_recoverable_tokens=getattr(finding, "estimated_recoverable_tokens", None),
-        estimate_basis=str(getattr(finding, "estimate_basis", "") or ""),
-        agent_id=candidates[0].agent_id if len(candidates) == 1 else "",
     )]
 
 
@@ -521,80 +271,7 @@ def _trim_to_proposals(finding: Any) -> list[CostProposal]:
     return proposals
 
 
-#: A ``sub_agent_id`` only names an agent definition when it is a plain slug.
-#: Claude Code stamps a UUID for inline Task dispatches, and there is no file to
-#: edit for those: that is the guidance-block fallback case, not a lookup to
-#: guess at.
-_AGENT_NAME_RE = re.compile(r"^[a-z][a-z0-9]*(?:-[a-z0-9]+)*$")
-
-#: Cap on transcripts read to locate the repos a finding's sessions ran in.
-_MAX_SCOPE_SESSIONS = 20
-
-
-def _session_cwds(session_ids: list[str], config: Any) -> dict[str, str]:
-    """``session_id -> repo cwd``, read from the sessions' own transcripts.
-
-    Reuses the relearn detector's resolver rather than re-deriving a cwd from
-    the encoded project directory name, which is unreliable. Best-effort: an
-    unreadable transcript simply contributes no cwd.
-    """
-    from tokenjam.core.optimize.analyzers.relearn import _repo_cwd_map_for
-    from tokenjam.core.transcript import resolve_projects_root
-
-    override = getattr(getattr(config, "loop", None), "transcript_path", None)
-    root = resolve_projects_root(override)
-    pairs = [(sid, sid) for sid in session_ids[:_MAX_SCOPE_SESSIONS]]
-    return _repo_cwd_map_for(pairs, root)
-
-
-def _agent_model_plumbing(over_powered: list[Any], config: Any) -> dict[str, Any]:
-    """Whether a flagged subagent has a definition file whose model can be set.
-
-    Scope routing is relearn's: sessions concentrated in one repo write into
-    that repo's ``.claude/agents/``, sessions spanning repos write into the
-    user-global one. The flagged rows are cost-ordered, so the first subagent
-    with a real definition file is the most expensive one that can be fixed
-    outright. No file means the guidance block stays the fix, which is the
-    inline Task-tool case.
-    """
-    from tokenjam.core.optimize.analyzers.model_downgrade import lookup_downgrade
-    from tokenjam.core.optimize.analyzers.relearn import _scope_for
-    from tokenjam.core.optimize.model_apply import (
-        APPLY_KIND_AGENT_MODEL,
-        default_agent_file_path,
-    )
-
-    named = [
-        r for r in over_powered
-        if _AGENT_NAME_RE.match(str(getattr(r, "sub_agent_id", "") or ""))
-    ]
-    if not named or config is None:
-        return {}
-    cwds = _session_cwds([str(r.session_id) for r in over_powered], config)
-    repos = {Path(cwd).name for cwd in cwds.values() if cwd}
-    scope = _scope_for(repos)
-    repo_cwd = next(iter(cwds.values()), "") if len(repos) == 1 else ""
-
-    for row in named:
-        proposed = lookup_downgrade(str(row.provider), str(row.model))
-        if not proposed:
-            continue
-        name = str(row.sub_agent_id)
-        path = default_agent_file_path(scope, repo_cwd, name)
-        if not path or not Path(path).is_file():
-            continue
-        return {
-            "apply_kind": APPLY_KIND_AGENT_MODEL,
-            "agent_name": name,
-            "target_path": path,
-            "scope": scope,
-            "current_model": str(row.model),
-            "proposed_model": proposed,
-        }
-    return {}
-
-
-def _subagent_to_proposals(finding: Any, config: Any = None) -> list[CostProposal]:
+def _subagent_to_proposals(finding: Any) -> list[CostProposal]:
     """One proposal covering the subagent right-sizing finding.
 
     Unlike the three advise-only analyzers, this one is workspace-appliable for
@@ -634,64 +311,6 @@ def _subagent_to_proposals(finding: Any, config: Any = None) -> list[CostProposa
     # Apply-capable when we have a concrete model to name in the rubric; else
     # degrade to advise-only (no clean workspace surface to write).
     apply_capable = bool(models)
-    # The stronger surface, when the flagged subagent has a definition file: set
-    # its `model:` key outright instead of writing a rubric the orchestrator has
-    # to read and honor. Falls back to that rubric when there is no file.
-    try:
-        agent_apply = _agent_model_plumbing(over_powered, config)
-    except Exception:
-        agent_apply = {}
-    if agent_apply:
-        advise_extra = (
-            f" {agent_apply['agent_name']} has its own definition file, so "
-            f"tokenjam can set its model key to "
-            f"{agent_apply['proposed_model']} directly. The change is committed "
-            f"where the file is in a repo and reverts in one call. Its next "
-            f"dispatch runs on the new model, which is where measurement starts."
-        )
-        return [CostProposal(
-            kind="cost",
-            analyzer="subagent",
-            signature=f"cost:subagent:{agent_apply['agent_name']}",
-            title=(
-                f"Over-powered subagent {agent_apply['agent_name']} "
-                f"({agent_apply['current_model']} to {agent_apply['proposed_model']})"
-            ),
-            target_key={
-                "models": models, "subagent": True,
-                "agent_name": agent_apply["agent_name"],
-            },
-            evidence=evidence,
-            baseline={
-                "flagged_subagents": subagents,
-                "flagged_cost_usd": float(getattr(finding, "flagged_cost_usd", 0.0) or 0.0),
-                "subagent_cost_usd": float(getattr(finding, "subagent_cost_usd", 0.0) or 0.0),
-                "percent_of_cost": float(getattr(finding, "percent_of_cost", 0.0) or 0.0),
-                "agent_name": agent_apply["agent_name"],
-                "current_model": agent_apply["current_model"],
-                "proposed_model": agent_apply["proposed_model"],
-            },
-            advise_text=(
-                "Lower the model tier for the flagged Task dispatches. "
-                + str(getattr(finding, "caveat", "") or "") + advise_extra
-            ).strip(),
-            suggestion=f"model: {agent_apply['proposed_model']}",
-            one_paste_fix=(
-                f"# In {agent_apply['target_path']}, frontmatter:\n"
-                f"model: {agent_apply['proposed_model']}"
-            ),
-            estimated_recoverable_usd=getattr(finding, "estimated_recoverable_usd", None),
-            estimated_recoverable_tokens=getattr(finding, "estimated_recoverable_tokens", None),
-            estimate_basis=str(getattr(finding, "estimate_basis", "") or ""),
-            advise_only=False,
-            apply_capable=True,
-            scope=agent_apply["scope"],
-            apply_kind=agent_apply["apply_kind"],
-            agent_name=agent_apply["agent_name"],
-            target_path=agent_apply["target_path"],
-            current_model=agent_apply["current_model"],
-            proposed_model=agent_apply["proposed_model"],
-        )]
     return [CostProposal(
         kind="cost",
         analyzer="subagent",
@@ -720,6 +339,70 @@ def _subagent_to_proposals(finding: Any, config: Any = None) -> list[CostProposa
         scope="project" if apply_capable else "",
         proposed_fix=proposed_fix if apply_capable else "",
     )]
+
+
+def _deadweight_to_proposals(finding: Any) -> list[CostProposal]:
+    """One proposal per dead-weight MCP server (Component C1).
+
+    Reads ONLY ``DeadweightFinding.dead_servers`` — the C2 tax table (which
+    lists every configured server, dead or alive, purely for ranked
+    visibility) never feeds a proposal here, so a server's schema-injection
+    tax is never counted both in the tax table AND a proposal (the same
+    dedup guarantee ``compute_deadweight_finding`` itself enforces on
+    ``estimated_recoverable_tokens``).
+
+    Dollar figures are deliberately left ``None``: the tax is a token
+    estimate (a cited per-server constant, not priced against any one
+    session's actual model), and stacking an unknown model rate onto an
+    already-``estimated`` token figure would compound uncertainty rather
+    than inform it — so this card is tokens-only, like the analyzer's own
+    finding.
+    """
+    if finding is None:
+        return []
+    proposals: list[CostProposal] = []
+    for server in getattr(finding, "dead_servers", []) or []:
+        evidence = (
+            f"`{server.name}` MCP server ({server.scope} scope, configured at "
+            f"{server.source}) made 0 tool calls across {server.sessions_present} "
+            f"session(s) in the window."
+        )
+        if server.deferred_sessions:
+            evidence += (
+                f" ToolSearch deferred its schema in {server.deferred_sessions} "
+                f"of those session(s)."
+            )
+        scope_flag = "user" if server.scope == "user" else "project"
+        proposals.append(CostProposal(
+            kind="cost",
+            analyzer="deadweight",
+            signature=f"cost:deadweight:{server.name}",
+            title=f"Unused MCP server: {server.name}",
+            target_key={
+                "server": server.name, "scope": server.scope, "source": server.source,
+            },
+            evidence=evidence,
+            baseline={
+                "sessions_present": server.sessions_present,
+                "invocations": server.invocations,
+                "deferred_sessions": server.deferred_sessions,
+                "scope": server.scope,
+                "source": server.source,
+                "example_sessions": list(server.example_sessions),
+            },
+            advise_text=(
+                server.fix + " Removing (or project-scoping) it is reversible "
+                "and loses no data; it only stops the standing schema-injection "
+                "tax on future sessions."
+            ),
+            suggestion=f"claude mcp remove {server.name} --scope {scope_flag}",
+            estimated_recoverable_tokens=server.estimated_tax_tokens_90d or None,
+            estimate_basis=(
+                server.tax_construction
+                + " Projected over a 90-day window from the sessions observed."
+            ),
+        ))
+    return proposals
 
 
 #: Default look-back for the daemon/CLI cost-proposal recompute. Matches the
@@ -756,7 +439,7 @@ def recompute_cost_proposals(
             db, config, since, until, agent_id=agent_id,
             findings=list(COST_ANALYZERS),
         )
-        proposals = cost_proposals_from_report(report, config=config)
+        proposals = cost_proposals_from_report(report)
     except Exception:
         return []
 
@@ -767,28 +450,23 @@ def recompute_cost_proposals(
     return proposals
 
 
-def cost_proposals_from_report(report: Any, config: Any = None) -> list[CostProposal]:
+def cost_proposals_from_report(report: Any) -> list[CostProposal]:
     """Every cost proposal derivable from an already-built ``OptimizeReport``.
 
     Reads the ``downsize`` finding off the typed ``report.downgrade`` slot and
-    the ``cache`` / ``trim`` / ``subagent`` / ``placement`` findings off
+    the ``cache`` / ``trim`` / ``subagent`` / ``deadweight`` findings off
     ``report.findings``. Missing findings (analyzer not run, no candidates)
-    contribute nothing. Never raises — a malformed finding is skipped so one bad
-    analyzer can't sink the inbox.
-
-    ``config`` is optional and used for one thing: looking up the local source
-    path a user registered for an agent, which decides whether the downsize card
-    can offer the gated model-id swap or falls back to its one-paste artifact.
-    Without it every card is advise-only.
+    contribute nothing. Never raises — a malformed finding is skipped so one
+    bad analyzer can't sink the inbox.
     """
     findings = getattr(report, "findings", {}) or {}
     proposals: list[CostProposal] = []
     adapters = (
-        (lambda f: _downsize_to_proposal(f, config), getattr(report, "downgrade", None)),
+        (_downsize_to_proposal, getattr(report, "downgrade", None)),
         (_cache_to_proposals, findings.get("cache")),
         (_trim_to_proposals, findings.get("trim")),
-        (lambda f: _subagent_to_proposals(f, config), findings.get("subagent")),
-        (_placement_to_proposals, findings.get("placement")),
+        (_subagent_to_proposals, findings.get("subagent")),
+        (_deadweight_to_proposals, findings.get("deadweight")),
     )
     for adapter, finding in adapters:
         try:

--- a/tokenjam/core/optimize/cost_proposals.py
+++ b/tokenjam/core/optimize/cost_proposals.py
@@ -30,7 +30,9 @@ proposals. It never touches the DB, the store, or the network.
 """
 from __future__ import annotations
 
+import re
 from dataclasses import dataclass
+from pathlib import Path
 from typing import Any
 
 # House-style label strings. Kept verbatim on every cost proposal so no channel
@@ -108,6 +110,23 @@ class CostProposal:
     rung:                 int  = 0
     scope:                str  = ""
     proposed_fix:         str  = ""
+    # Model-routing apply kinds (``core.optimize.model_apply``). Set only where
+    # the edit is a deterministic rewrite of a value already written down: an
+    # agent file's ``model:`` key, or one exact model-id string in a repo the
+    # user registered. Empty everywhere else, which leaves the card advise-only
+    # with its one-paste artifact.
+    apply_kind:           str  = ""
+    agent_name:           str  = ""
+    current_model:        str  = ""
+    proposed_model:       str  = ""
+    source_path:          str  = ""
+    target_path:          str  = ""
+    # Why the direct apply is not on offer, when it is not. Rendered on the card
+    # next to the one-paste fix so a fallback is never silent.
+    apply_blocked_reason: str  = ""
+    # The exact fix, with this agent's own measured values already substituted
+    # in. Every advise-only card carries one.
+    one_paste_fix:        str  = ""
 
 
 # --------------------------------------------------------------------------- #
@@ -115,16 +134,26 @@ class CostProposal:
 # proposals. All tolerate a None/empty finding (returns []).
 # --------------------------------------------------------------------------- #
 
-def _downsize_to_proposal(finding: Any) -> list[CostProposal]:
-    """One proposal covering the model-over-sizing finding.
+def _downsize_to_proposal(finding: Any, config: Any = None) -> list[CostProposal]:
+    """The model-over-sizing card(s).
 
-    ``DowngradeFinding.suggestions`` maps each oversized model to its cheaper
-    same-family alternative. The delta-verify pass later measures the model-mix
-    cost delta across ALL flagged models, so a single proposal (listing them)
-    keeps the estimate — which is a finding-level aggregate — coherent.
+    When the finding carries per-agent price rows, each agent gets its own card
+    with its own arithmetic (and, where the preconditions hold, the gated model-
+    id swap). Those rows partition the same candidate sessions, so the window-
+    wide card is NOT emitted alongside them: one source of over-sized spend,
+    one card.
+
+    Without those rows (no pricing data for a model on either side) the finding
+    falls back to the single window-wide card. ``DowngradeFinding.suggestions``
+    maps each oversized model to its cheaper same-family alternative, and the
+    delta-verify pass measures the model-mix cost delta across ALL flagged
+    models, so one proposal listing them keeps that aggregate estimate coherent.
     """
     if finding is None or getattr(finding, "candidate_sessions", 0) <= 0:
         return []
+    per_agent = _downsize_agent_proposals(finding, config)
+    if per_agent:
+        return per_agent
     suggestions: dict[str, str] = dict(getattr(finding, "suggestions", {}) or {})
     if not suggestions:
         return []
@@ -159,74 +188,239 @@ def _downsize_to_proposal(finding: Any) -> list[CostProposal]:
         },
         advise_text=advise,
         suggestion=suggestion,
+        one_paste_fix=suggestion,
         estimated_recoverable_usd=getattr(finding, "estimated_recoverable_usd", None),
         estimated_recoverable_tokens=getattr(finding, "estimated_recoverable_tokens", None),
         estimate_basis=str(getattr(finding, "estimate_basis", "") or ""),
     )]
 
 
-def _per_agent_cache_recoverable_by_model(finding: Any) -> dict[tuple[str, str], tuple[float, int]]:
-    """Sum of ``estimated_recoverable_usd``/``estimated_recoverable_tokens``
-    already claimed by the root-caused per-agent cards (A1 uncached / A2
-    thrash / A3 lookback), keyed by (provider, model).
+def _money(value: float) -> str:
+    """A dollar figure with enough precision to stay honest at small values.
 
-    The generic per-(provider, model) efficacy row and these per-agent checks
-    both read from the SAME underlying spans — a flagged agent's own calls
-    are part of the aggregate the generic row's efficacy is computed over. So
-    the dollars a per-agent card claims must be subtracted from the generic
-    row's figure before it's surfaced, or the Review-inbox rollup (which sums
-    every open card's ``estimated_recoverable_usd`` with no analyzer
-    allowlist) double-counts the same waste under two signatures. See
-    ``_cache_to_proposals``.
+    Never rendered bare: every call site pairs it with an estimated/measured tag
+    and the construction footnote.
     """
-    totals: dict[tuple[str, str], tuple[float, int]] = {}
-    groups = (
-        getattr(finding, "uncached_agents", []) or [],
-        getattr(finding, "thrash_agents", []) or [],
-        getattr(finding, "lookback_miss_agents", []) or [],
+    if abs(value) >= 1.0:
+        return f"${value:,.2f}"
+    return f"${value:.4f}"
+
+
+def _agent_arithmetic_line(row: Any) -> str:
+    """The card's arithmetic, spelled out with both sides of the comparison."""
+    window = (
+        f"{row.sessions} session(s) over {row.window_days:.0f} day(s): "
+        f"{row.input_tokens:,} input, {row.output_tokens:,} output, "
+        f"{row.cache_tokens:,} cache read and {row.cache_write_tokens:,} cache "
+        f"write tokens. At {row.model} rates that is "
+        f"{_money(row.current_cost_usd)}; the same tokens at {row.alt_model} "
+        f"rates are {_money(row.alternative_cost_usd)}. Difference: "
+        f"{_money(row.delta_usd)} over the window, up to "
+        f"{_money(row.projected_30d_delta_usd)} per 30 days at this rate "
+        f"(estimated)."
     )
-    for group in groups:
-        for c in group:
-            usd = getattr(c, "estimated_recoverable_usd", None) or 0.0
-            tokens = getattr(c, "estimated_recoverable_tokens", None) or 0
-            if usd <= 0 and tokens <= 0:
-                continue
-            key = (c.provider, c.model)
-            prev_usd, prev_tokens = totals.get(key, (0.0, 0))
-            totals[key] = (prev_usd + usd, prev_tokens + tokens)
-    return totals
+    if row.thinking_share_of_output is not None:
+        window += (
+            f" Thinking tokens were {row.thinking_share_of_output * 100:.0f}% of "
+            f"this agent's output tokens over the same sessions "
+            f"({row.thinking_tokens:,} of {row.output_tokens:,}, measured); "
+            f"they bill as output on both models."
+        )
+    return window
+
+
+def _model_swap_plumbing(row: Any, config: Any) -> dict[str, Any]:
+    """Whether this agent's swap can be written directly, and where.
+
+    The direct write is offered only when the user registered a local source
+    path for the agent and every precondition in
+    ``model_apply.model_swap_precheck`` holds. Otherwise the card keeps its
+    one-paste artifact and states the reason.
+    """
+    from tokenjam.core.optimize.model_apply import (
+        APPLY_KIND_MODEL_SWAP,
+        model_swap_precheck,
+    )
+
+    agents = getattr(config, "agents", None) or {}
+    agent_cfg = agents.get(row.agent_id) if hasattr(agents, "get") else None
+    source_path = str(getattr(agent_cfg, "source_path", "") or "")
+    check = model_swap_precheck(source_path, row.model)
+    if not check["ok"]:
+        return {"apply_capable": False, "apply_blocked_reason": check["reason"]}
+    return {
+        "apply_capable": True,
+        "apply_kind": APPLY_KIND_MODEL_SWAP,
+        "source_path": source_path,
+        "target_path": check["target_path"],
+        "current_model": row.model,
+        "proposed_model": row.alt_model,
+        "apply_blocked_reason": "",
+    }
+
+
+def _downsize_agent_proposals(finding: Any, config: Any) -> list[CostProposal]:
+    """One card per agent, carrying that agent's own price arithmetic.
+
+    Replaces the window-wide card when per-agent rows exist, so one source of
+    over-sized spend produces exactly one card rather than an aggregate plus its
+    own parts.
+    """
+    proposals: list[CostProposal] = []
+    for row in getattr(finding, "per_agent", []) or []:
+        plumbing = _model_swap_plumbing(row, config) if config is not None else {
+            "apply_capable": False,
+            "apply_blocked_reason": (
+                "no tj config was available to look up a registered source path."
+            ),
+        }
+        one_paste = (
+            f"{row.model} -> {row.alt_model}\n"
+            f"# Set this agent's model id to {row.alt_model} where it is "
+            f"configured, then redeploy or restart the agent."
+        )
+        advise = (
+            f"Route {row.agent_id}'s flagged structural-shaped work from "
+            f"{row.model} to {row.alt_model}. The price difference above is "
+            f"arithmetic on this agent's measured tokens, given the switch; "
+            f"whether the cheaper model answers as well is not measured here, "
+            f"so review the example sessions first."
+        )
+        if plumbing.get("apply_capable"):
+            advise += (
+                f" tokenjam can make this exact substitution in "
+                f"{plumbing['target_path']}, with the change committed and "
+                f"revertable in one call. After it is applied you must redeploy "
+                f"or restart the agent: measurement starts at the first call "
+                f"that runs on {row.alt_model}, not at the moment of the write."
+            )
+        elif plumbing.get("apply_blocked_reason"):
+            advise += f" Applying it here is not on offer: {plumbing['apply_blocked_reason']}"
+        proposals.append(CostProposal(
+            kind="cost",
+            analyzer="downsize",
+            signature=f"cost:downsize:{row.agent_id}",
+            title=f"Model over-sizing in {row.agent_id} ({row.model} to {row.alt_model})",
+            target_key={
+                "agent_id": row.agent_id,
+                "models": [row.model],
+                "suggestions": {row.model: row.alt_model},
+            },
+            evidence=_agent_arithmetic_line(row),
+            baseline={
+                "agent_id": row.agent_id,
+                "provider": row.provider,
+                "model": row.model,
+                "alt_model": row.alt_model,
+                "sessions": row.sessions,
+                "input_tokens": row.input_tokens,
+                "output_tokens": row.output_tokens,
+                "cache_tokens": row.cache_tokens,
+                "cache_write_tokens": row.cache_write_tokens,
+                "current_cost_usd": row.current_cost_usd,
+                "alternative_cost_usd": row.alternative_cost_usd,
+                "delta_usd": row.delta_usd,
+                "projected_30d_delta_usd": row.projected_30d_delta_usd,
+                "thinking_tokens": row.thinking_tokens,
+                "thinking_share_of_output": row.thinking_share_of_output,
+            },
+            advise_text=advise,
+            suggestion=one_paste,
+            one_paste_fix=one_paste,
+            estimated_recoverable_usd=row.delta_usd,
+            estimated_recoverable_tokens=row.total_tokens,
+            estimate_basis=row.estimate_basis,
+            agent_id=row.agent_id if row.agent_id != "unknown" else "",
+            advise_only=not plumbing.get("apply_capable", False),
+            apply_capable=bool(plumbing.get("apply_capable")),
+            apply_kind=str(plumbing.get("apply_kind", "")),
+            source_path=str(plumbing.get("source_path", "")),
+            target_path=str(plumbing.get("target_path", "")),
+            current_model=str(plumbing.get("current_model", "")),
+            proposed_model=str(plumbing.get("proposed_model", "")),
+            apply_blocked_reason=str(plumbing.get("apply_blocked_reason", "")),
+        ))
+    return proposals
+
+
+def _placement_to_proposals(finding: Any) -> list[CostProposal]:
+    """One card for the batch-placement candidates (advise-only).
+
+    Advise-only is not a formality here: moving a workload to the batch lane is
+    an architectural change in the user's own application, and the card says so
+    beside the number.
+    """
+    if finding is None:
+        return []
+    candidates = list(getattr(finding, "candidates", []) or [])
+    if not candidates:
+        return []
+    agents = ", ".join(c.agent_id for c in candidates[:5])
+    total = float(getattr(finding, "candidate_cost_usd", 0.0) or 0.0)
+    saving = float(getattr(finding, "estimated_recoverable_usd", 0.0) or 0.0)
+    percent = float(getattr(finding, "percent_of_window_cost", 0.0) or 0.0)
+    cadence = ", ".join(
+        f"{c.agent_id} every {c.median_gap_seconds / 3600:.1f}h across "
+        f"{c.sessions} runs"
+        for c in candidates[:5]
+    )
+    evidence = (
+        f"{len(candidates)} workload(s) ran on a regular cadence with no human "
+        f"turn after the first model call ({cadence}). They are "
+        f"{percent:.0f}% of the window's spend, {_money(total)} (measured)."
+    )
+    advise = (
+        f"The Batch API bills a flat 50% of standard prices, so the same work "
+        f"on the batch lane is {_money(saving)} less over this window "
+        f"(estimated). {getattr(finding, 'friction', '')} Nothing here is "
+        f"applied for you; the change lives in your own application code."
+    )
+    return [CostProposal(
+        kind="cost",
+        analyzer="placement",
+        signature="cost:placement:batch",
+        title="Batch API candidates (unattended, cadence-regular workloads)",
+        target_key={"agents": [c.agent_id for c in candidates], "placement": "batch"},
+        evidence=evidence,
+        baseline={
+            "candidates": [
+                {
+                    "agent_id": c.agent_id, "sessions": c.sessions,
+                    "median_gap_seconds": c.median_gap_seconds, "gap_cv": c.gap_cv,
+                    "cost_usd": c.cost_usd, "tokens": c.tokens,
+                    "estimated_batch_saving_usd": c.estimated_batch_saving_usd,
+                }
+                for c in candidates
+            ],
+            "candidate_cost_usd": total,
+            "window_cost_usd": float(getattr(finding, "window_cost_usd", 0.0) or 0.0),
+            "percent_of_window_cost": percent,
+        },
+        advise_text=advise,
+        suggestion=agents,
+        one_paste_fix=(
+            "# Submit these workloads through the Batch API instead of the "
+            "synchronous endpoint:\n"
+            + "\n".join(f"#   {c.agent_id}" for c in candidates)
+        ),
+        estimated_recoverable_usd=saving,
+        estimated_recoverable_tokens=getattr(finding, "estimated_recoverable_tokens", None),
+        estimate_basis=str(getattr(finding, "estimate_basis", "") or ""),
+        agent_id=candidates[0].agent_id if len(candidates) == 1 else "",
+    )]
 
 
 def _cache_to_proposals(finding: Any) -> list[CostProposal]:
-    """One proposal per flagged (provider, model) cache-efficacy row.
-
-    Reduced by whatever the more specific per-agent root-cause cards (A1/A2/
-    A3) already claim for that same (provider, model) — see
-    ``_per_agent_cache_recoverable_by_model`` — so the rollup never sums the
-    same underlying waste twice under two different signatures.
-    """
+    """One proposal per flagged (provider, model) cache-efficacy row."""
     if finding is None:
         return []
     from tokenjam.core.optimize.analyzers.cache_efficacy import (
         estimate_cache_recoverable,
     )
 
-    already_claimed = _per_agent_cache_recoverable_by_model(finding)
-
     proposals: list[CostProposal] = []
     for row in getattr(finding, "flagged", []) or []:
         usd, tokens = estimate_cache_recoverable([row])
-        claimed_usd, claimed_tokens = already_claimed.get((row.provider, row.model), (0.0, 0))
-        basis = str(getattr(finding, "estimate_basis", "") or "")
-        if claimed_usd > 0 or claimed_tokens > 0:
-            usd = round(max(0.0, (usd or 0.0) - claimed_usd), 6)
-            tokens = max(0, (tokens or 0) - claimed_tokens)
-            basis = (
-                basis + (" " if basis else "")
-                + f"Reduced by ${claimed_usd:.4f} already attributed to more "
-                "specific per-agent cache proposals for this model, so the "
-                "rollup does not double-count the same spend."
-            )
         evidence = (
             f"{row.provider}/{row.model}: {row.efficacy * 100:.0f}% of input "
             f"tokens served from cache over {row.input_tokens:,} input tokens "
@@ -254,159 +448,7 @@ def _cache_to_proposals(finding: Any) -> list[CostProposal]:
             ),
             estimated_recoverable_usd=usd,
             estimated_recoverable_tokens=tokens,
-            estimate_basis=basis,
-        ))
-    return proposals
-
-
-def _cache_uncached_to_proposals(finding: Any) -> list[CostProposal]:
-    """One proposal per A1 uncached-agent candidate (see
-    ``analyzers.cache_efficacy``): an agent group making cacheable calls with
-    prompt caching never attempted. Verified through the same efficacy metric
-    as ``_cache_to_proposals`` (agent-scoped), so no ``cost_verify`` change
-    is needed for this check."""
-    if finding is None:
-        return []
-    proposals: list[CostProposal] = []
-    for c in getattr(finding, "uncached_agents", []) or []:
-        evidence = (
-            f"{c.agent_id}: {c.calls} calls on {c.model} with zero prompt "
-            f"caching attempted (no cache reads, no cache writes) across "
-            f"{c.sessions} session(s); assumed stable prefix "
-            f"~{c.assumed_prefix_tokens:,} tokens (this agent's own p25 input size)."
-        )
-        proposals.append(CostProposal(
-            kind="cost",
-            analyzer="cache",
-            signature=f"cost:cache-uncached:{c.agent_id}",
-            title=f"Uncached agent: {c.agent_id}",
-            target_key={"agent_id": c.agent_id, "provider": c.provider, "model": c.model},
-            evidence=evidence,
-            baseline={
-                "agent_id": c.agent_id, "provider": c.provider, "model": c.model,
-                "calls": c.calls, "sessions": c.sessions,
-                "assumed_prefix_tokens": c.assumed_prefix_tokens,
-            },
-            advise_text=(
-                "Add a cache_control breakpoint on this agent's stable prefix "
-                "(system prompt / tool definitions) so repeated calls read "
-                "from cache instead of paying full input price every time."
-            ),
-            suggestion=c.cache_control_snippet,
-            estimated_recoverable_usd=c.estimated_recoverable_usd,
-            estimated_recoverable_tokens=c.estimated_recoverable_tokens,
-            estimate_basis=c.estimate_basis,
-            agent_id=c.agent_id,
-        ))
-    return proposals
-
-
-def _cache_thrash_to_proposals(finding: Any) -> list[CostProposal]:
-    """One proposal per A2 cache-thrash candidate. Card text branches on the
-    detected root cause: a TTL-cadence card (honest break-even, which may say
-    the switch isn't worth it) versus an instability checklist card."""
-    if finding is None:
-        return []
-    from tokenjam.core.optimize.analyzers.cache_efficacy import (
-        SILENT_INVALIDATOR_CHECKLIST,
-    )
-
-    proposals: list[CostProposal] = []
-    for c in getattr(finding, "thrash_agents", []) or []:
-        evidence = (
-            f"{c.agent_id}: caching attempted on {c.model} but read:write "
-            f"ratio is {c.read_write_ratio:.2f} over {c.calls} calls "
-            f"({c.cache_read_tokens:,} cache-read tokens vs "
-            f"{c.cache_write_tokens:,} cache-write tokens); median inter-call "
-            f"gap {c.inter_call_gap_p50_minutes:.1f} min."
-        )
-        if c.cause == "ttl":
-            if c.ttl_worth_it:
-                advise = (
-                    "Calls land more than 5 minutes apart, so the default "
-                    "5-minute cache write is expiring before it's reused. "
-                    "Switching to the 1-hour cache TTL is estimated to pay "
-                    "off at this cadence."
-                )
-            else:
-                advise = (
-                    "Calls land more than 5 minutes apart, so the default "
-                    "5-minute cache write is expiring before it's reused. "
-                    "The 1-hour TTL's write premium doesn't clear at this "
-                    "cadence: caching not worth it at this cadence."
-                )
-        else:
-            advise = (
-                "Calls land close enough together that a TTL expiry doesn't "
-                "explain the miss rate; the prefix itself is likely changing "
-                "between calls. " + SILENT_INVALIDATOR_CHECKLIST
-            )
-        proposals.append(CostProposal(
-            kind="cost",
-            analyzer="cache_thrash",
-            signature=f"cost:cache-thrash:{c.agent_id}",
-            title=f"Cache thrash: {c.agent_id}",
-            target_key={"agent_id": c.agent_id, "provider": c.provider, "model": c.model},
-            evidence=evidence,
-            baseline={
-                "agent_id": c.agent_id, "provider": c.provider, "model": c.model,
-                "calls": c.calls, "cache_write_tokens": c.cache_write_tokens,
-                "cache_read_tokens": c.cache_read_tokens,
-                "read_write_ratio": c.read_write_ratio, "cause": c.cause,
-                "inter_call_gap_p50_minutes": c.inter_call_gap_p50_minutes,
-                "ttl_worth_it": c.ttl_worth_it,
-                "ttl_breakeven_usd": c.ttl_breakeven_usd,
-            },
-            advise_text=advise,
-            suggestion=c.cache_control_snippet,
-            estimated_recoverable_usd=c.estimated_recoverable_usd,
-            estimated_recoverable_tokens=c.estimated_recoverable_tokens,
-            estimate_basis=c.estimate_basis,
-            agent_id=c.agent_id,
-        ))
-    return proposals
-
-
-def _cache_lookback_to_proposals(finding: Any) -> list[CostProposal]:
-    """One proposal per A3 20-block-lookback-miss candidate. Weakest-
-    confidence check of the three; the analyzer only classifies an agent here
-    when A1/A2 don't already explain its cache waste."""
-    if finding is None:
-        return []
-    from tokenjam.core.optimize.analyzers.cache_efficacy import LOOKBACK_BLOCK_LIMIT
-
-    proposals: list[CostProposal] = []
-    for c in getattr(finding, "lookback_miss_agents", []) or []:
-        evidence = (
-            f"{c.agent_id}: {c.miss_count} cache miss(es) on {c.model}, each "
-            f"directly following a turn with an estimated "
-            f"{c.avg_prior_turn_blocks:.0f} content blocks (lookback limit: "
-            f"{LOOKBACK_BLOCK_LIMIT})."
-        )
-        proposals.append(CostProposal(
-            kind="cost",
-            analyzer="cache",
-            signature=f"cost:cache-lookback:{c.agent_id}",
-            title=f"20-block lookback miss: {c.agent_id}",
-            target_key={"agent_id": c.agent_id, "provider": c.provider, "model": c.model},
-            evidence=evidence,
-            baseline={
-                "agent_id": c.agent_id, "provider": c.provider, "model": c.model,
-                "miss_count": c.miss_count,
-                "avg_prior_turn_blocks": c.avg_prior_turn_blocks,
-            },
-            advise_text=(
-                "Anthropic's cache breakpoint search looks back at most "
-                f"{LOOKBACK_BLOCK_LIMIT} content blocks. Long tool-heavy "
-                "turns push the prior breakpoint out of range; add an "
-                "intermediate cache_control breakpoint every ~15 blocks in "
-                "long tool-use turns."
-            ),
-            suggestion=c.cache_control_snippet,
-            estimated_recoverable_usd=c.estimated_recoverable_usd,
-            estimated_recoverable_tokens=c.estimated_recoverable_tokens,
-            estimate_basis=c.estimate_basis,
-            agent_id=c.agent_id,
+            estimate_basis=str(getattr(finding, "estimate_basis", "") or ""),
         ))
     return proposals
 
@@ -474,7 +516,80 @@ def _trim_to_proposals(finding: Any) -> list[CostProposal]:
     return proposals
 
 
-def _subagent_to_proposals(finding: Any) -> list[CostProposal]:
+#: A ``sub_agent_id`` only names an agent definition when it is a plain slug.
+#: Claude Code stamps a UUID for inline Task dispatches, and there is no file to
+#: edit for those: that is the guidance-block fallback case, not a lookup to
+#: guess at.
+_AGENT_NAME_RE = re.compile(r"^[a-z][a-z0-9]*(?:-[a-z0-9]+)*$")
+
+#: Cap on transcripts read to locate the repos a finding's sessions ran in.
+_MAX_SCOPE_SESSIONS = 20
+
+
+def _session_cwds(session_ids: list[str], config: Any) -> dict[str, str]:
+    """``session_id -> repo cwd``, read from the sessions' own transcripts.
+
+    Reuses the relearn detector's resolver rather than re-deriving a cwd from
+    the encoded project directory name, which is unreliable. Best-effort: an
+    unreadable transcript simply contributes no cwd.
+    """
+    from tokenjam.core.optimize.analyzers.relearn import _repo_cwd_map_for
+    from tokenjam.core.transcript import resolve_projects_root
+
+    override = getattr(getattr(config, "loop", None), "transcript_path", None)
+    root = resolve_projects_root(override)
+    pairs = [(sid, sid) for sid in session_ids[:_MAX_SCOPE_SESSIONS]]
+    return _repo_cwd_map_for(pairs, root)
+
+
+def _agent_model_plumbing(over_powered: list[Any], config: Any) -> dict[str, Any]:
+    """Whether a flagged subagent has a definition file whose model can be set.
+
+    Scope routing is relearn's: sessions concentrated in one repo write into
+    that repo's ``.claude/agents/``, sessions spanning repos write into the
+    user-global one. The flagged rows are cost-ordered, so the first subagent
+    with a real definition file is the most expensive one that can be fixed
+    outright. No file means the guidance block stays the fix, which is the
+    inline Task-tool case.
+    """
+    from tokenjam.core.optimize.analyzers.model_downgrade import lookup_downgrade
+    from tokenjam.core.optimize.analyzers.relearn import _scope_for
+    from tokenjam.core.optimize.model_apply import (
+        APPLY_KIND_AGENT_MODEL,
+        default_agent_file_path,
+    )
+
+    named = [
+        r for r in over_powered
+        if _AGENT_NAME_RE.match(str(getattr(r, "sub_agent_id", "") or ""))
+    ]
+    if not named or config is None:
+        return {}
+    cwds = _session_cwds([str(r.session_id) for r in over_powered], config)
+    repos = {Path(cwd).name for cwd in cwds.values() if cwd}
+    scope = _scope_for(repos)
+    repo_cwd = next(iter(cwds.values()), "") if len(repos) == 1 else ""
+
+    for row in named:
+        proposed = lookup_downgrade(str(row.provider), str(row.model))
+        if not proposed:
+            continue
+        name = str(row.sub_agent_id)
+        path = default_agent_file_path(scope, repo_cwd, name)
+        if not path or not Path(path).is_file():
+            continue
+        return {
+            "apply_kind": APPLY_KIND_AGENT_MODEL,
+            "agent_name": name,
+            "target_path": path,
+            "scope": scope,
+            "current_model": str(row.model),
+            "proposed_model": proposed,
+        }
+    return {}
+
+
+def _subagent_to_proposals(finding: Any, config: Any = None) -> list[CostProposal]:
     """One proposal covering the subagent right-sizing finding.
 
     Unlike the three advise-only analyzers, this one is workspace-appliable for
@@ -514,6 +629,64 @@ def _subagent_to_proposals(finding: Any) -> list[CostProposal]:
     # Apply-capable when we have a concrete model to name in the rubric; else
     # degrade to advise-only (no clean workspace surface to write).
     apply_capable = bool(models)
+    # The stronger surface, when the flagged subagent has a definition file: set
+    # its `model:` key outright instead of writing a rubric the orchestrator has
+    # to read and honor. Falls back to that rubric when there is no file.
+    try:
+        agent_apply = _agent_model_plumbing(over_powered, config)
+    except Exception:
+        agent_apply = {}
+    if agent_apply:
+        advise_extra = (
+            f" {agent_apply['agent_name']} has its own definition file, so "
+            f"tokenjam can set its model key to "
+            f"{agent_apply['proposed_model']} directly. The change is committed "
+            f"where the file is in a repo and reverts in one call. Its next "
+            f"dispatch runs on the new model, which is where measurement starts."
+        )
+        return [CostProposal(
+            kind="cost",
+            analyzer="subagent",
+            signature=f"cost:subagent:{agent_apply['agent_name']}",
+            title=(
+                f"Over-powered subagent {agent_apply['agent_name']} "
+                f"({agent_apply['current_model']} to {agent_apply['proposed_model']})"
+            ),
+            target_key={
+                "models": models, "subagent": True,
+                "agent_name": agent_apply["agent_name"],
+            },
+            evidence=evidence,
+            baseline={
+                "flagged_subagents": subagents,
+                "flagged_cost_usd": float(getattr(finding, "flagged_cost_usd", 0.0) or 0.0),
+                "subagent_cost_usd": float(getattr(finding, "subagent_cost_usd", 0.0) or 0.0),
+                "percent_of_cost": float(getattr(finding, "percent_of_cost", 0.0) or 0.0),
+                "agent_name": agent_apply["agent_name"],
+                "current_model": agent_apply["current_model"],
+                "proposed_model": agent_apply["proposed_model"],
+            },
+            advise_text=(
+                "Lower the model tier for the flagged Task dispatches. "
+                + str(getattr(finding, "caveat", "") or "") + advise_extra
+            ).strip(),
+            suggestion=f"model: {agent_apply['proposed_model']}",
+            one_paste_fix=(
+                f"# In {agent_apply['target_path']}, frontmatter:\n"
+                f"model: {agent_apply['proposed_model']}"
+            ),
+            estimated_recoverable_usd=getattr(finding, "estimated_recoverable_usd", None),
+            estimated_recoverable_tokens=getattr(finding, "estimated_recoverable_tokens", None),
+            estimate_basis=str(getattr(finding, "estimate_basis", "") or ""),
+            advise_only=False,
+            apply_capable=True,
+            scope=agent_apply["scope"],
+            apply_kind=agent_apply["apply_kind"],
+            agent_name=agent_apply["agent_name"],
+            target_path=agent_apply["target_path"],
+            current_model=agent_apply["current_model"],
+            proposed_model=agent_apply["proposed_model"],
+        )]
     return [CostProposal(
         kind="cost",
         analyzer="subagent",
@@ -578,7 +751,7 @@ def recompute_cost_proposals(
             db, config, since, until, agent_id=agent_id,
             findings=list(COST_ANALYZERS),
         )
-        proposals = cost_proposals_from_report(report)
+        proposals = cost_proposals_from_report(report, config=config)
     except Exception:
         return []
 
@@ -589,25 +762,28 @@ def recompute_cost_proposals(
     return proposals
 
 
-def cost_proposals_from_report(report: Any) -> list[CostProposal]:
+def cost_proposals_from_report(report: Any, config: Any = None) -> list[CostProposal]:
     """Every cost proposal derivable from an already-built ``OptimizeReport``.
 
     Reads the ``downsize`` finding off the typed ``report.downgrade`` slot and
-    the ``cache`` / ``trim`` / ``subagent`` findings off ``report.findings``.
-    Missing findings (analyzer not run, no candidates) contribute nothing. Never
-    raises — a malformed finding is skipped so one bad analyzer can't sink the
-    inbox.
+    the ``cache`` / ``trim`` / ``subagent`` / ``placement`` findings off
+    ``report.findings``. Missing findings (analyzer not run, no candidates)
+    contribute nothing. Never raises — a malformed finding is skipped so one bad
+    analyzer can't sink the inbox.
+
+    ``config`` is optional and used for one thing: looking up the local source
+    path a user registered for an agent, which decides whether the downsize card
+    can offer the gated model-id swap or falls back to its one-paste artifact.
+    Without it every card is advise-only.
     """
     findings = getattr(report, "findings", {}) or {}
     proposals: list[CostProposal] = []
     adapters = (
-        (_downsize_to_proposal, getattr(report, "downgrade", None)),
+        (lambda f: _downsize_to_proposal(f, config), getattr(report, "downgrade", None)),
         (_cache_to_proposals, findings.get("cache")),
-        (_cache_uncached_to_proposals, findings.get("cache")),
-        (_cache_thrash_to_proposals, findings.get("cache")),
-        (_cache_lookback_to_proposals, findings.get("cache")),
         (_trim_to_proposals, findings.get("trim")),
-        (_subagent_to_proposals, findings.get("subagent")),
+        (lambda f: _subagent_to_proposals(f, config), findings.get("subagent")),
+        (_placement_to_proposals, findings.get("placement")),
     )
     for adapter, finding in adapters:
         try:

--- a/tokenjam/core/optimize/cost_proposals.py
+++ b/tokenjam/core/optimize/cost_proposals.py
@@ -1061,7 +1061,64 @@ def _cluster_hash(value: Any) -> str:
     return hashlib.sha256(encoded.encode("utf-8")).hexdigest()[:12]
 
 
-def _script_to_proposals(finding: Any) -> list[CostProposal]:
+# --------------------------------------------------------------------------- #
+# Persona-gated fix modality — `script` / `reuse` / `verbosity` only.
+#
+# All three write the SAME class of artifact when apply-capable: a rung-1
+# CLAUDE.md note or rung-2 `.claude/skills/<slug>/SKILL.md` file (see
+# `relearn_apply.default_target_path`). Nothing in an SDK-only service's
+# request path ever reads a CLAUDE.md or a `.claude/skills/` note — those are
+# read by an interactive coding-agent harness. Offering that write to an SDK
+# caller is a write that visibly succeeds and changes nothing: a quiet lie in
+# the user's favour (CLAUDE.md anti-pattern #22). The finding underneath is
+# still true for an SDK caller; only the fix MODALITY is wrong, so this never
+# drops the recommendation — it demotes the card to advise-only and carries
+# the identical text as a copy-pasteable `suggestion` instead (the same
+# ``CostProposal.suggestion`` field every advise-only card already renders as
+# a first-class "the fix" block with a Copy button).
+# --------------------------------------------------------------------------- #
+
+def _persona_gated_write_fields(
+    persona: str, proposed_fix: str, rung: int, scope: str,
+) -> dict[str, Any]:
+    """Decide, from the window's dominant persona, whether the rung-1/rung-2
+    workspace write is offered — and fill in the ``CostProposal`` fields that
+    follow from that decision.
+
+    * ``"claude-code"`` — unchanged: the write is genuinely actionable, so it
+      stays offered exactly as before.
+    * ``"sdk"`` and ``"unknown"`` — no write offered. ``"unknown"`` means no
+      session in the window carries an identifiable agent_id and no declared
+      plan settles it either (`core.framing.dominant_persona`) — the exact
+      shape of a pure-SDK caller who never ran ``tj onboard``. Grouping it
+      with ``"sdk"`` here mirrors ``cmd_optimize._render_downgrade_cta``'s
+      CTA, and avoids the one failure mode called out for this fix: silently
+      offering a write to a persona that turns out to be SDK.
+    * ``"mixed"`` — both audiences are meaningfully represented (same
+      precedent as ``_render_downgrade_cta``, which renders both CTAs side
+      by side rather than picking one), and a script/reuse/verbosity finding
+      isn't attributable to one side of the mix or the other. The write
+      stays on offer for the claude-code share; the identical recommendation
+      is ALSO carried as ``suggestion`` so the sdk share of the mix isn't
+      left with a card that looks actionable but silently isn't, for them.
+    """
+    write_offered = persona in {"claude-code", "mixed"}
+    fields: dict[str, Any] = {
+        "advise_only": not write_offered,
+        "apply_capable": write_offered,
+        "rung": rung if write_offered else 0,
+        "scope": scope if write_offered else "",
+        "proposed_fix": proposed_fix if write_offered else "",
+    }
+    # Every persona except a clean claude-code window also gets the snippet
+    # fallback — "mixed" needs it alongside the write (see above), and
+    # "sdk"/"unknown" need it in place of the write.
+    if persona != "claude-code":
+        fields["suggestion"] = proposed_fix
+    return fields
+
+
+def _script_to_proposals(finding: Any, persona: str = "unknown") -> list[CostProposal]:
     """One proposal per flagged deterministic-tool-call cluster.
 
     Apply-capable at rung 2: a skill note naming the repeated call pattern and
@@ -1071,6 +1128,12 @@ def _script_to_proposals(finding: Any) -> list[CostProposal]:
     title, which embeds the cluster's own hash so two clusters never collide
     on the same skill file (`relearn_apply`'s create-only guard would otherwise
     let a second cluster's apply silently overwrite the first's skill note).
+
+    The write is only actually offered for a ``"claude-code"``/``"mixed"``
+    ``persona`` — see ``_persona_gated_write_fields``. An ``"sdk"``/
+    ``"unknown"`` window gets the identical recommendation as a
+    copy-pasteable snippet instead; the skill note would sit unread by any
+    SDK service's request path.
     """
     if finding is None:
         return []
@@ -1125,22 +1188,21 @@ def _script_to_proposals(finding: Any) -> list[CostProposal]:
             estimated_recoverable_usd=cluster.total_cost_usd or None,
             estimated_recoverable_tokens=cluster.total_tokens or None,
             estimate_basis=str(getattr(finding, "estimate_basis", "") or ""),
-            advise_only=False,
-            apply_capable=True,
-            rung=2,
-            scope="project",
-            proposed_fix=advise,
+            **_persona_gated_write_fields(persona, advise, rung=2, scope="project"),
         ))
     return proposals
 
 
-def _reuse_to_proposals(finding: Any) -> list[CostProposal]:
+def _reuse_to_proposals(finding: Any, persona: str = "unknown") -> list[CostProposal]:
     """One proposal per repeated planning-skeleton cluster.
 
     Apply-capable at rung 1: a CLAUDE.md note naming the recurring skeleton.
     Uses the finding's conservative ``cache_reuse_recoverable_*`` figure (you
     already paid for the plan once), not the ``script_replacement_*`` upper
     bound, matching ``ReuseFinding``'s own aggregate.
+
+    The write is only actually offered for a ``"claude-code"``/``"mixed"``
+    ``persona`` — see ``_persona_gated_write_fields``.
     """
     if finding is None:
         return []
@@ -1188,16 +1250,12 @@ def _reuse_to_proposals(finding: Any) -> list[CostProposal]:
             estimated_recoverable_usd=cluster.cache_reuse_recoverable_usd or None,
             estimated_recoverable_tokens=cluster.cache_reuse_recoverable_tokens or None,
             estimate_basis=str(getattr(finding, "estimate_basis", "") or ""),
-            advise_only=False,
-            apply_capable=True,
-            rung=1,
-            scope="project",
-            proposed_fix=advise,
+            **_persona_gated_write_fields(persona, advise, rung=1, scope="project"),
         ))
     return proposals
 
 
-def _verbosity_to_proposals(finding: Any) -> list[CostProposal]:
+def _verbosity_to_proposals(finding: Any, persona: str = "unknown") -> list[CostProposal]:
     """One proposal for the whole verbosity finding (unlike ``script``/
     ``reuse``, this is a single window-wide signal, not per-cluster).
 
@@ -1210,6 +1268,13 @@ def _verbosity_to_proposals(finding: Any) -> list[CostProposal]:
     go; a workspace note is the same class of soft, orchestrator-read surface
     the ``subagent`` rubric already uses, so this reuses that precedent
     rather than inventing a new one.
+
+    The write is only actually offered for a ``"claude-code"``/``"mixed"``
+    ``persona`` — see ``_persona_gated_write_fields``. This is the sharpest
+    case of the three: the lever itself (``max_tokens``) is genuinely
+    SDK-actionable — an SDK caller can cap it in their own request — it is
+    only the CLAUDE.md *artifact* that is the wrong surface for them. Gating
+    still carries the cap as a ``suggestion`` so that lever isn't lost.
     """
     if finding is None:
         return []
@@ -1250,11 +1315,7 @@ def _verbosity_to_proposals(finding: Any) -> list[CostProposal]:
         estimated_recoverable_usd=getattr(finding, "estimated_recoverable_usd", None),
         estimated_recoverable_tokens=getattr(finding, "estimated_recoverable_tokens", None),
         estimate_basis=str(getattr(finding, "estimate_basis", "") or ""),
-        advise_only=False,
-        apply_capable=True,
-        rung=1,
-        scope="project",
-        proposed_fix=advise,
+        **_persona_gated_write_fields(persona, advise, rung=1, scope="project"),
     )]
 
 
@@ -1335,8 +1396,16 @@ def cost_proposals_from_report(
     the advise text without a number, same as the CLI. Defaults to ``"api"``
     so existing callers that don't know their caller's plan keep today's
     behaviour.
+
+    ``script`` / ``reuse`` / ``verbosity`` read ``report.persona`` (set once
+    by ``runner.build_report`` — see ``AnalyzerContext.persona``) to decide
+    whether their rung-1/rung-2 workspace write is offered at all — see
+    ``_persona_gated_write_fields``. A report built without that field (e.g.
+    hand-constructed in a test) defaults to ``"unknown"``, which keeps the
+    write off rather than assuming ``"claude-code"``.
     """
     findings = getattr(report, "findings", {}) or {}
+    persona = str(getattr(report, "persona", "") or "unknown")
     proposals: list[CostProposal] = []
     adapters = (
         (lambda f: _downsize_to_proposal(f, config), getattr(report, "downgrade", None)),
@@ -1348,9 +1417,9 @@ def cost_proposals_from_report(
         (lambda f: _subagent_to_proposals(f, config), findings.get("subagent")),
         (lambda f: _placement_to_proposals(f, pricing_mode=pricing_mode), findings.get("placement")),
         (_deadweight_to_proposals, findings.get("deadweight")),
-        (_script_to_proposals, findings.get("script")),
-        (_reuse_to_proposals, findings.get("reuse")),
-        (_verbosity_to_proposals, findings.get("verbosity")),
+        (lambda f: _script_to_proposals(f, persona=persona), findings.get("script")),
+        (lambda f: _reuse_to_proposals(f, persona=persona), findings.get("reuse")),
+        (lambda f: _verbosity_to_proposals(f, persona=persona), findings.get("verbosity")),
     )
     for adapter, finding in adapters:
         try:

--- a/tokenjam/core/optimize/cost_proposals.py
+++ b/tokenjam/core/optimize/cost_proposals.py
@@ -511,7 +511,7 @@ def estimated_recoverable_rollup(
     """
     seen: dict[str, dict[str, Any]] = {}
     for p in proposals:
-        row = asdict(p) if is_dataclass(p) else dict(p)
+        row = asdict(p) if is_dataclass(p) and not isinstance(p, type) else dict(p)
         sig = str(row.get("signature") or "")
         if not sig or sig in seen:
             continue  # empty/duplicate signature never counts twice

--- a/tokenjam/core/optimize/cost_proposals.py
+++ b/tokenjam/core/optimize/cost_proposals.py
@@ -1,21 +1,21 @@
 """Adapt cost-analyzer findings into Review-inbox proposals ("advisories with
 receipts").
 
-The self-improve loop's relearn detector already produces
-``RelearnCluster`` proposals that the Lens Improve inbox renders and that a
+The self-improve loop's pothole detector already produces
+``PotholeCluster`` proposals that the Lens Improve inbox renders and that a
 user can mark, apply, and verify. Three *cost* analyzers — ``downsize``
 (model over-sizing), ``cache`` (cache efficacy), ``trim`` (prompt bloat) —
 produce findings of a different shape. This module adapts each finding into a
-``CostProposal`` so the inbox can list them BESIDE the relearn proposals, typed
+``CostProposal`` so the inbox can list them BESIDE the pothole proposals, typed
 by a distinct ``kind`` field.
 
-Two structural facts carry over from the relearn ``advise_only`` lane and are
+Two structural facts carry over from the pothole ``advise_only`` lane and are
 NOT optional here:
 
   * **Advise-only everywhere.** A cost fix lives in the user's own application
     code (a model-routing decision, a cache-prefix change, a prompt edit), not
     a workspace tokenjam may write into. So a cost proposal has NO apply path —
-    exactly like an ``advise_only`` ``RelearnCluster`` (empty
+    exactly like an ``advise_only`` ``PotholeCluster`` (empty
     ``suggested_target``). The card carries a recommendation and, where
     sensible, a copyable config/code suggestion; the user applies it themselves.
   * **Estimated / correlational, never causal.** Every saving figure a cost
@@ -42,31 +42,20 @@ COST_CORRELATIONAL_CAVEAT = (
     "before changing anything."
 )
 
-#: The analyzers this wiring covers, by registration name.
-COST_ANALYZERS = ("downsize", "cache", "trim", "subagent", "deadweight")
-
-# The rung-1 sizing-rubric note a CC-origin subagent proposal writes into the
-# workspace CLAUDE.md when applied. A shape-based default, not a per-subagent
-# edit — it names the observed oversized dispatches and states the routing rule.
-SUBAGENT_RUBRIC_INTRO = (
-    "Right-size Task-dispatched subagents: default a subagent to the cheapest "
-    "same-family model that fits its shape, and only reach for a premium-tier "
-    "model (Opus / Fable) when the subtask genuinely needs deep reasoning. A "
-    "subagent that does little tool work and returns a short result rarely needs "
-    "the premium tier."
-)
+#: The three analyzers this wiring covers, by registration name.
+COST_ANALYZERS = ("downsize", "cache", "trim")
 
 
 @dataclass
 class CostProposal:
     """One cost analyzer's finding, shaped for the Review inbox.
 
-    Mirrors the fields the inbox already reads off a ``RelearnCluster`` (title,
+    Mirrors the fields the inbox already reads off a ``PotholeCluster`` (title,
     evidence, an estimate with its basis, ``advise_only``) plus the cost-
     specific ``target_key`` the delta-verify pass re-measures against.
     """
     kind:      str                     # always "cost" — the inbox discriminator
-    analyzer:  str                     # "downsize" | "cache" | "trim" | "subagent"
+    analyzer:  str                     # "downsize" | "cache" | "trim"
     signature: str                     # stable identity for dedup + verify keying
     title:     str
     # WHICH thing is flagged, machine-readable — the key ``cost_verify`` uses to
@@ -96,18 +85,6 @@ class CostProposal:
     # Best-effort service scope for the marker/expectation the user creates on
     # "mark applied" (Expectation.agent_id). "" when the finding spans agents.
     agent_id:             str = ""
-    # Workspace-apply plumbing (subagent right-sizing only). Unlike the three
-    # advise-only analyzers, a CC-origin subagent finding HAS a writable surface
-    # — a rung-1 sizing rubric note in the workspace's CLAUDE.md — so its card
-    # can route an actual, reversible, human-gated write through the existing
-    # relearn apply path (``relearn_apply.apply_relearn_fix``). The adapter (not
-    # the analyzer) supplies these; ``apply_capable`` gates the apply action, and
-    # a proposal with no clean workspace surface degrades to advise-only like the
-    # other three (``apply_capable=False``, ``advise_only=True``).
-    apply_capable:        bool = False
-    rung:                 int  = 0
-    scope:                str  = ""
-    proposed_fix:         str  = ""
 
 
 # --------------------------------------------------------------------------- #
@@ -271,195 +248,6 @@ def _trim_to_proposals(finding: Any) -> list[CostProposal]:
     return proposals
 
 
-def _subagent_to_proposals(finding: Any) -> list[CostProposal]:
-    """One proposal covering the subagent right-sizing finding.
-
-    Unlike the three advise-only analyzers, this one is workspace-appliable for
-    the common (CC-origin) case: the fan-out model choice is made by the
-    orchestrating agent, which reads the workspace's CLAUDE.md — so a rung-1
-    sizing rubric note IS a legitimate, reversible workspace fix. The subagent
-    analyzer runs only over Claude Code data (``sub_agent_id`` is populated by
-    the CC backfill; other runtimes carry NULL and are ignored), so a finding
-    here is CC-origin, hence ``apply_capable``. If no oversized model is priced
-    (nothing to key a delta on), the proposal degrades to advise-only.
-
-    The delta-verify pass measures the fan-out model-mix cost delta across the
-    over-powered models, so a single proposal listing them keeps the finding-
-    level estimate coherent (mirrors the downsize adapter).
-    """
-    if finding is None:
-        return []
-    flagged = list(getattr(finding, "flagged", []) or [])
-    over_powered = [r for r in flagged if "over_powered" in (getattr(r, "flags", []) or [])]
-    if not over_powered:
-        return []
-
-    models = sorted({str(r.model) for r in over_powered})
-    subagents = len({(r.session_id, r.sub_agent_id) for r in over_powered})
-    pct = float(getattr(finding, "percent_of_cost", 0.0) or 0.0) * 100
-    model_list = ", ".join(models)
-    evidence = (
-        f"{subagents} subagent dispatch(es) ran on a premium-tier model "
-        f"({model_list}) but did little work (small output, few tool calls). "
-        f"Subagents are {pct:.0f}% of the window's cost."
-    )
-    proposed_fix = (
-        SUBAGENT_RUBRIC_INTRO
-        + f"\n\nObserved oversized dispatches ran on: {model_list}. Route that "
-        "shape to the cheaper same-family model next time."
-    )
-    # Apply-capable when we have a concrete model to name in the rubric; else
-    # degrade to advise-only (no clean workspace surface to write).
-    apply_capable = bool(models)
-    return [CostProposal(
-        kind="cost",
-        analyzer="subagent",
-        signature="cost:subagent",
-        title="Over-powered subagent dispatches (route the fan-out to a cheaper model)",
-        target_key={"models": models, "subagent": True},
-        evidence=evidence,
-        baseline={
-            "flagged_subagents": subagents,
-            "flagged_cost_usd": float(getattr(finding, "flagged_cost_usd", 0.0) or 0.0),
-            "subagent_cost_usd": float(getattr(finding, "subagent_cost_usd", 0.0) or 0.0),
-            "percent_of_cost": float(getattr(finding, "percent_of_cost", 0.0) or 0.0),
-        },
-        advise_text=(
-            "Lower the model tier for the flagged Task dispatches. On Claude Code "
-            "this is a sizing rubric in your CLAUDE.md (apply it below) that the "
-            "orchestrating agent reads before it spawns subagents. "
-            + str(getattr(finding, "caveat", "") or "")
-        ).strip(),
-        estimated_recoverable_usd=getattr(finding, "estimated_recoverable_usd", None),
-        estimated_recoverable_tokens=getattr(finding, "estimated_recoverable_tokens", None),
-        estimate_basis=str(getattr(finding, "estimate_basis", "") or ""),
-        advise_only=not apply_capable,
-        apply_capable=apply_capable,
-        rung=1 if apply_capable else 0,
-        scope="project" if apply_capable else "",
-        proposed_fix=proposed_fix if apply_capable else "",
-    )]
-
-
-def _mcp_remove_plumbing(server: Any) -> dict[str, Any]:
-    """Whether ``server``'s config entry can be removed directly, and where.
-
-    Unlike ``model_swap`` there is no search step: ``ConfiguredServer``
-    already resolved the exact config file at detection time. This just
-    re-verifies that still holds (the file can have moved, or a human can
-    have already removed the entry by hand) at proposal-build time, so the
-    card's pre-filled target is current, not stale analyzer-time data.
-    """
-    from tokenjam.core.optimize.analyzers.deadweight import (
-        APPLY_KIND_MCP_REMOVE,
-        mcp_remove_precheck,
-    )
-
-    check = mcp_remove_precheck(server.source, server.name)
-    if not check["ok"]:
-        return {"apply_capable": False, "apply_blocked_reason": check["reason"]}
-    return {
-        "apply_capable": True,
-        "apply_kind": APPLY_KIND_MCP_REMOVE,
-        "source_path": check["target_path"],
-        "target_path": check["target_path"],
-        "apply_blocked_reason": "",
-    }
-
-
-def _deadweight_to_proposals(finding: Any) -> list[CostProposal]:
-    """One proposal per dead-weight MCP server (Component C1).
-
-    Reads ONLY ``DeadweightFinding.dead_servers`` — the C2 tax table (which
-    lists every configured server, dead or alive, purely for ranked
-    visibility) never feeds a proposal here, so a server's schema-injection
-    tax is never counted both in the tax table AND a proposal (the same
-    dedup guarantee ``compute_deadweight_finding`` itself enforces on
-    ``estimated_recoverable_tokens`` / ``estimated_recoverable_usd``).
-
-    ``estimated_recoverable_usd`` is carried straight off the analyzer's own
-    ``ServerDeadweight.estimated_tax_usd_90d`` — the analyzer already prices
-    the token tax through ``core/pricing.py`` at the dominant model observed
-    in that server's sessions (never a hardcoded rate; see
-    ``deadweight._pricing_note``). Stays ``None`` when no priced model was
-    observed for that server — this adapter never invents a rate itself.
-
-    Apply-capable, like ``downsize``'s ``model_swap`` cards: the fix is a
-    deterministic edit of a value already written down (the server's own
-    ``mcpServers`` entry), so it routes through the same
-    ``relearn_apply.apply_relearn_fix`` machinery under
-    ``APPLY_KIND_MCP_REMOVE`` — reversible, git-committed where the config
-    lives in a repo, one-step revert. Falls back to the one-paste ``claude
-    mcp remove`` command, with the reason stated, when the precondition
-    doesn't hold (file missing, malformed, or the entry already gone).
-    """
-    if finding is None:
-        return []
-    proposals: list[CostProposal] = []
-    for server in getattr(finding, "dead_servers", []) or []:
-        evidence = (
-            f"`{server.name}` MCP server ({server.scope} scope, configured at "
-            f"{server.source}) made 0 tool calls across {server.sessions_present} "
-            f"session(s) in the window."
-        )
-        if server.deferred_sessions:
-            evidence += (
-                f" ToolSearch deferred its schema in {server.deferred_sessions} "
-                f"of those session(s)."
-            )
-        scope_flag = "user" if server.scope == "user" else "project"
-        plumbing = _mcp_remove_plumbing(server)
-        advise = (
-            server.fix + " Removing (or project-scoping) it is reversible "
-            "and loses no data; it only stops the standing schema-injection "
-            "tax on future sessions."
-        )
-        if plumbing.get("apply_capable"):
-            advise += (
-                f" tokenjam can remove this exact entry from "
-                f"{plumbing['target_path']}, with the change committed and "
-                f"revertable in one call."
-            )
-        elif plumbing.get("apply_blocked_reason"):
-            advise += f" Applying it here is not on offer: {plumbing['apply_blocked_reason']}"
-        proposals.append(CostProposal(
-            kind="cost",
-            analyzer="deadweight",
-            signature=f"cost:deadweight:{server.name}",
-            title=f"Unused MCP server: {server.name}",
-            target_key={
-                "server": server.name, "scope": server.scope, "source": server.source,
-            },
-            evidence=evidence,
-            baseline={
-                "sessions_present": server.sessions_present,
-                "invocations": server.invocations,
-                "deferred_sessions": server.deferred_sessions,
-                "scope": server.scope,
-                "source": server.source,
-                "example_sessions": list(server.example_sessions),
-                "priced_model": server.priced_model,
-            },
-            advise_text=advise,
-            suggestion=f"claude mcp remove {server.name} --scope {scope_flag}",
-            estimated_recoverable_tokens=server.estimated_tax_tokens_90d or None,
-            estimated_recoverable_usd=server.estimated_tax_usd_90d,
-            estimate_basis=(
-                server.tax_construction
-                + " Projected over a 90-day window from the sessions observed."
-            ),
-            advise_only=not plumbing.get("apply_capable", False),
-            apply_capable=bool(plumbing.get("apply_capable")),
-            apply_kind=str(plumbing.get("apply_kind", "")),
-            agent_name=server.name,
-            source_path=str(plumbing.get("source_path", "")),
-            target_path=str(plumbing.get("target_path", "")),
-            scope=server.scope,
-            apply_blocked_reason=str(plumbing.get("apply_blocked_reason", "")),
-        ))
-    return proposals
-
-
 #: Default look-back for the daemon/CLI cost-proposal recompute. Matches the
 #: monthly framing the cost analyzers project against.
 DEFAULT_COST_WINDOW_DAYS = 30
@@ -483,7 +271,7 @@ def recompute_cost_proposals(
     """
     from datetime import timedelta
 
-    from tokenjam.core.optimize import relearn_store
+    from tokenjam.core.optimize import pothole_store
     from tokenjam.core.optimize.runner import build_report
     from tokenjam.utils.time_parse import utcnow
 
@@ -499,7 +287,7 @@ def recompute_cost_proposals(
         return []
 
     try:
-        relearn_store.write_cost_proposals(proposals, config=config)
+        pothole_store.write_cost_proposals(proposals, config=config)
     except Exception:
         pass
     return proposals
@@ -509,19 +297,15 @@ def cost_proposals_from_report(report: Any) -> list[CostProposal]:
     """Every cost proposal derivable from an already-built ``OptimizeReport``.
 
     Reads the ``downsize`` finding off the typed ``report.downgrade`` slot and
-    the ``cache`` / ``trim`` / ``subagent`` / ``deadweight`` findings off
-    ``report.findings``. Missing findings (analyzer not run, no candidates)
-    contribute nothing. Never raises — a malformed finding is skipped so one
-    bad analyzer can't sink the inbox.
+    the ``cache`` / ``trim`` findings off ``report.findings``. Missing findings
+    (analyzer not run, no candidates) contribute nothing. Never raises — a
+    malformed finding is skipped so one bad analyzer can't sink the inbox.
     """
-    findings = getattr(report, "findings", {}) or {}
     proposals: list[CostProposal] = []
     adapters = (
         (_downsize_to_proposal, getattr(report, "downgrade", None)),
-        (_cache_to_proposals, findings.get("cache")),
-        (_trim_to_proposals, findings.get("trim")),
-        (_subagent_to_proposals, findings.get("subagent")),
-        (_deadweight_to_proposals, findings.get("deadweight")),
+        (_cache_to_proposals, (getattr(report, "findings", {}) or {}).get("cache")),
+        (_trim_to_proposals, (getattr(report, "findings", {}) or {}).get("trim")),
     )
     for adapter, finding in adapters:
         try:

--- a/tokenjam/core/optimize/cost_verify.py
+++ b/tokenjam/core/optimize/cost_verify.py
@@ -1,7 +1,7 @@
 """Delta-verify for applied cost proposals — the receipts.
 
 A cost proposal is advise-only, so there is no transcript recurrence to
-re-count (that is ``relearn_verify``'s job). What we CAN measure is whether the
+re-count (that is ``pothole_verify``'s job). What we CAN measure is whether the
 cost signal the analyzer flagged actually moved after the user marked their
 change: fewer dollars on the oversized model, a higher cache hit ratio, fewer
 input tokens per call on the bloated step.
@@ -15,7 +15,7 @@ the SAME ``core.cost.calculate_cost`` the rest of tokenjam uses (per-model,
 per-token-type, BOTH ``cache_tokens`` and ``cache_write_tokens`` included — the
 recurring omission this workspace guards against).
 
-Honesty (identical discipline to ``relearn_verify``):
+Honesty (identical discipline to ``pothole_verify``):
 
   * **Correlational, never causal.** The user's change is one of many things
     that shifted at the marker. This measures co-occurrence and says so.
@@ -34,7 +34,7 @@ from datetime import datetime, timedelta, timezone
 from typing import Any
 
 from tokenjam.core.cost import calculate_cost
-from tokenjam.core.optimize.relearn_verify import (
+from tokenjam.core.optimize.pothole_verify import (
     VERDICT_IMPROVED,
     VERDICT_INSUFFICIENT_DATA,
     VERDICT_REGRESSED,
@@ -89,17 +89,12 @@ def _window_bounds(marker: datetime, now: datetime) -> tuple[datetime, datetime,
 def _rows_for(
     conn: Any, since: datetime, until: datetime, agent_id: str | None,
     *, model: str | None = None, provider: str | None = None,
-    subagent_only: bool = False,
 ) -> list[tuple]:
     """LLM spans in ``[since, until)`` with optional agent/model/provider
     filters. Returns (session_id, provider, model, input, output, cache,
-    cache_write). ``subagent_only`` scopes to Task-dispatched subagent spans
-    (``sub_agent_id IS NOT NULL``) — the fan-out the subagent analyzer flags.
-    Never raises — a bad query yields ``[]``."""
+    cache_write). Never raises — a bad query yields ``[]``."""
     clauses = ["start_time >= $1", "start_time < $2", "model IS NOT NULL"]
     params: list[Any] = [since, until]
-    if subagent_only:
-        clauses.append("sub_agent_id IS NOT NULL")
     if agent_id:
         params.append(agent_id)
         clauses.append(f"agent_id = ${len(params)}")
@@ -288,19 +283,6 @@ def measure_cost_delta(
         realized_usd = (saved_tokens / 1_000_000) * input_rate
         post_calls = post["calls"]
 
-    elif analyzer == "subagent":
-        # Fan-out model-mix cost delta: per-session dollars spent on the
-        # oversized model(s) across SUBAGENT spans only (sub_agent_id NOT NULL),
-        # before vs after the marker. Same shape as downsize, scoped to the
-        # Task-dispatched fan-out the subagent analyzer flags.
-        models = {str(m) for m in (target.get("models") or [])}
-        pre = _downsize_metric(
-            _rows_for(conn, pre_start, pre_end, agent_id, subagent_only=True), models)
-        post_rows = _rows_for(conn, post_start, post_end, agent_id, subagent_only=True)
-        post = _downsize_metric(post_rows, models)
-        realized_usd = max(0.0, pre["value"] - post["value"]) * post["sessions"]
-        post_calls = post["calls"]
-
     else:
         return {**empty, "reason": f"unknown cost analyzer {analyzer!r}"}
 
@@ -390,7 +372,7 @@ def rescan_all(
 def cost_compound_ledger(records: list[dict[str, Any]]) -> dict[str, Any]:
     """The Applied section's cost summary: total realized dollars across every
     VERIFIED, improved (non-reverted) cost fix, plus a verdict breakdown. The
-    dollar-denominated sibling of ``relearn_verify.compound_ledger``."""
+    dollar-denominated sibling of ``pothole_verify.compound_ledger``."""
     total_usd = 0.0
     total_tokens = 0
     verified = improved = regressed = insufficient = 0

--- a/tokenjam/core/optimize/cost_verify.py
+++ b/tokenjam/core/optimize/cost_verify.py
@@ -481,10 +481,19 @@ def rescan_all(
 def cost_compound_ledger(records: list[dict[str, Any]]) -> dict[str, Any]:
     """The Applied section's cost summary: total realized dollars across every
     VERIFIED, improved (non-reverted) cost fix, plus a verdict breakdown. The
-    dollar-denominated sibling of ``relearn_verify.compound_ledger``."""
+    dollar-denominated sibling of ``relearn_verify.compound_ledger``.
+
+    The named buckets (``improved`` + ``no_change`` + ``regressed`` +
+    ``insufficient_data``) must always sum to ``verified_count`` — every
+    verdict ``measure_cost_delta`` can produce needs a bucket here, or
+    ``verified_count`` silently outgrows its own breakdown (the deadweight
+    analyzer's ``no_change`` verdict was the first one this ledger hadn't
+    seen before; this bucket closes that gap for it and any future analyzer
+    reusing the same verdict).
+    """
     total_usd = 0.0
     total_tokens = 0
-    verified = improved = regressed = insufficient = 0
+    verified = improved = no_change = regressed = insufficient = 0
     for rec in records:
         if rec.get("state") == "reverted":
             continue
@@ -497,6 +506,8 @@ def cost_compound_ledger(records: list[dict[str, Any]]) -> dict[str, Any]:
             improved += 1
             total_usd += verify.get("realized_usd_delta") or 0.0
             total_tokens += verify.get("realized_tokens_delta") or 0
+        elif verdict == VERDICT_NO_CHANGE:
+            no_change += 1
         elif verdict == VERDICT_REGRESSED:
             regressed += 1
         elif verdict == VERDICT_INSUFFICIENT_DATA:
@@ -506,6 +517,7 @@ def cost_compound_ledger(records: list[dict[str, Any]]) -> dict[str, Any]:
         "total_realized_tokens": total_tokens,
         "verified_count": verified,
         "improved_count": improved,
+        "no_change_count": no_change,
         "regressed_count": regressed,
         "insufficient_data_count": insufficient,
         "estimate_basis": ESTIMATE_BASIS_COST_VERIFY,

--- a/tokenjam/core/optimize/cost_verify.py
+++ b/tokenjam/core/optimize/cost_verify.py
@@ -1,7 +1,7 @@
 """Delta-verify for applied cost proposals — the receipts.
 
 A cost proposal is advise-only, so there is no transcript recurrence to
-re-count (that is ``pothole_verify``'s job). What we CAN measure is whether the
+re-count (that is ``relearn_verify``'s job). What we CAN measure is whether the
 cost signal the analyzer flagged actually moved after the user marked their
 change: fewer dollars on the oversized model, a higher cache hit ratio, fewer
 input tokens per call on the bloated step.
@@ -15,7 +15,7 @@ the SAME ``core.cost.calculate_cost`` the rest of tokenjam uses (per-model,
 per-token-type, BOTH ``cache_tokens`` and ``cache_write_tokens`` included — the
 recurring omission this workspace guards against).
 
-Honesty (identical discipline to ``pothole_verify``):
+Honesty (identical discipline to ``relearn_verify``):
 
   * **Correlational, never causal.** The user's change is one of many things
     that shifted at the marker. This measures co-occurrence and says so.
@@ -34,7 +34,7 @@ from datetime import datetime, timedelta, timezone
 from typing import Any
 
 from tokenjam.core.cost import calculate_cost
-from tokenjam.core.optimize.pothole_verify import (
+from tokenjam.core.optimize.relearn_verify import (
     VERDICT_IMPROVED,
     VERDICT_INSUFFICIENT_DATA,
     VERDICT_REGRESSED,
@@ -89,12 +89,17 @@ def _window_bounds(marker: datetime, now: datetime) -> tuple[datetime, datetime,
 def _rows_for(
     conn: Any, since: datetime, until: datetime, agent_id: str | None,
     *, model: str | None = None, provider: str | None = None,
+    subagent_only: bool = False,
 ) -> list[tuple]:
     """LLM spans in ``[since, until)`` with optional agent/model/provider
     filters. Returns (session_id, provider, model, input, output, cache,
-    cache_write). Never raises — a bad query yields ``[]``."""
+    cache_write). ``subagent_only`` scopes to Task-dispatched subagent spans
+    (``sub_agent_id IS NOT NULL``) — the fan-out the subagent analyzer flags.
+    Never raises — a bad query yields ``[]``."""
     clauses = ["start_time >= $1", "start_time < $2", "model IS NOT NULL"]
     params: list[Any] = [since, until]
+    if subagent_only:
+        clauses.append("sub_agent_id IS NOT NULL")
     if agent_id:
         params.append(agent_id)
         clauses.append(f"agent_id = ${len(params)}")
@@ -147,6 +152,20 @@ def _downsize_metric(rows: list[tuple], models: set[str]) -> dict[str, Any]:
             "oversized_usd": oversized_usd}
 
 
+def _placement_metric(rows: list[tuple]) -> dict[str, Any]:
+    """Per-session dollars on the flagged workload group.
+
+    Usage records carry no batch/service-tier marker today, so the receipt is a
+    spend drop on the same workload after the user marks the change applied,
+    with no claim about what caused it.
+    """
+    sessions = {str(r[0] or "") for r in rows}
+    n_sessions = len(sessions)
+    total_usd = _priced_usd(rows)
+    return {"value": (total_usd / n_sessions) if n_sessions else 0.0,
+            "sessions": n_sessions, "calls": len(rows), "total_usd": total_usd}
+
+
 def _cache_metric(rows: list[tuple]) -> dict[str, Any]:
     """Cache-read efficacy = cache_tokens / (input + cache) for the flagged
     (provider, model), plus the input-vs-cache priced value of the gap."""
@@ -156,25 +175,6 @@ def _cache_metric(rows: list[tuple]) -> dict[str, Any]:
     efficacy = (cache_tok / total) if total else 0.0
     return {"value": efficacy, "sessions": len({str(r[0] or "") for r in rows}),
             "calls": len(rows), "input_tokens": input_tok, "cache_tokens": cache_tok}
-
-
-def _cache_thrash_metric(rows: list[tuple], rates: Any) -> dict[str, Any]:
-    """Read:write ratio for a flagged agent's cache-thrash pattern (A2), plus
-    the priced 'wasted' value: what was paid to write the prefix versus what
-    the same tokens would have cost read from a stable cache. Mirrors
-    ``analyzers.cache_efficacy._classify_a2``'s arithmetic so the pre/post
-    delta is directly comparable to the card's own estimate."""
-    write_tok = sum(int(r[6] or 0) for r in rows)
-    read_tok = sum(int(r[5] or 0) for r in rows)
-    ratio = (read_tok / write_tok) if write_tok else 0.0
-    wasted_usd = 0.0
-    if rates is not None and write_tok:
-        wasted_usd = (write_tok / 1_000_000) * max(
-            0.0, rates.cache_write_per_mtok - rates.cache_read_per_mtok,
-        )
-    return {"value": ratio, "sessions": len({str(r[0] or "") for r in rows}),
-            "calls": len(rows), "write_tokens": write_tok, "read_tokens": read_tok,
-            "wasted_usd": wasted_usd}
 
 
 def _trim_metric(rows: list[tuple]) -> dict[str, Any]:
@@ -287,21 +287,6 @@ def measure_cost_delta(
         realized_usd = (shifted / 1_000_000) * rate_delta
         post_calls = post["calls"]
 
-    elif analyzer == "cache_thrash":
-        # A2's write:read thrash receipt: less wasted spend after the marker,
-        # for the flagged agent's dominant (provider, model).
-        provider = str(target.get("provider") or "") or None
-        model = str(target.get("model") or "") or None
-        rates = get_rates(provider or "unknown", model or "")
-        pre = _cache_thrash_metric(
-            _rows_for(conn, pre_start, pre_end, agent_id, model=model, provider=provider),
-            rates,
-        )
-        post_rows = _rows_for(conn, post_start, post_end, agent_id, model=model, provider=provider)
-        post = _cache_thrash_metric(post_rows, rates)
-        realized_usd = max(0.0, pre["wasted_usd"] - post["wasted_usd"])
-        post_calls = post["calls"]
-
     elif analyzer == "trim":
         pre = _trim_metric(_rows_for(conn, pre_start, pre_end, agent_id))
         post_rows = _rows_for(conn, post_start, post_end, agent_id)
@@ -315,6 +300,31 @@ def measure_cost_delta(
         rates = get_rates(prov, model)
         input_rate = rates.input_per_mtok if rates is not None else 0.0
         realized_usd = (saved_tokens / 1_000_000) * input_rate
+        post_calls = post["calls"]
+
+    elif analyzer == "subagent":
+        # Fan-out model-mix cost delta: per-session dollars spent on the
+        # oversized model(s) across SUBAGENT spans only (sub_agent_id NOT NULL),
+        # before vs after the marker. Same shape as downsize, scoped to the
+        # Task-dispatched fan-out the subagent analyzer flags.
+        models = {str(m) for m in (target.get("models") or [])}
+        pre = _downsize_metric(
+            _rows_for(conn, pre_start, pre_end, agent_id, subagent_only=True), models)
+        post_rows = _rows_for(conn, post_start, post_end, agent_id, subagent_only=True)
+        post = _downsize_metric(post_rows, models)
+        realized_usd = max(0.0, pre["value"] - post["value"]) * post["sessions"]
+        post_calls = post["calls"]
+
+    elif analyzer == "placement":
+        # Spend on the flagged workload group, per session, before versus after
+        # the marker. Scoped by agent where the card names a single workload;
+        # a multi-workload card measures the whole set it listed.
+        agents = [str(a) for a in (target.get("agents") or []) if a]
+        scope_agent = agent_id or (agents[0] if len(agents) == 1 else None)
+        pre = _placement_metric(_rows_for(conn, pre_start, pre_end, scope_agent))
+        post_rows = _rows_for(conn, post_start, post_end, scope_agent)
+        post = _placement_metric(post_rows)
+        realized_usd = max(0.0, pre["value"] - post["value"]) * post["sessions"]
         post_calls = post["calls"]
 
     else:
@@ -406,7 +416,7 @@ def rescan_all(
 def cost_compound_ledger(records: list[dict[str, Any]]) -> dict[str, Any]:
     """The Applied section's cost summary: total realized dollars across every
     VERIFIED, improved (non-reverted) cost fix, plus a verdict breakdown. The
-    dollar-denominated sibling of ``pothole_verify.compound_ledger``."""
+    dollar-denominated sibling of ``relearn_verify.compound_ledger``."""
     total_usd = 0.0
     total_tokens = 0
     verified = improved = regressed = insufficient = 0

--- a/tokenjam/core/optimize/cost_verify.py
+++ b/tokenjam/core/optimize/cost_verify.py
@@ -37,6 +37,7 @@ from tokenjam.core.cost import calculate_cost
 from tokenjam.core.optimize.relearn_verify import (
     VERDICT_IMPROVED,
     VERDICT_INSUFFICIENT_DATA,
+    VERDICT_NO_CHANGE,
     VERDICT_REGRESSED,
 )
 from tokenjam.core.pricing import get_rates
@@ -152,20 +153,6 @@ def _downsize_metric(rows: list[tuple], models: set[str]) -> dict[str, Any]:
             "oversized_usd": oversized_usd}
 
 
-def _placement_metric(rows: list[tuple]) -> dict[str, Any]:
-    """Per-session dollars on the flagged workload group.
-
-    Usage records carry no batch/service-tier marker today, so the receipt is a
-    spend drop on the same workload after the user marks the change applied,
-    with no claim about what caused it.
-    """
-    sessions = {str(r[0] or "") for r in rows}
-    n_sessions = len(sessions)
-    total_usd = _priced_usd(rows)
-    return {"value": (total_usd / n_sessions) if n_sessions else 0.0,
-            "sessions": n_sessions, "calls": len(rows), "total_usd": total_usd}
-
-
 def _cache_metric(rows: list[tuple]) -> dict[str, Any]:
     """Cache-read efficacy = cache_tokens / (input + cache) for the flagged
     (provider, model), plus the input-vs-cache priced value of the gap."""
@@ -184,6 +171,18 @@ def _trim_metric(rows: list[tuple]) -> dict[str, Any]:
     value = (input_tok / calls) if calls else 0.0
     return {"value": value, "sessions": len({str(r[0] or "") for r in rows}),
             "calls": calls, "input_tokens": input_tok}
+
+
+def _deadweight_metric(rows: list[tuple]) -> dict[str, Any]:
+    """Average total input tokens PER SESSION (not per call). An MCP schema-
+    injection tax is paid once per session's context, not once per call, so
+    the per-session average — not ``_trim_metric``'s per-call average — is
+    the comparable metric for the deadweight branch."""
+    input_tok = sum(int(r[3] or 0) for r in rows)
+    sessions = {str(r[0] or "") for r in rows}
+    n_sessions = len(sessions)
+    value = (input_tok / n_sessions) if n_sessions else 0.0
+    return {"value": value, "sessions": n_sessions, "calls": len(rows), "input_tokens": input_tok}
 
 
 def _dominant_model(rows: list[tuple]) -> tuple[str, str]:
@@ -218,6 +217,76 @@ def _verdict(realized_usd_delta: float, post_calls: int) -> tuple[str, str]:
         f"no measured improvement on the flagged cost dimension (realized delta "
         f"${realized_usd_delta:.4f}) across {post_calls} call(s) after your change",
     )
+
+
+def _measure_deadweight_delta(
+    conn: Any, target: dict[str, Any], agent_id: str | None,
+    pre_start: datetime, pre_end: datetime, post_start: datetime, post_end: datetime,
+    now: datetime,
+) -> dict[str, Any]:
+    """Deadweight's verify branch: is the server still in its configured set,
+    and if not, how much did per-session input tokens drop.
+
+    Distinct from the other four analyzers' improved/regressed verdict: a
+    server that's STILL configured is ``no_change`` — nothing to measure
+    yet, never folded into "regressed" (the user hasn't actually acted on
+    the card). Only once the server is gone from its detected source does
+    this measure a real delta, gated by the same exposure floor as every
+    other cost analyzer; a delta at or below zero still surfaces as
+    ``regressed``, never silently kept as a win.
+    """
+    from tokenjam.core.optimize.analyzers.deadweight import server_still_configured
+
+    server_name = str(target.get("server") or "")
+    source = str(target.get("source") or "")
+    still_configured = server_still_configured(server_name, source)
+
+    pre = _deadweight_metric(_rows_for(conn, pre_start, pre_end, agent_id))
+    post_rows = _rows_for(conn, post_start, post_end, agent_id)
+    post = _deadweight_metric(post_rows)
+
+    base = {
+        "pre_value": round(pre["value"], 6),
+        "post_value": round(post["value"], 6),
+        "pre_sessions": pre["sessions"],
+        "post_sessions": post["sessions"],
+        "estimate_basis": ESTIMATE_BASIS_COST_VERIFY,
+        "last_checked_at": now.isoformat(),
+    }
+
+    if still_configured:
+        return {
+            **base,
+            "verdict": VERDICT_NO_CHANGE,
+            "reason": (
+                f"`{server_name}` still appears in its configured set "
+                f"({source or 'unknown source'}); nothing to measure until "
+                f"it's actually removed or project-scoped"
+            ),
+            "realized_usd_delta": None,
+            "realized_tokens_delta": None,
+        }
+
+    per_session_drop = max(0.0, pre["value"] - post["value"])
+    saved_tokens = per_session_drop * post["sessions"]
+    realized_tokens: int | None = int(saved_tokens)
+    prov, model = _dominant_model(post_rows)
+    rates = get_rates(prov, model)
+    input_rate = rates.input_per_mtok if rates is not None else 0.0
+    realized_usd = round((saved_tokens / 1_000_000) * input_rate, 6)
+
+    verdict, reason = _verdict(realized_usd, post["calls"])
+    if verdict == VERDICT_INSUFFICIENT_DATA:
+        realized_usd = None  # type: ignore[assignment]
+        realized_tokens = None
+
+    return {
+        **base,
+        "verdict": verdict,
+        "reason": reason,
+        "realized_usd_delta": realized_usd,
+        "realized_tokens_delta": realized_tokens,
+    }
 
 
 def measure_cost_delta(
@@ -315,17 +384,13 @@ def measure_cost_delta(
         realized_usd = max(0.0, pre["value"] - post["value"]) * post["sessions"]
         post_calls = post["calls"]
 
-    elif analyzer == "placement":
-        # Spend on the flagged workload group, per session, before versus after
-        # the marker. Scoped by agent where the card names a single workload;
-        # a multi-workload card measures the whole set it listed.
-        agents = [str(a) for a in (target.get("agents") or []) if a]
-        scope_agent = agent_id or (agents[0] if len(agents) == 1 else None)
-        pre = _placement_metric(_rows_for(conn, pre_start, pre_end, scope_agent))
-        post_rows = _rows_for(conn, post_start, post_end, scope_agent)
-        post = _placement_metric(post_rows)
-        realized_usd = max(0.0, pre["value"] - post["value"]) * post["sessions"]
-        post_calls = post["calls"]
+    elif analyzer == "deadweight":
+        # Distinct verdict shape (no_change is possible) — computed and
+        # returned by its own helper rather than falling into the shared
+        # improved/regressed tail below.
+        return _measure_deadweight_delta(
+            conn, target, agent_id, pre_start, pre_end, post_start, post_end, now,
+        )
 
     else:
         return {**empty, "reason": f"unknown cost analyzer {analyzer!r}"}

--- a/tokenjam/core/optimize/cost_verify.py
+++ b/tokenjam/core/optimize/cost_verify.py
@@ -158,6 +158,25 @@ def _cache_metric(rows: list[tuple]) -> dict[str, Any]:
             "calls": len(rows), "input_tokens": input_tok, "cache_tokens": cache_tok}
 
 
+def _cache_thrash_metric(rows: list[tuple], rates: Any) -> dict[str, Any]:
+    """Read:write ratio for a flagged agent's cache-thrash pattern (A2), plus
+    the priced 'wasted' value: what was paid to write the prefix versus what
+    the same tokens would have cost read from a stable cache. Mirrors
+    ``analyzers.cache_efficacy._classify_a2``'s arithmetic so the pre/post
+    delta is directly comparable to the card's own estimate."""
+    write_tok = sum(int(r[6] or 0) for r in rows)
+    read_tok = sum(int(r[5] or 0) for r in rows)
+    ratio = (read_tok / write_tok) if write_tok else 0.0
+    wasted_usd = 0.0
+    if rates is not None and write_tok:
+        wasted_usd = (write_tok / 1_000_000) * max(
+            0.0, rates.cache_write_per_mtok - rates.cache_read_per_mtok,
+        )
+    return {"value": ratio, "sessions": len({str(r[0] or "") for r in rows}),
+            "calls": len(rows), "write_tokens": write_tok, "read_tokens": read_tok,
+            "wasted_usd": wasted_usd}
+
+
 def _trim_metric(rows: list[tuple]) -> dict[str, Any]:
     """Average input tokens per call on the flagged step."""
     input_tok = sum(int(r[3] or 0) for r in rows)
@@ -266,6 +285,21 @@ def measure_cost_delta(
         if rates is not None:
             rate_delta = max(0.0, rates.input_per_mtok - rates.cache_read_per_mtok)
         realized_usd = (shifted / 1_000_000) * rate_delta
+        post_calls = post["calls"]
+
+    elif analyzer == "cache_thrash":
+        # A2's write:read thrash receipt: less wasted spend after the marker,
+        # for the flagged agent's dominant (provider, model).
+        provider = str(target.get("provider") or "") or None
+        model = str(target.get("model") or "") or None
+        rates = get_rates(provider or "unknown", model or "")
+        pre = _cache_thrash_metric(
+            _rows_for(conn, pre_start, pre_end, agent_id, model=model, provider=provider),
+            rates,
+        )
+        post_rows = _rows_for(conn, post_start, post_end, agent_id, model=model, provider=provider)
+        post = _cache_thrash_metric(post_rows, rates)
+        realized_usd = max(0.0, pre["wasted_usd"] - post["wasted_usd"])
         post_calls = post["calls"]
 
     elif analyzer == "trim":

--- a/tokenjam/core/optimize/receipts.py
+++ b/tokenjam/core/optimize/receipts.py
@@ -1,0 +1,108 @@
+"""Component G1: the cumulative "verified saved" receipts — the measured
+twin of Component E's estimated-recoverable rollup
+(``cost_proposals.estimated_recoverable_rollup``).
+
+Combines two independently-verified ledgers:
+
+  * the relearn ledger (``relearn_verify.compound_ledger``) — realized
+    TOKENS saved across workspace-write fixes (notes/skills/hooks/wrappers/
+    config), keyed by recurrence rate.
+  * the cost-verify ledger (``cost_verify.cost_compound_ledger``) — realized
+    TOKENS AND DOLLARS across advise-only cost proposals, priced per-model
+    per-token-type by ``core.cost.calculate_cost``.
+
+The two ledgers are summed WITHIN their own unit (tokens with tokens,
+dollars with dollars) but never cross-converted. A relearn fix has no model
+attached — it isn't scoped to one provider/model, so there is no real
+per-token $ rate to price its savings at; inventing one would fabricate
+precision this house style forbids. ``verified_saved_usd`` is therefore the
+cost-verify ledger's own real, per-model-priced dollars only;
+``verified_saved_tokens`` adds the relearn ledger's tokens on top of the
+cost ledger's tokens (both are genuine token counts — safely additive),
+broken out individually below so neither contribution is silently dropped.
+
+Regressed / no-change / insufficient-data counts from BOTH ledgers are
+carried into the combined breakdown, never hidden — the honesty is the
+feature (spec §2b Component G1). Never raises: a malformed record list just
+contributes zeros (the two source ``compound_ledger`` functions are
+themselves never-raise).
+"""
+from __future__ import annotations
+
+from typing import Any
+
+from tokenjam.core.optimize import cost_verify, relearn_verify
+
+#: The confidence tag every G1 figure carries — the counterpart to
+#: ``cost_proposals.COST_ESTIMATE_CONFIDENCE`` ("estimated"). Kept as a
+#: distinct string so nothing can accidentally render the two ledgers'
+#: numbers under the same label.
+ESTIMATE_CONFIDENCE_MEASURED = "measured"
+
+RECEIPTS_BASIS = (
+    "verified_saved_usd = the cost-verify ledger's realized dollars only "
+    "(real, per-model per-token-type pricing, only counted once a fix's "
+    "post-apply exposure window clears the verify gate). "
+    "verified_saved_tokens = relearn-ledger tokens + cost-verify-ledger "
+    "tokens (both real token counts, safely additive). Relearn's token "
+    "savings are never converted to dollars: a relearn fix has no single "
+    "model to price at. Measured, correlational with your change, never a "
+    "causal claim; regressed / no-change / insufficient-data fixes are "
+    "counted here, not hidden."
+)
+
+
+def verified_saved_summary(
+    relearn_records: list[dict[str, Any]],
+    cost_records: list[dict[str, Any]],
+) -> dict[str, Any]:
+    """The dashboard's single "verified saved to date: $Y" figure (G1) — the
+    measured twin of Component E's estimated-recoverable rollup.
+
+    Pure: takes the two ledgers' raw applied-fix record lists
+    (``relearn_apply.list_applied`` / ``cost_apply.list_applied``) and
+    returns the combined receipt. Never raises — a bad record list degrades
+    to a zeroed, ``verified_count == 0`` summary rather than an exception.
+    """
+    relearn_ledger = relearn_verify.compound_ledger(relearn_records or [])
+    cost_ledger = cost_verify.cost_compound_ledger(cost_records or [])
+
+    relearn_tokens = int(relearn_ledger.get("total_realized_tokens_saved") or 0)
+    cost_tokens = int(cost_ledger.get("total_realized_tokens") or 0)
+    cost_usd = round(float(cost_ledger.get("total_realized_usd") or 0.0), 6)
+
+    return {
+        "verified_saved_usd": cost_usd,
+        "verified_saved_tokens": relearn_tokens + cost_tokens,
+        "relearn_tokens_saved": relearn_tokens,
+        "cost_tokens_saved": cost_tokens,
+        "cost_usd_saved": cost_usd,
+        "verified_count": (
+            int(relearn_ledger.get("verified_count") or 0)
+            + int(cost_ledger.get("verified_count") or 0)
+        ),
+        "improved_count": (
+            int(relearn_ledger.get("improved_count") or 0)
+            + int(cost_ledger.get("improved_count") or 0)
+        ),
+        "regressed_count": (
+            int(relearn_ledger.get("regressed_count") or 0)
+            + int(cost_ledger.get("regressed_count") or 0)
+        ),
+        # cost_verify has no no_change/enforcement_disabled verdicts (its
+        # `_verdict` only ever returns improved/regressed/insufficient_data)
+        # — these two counts are relearn-only, carried through unchanged.
+        "no_change_count": int(relearn_ledger.get("no_change_count") or 0),
+        "enforcement_disabled_count": int(relearn_ledger.get("enforcement_disabled_count") or 0),
+        "insufficient_data_count": (
+            int(relearn_ledger.get("insufficient_data_count") or 0)
+            + int(cost_ledger.get("insufficient_data_count") or 0)
+        ),
+        "estimate_confidence": ESTIMATE_CONFIDENCE_MEASURED,
+        "estimate_basis": RECEIPTS_BASIS,
+        # The two source ledgers, untouched — a caller that wants the
+        # relearn-only or cost-only view (e.g. the existing Applied
+        # sections) doesn't need to recompute them separately.
+        "relearn_ledger": relearn_ledger,
+        "cost_ledger": cost_ledger,
+    }

--- a/tokenjam/core/optimize/relearn_apply.py
+++ b/tokenjam/core/optimize/relearn_apply.py
@@ -184,11 +184,15 @@ def _git_commit(repo_root: Path, rel_paths: list[str], message: str) -> str | No
     return (sha.stdout or "").strip() or None
 
 
-def _commit_message(action: str, title: str, signature: str, rung: int) -> str:
+def _commit_message(
+    action: str, title: str, signature: str, rung: int, kind: str | None = None,
+) -> str:
     # Neutral, tool-attributed, no internal ticket IDs — this lands in ANY
-    # target repo (including public ones), not just tokenjam's own.
+    # target repo (including public ones), not just tokenjam's own. `kind` is
+    # passed for the apply kinds that sit outside the rung ladder (the model
+    # edits), so the message names what was actually written.
     return (
-        f"tokenjam: {action} fix (rung {rung} · {RUNG_KIND.get(rung, '?')})\n\n"
+        f"tokenjam: {action} fix (rung {rung} · {kind or RUNG_KIND.get(rung, '?')})\n\n"
         f"{title}\n\n"
         f"Applied by TokenJam's loop (signature: {signature}).\n"
         f"Revert from the Review inbox, or via the applied_fixes ledger."
@@ -821,10 +825,15 @@ def _build_write_plan(cluster: dict, target_path: str) -> dict[str, Any]:
     symlink, or (rung 1) the target isn't an allowlisted note file."""
     import difflib
 
+    from tokenjam.core.optimize.model_apply import APPLY_KINDS, build_model_plan
+
     signature = cluster["signature"]
+    apply_kind = str(cluster.get("apply_kind") or "")
     rung = int(cluster["rung"])
-    if rung not in RUNG_KIND:
+    if not apply_kind and rung not in RUNG_KIND:
         raise RelearnApplyRefused(f"unknown rung {rung}.")
+    if apply_kind and apply_kind not in APPLY_KINDS:
+        raise RelearnApplyRefused(f"unknown apply kind {apply_kind!r}.")
     if not target_path:
         raise RelearnApplyRefused("no target path given — pick one before approving.")
 
@@ -837,7 +846,14 @@ def _build_write_plan(cluster: dict, target_path: str) -> dict[str, Any]:
         )
     pre_image = _read_pre_image(target)
 
-    if rung == RUNG_NOTE:
+    if apply_kind:
+        # The two model-routing kinds (an agent file's `model:` key, a
+        # registered repo's model-id string). Both are edits of an existing
+        # value, so they skip the rung ladder entirely and only rewrite bytes
+        # that were already there; everything downstream (backup, git commit,
+        # ledger, revert) is the shared machinery.
+        new_content = build_model_plan(cluster, target, pre_image)
+    elif rung == RUNG_NOTE:
         if not _is_allowed_note_target(target, pre_image):
             raise RelearnApplyRefused(
                 f"{target} is not an allowlisted note target (must be a CLAUDE.md/*.md "
@@ -863,7 +879,7 @@ def _build_write_plan(cluster: dict, target_path: str) -> dict[str, Any]:
     return {
         "signature": signature, "rung": rung, "slug": slug, "target_path": str(target),
         "pre_image": pre_image, "new_content": new_content, "diff": diff,
-        "kind": RUNG_KIND[rung],
+        "kind": apply_kind or RUNG_KIND[rung],
     }
 
 
@@ -901,7 +917,7 @@ def apply_relearn_fix(
     _write_target(target, plan["new_content"])
 
     enforcement: dict[str, Any] | None = None
-    if rung in ENFORCEMENT_RUNGS:
+    if rung in ENFORCEMENT_RUNGS and not cluster.get("apply_kind"):
         target.chmod(0o755)
         settings_path = target.parent.parent / "settings.json"
         patch_path = target.parent / f"{plan['slug']}.settings-patch.json"
@@ -924,7 +940,10 @@ def apply_relearn_fix(
             rel_paths.append(str(Path(enforcement["patch_path"]).relative_to(repo_root)))
         commit_sha = _git_commit(
             repo_root, rel_paths,
-            _commit_message("apply", cluster.get("title", plan["signature"]), plan["signature"], rung),
+            _commit_message(
+                "apply", cluster.get("title", plan["signature"]), plan["signature"],
+                rung, plan["kind"],
+            ),
         )
 
     from tokenjam.utils.time_parse import utcnow
@@ -1100,7 +1119,10 @@ def revert_applied_fix(config: TjConfig, fix_id: str) -> dict:
         if add is not None and add.returncode == 0:
             commit = _run_git(
                 ["commit", "--no-verify", "-m",
-                 _commit_message("revert", rec["title"], rec["signature"], rec["rung"]),
+                 _commit_message(
+                     "revert", rec["title"], rec["signature"], rec["rung"],
+                     rec.get("kind"),
+                 ),
                  "--", rel],
                 repo_root,
             )

--- a/tokenjam/core/optimize/runner.py
+++ b/tokenjam/core/optimize/runner.py
@@ -317,6 +317,9 @@ def _build_finding_constructors() -> dict:
     from tokenjam.core.optimize.analyzers.cache_efficacy import (
         CacheEfficacyFinding,
         CacheEfficacyRow,
+        LookbackMissCandidate,
+        ThrashAgentCandidate,
+        UncachedAgentCandidate,
     )
     from tokenjam.core.optimize.analyzers.cache_recommend import (
         CachePrefixCandidate,
@@ -355,6 +358,9 @@ def _build_finding_constructors() -> dict:
     def _cache_efficacy(d: dict) -> CacheEfficacyFinding:
         rows = [CacheEfficacyRow(**r) for r in d.get("rows") or []]
         flagged = [CacheEfficacyRow(**r) for r in d.get("flagged") or []]
+        uncached = [UncachedAgentCandidate(**c) for c in d.get("uncached_agents") or []]
+        thrash = [ThrashAgentCandidate(**c) for c in d.get("thrash_agents") or []]
+        lookback = [LookbackMissCandidate(**c) for c in d.get("lookback_miss_agents") or []]
         return CacheEfficacyFinding(
             rows=rows, flagged=flagged,
             confidence=d.get("confidence", "structural"),
@@ -363,6 +369,8 @@ def _build_finding_constructors() -> dict:
             estimated_recoverable_tokens=d.get("estimated_recoverable_tokens"),
             estimate_basis=d.get("estimate_basis", ""),
             estimate_confidence=d.get("estimate_confidence", "heuristic"),
+            uncached_agents=uncached, thrash_agents=thrash,
+            lookback_miss_agents=lookback,
         )
 
     def _cache_recommend(d: dict) -> CacheRecommendFinding:

--- a/tokenjam/core/optimize/runner.py
+++ b/tokenjam/core/optimize/runner.py
@@ -12,6 +12,7 @@ from datetime import datetime
 from typing import Any
 
 from tokenjam.core.config import TjConfig
+from tokenjam.core.framing import agent_persona_mix, config_declared_plan, dominant_persona
 from tokenjam.utils.time_parse import utcnow
 from tokenjam.core.optimize.registry import ANALYZER_REGISTRY
 from tokenjam.core.optimize.types import (
@@ -118,7 +119,15 @@ def build_report(
     summary = summarize_window(conn, since, until, agent_id=agent_id)
     window_days = max(summary.days, 1.0 / 86400.0)
 
-    report = OptimizeReport(window=summary)
+    # Dominant persona for this window, computed exactly once — see
+    # `AnalyzerContext.persona` / `OptimizeReport.persona`. Same functions
+    # (`agent_persona_mix` / `dominant_persona`) the CLI uses for its own
+    # persona-dependent CTA (`cmd_optimize._render_downgrade_cta`); this is
+    # not a second classifier, just a second place that needed the answer.
+    agent_mix = agent_persona_mix(conn, since, until, agent_id=agent_id)
+    persona = dominant_persona(agent_mix, declared_plan=config_declared_plan(config))
+
+    report = OptimizeReport(window=summary, persona=persona)
     if summary.thin_data:
         report.notes.append(
             "Window contains less than ~1 week of activity — projections shown "
@@ -136,6 +145,7 @@ def build_report(
         report=report,
         budget_provider_filter=budget_provider_filter,
         budget_usd_override=budget_usd_override,
+        persona=persona,
     )
 
     selected = set(findings) if findings is not None else set(ANALYZER_REGISTRY.keys())
@@ -306,6 +316,7 @@ def report_from_dict(d: dict) -> OptimizeReport:
         budgets=budgets,
         notes=list(d.get("notes") or []),
         findings=findings,
+        persona=str(d.get("persona", "unknown")),
     )
 
 

--- a/tokenjam/core/optimize/runner.py
+++ b/tokenjam/core/optimize/runner.py
@@ -389,6 +389,9 @@ def _build_finding_constructors() -> dict:
             skipped_provider_count=int(d.get("skipped_provider_count", 0)),
             confidence=d.get("confidence", "structural"),
             hint=d.get("hint"),
+            estimated_recoverable_usd=d.get("estimated_recoverable_usd"),
+            estimated_recoverable_tokens=d.get("estimated_recoverable_tokens"),
+            estimate_basis=d.get("estimate_basis", ""),
         )
 
     def _workflow_restructure(d: dict) -> WorkflowRestructureFinding:

--- a/tokenjam/core/optimize/runner.py
+++ b/tokenjam/core/optimize/runner.py
@@ -353,6 +353,12 @@ def _build_finding_constructors() -> dict:
         VerbosityCandidate,
         VerbosityFinding,
     )
+    from tokenjam.core.optimize.analyzers.deadweight import (
+        ContextTaxRow,
+        DEADWEIGHT_HONESTY_CAVEAT,
+        DeadweightFinding,
+        ServerDeadweight,
+    )
     from tokenjam.core.optimize.types import ReuseCluster, ReuseFinding
 
     def _cache_efficacy(d: dict) -> CacheEfficacyFinding:
@@ -509,6 +515,23 @@ def _build_finding_constructors() -> dict:
             estimate_confidence=d.get("estimate_confidence", "heuristic"),
         )
 
+    def _deadweight(d: dict) -> DeadweightFinding:
+        servers = [ServerDeadweight(**s) for s in d.get("servers") or []]
+        dead_servers = [ServerDeadweight(**s) for s in d.get("dead_servers") or []]
+        tax_table = [ContextTaxRow(**r) for r in d.get("tax_table") or []]
+        return DeadweightFinding(
+            sessions_scanned=int(d.get("sessions_scanned", 0)),
+            configured_servers=int(d.get("configured_servers", 0)),
+            servers=servers,
+            dead_servers=dead_servers,
+            tax_table=tax_table,
+            estimated_recoverable_tokens=d.get("estimated_recoverable_tokens"),
+            estimate_basis=d.get("estimate_basis", ""),
+            estimate_confidence=d.get("estimate_confidence", "estimated"),
+            caveat=d.get("caveat", DEADWEIGHT_HONESTY_CAVEAT),
+            notes=list(d.get("notes") or []),
+        )
+
     return {
         "cache": _cache_efficacy,
         "cache-recommend": _cache_recommend,
@@ -518,6 +541,7 @@ def _build_finding_constructors() -> dict:
         "subagent": _subagent,
         "summarize": _summarize,
         "relearn": _relearn,
+        "deadweight": _deadweight,
         "verbosity": _verbosity,
     }
 

--- a/tokenjam/core/optimize/types.py
+++ b/tokenjam/core/optimize/types.py
@@ -118,6 +118,13 @@ class DowngradeFinding:
     n_sessions:                   int          = 0
     ci_low:                       float | None = None
     ci_high:                      float | None = None
+    # Per-agent price arithmetic for the proposed swap (one
+    # `analyzers.downsize_agents.AgentPriceRow` per agent/model group over the
+    # candidate sessions): exact per-type tokens at the current model's rates
+    # versus the proposed model's, over the window and projected to 30 days.
+    # Typed loosely to keep `types` free of an analyzer import; empty when no
+    # candidate group had pricing data for both sides.
+    per_agent:                    list[Any]    = field(default_factory=list)
 
 
 @dataclass

--- a/tokenjam/core/optimize/types.py
+++ b/tokenjam/core/optimize/types.py
@@ -278,6 +278,13 @@ class OptimizeReport:
     # Existing analyzers (downsize, budget-projection) keep their
     # typed slots above for backwards-compat with cmd_optimize and mcp.
     findings:  dict = field(default_factory=dict)
+    # Dominant user persona for the window ("claude-code" | "sdk" | "mixed" |
+    # "unknown") — see `tokenjam.core.framing.dominant_persona`. Computed once
+    # by `runner.build_report` (mirrors `AnalyzerContext.persona` below) and
+    # carried on the report so a consumer working from the built report alone
+    # (e.g. `cost_proposals.cost_proposals_from_report`) never has to
+    # recompute it from a bare `conn`.
+    persona:   str = "unknown"
 
 
 @dataclass
@@ -302,6 +309,14 @@ class AnalyzerContext:
     # Budget-analyzer flow control:
     budget_provider_filter: str | None    = None
     budget_usd_override:    float | None  = None
+    # Dominant user persona for the window — see `OptimizeReport.persona`
+    # above. Computed once in `runner.build_report` via
+    # `tokenjam.core.framing.agent_persona_mix` / `dominant_persona` (the
+    # same functions the CLI's own persona-dependent CTA already uses), not
+    # a second classifier. Analyzers that need to know whether they're
+    # looking at an SDK caller (e.g. deciding fix modality) read it here
+    # instead of re-deriving it from `conn`.
+    persona:                str            = "unknown"
 
 
 # ---------------------------------------------------------------------------

--- a/tokenjam/ui/index.html
+++ b/tokenjam/ui/index.html
@@ -7702,7 +7702,7 @@ function CostLedgerSummary({ ledger }) {
         <span style="font-size:20px;font-weight:600;color:var(--accent)">${fmtUsd(ledger.total_realized_usd)}</span>
         <span class="dim" style="font-size:12px">realized across ${ledger.improved_count} verified change(s) <span class="estimated-tag" title="estimated / correlational — never a hard causal claim">est.</span></span>
       </div>
-      <div class="dim" style="font-size:11.5px;margin-top:6px">${ledger.verified_count} checked · ${ledger.improved_count} improved · ${ledger.regressed_count} no movement · ${ledger.insufficient_data_count} still measuring</div>
+      <div class="dim" style="font-size:11.5px;margin-top:6px">${ledger.verified_count} checked · ${ledger.improved_count} improved · ${ledger.no_change_count} no change · ${ledger.regressed_count} no movement · ${ledger.insufficient_data_count} still measuring</div>
     </div>`;
 }
 

--- a/tokenjam/ui/index.html
+++ b/tokenjam/ui/index.html
@@ -1549,9 +1549,9 @@ const html = htm.bind(h);
 // --- API ---
 const apiKeyMeta = document.querySelector('meta[name="tj-api-key"]');
 const API_KEY = apiKeyMeta ? apiKeyMeta.getAttribute('content') : null;
-// Local write token (require_relearn_write_auth, api/deps.py) -- always
+// Local write token (require_pothole_write_auth, api/deps.py) -- always
 // present (injected regardless of api.auth.enabled), required on every
-// mutating relearn call (apply/enable/disable/revert/refresh). Sent on every
+// mutating pothole call (apply/enable/disable/revert/refresh). Sent on every
 // POST below; routes that don't check it simply ignore the extra header.
 const writeTokenMeta = document.querySelector('meta[name="tj-write-token"]');
 const WRITE_TOKEN = writeTokenMeta ? writeTokenMeta.getAttribute('content') : null;
@@ -7419,27 +7419,27 @@ function AnalyticsView({ params, route = 'analytics', embedded = false, kpiCapti
 // explorer (which reads `since` from the same URL params).
 // ---- Review inbox (Improve lens home) ----
 // The self-improve loop's Approve stage (self-improve-loop SPEC.md §12 /
-// §8 reuse map): pending relearn fixes the cross-session relearn aggregator
-// (core/optimize/analyzers/relearn.py, served from a background-refreshed
-// cache at GET /relearn/proposals — see api/routes/relearn.py) land here for
+// §8 reuse map): pending pothole fixes the cross-session pothole aggregator
+// (core/optimize/analyzers/pothole.py, served from a background-refreshed
+// cache at GET /pothole/proposals — see api/routes/pothole.py) land here for
 // a human to review. Phase 2 wires Approve to a real write, routed by rung,
-// through POST /relearn/apply (core.optimize.relearn_apply — git-commit or
+// through POST /pothole/apply (core.optimize.pothole_apply — git-commit or
 // gzip-backup reversible, disabled-by-default for hook/wrapper/config rungs).
 // Dismiss stays a client-side-only hide (localStorage, never sent to the
 // server). The chassis (listhead / listbox / addbar / cur-modal) is forked
 // from Optimize ▸ Summarize's curate → diff → Apply/Reject screen
 // (~6410-7040 above), per Phase A's scaffold.
-const RELEARN_DISMISSED_KEY = 'tj_relearn_dismissed_v1';
+const POTHOLE_DISMISSED_KEY = 'tj_pothole_dismissed_v1';
 
-function loadDismissedRelearns() {
+function loadDismissedPotholes() {
   try {
-    const raw = localStorage.getItem(RELEARN_DISMISSED_KEY);
+    const raw = localStorage.getItem(POTHOLE_DISMISSED_KEY);
     return raw ? new Set(JSON.parse(raw)) : new Set();
   } catch (e) { return new Set(); }
 }
 
-function saveDismissedRelearns(set) {
-  try { localStorage.setItem(RELEARN_DISMISSED_KEY, JSON.stringify([...set])); } catch (e) { /* best-effort */ }
+function saveDismissedPotholes(set) {
+  try { localStorage.setItem(POTHOLE_DISMISSED_KEY, JSON.stringify([...set])); } catch (e) { /* best-effort */ }
 }
 
 const RUNG_LABELS = {
@@ -7502,7 +7502,7 @@ function CompoundLedgerSummary({ ledger }) {
     </div>`;
 }
 
-function RelearnRow({ cluster, checked, onToggle, onExpand }) {
+function PotholeRow({ cluster, checked, onToggle, onExpand }) {
   const tokens = cluster.estimated_recoverable_tokens || 0;
   return html`
     <tr class="cur-row" key=${cluster.signature}>
@@ -7520,7 +7520,7 @@ function RelearnRow({ cluster, checked, onToggle, onExpand }) {
 // The card's Approve flow: preview -> (optional active-session warning ->
 // "apply anyway") -> write. Scope + target are ALWAYS human-editable before
 // Approve (§7 — repo-identity is noisy; never trust the suggestion blindly).
-function RelearnApplyModal({ cluster, onClose, onApplied }) {
+function PotholeApplyModal({ cluster, onClose, onApplied }) {
   const [scope, setScope] = useState('project');
   const [target, setTarget] = useState('');
   const [busy, setBusy] = useState(false);
@@ -7541,15 +7541,8 @@ function RelearnApplyModal({ cluster, onClose, onApplied }) {
     if (!target.trim()) { setError('enter a target path first'); return; }
     setBusy(true); setError(null);
     try {
-      // Only the proposal's ID travels: the server reads the cluster content
-      // from its own stored proposals, so the browser can't apply anything the
-      // detector didn't produce. Scope + target stay client-supplied because
-      // the human edits them here before approving.
-      const body = {
-        proposal_id: cluster.proposal_id,
-        scope, target_path: target.trim(), go: true, force: !!force,
-      };
-      const r = await apiPostOrDetail('/relearn/apply', body);
+      const body = { ...cluster, scope, target_path: target.trim(), go: true, force: !!force };
+      const r = await apiPostOrDetail('/pothole/apply', body);
       setWarning(null);
       setResult(r.record);
       onApplied && onApplied(r.record);
@@ -7658,13 +7651,13 @@ function AppliedFixRow({ rec, onChanged }) {
       ${rec.state === 'applied' ? html`<${VerifyLine} verify=${rec.verify} rung=${rec.rung} />` : null}
       ${error ? html`<div style="color:var(--error);font-size:12px">${error}</div>` : null}
       <div style="display:flex;gap:10px;align-items:center">
-        ${rec.state === 'applied' ? html`<span class="sz-link" onClick=${() => call(() => apiPostOrDetail(`/relearn/${rec.id}/revert`, {}))}>${busy ? 'working…' : 'Revert'}</span>` : null}
+        ${rec.state === 'applied' ? html`<span class="sz-link" onClick=${() => call(() => apiPostOrDetail(`/pothole/${rec.id}/revert`, {}))}>${busy ? 'working…' : 'Revert'}</span>` : null}
         ${isEnforcement && rec.state === 'applied' && !(enforcement && enforcement.enabled) ? (
           confirming
-            ? html`<span style="color:var(--warn);font-size:12px">This intercepts your tool calls on every matching call. <span class="sz-link" onClick=${() => call(() => apiPostOrDetail(`/relearn/${rec.id}/enable`, { confirm: true }))}>Confirm enable →</span> <span class="sz-link" onClick=${() => setConfirming(false)}>cancel</span></span>`
+            ? html`<span style="color:var(--warn);font-size:12px">This intercepts your tool calls on every matching call. <span class="sz-link" onClick=${() => call(() => apiPostOrDetail(`/pothole/${rec.id}/enable`, { confirm: true }))}>Confirm enable →</span> <span class="sz-link" onClick=${() => setConfirming(false)}>cancel</span></span>`
             : html`<span class="sz-link" onClick=${() => setConfirming(true)}>Enable enforcement…</span>`
         ) : null}
-        ${isEnforcement && rec.state === 'applied' && enforcement && enforcement.enabled ? html`<span class="sz-link" onClick=${() => call(() => apiPostOrDetail(`/relearn/${rec.id}/disable`, {}))}>Disable enforcement</span>` : null}
+        ${isEnforcement && rec.state === 'applied' && enforcement && enforcement.enabled ? html`<span class="sz-link" onClick=${() => call(() => apiPostOrDetail(`/pothole/${rec.id}/disable`, {}))}>Disable enforcement</span>` : null}
       </div>
     </div>`;
 }
@@ -7672,11 +7665,11 @@ function AppliedFixRow({ rec, onChanged }) {
 // ---- Cost proposals (the same inbox, a distinct `kind`) ----
 // The downsize/cache/trim analyzers' findings adapted into advise-only
 // proposals (core/optimize/cost_proposals.py), served at
-// GET /relearn/cost-proposals. They carry NO apply path — the fix lives in the
+// GET /pothole/cost-proposals. They carry NO apply path — the fix lives in the
 // user's own application code — so "Mark applied" only drops a marker the
 // delta-verify pass (core/optimize/cost_verify.py) measures a realized dollar
 // delta against, shown back here as a receipt.
-const COST_ANALYZER_LABELS = { downsize: 'downsize', cache: 'cache', trim: 'trim', subagent: 'subagent' };
+const COST_ANALYZER_LABELS = { downsize: 'downsize', cache: 'cache', trim: 'trim' };
 
 function fmtUsd(v) {
   const n = Number(v || 0);
@@ -7685,7 +7678,7 @@ function fmtUsd(v) {
 
 // One applied cost proposal's realized-delta receipt: verdict + the measured
 // dollar/token delta (shown only for a real "improved" verdict), reusing the
-// same VERDICT_LABELS the relearn lane uses. Correlational, never causal.
+// same VERDICT_LABELS the pothole lane uses. Correlational, never causal.
 function CostVerifyLine({ verify }) {
   if (!verify) return null;
   const label = VERDICT_LABELS[verify.verdict] || { text: 'Not yet checked', color: 'var(--text-dim)' };
@@ -7716,35 +7709,15 @@ function CostLedgerSummary({ ledger }) {
 // One pending cost proposal card. Advise-only: an evidence line, the
 // recommendation, an optional copyable suggestion, and a labeled estimate — but
 // only a "Mark applied" marker button, never an apply-to-code write.
-function CostProposalCard({ prop, busy, onMark, onDismiss, onChanged }) {
+function CostProposalCard({ prop, busy, onMark, onDismiss }) {
   const usd = prop.estimated_recoverable_usd;
   const toks = prop.estimated_recoverable_tokens;
-  // Workspace-apply state (subagent, CC-origin only): a target path + a dry-run
-  // diff before the real, reversible write — routed through the same
-  // human-gated relearn apply path.
-  const [target, setTarget] = useState('');
-  const [wbusy, setWbusy] = useState(false);
-  const [werr, setWerr] = useState(null);
-  const [preview, setPreview] = useState(null);
-
-  const applyWorkspace = async (go) => {
-    if (!target.trim()) { setWerr('enter a CLAUDE.md path to write the note into'); return; }
-    setWbusy(true); setWerr(null);
-    try {
-      const r = await apiPostOrDetail('/relearn/cost-proposals/apply-workspace',
-        { ...prop, target_path: target.trim(), go });
-      if (go) { onChanged && onChanged(); }
-      else { setPreview((r.applied && r.applied.diff) || '(no changes)'); }
-    } catch (e) { setWerr(e.message || String(e)); }
-    finally { setWbusy(false); }
-  };
-
   return html`
     <div class="opt-section" style="margin:0 0 10px;padding:12px 14px;border:1px solid var(--border);border-radius:8px" key=${prop.signature}>
       <div style="display:flex;align-items:center;gap:8px;flex-wrap:wrap">
         <span class="rev-state staged" style="background:var(--accent-soft,rgba(120,120,255,.15))">cost · ${COST_ANALYZER_LABELS[prop.analyzer] || prop.analyzer}</span>
         <span style="font-weight:500">${prop.title}</span>
-        <span class="dim" style="font-size:11px">${prop.apply_capable ? 'workspace fix · rung 1' : 'advise-only'}</span>
+        <span class="dim" style="font-size:11px">advise-only</span>
         ${(usd != null || toks != null) ? html`<span class="mono" style="margin-left:auto;color:var(--accent);font-size:12.5px">${usd != null ? '~' + fmtUsd(usd) : ''}${toks ? ' · ~' + fmtTokens(toks) + ' tok' : ''} <span class="estimated-tag" title=${prop.estimate_basis || 'estimated / correlational'}>est.</span></span>` : null}
       </div>
       <div class="sz-note" style="margin-top:8px">${prop.evidence}</div>
@@ -7752,28 +7725,11 @@ function CostProposalCard({ prop, busy, onMark, onDismiss, onChanged }) {
       <div class="sz-note" style="margin-top:2px">${prop.advise_text}</div>
       ${prop.suggestion ? html`<pre class="rev-diff" style="margin:8px 0 0;white-space:pre-wrap;font-size:11.5px">${prop.suggestion}</pre>` : null}
       <div class="opt-caveat" style="font-size:11.5px;margin-top:8px">${prop.caveat}</div>
-
-      ${prop.apply_capable ? html`
-        <div class="opt-section" style="margin:10px 0 0">
-          <div class="opt-title" style="font-size:12.5px">Apply the sizing note <span class="dim" style="font-weight:400">· writes a reversible rung-1 note; confirm the target first</span></div>
-          <div style="display:flex;gap:8px;margin-top:6px;flex-wrap:wrap">
-            <input class="rename-input" style="flex:1;min-width:280px" value=${target}
-              placeholder="/absolute/path/to/CLAUDE.md" onInput=${e => setTarget(e.target.value)} />
-            <button class="cur-btn" disabled=${wbusy} onClick=${() => applyWorkspace(false)}>${wbusy ? 'working…' : 'Preview note'}</button>
-            <button class="cur-btn primary" disabled=${wbusy} onClick=${() => applyWorkspace(true)}>Apply note →</button>
-          </div>
-          ${preview ? html`<pre class="rev-diff" style="margin:8px 0 0;white-space:pre-wrap;font-size:11.5px">${preview}</pre>` : null}
-          ${werr ? html`<div style="color:var(--error);font-size:12px;margin-top:6px">${werr}</div>` : null}
-          <div class="dim" style="font-size:11.5px;margin-top:6px">Applying also records a checkpoint so the loop measures the realized fan-out cost delta after it.</div>
-        </div>
-      ` : html`
-        <div style="display:flex;gap:12px;align-items:center;margin-top:10px">
-          <button class="cur-btn primary" disabled=${busy} onClick=${() => onMark(prop)}>${busy ? 'Marking…' : 'Mark applied →'}</button>
-          <span class="sz-link" onClick=${() => onDismiss(prop.signature)}>Dismiss</span>
-          <span class="dim" style="font-size:11.5px">Marking records a checkpoint; the loop then measures the realized delta over your later calls.</span>
-        </div>
-      `}
-      ${prop.apply_capable ? html`<div style="margin-top:8px"><span class="sz-link" onClick=${() => onDismiss(prop.signature)}>Dismiss</span></div>` : null}
+      <div style="display:flex;gap:12px;align-items:center;margin-top:10px">
+        <button class="cur-btn primary" disabled=${busy} onClick=${() => onMark(prop)}>${busy ? 'Marking…' : 'Mark applied →'}</button>
+        <span class="sz-link" onClick=${() => onDismiss(prop.signature)}>Dismiss</span>
+        <span class="dim" style="font-size:11.5px">Marking records a checkpoint; the loop then measures the realized delta over your later calls.</span>
+      </div>
     </div>`;
 }
 
@@ -7783,7 +7739,7 @@ function CostAppliedRow({ rec, onChanged }) {
   const [error, setError] = useState(null);
   const revert = async () => {
     setBusy(true); setError(null);
-    try { await apiPostOrDetail(`/relearn/cost-applied/${rec.id}/revert`, {}); onChanged && onChanged(); }
+    try { await apiPostOrDetail(`/pothole/cost-applied/${rec.id}/revert`, {}); onChanged && onChanged(); }
     catch (e) { setError(e.message || String(e)); }
     finally { setBusy(false); }
   };
@@ -7803,7 +7759,7 @@ function CostAppliedRow({ rec, onChanged }) {
 
 function ReviewInboxView({ params }) {
   const [d, setD] = useState({ loading: true, error: null, status: 'never_run', computedAt: null, clusters: [] });
-  const [dismissed, setDismissed] = useState(() => loadDismissedRelearns());
+  const [dismissed, setDismissed] = useState(() => loadDismissedPotholes());
   const [checked, setChecked] = useState(() => new Set());
   const [modalSig, setModalSig] = useState(null);
   const [refreshing, setRefreshing] = useState(false);
@@ -7817,7 +7773,7 @@ function ReviewInboxView({ params }) {
 
   const load = useCallback(async () => {
     try {
-      const r = await api('/relearn/proposals');
+      const r = await api('/pothole/proposals');
       const f = r.finding || {};
       setD({
         loading: false, error: null, status: r.status, computedAt: r.computed_at,
@@ -7831,7 +7787,7 @@ function ReviewInboxView({ params }) {
 
   const loadApplied = useCallback(async () => {
     try {
-      const r = await api('/relearn/applied');
+      const r = await api('/pothole/applied');
       setApplied(r.applied || []);
       setLedger(r.ledger || null);
     } catch (e) { /* the pending list is the load-bearing view; degrade quietly */ }
@@ -7839,11 +7795,11 @@ function ReviewInboxView({ params }) {
 
   const loadCost = useCallback(async () => {
     try {
-      const r = await api('/relearn/cost-proposals');
+      const r = await api('/pothole/cost-proposals');
       setCostProps(r.proposals || []);
-    } catch (e) { /* the relearn list is load-bearing; degrade quietly */ }
+    } catch (e) { /* the pothole list is load-bearing; degrade quietly */ }
     try {
-      const r = await api('/relearn/cost-applied');
+      const r = await api('/pothole/cost-applied');
       setCostApplied(r.applied || []);
       setCostLedger(r.ledger || null);
     } catch (e) { /* degrade quietly */ }
@@ -7859,27 +7815,27 @@ function ReviewInboxView({ params }) {
 
   const doRefresh = useCallback(async () => {
     setRefreshing(true);
-    try { await apiPost('/relearn/refresh', {}); } catch (e) { /* surfaced via next load()'s status */ }
+    try { await apiPost('/pothole/refresh', {}); } catch (e) { /* surfaced via next load()'s status */ }
     // The cost proposals + their realized deltas recompute on the same cadence.
-    try { await apiPost('/relearn/cost-proposals/refresh', {}); } catch (e) { /* degrade quietly */ }
+    try { await apiPost('/pothole/cost-proposals/refresh', {}); } catch (e) { /* degrade quietly */ }
     setTimeout(() => { setRefreshing(false); load(); loadCost(); }, 1500);
   }, [load, loadCost]);
 
   const markCostApplied = useCallback(async (prop) => {
     setMarking(prop.signature);
     try {
-      await apiPostOrDetail('/relearn/cost-proposals/apply', prop);
+      await apiPostOrDetail('/pothole/cost-proposals/apply', prop);
       await loadCost();
     } catch (e) { /* surfaced on next refresh; keep the card in place */ }
     finally { setMarking(null); }
   }, [loadCost]);
 
   const visible = (d.clusters || []).filter(c => !dismissed.has(c.signature) && !appliedSigs.has(c.signature));
-  const relearnCount = visible.length;
+  const potholeCount = visible.length;
   const toggle = sig => setChecked(s => { const n = new Set(s); n.has(sig) ? n.delete(sig) : n.add(sig); return n; });
   const dismissChecked = () => {
     const next = new Set([...dismissed, ...checked]);
-    setDismissed(next); saveDismissedRelearns(next);
+    setDismissed(next); saveDismissedPotholes(next);
     setChecked(new Set());
   };
   const modalCluster = modalSig ? (d.clusters || []).find(c => c.signature === modalSig) : null;
@@ -7893,16 +7849,16 @@ function ReviewInboxView({ params }) {
 
   const dismissCost = (sig) => {
     const next = new Set([...dismissed, sig]);
-    setDismissed(next); saveDismissedRelearns(next);
+    setDismissed(next); saveDismissedPotholes(next);
   };
 
   return html`
     <div class="page-title">Review inbox <span class="sz-sub">· pending fixes</span></div>
-    <div class="sz-note">The recurring mistakes your agent keeps repeating land here so it can relearn them. Each row links its evidence (repro sessions) and the proposed fix. <b>Approve</b> writes the fix (git-committed, or backed up if the target isn't a git repo) at its rung; you confirm the scope and target first. <b>Dismiss</b> hides a row locally (this browser only; it is not sent to the server).</div>
+    <div class="sz-note">Pothole fixes the self-improve loop's cross-session detector finds land here for review — each row links its evidence (repro sessions) and the proposed fix. <b>Approve</b> writes the fix (git-committed, or backed up if the target isn't a git repo) at its rung — you confirm the scope + target first; <b>Dismiss</b> hides a row locally (this browser only — it is not sent to the server).</div>
 
     <div class="cur-listhead">
       <span>
-        ${relearnCount} pending · <b style="color:var(--warn)">${relearnCount}</b> recurring mistakes · <b style="color:var(--accent)">0</b> strategies
+        ${potholeCount} pending · <b style="color:var(--warn)">${potholeCount}</b> potholes · <b style="color:var(--accent)">0</b> strategies
         ${d.computedAt ? html` · <span class="dim" style="font-size:12px">last scanned ${d.computedAt.slice(0, 16).replace('T', ' ')} UTC${d.sessionsScanned != null ? ' · ' + d.sessionsScanned + ' sessions scanned' : ''}</span>` : null}
         ${d.status === 'computing' ? html` · <span style="color:var(--warn)">scanning…</span>` : null}
       </span>
@@ -7915,20 +7871,20 @@ function ReviewInboxView({ params }) {
           ${d.error ? html`<tr><td colspan="6" class="dim" style="padding:32px 16px;text-align:center;color:var(--error)">Couldn't load proposals: ${d.error}</td></tr>` : null}
           ${!d.error && d.loading ? html`<tr><td colspan="6" class="dim" style="padding:32px 16px;text-align:center">Loading…</td></tr>` : null}
           ${!d.error && !d.loading && d.status === 'never_run' ? html`<tr><td colspan="6" class="dim" style="padding:32px 16px;text-align:center">No scan has run yet — click <span class="sz-link" onClick=${doRefresh}>Rescan now</span> to kick one off.</td></tr>` : null}
-          ${!d.error && !d.loading && d.status !== 'never_run' && relearnCount === 0 ? html`<tr><td colspan="6" class="dim" style="padding:32px 16px;text-align:center">No pending fixes — the last scan found nothing recurring enough to propose (or you've dismissed/applied everything).</td></tr>` : null}
-          ${!d.error && !d.loading ? visible.map(c => html`<${RelearnRow} key=${c.signature} cluster=${c} checked=${checked.has(c.signature)} onToggle=${() => toggle(c.signature)} onExpand=${() => setModalSig(c.signature)} />`) : null}
+          ${!d.error && !d.loading && d.status !== 'never_run' && potholeCount === 0 ? html`<tr><td colspan="6" class="dim" style="padding:32px 16px;text-align:center">No pending fixes — the last scan found nothing recurring enough to propose (or you've dismissed/applied everything).</td></tr>` : null}
+          ${!d.error && !d.loading ? visible.map(c => html`<${PotholeRow} key=${c.signature} cluster=${c} checked=${checked.has(c.signature)} onToggle=${() => toggle(c.signature)} onExpand=${() => setModalSig(c.signature)} />`) : null}
         </tbody>
       </table>
     </div>
     <div class="cur-addbar">
       <button class="cur-btn" disabled=${checked.size === 0} onClick=${dismissChecked}>Dismiss checked</button>
-      <span class="dim" style="font-size:12px">${relearnCount ? 'Click a row for its evidence, proposed fix, and to Approve.' : 'Nothing to review yet.'}</span>
+      <span class="dim" style="font-size:12px">${potholeCount ? 'Click a row for its evidence, proposed fix, and to Approve.' : 'Nothing to review yet.'}</span>
     </div>
 
     ${visibleCost.length > 0 ? html`
-      <div class="opt-title" style="font-size:14px;margin-top:24px">Cost advisories <span class="dim" style="font-weight:400;font-size:12px">· ${visibleCost.length} from the downsize, cache, trim, and subagent analyzers, with verified receipts once you apply one</span></div>
+      <div class="opt-title" style="font-size:14px;margin-top:24px">Cost advisories <span class="dim" style="font-weight:400;font-size:12px">· ${visibleCost.length} from the downsize / cache / trim analyzers — advise-only, with verified receipts once you mark one applied</span></div>
       <div style="margin-top:8px">
-        ${visibleCost.map(p => html`<${CostProposalCard} key=${p.signature} prop=${p} busy=${marking === p.signature} onMark=${markCostApplied} onDismiss=${dismissCost} onChanged=${() => { loadCost(); loadApplied(); }} />`)}
+        ${visibleCost.map(p => html`<${CostProposalCard} key=${p.signature} prop=${p} busy=${marking === p.signature} onMark=${markCostApplied} onDismiss=${dismissCost} />`)}
       </div>
     ` : null}
 
@@ -7948,7 +7904,7 @@ function ReviewInboxView({ params }) {
       </div>
     ` : null}
 
-    <${RelearnApplyModal} cluster=${modalCluster} onClose=${() => setModalSig(null)} onApplied=${onApplied} />
+    <${PotholeApplyModal} cluster=${modalCluster} onClose=${() => setModalSig(null)} onApplied=${onApplied} />
   `;
 }
 
@@ -7970,7 +7926,7 @@ function DashboardView({ params }) {
       // full cost history — that user upgrading to review past spend must NOT
       // see "No data yet" (the front door was gating purely on active agents and
       // returning before /cost was ever fetched — issue: historical-only empty).
-      const [cost, status, compare, opt, al, drift, traces, relearn] = await Promise.all([
+      const [cost, status, compare, opt, al, drift, traces, pothole] = await Promise.all([
         api('/cost', { since, group_by: 'day' }),
         api('/status').catch(() => ({ agents: [] })),
         api('/cost/compare', { since, compare: 'previous' }).catch(() => null),
@@ -7978,7 +7934,7 @@ function DashboardView({ params }) {
         api('/alerts', { since, unread: 'true' }).catch(() => ({ alerts: [] })),
         api('/drift').catch(() => ({ agents: [] })),
         api('/traces', { since, limit: 6 }).catch(() => ({ traces: [] })),
-        api('/relearn/proposals').catch(() => ({ finding: null })),
+        api('/pothole/proposals').catch(() => ({ finding: null })),
       ]);
       // "No data yet" only when there is genuinely NO telemetry: no cost history
       // AND no tokens AND no sessions/agents AND no traces. Historical cost or
@@ -7989,7 +7945,7 @@ function DashboardView({ params }) {
       const empty = !hasCost && !hasAgents && !hasTraces;
       setD({ loading: false, empty, error: null, cost, compare, opt,
         alerts: al.alerts || [], drift, traces: traces.traces || [],
-        pendingFixes: ((relearn && relearn.finding && relearn.finding.clusters) || []).length });
+        pendingFixes: ((pothole && pothole.finding && pothole.finding.clusters) || []).length });
     } catch (e) {
       setD(s => ({ ...s, loading: false, error: e.message || String(e) }));
     }


### PR DESCRIPTION
> **Stack slice of #482.** One of 12 concern-scoped PRs split out of #482. Its base is the previous slice, so the diff above shows only this slice's changes.
>
> **Do not merge this PR directly.** The complete change lands in one merge via the anchor PR #482, which contains every commit in this stack and is green. CI on a mid-stack slice may be red: slices are ordered by concern rather than by dependency, so a branch can reference code that lands in a later slice. That is an artifact of the ordering, not a defect in this diff.

Adapts each cost analyzer's finding into a typed `CostProposal` so findings can be listed and acted on in one place.

Most cards are advise-only, because the fix lives in your own application code and the printed snippet **is** the fix. Marking one applied records the change plus a ledger entry rather than writing code. `model_apply` performs the two deterministic model-id writes: rewriting the `model:` key in an agent's frontmatter, and swapping one exact model-id string in a registered git repo, both through the same snapshot/commit/revert machinery.
