### PR TITLE
Fix #509: pre-check serve port and fail fast on bind conflict

### DIFF
--- a/tests/unit/test_cmd_serve_port_precheck.py
+++ b/tests/unit/test_cmd_serve_port_precheck.py
@@ -1,0 +1,68 @@
+"""Unit tests for `tj serve`'s port-in-use pre-check (issue #509).
+
+Before starting uvicorn, `tj serve` must detect an already-bound port and
+fail fast with an actionable message, rather than printing "Application
+startup complete" and THEN an EADDRINUSE bind error that reads like the
+server booted and crashed.
+"""
+from __future__ import annotations
+
+import socket
+from unittest.mock import MagicMock, patch
+
+from click.testing import CliRunner
+
+from tokenjam.cli.cmd_serve import _port_in_use, cmd_serve
+from tokenjam.core.config import TjConfig
+
+
+def _serve_ctx_obj():
+    """Minimal ctx.obj for cmd_serve — the pre-check runs before the db/pipeline
+    are touched, so a bare config plus a placeholder db is enough."""
+    return {"config": TjConfig(version="1"), "db": MagicMock()}
+
+
+class TestPortInUsePreCheck:
+    def test_fails_fast_with_clear_message_when_port_taken(self):
+        """The pre-check message names the port and points at `tj stop` /
+        `--port`, and uvicorn is never reached."""
+        with patch("tokenjam.cli.cmd_serve._port_in_use", return_value=True), \
+             patch("uvicorn.run") as run_mock:
+            result = CliRunner().invoke(cmd_serve, [], obj=_serve_ctx_obj())
+
+        assert result.exit_code == 1, result.output
+        assert "already in use" in result.output
+        assert "tj stop" in result.output
+        assert "--port" in result.output
+        # Never fell through to actually starting the server.
+        run_mock.assert_not_called()
+
+    def test_starts_when_port_free(self):
+        """When the port is free the pre-check is a no-op and uvicorn starts."""
+        with patch("tokenjam.cli.cmd_serve._port_in_use", return_value=False), \
+             patch("uvicorn.run") as run_mock, \
+             patch("tokenjam.core.ingest.build_default_pipeline",
+                   return_value=MagicMock()), \
+             patch("tokenjam.api.app.create_app", return_value=MagicMock()):
+            result = CliRunner().invoke(cmd_serve, [], obj=_serve_ctx_obj())
+
+        assert result.exit_code == 0, result.output
+        run_mock.assert_called_once()
+
+
+class TestPortInUseDetection:
+    def test_detects_bound_port(self):
+        """A held socket makes _port_in_use return True for that port."""
+        with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as held:
+            held.bind(("127.0.0.1", 0))
+            held.listen(1)
+            port = held.getsockname()[1]
+            assert _port_in_use("127.0.0.1", port) is True
+
+    def test_free_port_is_not_in_use(self):
+        """A port that nothing holds reads as free. We grab a free port,
+        release it, then check — a benign race, adequate for this assertion."""
+        with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
+            sock.bind(("127.0.0.1", 0))
+            port = sock.getsockname()[1]
+        assert _port_in_use("127.0.0.1", port) is False

--- a/tests/unit/test_cmd_serve_port_precheck.py
+++ b/tests/unit/test_cmd_serve_port_precheck.py
@@ -66,3 +66,20 @@ class TestPortInUseDetection:
             sock.bind(("127.0.0.1", 0))
             port = sock.getsockname()[1]
         assert _port_in_use("127.0.0.1", port) is False
+
+    def test_ipv6_host_free_port_is_not_in_use(self):
+        """An IPv6 bind_host must not be misread as a conflict: the pre-check
+        picks AF_INET6 by host, so a free port on `::1` reads as free rather
+        than raising a bogus OSError against an IPv4 socket (Greptile P1)."""
+        with socket.socket(socket.AF_INET6, socket.SOCK_STREAM) as sock:
+            sock.bind(("::1", 0))
+            port = sock.getsockname()[1]
+        assert _port_in_use("::1", port) is False
+
+    def test_ipv6_host_detects_bound_port(self):
+        """A held IPv6 socket reads as in-use for that host/port."""
+        with socket.socket(socket.AF_INET6, socket.SOCK_STREAM) as held:
+            held.bind(("::1", 0))
+            held.listen(1)
+            port = held.getsockname()[1]
+            assert _port_in_use("::1", port) is True

--- a/tokenjam/cli/cmd_serve.py
+++ b/tokenjam/cli/cmd_serve.py
@@ -1,11 +1,30 @@
 from __future__ import annotations
 
 import click
+import socket
 from contextlib import asynccontextmanager
 from typing import AsyncIterator
 
 from tokenjam.core.server_state import server_state_path
 from tokenjam.utils.formatting import console
+
+
+def _port_in_use(host: str, port: int) -> bool:
+    """Return True if *port* on *host* is already bound.
+
+    Pre-flight check so `tj serve` can fail fast with a clear message instead
+    of the confusing "Application startup complete" -> EADDRINUSE sequence
+    uvicorn prints when it can't bind the port (issue #509). We attempt the
+    bind ourselves and release it immediately; a subsequent uvicorn bind on
+    the same address is racy in theory but the window is negligible and the
+    goal here is a clear diagnostic, not a lock.
+    """
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
+        try:
+            sock.bind((host, port))
+        except OSError:
+            return True
+    return False
 
 
 @click.command("serve")
@@ -19,6 +38,20 @@ def cmd_serve(ctx: click.Context, host: str | None, port: int | None,
     config = ctx.obj["config"]
     bind_host = host or config.api.host
     bind_port = port or config.api.port
+
+    # Fail fast with a clear message if the port is already bound, rather than
+    # letting uvicorn print "Application startup complete" and THEN a bind
+    # error that reads like a crash-after-boot (issue #509).
+    if _port_in_use(bind_host, bind_port):
+        console.print(
+            f"[red]Port {bind_port} is already in use[/red] — is [bold]tj serve[/bold] "
+            f"already running?"
+        )
+        console.print(
+            "  Run [bold]tj stop[/bold] to stop it, or [bold]tj serve --port <n>[/bold] "
+            "to use a different port."
+        )
+        raise SystemExit(1)
 
     import uvicorn
     from fastapi import FastAPI

--- a/tokenjam/cli/cmd_serve.py
+++ b/tokenjam/cli/cmd_serve.py
@@ -19,7 +19,11 @@ def _port_in_use(host: str, port: int) -> bool:
     the same address is racy in theory but the window is negligible and the
     goal here is a clear diagnostic, not a lock.
     """
-    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
+    # Pick the address family from the host so an IPv6 bind_host (e.g. "::" or
+    # "::1") doesn't raise a bogus "invalid argument" OSError against an IPv4
+    # socket and get misread as a port conflict.
+    family = socket.AF_INET6 if ":" in host else socket.AF_INET
+    with socket.socket(family, socket.SOCK_STREAM) as sock:
         try:
             sock.bind((host, port))
         except OSError:


### PR DESCRIPTION
`tj serve` currently lets uvicorn print "Application startup complete" and THEN an EADDRINUSE bind error when the port is taken, which reads like the server booted and crashed. This adds a pre-flight port check that fails fast with an actionable message.

## Summary
- Add `_port_in_use(host, port)` helper in `cmd_serve.py` that attempts the bind uvicorn would and releases it immediately.
- Before handing off to uvicorn, if the port is already bound, print a clear message naming the port and pointing at `tj stop` / `tj serve --port <n>`, then exit 1 — uvicorn is never reached.

## #509: confusing port-in-use failure
- **Symptom:** with 7391 held, `tj serve` logged `starting… Application startup complete` then `[Errno 48] address already in use … shutdown`, reading like a crash-after-boot.
- **Root cause:** uvicorn only surfaces the bind error after its lifespan startup log, so the failure ordering is misleading.
- **Fix:** pre-check the bind address in the serve command and fail fast with a diagnostic before uvicorn starts.

## `tj stop` sweep
The issue also asked to confirm `tj stop` frees 7391. The existing orphan-foreground sweep in `cmd_stop.py` already reaps a lingering foreground `tj serve` (its `pgrep -f` pattern matches `tj serve`), and the existing `tests/unit/test_cmd_stop.py` suite covers it. No change was needed there.

## Tests / Verification
- New `tests/unit/test_cmd_serve_port_precheck.py`: fails-fast message + never reaches uvicorn when port taken; starts normally when free; real-socket detection for bound vs free ports. 4 passed locally.
- `tests/unit/test_cmd_stop.py`: 8 passed (sweep behavior unchanged).
- `ruff check` clean on touched files; `mypy tokenjam/cli/cmd_serve.py` clean (one pre-existing unrelated error in `optimize/validate.py`).

## What's NOT in this PR
- No change to `cmd_stop.py` — the sweep already handles foreground `tj serve` processes, so tightening it would be a speculative drive-by.
- The pre-check is a best-effort diagnostic, not a lock — there is a negligible bind race between the check and uvicorn's own bind, which is acceptable for a clarity fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)