### PR TITLE
chore: pin ruff <0.16 to unbreak CI lint

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -61,7 +61,7 @@ langchain = ["langchain>=0.2"]
 crewai    = ["crewai>=0.28"]
 autogen   = ["pyautogen>=0.2"]
 litellm   = ["litellm>=1.40"]
-dev       = ["pytest", "pytest-asyncio", "httpx", "ruff", "mypy"]
+dev       = ["pytest", "pytest-asyncio", "httpx", "ruff>=0.15.12,<0.16", "mypy"]
 # Kept as a no-op extra for back-compat — `pipx install 'tokenjam[mcp]'` still
 # works, just installs the same fastmcp that's now in the base dependencies.
 # Documented in `docs/installation.md` so users know they no longer need it.


### PR DESCRIPTION
`main`'s CI went red with 472 lint errors and no code change on our side — an unpinned `ruff` picked up **0.16.0**, which promoted a large batch of rules to its stable default set.

## Summary
- Pin `ruff>=0.15.12,<0.16` in `[dev]` so CI installs the 0.15.x line the tree already passes.

## Root cause
`[dev]` listed bare `"ruff"`. When ruff 0.16.0 released (2026-07-23) its default rule selection changed (E402 ×379, BLE001 ×195, I001 ×66, RUF100 ×66, S110/112, UP035/037, PLW1510, F401 ×13, …), producing 472 findings against the existing code. The Lint step (`ruff check tokenjam/`) is blocking, so main + every open PR failed simultaneously.

## Tests / Verification
- CI on this branch installs 0.15.12 (per the pin) → Lint passes. Local `ruff 0.15.12 → All checks passed!` on the same tree.

## What's NOT in this PR
- Adopting 0.16's stricter defaults / burning down the 472 — deferred to a separate decision (pin now, unblock the queue). Alternative long-term fix: freeze an explicit `[tool.ruff.lint] select` so the rule set no longer tracks ruff's changing defaults.

🤖 Generated with [Claude Code](https://claude.com/claude-code)