### PR TITLE
chore: de-risk stale codex backfill import-guard in onboard (#485)

### DIFF
--- a/tests/unit/test_onboard_path_branch.py
+++ b/tests/unit/test_onboard_path_branch.py
@@ -180,40 +180,18 @@ def test_flag_shortcut_skips_path_question(monkeypatch):
 
 
 class TestDefensiveCodexBackfill:
-    def test_missing_adapter_is_forward_only(self, monkeypatch):
-        """When the Codex backfill adapter hasn't shipped, we report nothing and
-        claim no data (honesty) — never crash."""
-        import builtins
-
-        real_import = builtins.__import__
-
-        def _no_codex(name, *a, **k):
-            if name == "tokenjam.core.ingest_adapters.codex":
-                raise ImportError("not shipped yet")
-            return real_import(name, *a, **k)
-
-        monkeypatch.setattr(builtins, "__import__", _no_codex)
-        msg, has_data, total = _try_backfill_codex(object())
-        assert msg is None
-        assert has_data is False
-        assert total == 0
-
     def test_reports_when_adapter_ingests(self, monkeypatch):
-        """When the adapter exists and ingests, we report the count and mark
+        """When the adapter ingests, we report the count and mark
         has_data True."""
-        import sys
-        import types
-
-        fake = types.ModuleType("tokenjam.core.ingest_adapters.codex")
 
         class _Result:
             sessions_total = 3
             sessions_new = 2
             total_cost_usd = 4.0
 
-        fake.ingest_codex = lambda db, config=None: _Result()  # type: ignore[attr-defined]
-        monkeypatch.setitem(
-            sys.modules, "tokenjam.core.ingest_adapters.codex", fake,
+        monkeypatch.setattr(
+            "tokenjam.cli.cmd_onboard.ingest_codex",
+            lambda db, config=None: _Result(),
         )
 
         class _DB:

--- a/tokenjam/cli/cmd_onboard.py
+++ b/tokenjam/cli/cmd_onboard.py
@@ -15,6 +15,7 @@ from rich.markup import escape
 from tokenjam.cli.banner import print_welcome_banner
 from tokenjam.cli.onboard_detect import SdkMatch, detect_stack, install_hint
 from tokenjam.core.config import find_config_file
+from tokenjam.core.ingest_adapters.codex import ingest_codex
 from tokenjam.otel.semconv import SUBSCRIPTION_PLAN_TIERS
 from tokenjam.utils.formatting import console, display_path
 
@@ -915,29 +916,20 @@ def _prompt_usage_path() -> str:
 
 
 def _try_backfill_codex(config) -> tuple[str | None, bool, int]:
-    """Best-effort Codex backfill, called defensively (#448).
+    """Best-effort Codex backfill, called on the `--codex` / combination flows.
 
-    The Codex on-disk backfill adapter (`tj backfill codex`,
-    `core/ingest_adapters/codex.py`) parses `~/.codex/sessions/**/rollout-*.jsonl`.
-    It's resolved at runtime via a guarded import so the combination / --codex
-    flows degrade gracefully on any older tree where that adapter is absent. When
-    it's unavailable, returns forward-only framing so the caller can say "wired —
-    data flows as you use Codex" instead of claiming a backfill that didn't
-    happen (honesty discipline, Rule 14).
+    The Codex on-disk backfill adapter (`tj backfill codex`) is imported at
+    module scope, so a genuine import failure surfaces rather than being
+    swallowed. Runtime ingest errors (e.g. the daemon holding the DB write
+    lock) are still handled defensively so onboard never crashes — returning
+    forward-only framing ("wired — data flows as you use Codex") instead of
+    claiming a backfill that didn't happen (honesty discipline, Rule 14).
 
     Returns ``(message, has_data, sessions_total)``:
       * ``message`` — a human summary line, or None if nothing to report.
       * ``has_data`` — True only when at least one session was actually ingested.
       * ``sessions_total`` — distinct sessions ingested (0 when unavailable).
     """
-    try:
-        from tokenjam.core.ingest_adapters.codex import (  # type: ignore[import]
-            ingest_codex,
-        )
-    except Exception:
-        # Adapter not shipped yet (or import error) — forward-only, no claim.
-        return None, False, 0
-
     try:
         from tokenjam.core.db import open_db
         db = open_db(config.storage)


### PR DESCRIPTION
`_try_backfill_codex` in `cmd_onboard.py` guarded its `ingest_codex` import behind "adapter may not have landed" defensiveness left over from #448. That framing is stale — the adapter has shipped and is already imported unconditionally by `cmd_backfill.py`, so the guard could never trip and only served to swallow a genuine import failure into silent forward-only framing.

## Summary
- Hoist `from tokenjam.core.ingest_adapters.codex import ingest_codex` to module scope in `cmd_onboard.py`, matching `cmd_backfill.py`.
- Drop the `try/except ImportError` guard inside `_try_backfill_codex`; the runtime-ingest `try/except` (daemon lock, I/O errors) is untouched so onboard still never crashes.
- Refresh the docstring to describe the real behavior.

## Why
A real import breakage in the codex adapter would previously be masked as "no Codex data / forward-only" instead of surfacing. Symmetric with claude-code, codex auto-backfill on `tj onboard --codex` already ran by default and continues to — this is pure cleanup with no behavior change on the happy path.

## Tests / Verification
- Removed `test_missing_adapter_is_forward_only` (it stubbed the import failure the guard used to catch — no longer a reachable path).
- `test_reports_when_adapter_ingests` now patches the module-global `tokenjam.cli.cmd_onboard.ingest_codex` rather than `sys.modules` (module-scope import binds the name at import time).
- `python3 -m pytest tests/unit/test_onboard_path_branch.py` — 22 passed.
- `ruff check` + `mypy` clean on `cmd_onboard.py`.

## What's NOT in this PR
- The `TestDefensiveCodexBackfill` class name is now slightly generous (only runtime errors are "defensive" now) but renaming it is cosmetic and out of scope.

Closes #485

🤖 Generated with [Claude Code](https://claude.com/claude-code)