### PR TITLE
chore: bump version to 0.6.0

### DIFF
--- a/npm-wrapper/package.json
+++ b/npm-wrapper/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tokenjam",
-  "version": "0.5.4",
+  "version": "0.6.0",
   "description": "Zero-install launcher for TokenJam (tj): npx tokenjam runs the Python CLI via uvx/pipx and reports the recurring mistakes your AI agent keeps repeating, no setup required.",
   "keywords": ["claude-code", "ccusage", "tokens", "cost-optimization", "llm", "agents", "observability", "tokenjam", "anthropic", "claude", "token-usage", "agent-behavior", "cli", "statusline", "opentelemetry", "agent-observability"],
   "homepage": "https://tokenjam.dev",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "tokenjam"
-version = "0.5.7"
+version = "0.6.0"
 description = "TokenJam: a local-first, OTel-native cost-saving utility for AI agents"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/sdk-ts/package.json
+++ b/sdk-ts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tokenjam/sdk",
-  "version": "0.5.7",
+  "version": "0.6.0",
   "description": "TypeScript SDK for TokenJam — local-first observability for AI agents",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",


### PR DESCRIPTION
Bumps the version to 0.6.0 across the three lockstep files, via `scripts/release.sh 0.6.0`.

- `pyproject.toml` 0.5.7 -> 0.6.0
- `sdk-ts/package.json` 0.5.7 -> 0.6.0 (the pair `version-lockstep` gates on)
- `npm-wrapper/package.json` 0.5.4 -> 0.6.0 (was drifting three versions behind; the release workflow overwrites this from the tag, but keeping it current avoids local `npm pack` drift)

The script's straggler scan found no other literal `0.5.7` references left in the repo.

Cutting 0.6.0 for the self-improve work already merged to `main`: the `relearn` cross-session detector with human-gated reversible apply, the cost-proposal inbox, four new analyzers (`resend`, `deadweight`, batch `placement`, per-agent `downsize`), the `tj relearn` command group, the `/relearn/*` API with a local write-token guard, the Review-inbox UI, and the `[optimize]` / `[loop]` config blocks.

Note for the release notes: `capture.prompts` and `capture.tool_inputs` now default to true, so existing installs begin persisting prompt text and tool arguments locally on upgrade.
