### PR TITLE
Fix #508: label downsize analyzer "Downsize" in tj optimize

### DIFF
--- a/tests/integration/test_cli.py
+++ b/tests/integration/test_cli.py
@@ -1203,7 +1203,7 @@ def test_optimize_flags_downgrade_candidate(runner, db, config):
 
     result = _invoke(runner, db, config, ["optimize"])
     assert result.exit_code == 0
-    assert "Model downgrade" in result.output
+    assert "Downsize" in result.output
     # Mandatory caveat must appear in human output
     assert "Candidate-flagging heuristic" in result.output
 
@@ -1336,7 +1336,7 @@ def test_optimize_local_suppresses_dollar_figures(runner, db, config):
     assert "Local inference" in out
     assert "no marginal cost" in out
     # Token framing in downgrade body
-    if "Model downgrade" in out:
+    if "Downsize" in out:
         assert "Relevant for capacity planning" in out
 
 
@@ -1423,11 +1423,11 @@ def test_optimize_ranks_findings_by_reclaimable_share_not_registry_order(runner,
     # downsize always ran first in ANALYZER_ORDER.
     assert "① Workflow restructure" in out or "① Reuse" in out
     # ...and downsize no longer gets the fixed ① slot it always used to.
-    assert "① Model downgrade" not in out
+    assert "① Downsize" not in out
     # It's still surfaced — honesty discipline forbids a silent drop — just
     # collapsed into the de-minimis pointer list instead of a numbered slot.
     assert "Minor findings" in out
-    assert "Model downgrade" in out
+    assert "Downsize" in out
     assert "of window tokens" in out
 
 

--- a/tokenjam/cli/cmd_optimize.py
+++ b/tokenjam/cli/cmd_optimize.py
@@ -459,7 +459,7 @@ _ALWAYS_FULL_FINDINGS = {"relearn"}
 # Display labels for the "Minor findings" collapsed pointer list — must match
 # the header text each renderer prints in its numbered form.
 _MINOR_FINDING_LABELS = {
-    "downsize":        "Model downgrade",
+    "downsize":        "Downsize",
     "cache":           "Cache efficacy",
     "cache-recommend": "Cache recommend",
     "resend":          "Context resend",
@@ -820,7 +820,7 @@ def _render_report(
                 )
             else:
                 console.print(
-                    f"{_finding_header(marker, 'Model downgrade:')} "
+                    f"{_finding_header(marker, 'Downsize:')} "
                     "[dim]no candidates in this window — sessions don't match "
                     "the smaller-model shape (small input/output, few tool "
                     "calls).[/dim]"
@@ -971,7 +971,7 @@ def _render_downgrade(
     `_render_downgrade_cta`.
     """
     console.print(
-        f"  [bold]{marker} Model downgrade:[/bold] "
+        f"  [bold]{marker} Downsize:[/bold] "
         f"{d.percent_of_sessions:.0f}% of sessions match a smaller-model "
         f"candidate shape"
     )


### PR DESCRIPTION
`tj optimize` labeled the `downsize` analyzer's finding as "Model downgrade", inconsistent with its CLI arg / registry name `downsize`.

## Summary
- Rename the human-readable label from "Model downgrade" to "Downsize" everywhere it renders in `tj optimize` output.
- Behavior unchanged — naming only. The honesty caveat wording (Rule 14) is untouched.

## Fix (#508)
The label appeared in three places in `cmd_optimize.py`:
- `_MINOR_FINDING_LABELS["downsize"]` — the collapsed "Minor findings" pointer line.
- The numbered-slot finding header (`_render_downgrade`).
- The empty-state header when there are no candidates in the window.

All three now read "Downsize", matching `@register("downsize")` (file `model_downgrade.py`) so a user who runs `tj optimize downsize` sees the same word in the output. The `① Model downgrade` mention in code/test docstrings (historical bug reference for #97) was left as-is since it's explanatory prose, not user-facing.

## Tests / Verification
- Updated the display-label assertions in `tests/integration/test_cli.py` (the three that asserted the rendered string "Model downgrade" / "① Model downgrade") to "Downsize" / "① Downsize".
- `ruff check` + `mypy` clean on `cmd_optimize.py`.
- `pytest tests/integration/test_cli.py -k optimize` → 13 passed.

## What's NOT in this PR
- No change to registry strings, file names, or the `downgrade` field name on `OptimizeReport` / the JSON payload — those are stable identifiers, out of scope for a label-only fix.
- Historical `Model downgrade` references inside docstrings / comments (which describe the #97 bug) were left untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)