### PR TITLE
Fix #506: broaden tj home setup detection to config OR populated DB

### DIFF
--- a/tests/unit/test_onboard_first_run.py
+++ b/tests/unit/test_onboard_first_run.py
@@ -100,7 +100,10 @@ def test_nudge_no_daemon_still_points_at_tj_serve(capsys):
 
 
 def test_home_when_not_configured_points_at_onboarding(monkeypatch, capsys):
-    monkeypatch.setattr("tokenjam.cli.home.find_config_file", lambda: None)
+    # No config discoverable AND no populated DB → truly a fresh user (#506).
+    monkeypatch.setattr("tokenjam.cli.home.find_config_file", lambda *a, **k: None)
+    monkeypatch.setattr("tokenjam.cli.home._db_has_data", lambda: False)
+    monkeypatch.delenv("TJ_CONFIG", raising=False)
     print_home()
     out = capsys.readouterr().out
     assert "TokenJam" in out                     # banner
@@ -111,7 +114,7 @@ def test_home_when_not_configured_points_at_onboarding(monkeypatch, capsys):
 def test_home_when_configured_shows_next_best_actions(monkeypatch, capsys, tmp_path):
     cfg = tmp_path / "config.toml"
     cfg.write_text("version = '1'\n")
-    monkeypatch.setattr("tokenjam.cli.home.find_config_file", lambda: cfg)
+    monkeypatch.setattr("tokenjam.cli.home.find_config_file", lambda *a, **k: cfg)
     print_home()
     out = capsys.readouterr().out
     assert "You're set up" in out
@@ -119,10 +122,29 @@ def test_home_when_configured_shows_next_best_actions(monkeypatch, capsys, tmp_p
         assert cmd in out, out
 
 
+def test_home_when_db_populated_but_no_config_is_set_up(monkeypatch, capsys, tmp_path):
+    """#506: a user who backfilled (populated DB) but never ran full `tj onboard`
+    has no config file, yet must NOT be told "Not set up yet"."""
+    # No config discoverable anywhere...
+    monkeypatch.setattr("tokenjam.cli.home.find_config_file", lambda *a, **k: None)
+    monkeypatch.delenv("TJ_CONFIG", raising=False)
+    # ...but a non-empty DB file exists at the default path.
+    db = tmp_path / ".tj" / "telemetry.duckdb"
+    db.parent.mkdir(parents=True)
+    db.write_bytes(b"\x00" * 4096)
+    monkeypatch.setattr("pathlib.Path.home", lambda: tmp_path)
+    print_home()
+    out = capsys.readouterr().out
+    assert "You're set up" in out, out
+    assert "Not set up yet" not in out
+
+
 def test_bare_tj_renders_home_without_opening_db(monkeypatch):
     """`tj` with no subcommand prints the home screen and must NOT open the DB
     (so it works while `tj serve` holds the write lock)."""
-    monkeypatch.setattr("tokenjam.cli.home.find_config_file", lambda: None)
+    monkeypatch.setattr("tokenjam.cli.home.find_config_file", lambda *a, **k: None)
+    monkeypatch.setattr("tokenjam.cli.home._db_has_data", lambda: False)
+    monkeypatch.delenv("TJ_CONFIG", raising=False)
     monkeypatch.setattr(
         "tokenjam.cli.main.open_db",
         lambda *a, **k: (_ for _ in ()).throw(AssertionError("bare tj opened the DB")),

--- a/tests/unit/test_onboard_first_run.py
+++ b/tests/unit/test_onboard_first_run.py
@@ -115,6 +115,10 @@ def test_home_when_configured_shows_next_best_actions(monkeypatch, capsys, tmp_p
     cfg = tmp_path / "config.toml"
     cfg.write_text("version = '1'\n")
     monkeypatch.setattr("tokenjam.cli.home.find_config_file", lambda *a, **k: cfg)
+    # Clear TJ_CONFIG so a stray env var on the runner can't short-circuit
+    # _is_set_up() via its env branch and bypass the patched find_config_file
+    # this test means to exercise.
+    monkeypatch.delenv("TJ_CONFIG", raising=False)
     print_home()
     out = capsys.readouterr().out
     assert "You're set up" in out

--- a/tokenjam/cli/home.py
+++ b/tokenjam/cli/home.py
@@ -5,21 +5,69 @@ onboarding; a returning (already-configured) user gets the highest-value
 commands surfaced instead of a bare Click help dump, so the post-onboard nudge
 isn't a one-time thing they scroll past.
 
-Deliberately does NOT open the database — it reads only config presence, so it
-stays fast and works even while ``tj serve`` holds the DuckDB write lock.
+Deliberately does NOT open the database — it reads only config presence and the
+DB file's existence on disk, so it stays fast and works even while ``tj serve``
+holds the DuckDB write lock.
 """
 from __future__ import annotations
 
+import os
+from pathlib import Path
+
 from tokenjam.cli.banner import print_welcome_banner
-from tokenjam.core.config import find_config_file
+from tokenjam.core.config import StorageConfig, find_config_file
 from tokenjam.utils.formatting import console
+
+
+def _db_has_data() -> bool:
+    """Cheaply detect a populated on-disk DB WITHOUT opening it.
+
+    A user who backfilled (or otherwise ingested spans) but never ran full
+    ``tj onboard`` has no config file, yet is clearly set up (#506). We must
+    not open the DB here — that would fail while ``tj serve`` holds the write
+    lock — so we treat the presence of a non-empty DB file as the signal.
+
+    Resolves the DB path from an existing config's ``[storage] path`` when one
+    is discoverable, else from the default (``~/.tj/telemetry.duckdb``).
+    """
+    db_path = StorageConfig.path
+    cfg_file = find_config_file()
+    if cfg_file is not None:
+        # Cheap TOML parse (no DB open) to honor a custom storage path.
+        try:
+            from tokenjam.core.config import load_config
+
+            db_path = load_config(str(cfg_file)).storage.path
+        except Exception:
+            pass
+    try:
+        p = Path(db_path).expanduser()
+        return p.is_file() and p.stat().st_size > 0
+    except OSError:
+        return False
+
+
+def _is_set_up() -> bool:
+    """True if the user is set up: any discoverable config OR a populated DB.
+
+    ``find_config_file`` covers the global (``~/.config/tj/config.toml``),
+    project-local (``.tj/config.toml``), and ``tokenjam.toml`` locations; we
+    also honor ``TJ_CONFIG`` so an env-pointed config counts. Failing that, a
+    non-empty DB (e.g. from ``tj backfill``) means they're set up too (#506).
+    """
+    tj_config = os.environ.get("TJ_CONFIG")
+    if tj_config and Path(tj_config).expanduser().is_file():
+        return True
+    if find_config_file() is not None:
+        return True
+    return _db_has_data()
 
 
 def print_home() -> None:
     """Render the bare-``tj`` home screen."""
     print_welcome_banner()
 
-    if find_config_file() is None:
+    if not _is_set_up():
         console.print("[bold]Not set up yet.[/bold] Get started:")
         console.print()
         console.print("  [bold]tj onboard --claude-code[/bold]   "


### PR DESCRIPTION
The bare `tj` home screen wrongly told already-set-up users "Not set up yet" when they had a populated DB but no on-disk config file (e.g. backfilled history without running full `tj onboard`).

## Summary
- `print_home` (`cli/home.py`) now routes its set-up check through a new `_is_set_up()` helper.
- A user is treated as set up if **any** config is discoverable OR the on-disk DB file is non-empty.

## Root cause + fix
The old check was a single `find_config_file() is None`. `find_config_file` already covers global / project-local / `tokenjam.toml`, but a user who only backfilled has **no config file at all** while clearly being set up (plan tier resolves, populated `~/.tj/telemetry.duckdb`).

`_is_set_up()` now returns True when:
1. `TJ_CONFIG` points at an existing file, or
2. `find_config_file()` finds a config, or
3. `_db_has_data()` — the resolved DB file exists and is non-empty.

`_db_has_data()` resolves the DB path from an existing config's `[storage] path` (cheap TOML parse, no DB open) or the default `~/.tj/telemetry.duckdb`, then only `stat()`s the file. It **never opens the database**, so the home screen stays fast and keeps working while `tj serve` holds the DuckDB write lock (the module's original invariant).

## Tests / Verification
- `tests/unit/test_onboard_first_run.py`: added `test_home_when_db_populated_but_no_config_is_set_up` (populated DB + no config → "You're set up", not "Not set up yet").
- Hardened the existing not-configured tests to also stub `_db_has_data`/`TJ_CONFIG` so they don't depend on the test machine having a stray real DB.
- `ruff check` + `mypy` clean on touched files; the full `test_onboard_first_run.py` file passes (18 tests).

## What's NOT in this PR
- No change to the DB "has data" definition beyond file presence + non-zero size — deliberately avoids opening the DB (would break under the serve write-lock). A truly empty-but-initialized DB is rare (onboard writes config alongside), and querying row counts here would violate the module's no-DB-open contract.

🤖 Generated with [Claude Code](https://claude.com/claude-code)