### PR TITLE
Lens UI: inbox & nav polish + a navigation/loading performance pass

### DIFF
--- a/tests/unit/test_cmd_serve_port_precheck.py
+++ b/tests/unit/test_cmd_serve_port_precheck.py
@@ -83,3 +83,23 @@ class TestPortInUseDetection:
             held.listen(1)
             port = held.getsockname()[1]
             assert _port_in_use("::1", port) is True
+
+    def test_probe_sets_so_reuseaddr_to_match_uvicorn(self):
+        """The probe must set SO_REUSEADDR, exactly as uvicorn's own bind does.
+
+        Without it, a port left in TIME_WAIT by a just-Ctrl-C'd server reads
+        as in-use even though uvicorn WOULD bind it, so the pre-flight check
+        manufactured a false "already in use" that blocked a legitimate quick
+        restart. TIME_WAIT is not deterministically reproducible across OSes,
+        so we spy the option on the probe socket instead of racing a real
+        connection close.
+        """
+        sock = MagicMock()
+        sock.__enter__.return_value = sock
+        sock.bind.return_value = None  # port reads as bindable
+        with patch("tokenjam.cli.cmd_serve.socket.socket", return_value=sock):
+            assert _port_in_use("127.0.0.1", 7391) is False
+
+        sock.setsockopt.assert_any_call(
+            socket.SOL_SOCKET, socket.SO_REUSEADDR, 1
+        )

--- a/tests/unit/test_cost_proposals.py
+++ b/tests/unit/test_cost_proposals.py
@@ -987,6 +987,66 @@ def test_resend_adapter_empty_without_a_repeat_share():
     assert _resend_to_proposals(ResendFinding()) == []   # never ran / no data
 
 
+def _resend_finding():
+    from tokenjam.core.optimize.analyzers.context_resend import ResendFinding
+    return ResendFinding(
+        sessions_examined=5, repeat_share=0.6, repeat_tokens=10_000,
+        estimated_recoverable_tokens=6_830, estimated_recoverable_usd=0.5,
+        estimate_basis="resend basis", fix_compaction="Run /compact.",
+        fix_cache_control='{"cache_control": {"type": "ephemeral"}}',
+        caveat="conservative lower bound",
+    )
+
+
+def test_resend_suppresses_cache_control_snippet_for_claude_code():
+    # The cache_control snippet is the SDK lever. A Claude Code window never
+    # constructs the request, so it is not theirs to paste — the card must lead
+    # with /compact and show NO snippet, matching how the cache family gates.
+    from tokenjam.core.optimize.cost_proposals import _resend_to_proposals
+
+    prop = _resend_to_proposals(_resend_finding(), persona="claude-code")[0]
+    assert prop.suggestion == "", "cache_control snippet must be suppressed for claude-code"
+    assert "cache_control" not in prop.suggestion
+    assert prop.advise_text.startswith("Run /compact.")
+    # The paste fallback is the compaction guidance, never the snippet.
+    assert prop.one_paste_fix == "Run /compact."
+
+
+def test_resend_keeps_cache_control_snippet_for_sdk():
+    # An SDK/API developer DOES author the request, so the snippet is a real
+    # lever for them and must survive. Suppressing it there would cost that
+    # persona a genuine fix.
+    from tokenjam.core.optimize.cost_proposals import _resend_to_proposals
+
+    for persona in ("sdk", "mixed", "unknown"):
+        prop = _resend_to_proposals(_resend_finding(), persona=persona)[0]
+        assert "cache_control" in prop.suggestion, f"snippet must survive for {persona}"
+
+
+def test_resend_caveat_is_not_duplicated():
+    # The caveat is carried once via `caveat=`, and must NOT also be folded into
+    # advise_text — doing both printed the same sentence twice on the card
+    # (description paragraph + caveat line render the joined fields).
+    from tokenjam.core.optimize.cost_proposals import _resend_to_proposals
+
+    prop = _resend_to_proposals(_resend_finding(), persona="claude-code")[0]
+    assert prop.caveat == "conservative lower bound"
+    assert "conservative lower bound" not in prop.advise_text
+    assert prop.advise_text == "Run /compact."
+
+
+def test_resend_persona_flows_through_the_report_dispatch():
+    # End to end: cost_proposals_from_report must thread report.persona into the
+    # resend adapter (it was the one adapter that didn't take persona).
+    from tokenjam.core.optimize.cost_proposals import cost_proposals_from_report
+
+    rep = _report()
+    rep.findings["resend"] = _resend_finding()
+    rep.persona = "claude-code"
+    prop = {p.analyzer: p for p in cost_proposals_from_report(rep)}["resend"]
+    assert prop.suggestion == "", "report persona must reach the resend adapter"
+
+
 # --- cost-proposals recompute: locking + error surfacing (requirement #5) --- #
 
 def test_recompute_cost_proposals_records_failure_without_wiping_the_last_good_result(

--- a/tests/unit/test_lens_ui_regression.py
+++ b/tests/unit/test_lens_ui_regression.py
@@ -2287,6 +2287,27 @@ def test_sessions_nav_entry_present(html):
     assert "sessions: 'improve'" in html
 
 
+def test_sizing_note_apply_explains_unregistered_project(html):
+    # A project-scoped sizing-note card whose target tokenjam couldn't resolve
+    # (prop.target_path empty, because the project was never onboarded
+    # per-project) must EXPLAIN the two exits instead of showing an empty box
+    # that only errors on Apply: paste the path, or run `tj onboard
+    # --add-project` from the repo so tokenjam learns it.
+    start = html.index("function CostProposalCard")
+    end = html.index("function InboxStatTiles", start)
+    row = html[start:end]
+    # The input pre-fills from the backend's resolved path when there is one.
+    assert "useState(prop.target_path || '')" in row
+    # The guidance is gated on there being no resolved path, and names both exits.
+    assert "!prop.target_path ? html`" in row
+    assert "tj onboard --add-project" in row
+    assert "paste the project's" in row
+    # The Apply-time validation points at the same two exits, not a bare
+    # "enter a path".
+    assert "run `tj onboard --add-project` from that repo" in row
+    assert "enter a CLAUDE.md path to write the note into" not in html
+
+
 def test_no_duplicate_status_nav_entry(html):
     # Status and Sessions used to be two sidebar entries rendering the SAME
     # StatusView for their bare route, so clicking between them changed nothing

--- a/tests/unit/test_lens_ui_regression.py
+++ b/tests/unit/test_lens_ui_regression.py
@@ -2287,6 +2287,22 @@ def test_sessions_nav_entry_present(html):
     assert "sessions: 'improve'" in html
 
 
+def test_no_duplicate_status_nav_entry(html):
+    # Status and Sessions used to be two sidebar entries rendering the SAME
+    # StatusView for their bare route, so clicking between them changed nothing
+    # on screen. Exactly one of them survives (Sessions), and the Status nav
+    # link is gone. #/status stays a route-level alias for old bookmarks, so
+    # the `case 'status'` label must remain even though no link points at it.
+    assert 'data-view="status"' not in html, "the duplicate Status nav link must be gone"
+    assert "case 'status':" in html, "keep #/status as a silent route alias"
+    # The two labels must not both render the split-zone page title.
+    assert '<div class="page-title">Sessions</div>' in html
+    assert '<div class="page-title">Status</div>' not in html
+    # Exactly one nav-link resolves to the sessions/status surface (count the
+    # actual anchor, not raw string hits — a comment may mention the attribute).
+    assert html.count('class="nav-link" data-view="sessions"') == 1
+
+
 # --- stat tiles / applied-tab unit hierarchy follows the server framing ---- #
 # NOTE (inbox redesign): the perpetual verify/receipts layer these tests used
 # to exercise (ReceiptsHeader's "Verified saved to date" tile, CostLedgerSummary)

--- a/tests/unit/test_lens_ui_regression.py
+++ b/tests/unit/test_lens_ui_regression.py
@@ -2300,12 +2300,16 @@ def test_sizing_note_apply_explains_unregistered_project(html):
     assert "useState(prop.target_path || '')" in row
     # The guidance is gated on there being no resolved path, and names both exits.
     assert "!prop.target_path ? html`" in row
-    assert "tj onboard --add-project" in row
     assert "paste the project's" in row
-    # The Apply-time validation points at the same two exits, not a bare
-    # "enter a path".
-    assert "run `tj onboard --add-project` from that repo" in row
+    # The register-command is one-click copyable, not just prose.
+    assert '<${CopySnippetButton} text="tj onboard --add-project" />' in row
+    # Smarter UX: "no path yet" is not an error. The buttons are disabled until
+    # a path exists, so nothing can fire, and the empty-path guard NEVER sets a
+    # red validation line — the always-visible guidance block is the messaging.
+    assert "disabled=${wbusy || !target.trim()}" in row
+    assert "if (!target.trim()) return;" in row
     assert "enter a CLAUDE.md path to write the note into" not in html
+    assert "Paste a project CLAUDE.md path above, or run" not in html
 
 
 def test_no_duplicate_status_nav_entry(html):

--- a/tests/unit/test_lens_ui_regression.py
+++ b/tests/unit/test_lens_ui_regression.py
@@ -2378,7 +2378,18 @@ def test_fixes_applied_tile_never_claims_verification(html):
     end = html.index("function ReviewInboxView", start)
     tile = html[start:end]
     assert ">Fixes applied<" in tile
-    assert "estimates only, savings are not measured after the fact" in tile
+    # The estimates-only qualifier lives in the tile's sub-line (the header
+    # "Fixes applied" doesn't itself say "estimate", so the sub-line carries
+    # the honesty). Wording was tightened when the tile adopted the mockup's
+    # denser styling; the claim it makes must not weaken.
+    # The figure must always be dated to apply time, so it can never be read as
+    # a live measurement of what actually happened afterward. Wording has moved
+    # (an earlier draft said "estimates only, not re-measured"); the claim must
+    # not weaken, and the bare-count fallback must say why it has no figure.
+    assert "estimated when applied" in tile
+    # The count fallback carries no figure, so it makes no savings claim to
+    # qualify — it must show recency, never a number dressed up as a saving.
+    assert "most recent ${daysAgoLabel(lastAppliedAt)" in tile
     # The old tile label and the mockup's own VERIFIED chip never render (a
     # rendered-text check, not a comment check — explanatory code comments
     # pointing at c0316aba legitimately use the word "verified").
@@ -2426,7 +2437,11 @@ def test_estimated_recoverable_tile_leads_with_dollars_only_at_half_priceable(ht
     end = html.index("function ReviewInboxView", start)
     tile = html[start:end]
     assert "priceable.length * 2 >= openItems.length" in tile
-    assert 'class="estimated-tag"' in tile
+    # The `est.` pill was dropped for the denser mockup styling, so the
+    # estimate framing has to survive in the tile's own label + hover title —
+    # the figure must never read as a measured number.
+    assert ">Estimated recoverable " in tile
+    assert "sum of each open item's est./mo figure" in tile
 
 
 def test_estimated_tile_hides_when_there_are_no_open_items(html):
@@ -2452,9 +2467,14 @@ def test_review_inbox_intro_matches_the_founder_approved_mockup(html):
     assert intro in html
     # The loop-first phrasing from the pre-redesign copy is gone.
     assert "land here so it can relearn them" not in html
-    # The Approve/Dismiss mechanics the old intro stated are preserved, just
-    # relocated to the Recurring-mistakes tab (the tab those actions live in)
-    # instead of a page-wide intro paragraph.
+    # The Approve/Dismiss mechanics the old intro stated are preserved. They
+    # have now moved a second time: off the tab's explainer paragraph (three
+    # dense lines above the list) and onto the two controls they describe, so
+    # each consequence is stated at the moment it can still be declined. The
+    # write disclosure sits on the modal's Approve button (the body only
+    # reports git-commit-vs-backup AFTER the write); the local-only disclosure
+    # sits on the bulk Dismiss button. The strings must survive wherever they
+    # live, which is what these assertions pin.
     assert "git-committed, or backed up if the target is not a git repo" in html
     assert "you confirm the scope and target first" in html
     assert "this browser only; it is not sent to the server" in html
@@ -2518,18 +2538,48 @@ def test_select_all_toggles_off_when_everything_is_selected(html):
 
 def test_select_all_applies_only_to_the_rendered_rows(html):
     # THE load-bearing one. The list filters out locally-dismissed rows and rows
-    # approved in this session, so select-all must iterate `visible`, never the
-    # unfiltered d.clusters, or it would dismiss rows the user never saw.
+    # already applied (in this session OR any earlier one), so select-all must
+    # iterate `visible`, never the unfiltered d.clusters, or it would dismiss
+    # rows the user never saw.
     start = html.index("const selectedVisible =")
     end = html.index("const modalCluster =", start)
     block = html[start:end]
     assert "visible.filter(c => checked.has(c.signature))" in block
     assert "visible.map(c => c.signature)" in block
     assert "d.clusters" not in block
-    # The filter that makes `visible` a strict subset is still in place.
+    # The filter that makes `visible` a strict subset is still in place. This
+    # previously pinned the `!appliedSigs.has(...)` form verbatim, which meant
+    # the suite was ENFORCING the session-local-only filter that re-offered
+    # already-applied fixes; see the dedicated ledger test above for why that
+    # was a defect rather than a design.
     assert (
         "const visible = (d.clusters || []).filter(c => !dismissed.has(c.signature) "
-        "&& !appliedSigs.has(c.signature))"
+        "&& !appliedSigsAll.has(c.signature))"
+    ) in html
+
+
+def test_open_mistakes_exclude_already_applied_fixes_from_the_ledger(html):
+    # An already-applied recurring mistake must not come back as an open
+    # proposal. `appliedSigs` is session-local and starts empty on every page
+    # load, so filtering on it alone re-offered every fix applied in an earlier
+    # session: approving one then attempted to rewrite the hook its own earlier
+    # approval had created, and only relearn_apply's file-ownership guard
+    # stopped the double write. It also inflated the tab count and the
+    # ESTIMATED RECOVERABLE tile with savings already banked.
+    assert "const appliedSigsAll = new Set([" in html
+    assert "...appliedSigs," in html
+    assert "...(applied || []).filter(r => r.state !== 'reverted').map(r => r.signature)," in html
+    assert (
+        "const visible = (d.clusters || []).filter(c => !dismissed.has(c.signature) "
+        "&& !appliedSigsAll.has(c.signature))"
+    ) in html
+    # The session-local set alone must never again be the whole filter.
+    assert "!appliedSigs.has(c.signature))" not in html
+    # Same rule on the cost half, which already read its ledger correctly — the
+    # two halves of this view drifted apart silently once.
+    assert (
+        "const costAppliedSigs = new Set((costApplied || [])"
+        ".filter(r => r.state !== 'reverted').map(r => r.signature))"
     ) in html
 
 
@@ -2546,27 +2596,46 @@ def test_dismiss_checked_cannot_reach_an_unlisted_row(html):
 def test_dismiss_button_states_its_blast_radius(html):
     # The action names how many rows it will act on before it fires, and counts
     # the same scoped selection the header checkbox reports.
+    # Asserted as separate facts rather than one contiguous string: the button
+    # now also carries a title, and a brittle exact-markup match would fail on
+    # any attribute added between the handler and the label without the guarded
+    # behaviour having changed at all.
+    assert "disabled=${selectedCount === 0} onClick=${dismissChecked}" in html
     assert (
-        "disabled=${selectedCount === 0} onClick=${dismissChecked}>"
         "${selectedCount ? `Dismiss ${selectedCount} checked` : 'Dismiss checked'}"
     ) in html
+    # And it states WHERE the dismissal lands, since "dismiss" reads like a
+    # server-side action when the intro no longer spells it out at length.
+    assert "Hides these rows locally" in html
     # Not the raw, unscoped set that could overstate it.
     assert "disabled=${checked.size === 0}" not in html
 
 
 def test_select_all_adds_no_bulk_approve(html):
-    # Dismiss is local and undone by a reload; Approve writes to disk. Exactly
-    # one bulk action exists in the Recurring-mistakes tab's listhead (inbox
-    # redesign moved the bulk-dismiss button off the old `cur-addbar` footer
-    # and into the tab's listhead, beside the select-all box).
+    # Dismiss is local and undone by a reload; Approve writes to disk. The
+    # listhead carries exactly TWO bulk actions — "Review N checked" (opens
+    # each checked row's modal in turn) and "Dismiss N checked" — and neither
+    # writes anything. The invariant this pin defends is that no bulk control
+    # can APPROVE; it is not a cap on the number of buttons, so a third
+    # non-writing control may be added, but a writing one may not.
+    # Scoped to the whole Recurring-mistakes tab block, not just its listhead:
+    # the two bulk buttons now sit BELOW the scroll box (they used to be in the
+    # head, beside select-all), so a head-only slice would miss them entirely
+    # and pass vacuously.
     view = html[html.index("function ReviewInboxView"):]
     start = view.index("tab === 'mistakes' ? html`")
-    end = view.index('<div class="cur-listbox">', start)
+    end = view.index("tab === 'advisories' ? html`", start)
     head = view[start:end]
-    assert head.count("<button") == 1
     assert "dismissChecked" in head
+    assert "startReview(selectedVisible.map(c => c.signature))" in head
     assert "onClick=${approveChecked}" not in html
     assert "Approve checked" not in html
+    # The queue only navigates. If startReview ever gains a POST, that is a
+    # bulk approve wearing a different name.
+    review_fn = html[html.index("const startReview = (sigs) =>"):]
+    review_fn = review_fn[: review_fn.index("\n  };")]
+    for writing_call in ("apiPost", "apiPostOrDetail", "doApprove", "/apply"):
+        assert writing_call not in review_fn, f"startReview must not write: {writing_call}"
 
 
 # --- no dollar figure escapes the framing, and no false basis in a comment -- #

--- a/tests/unit/test_lens_ui_regression.py
+++ b/tests/unit/test_lens_ui_regression.py
@@ -566,7 +566,9 @@ def test_trim_card_no_longer_a_flat_three_column_table(html):
 # --- #210: Analytics pivot explorer (subsumes #214 leaderboard + #216) ----- #
 def test_analytics_screen_registered(html):
     assert "function AnalyticsView" in html
-    assert "case 'analytics': return html`<${AnalyticsView}" in html
+    # Keep-alive router: the view is wired via the PRIMARY_VIEWS registry (which
+    # replaced the switch-and-unmount router) rather than a `case` arm.
+    assert "['analytics', AnalyticsView]" in html
     assert 'href="#/analytics"' in html  # sidebar nav link
 
 
@@ -849,10 +851,12 @@ def test_review_inbox_is_default_landing(html):
     assert "location.hash = '#/dashboard'" not in html  # no hash-assign redirect
     assert "history.replaceState(null, '', '#/review')" in html
     assert "function ReviewInboxView" in html
-    assert "case 'review': return html`<${ReviewInboxView}" in html
+    # Keep-alive router: Review + Dashboard are wired through the PRIMARY_VIEWS
+    # registry (which replaced the switch), both mounted-and-kept-alive.
+    assert "['review',    ReviewInboxView]" in html
     assert 'href="#/review"' in html
     assert "function DashboardView" in html
-    assert "case 'dashboard': return html`<${DashboardView}" in html
+    assert "['dashboard', DashboardView]" in html
     assert 'href="#/dashboard"' in html
 
 
@@ -861,7 +865,9 @@ def test_overview_retired(html):
     # through to the Dashboard.
     assert "function OverviewView" not in html
     assert 'href="#/overview"' not in html
-    assert "case 'overview':\n    case 'dashboard'" in html
+    # Keep-alive router: #/overview folds into the Dashboard key via primaryKeyFor
+    # (replaced the switch's `case 'overview': case 'dashboard'` fallthrough).
+    assert "if (v === 'overview') return 'dashboard';" in html
 
 
 def test_dashboard_embeds_analytics_explorer(html):
@@ -2025,7 +2031,10 @@ def test_summarize_nav_child_and_route(html):
     # section is active, routing to #/optimize/summarize (the router already
     # splits view/param). The nav reveal logic shows children per active section.
     assert 'href="#/optimize/summarize" class="nav-link nav-child" data-view="optimize" data-param="summarize"' in html
-    assert "if (route.param === 'summarize') return html`<${SummarizeView} params=${p} />`;" in html
+    # Keep-alive router: #/optimize/summarize resolves to the 'summarize' primary
+    # key (a kept-alive sub-view in PRIMARY_VIEWS), not a switch `case` arm.
+    assert "if (v === 'optimize' && route.param === 'summarize') return 'summarize';" in html
+    assert "['summarize', SummarizeView]" in html
     # nav-child reveal: a child shows only while its section is active.
     assert "el.classList.contains('nav-child')" in html
     assert "el.style.display = (v === view) ? 'flex' : 'none';" in html
@@ -2283,7 +2292,10 @@ def test_sessions_nav_entry_present(html):
         '<a href="#/sessions" class="nav-link" data-view="sessions" '
         'data-lens="improve">' in html
     )
-    assert "case 'sessions':" in html
+    # Keep-alive router: the bare #/sessions route lands on StatusView (the
+    # session list) via the PRIMARY_VIEWS registry — the same StatusView the
+    # Status alias used to render — kept alive so returning is instant.
+    assert "['sessions',  StatusView]" in html
     assert "sessions: 'improve'" in html
 
 
@@ -2319,7 +2331,10 @@ def test_no_duplicate_status_nav_entry(html):
     # link is gone. #/status stays a route-level alias for old bookmarks, so
     # the `case 'status'` label must remain even though no link points at it.
     assert 'data-view="status"' not in html, "the duplicate Status nav link must be gone"
-    assert "case 'status':" in html, "keep #/status as a silent route alias"
+    # Keep-alive router: #/status (and #/runs) remain silent aliases for Sessions,
+    # resolved to the 'sessions' key in primaryKeyFor (replaced `case 'status'`).
+    assert "if (v === 'status' || v === 'runs') return 'sessions';" in html, \
+        "keep #/status as a silent alias for Sessions"
     # The two labels must not both render the split-zone page title.
     assert '<div class="page-title">Sessions</div>' in html
     assert '<div class="page-title">Status</div>' not in html

--- a/tests/unit/test_relearn_apply.py
+++ b/tests/unit/test_relearn_apply.py
@@ -895,3 +895,59 @@ def test_memory_storage_apply_and_revert_round_trip_via_temp_root(tmp_path):
     reverted = pa.revert_applied_fix(cfg, fix_id)
     assert reverted["state"] == "reverted"
     assert target.read_text() == "# Repo\n"
+
+
+# --- Ownership markers survive the pothole -> relearn rename ------------------
+# Regression: the feature was renamed, and every artifact written by the older
+# versions carries `tokenjam:pothole:`. The three "is this file ours?" checks
+# keyed on the CURRENT marker only, so those live files read as strangers':
+# re-apply refused with "wasn't written by TokenJam" (observed on 4 installed
+# hooks), and a rung-1 note re-apply appended a duplicate block instead of
+# replacing it. Root CLAUDE.md anti-pattern #21.
+
+LEGACY_HOOK = (
+    '#!/usr/bin/env python3\n"""TokenJam self-improve hook.\n\n'
+    '# tokenjam:pothole:cwd_confusion\n"""\n'
+)
+
+
+def test_legacy_pothole_marker_is_recognised_as_tokenjams_own():
+    assert pa._carries_tokenjam_marker(LEGACY_HOOK) is True
+    assert pa._carries_tokenjam_marker("# tokenjam:relearn:sig") is True
+
+
+def test_a_foreign_file_is_still_not_ours():
+    # The guard must keep refusing genuinely foreign files; widening it to
+    # accept legacy markers must not widen it to accept everything.
+    assert pa._carries_tokenjam_marker("import os\nprint('hi')\n") is False
+    assert pa._carries_tokenjam_marker("") is False
+    assert pa._carries_tokenjam_marker(None) is False
+
+
+def test_every_known_marker_generation_is_listed():
+    # Append-only: dropping a prefix silently orphans that generation of files
+    # on every machine that still has them.
+    assert "tokenjam:relearn:" in pa.TOKENJAM_MARKER_PREFIXES
+    assert "tokenjam:pothole:" in pa.TOKENJAM_MARKER_PREFIXES
+
+
+def test_legacy_note_block_is_replaced_and_normalised_not_duplicated():
+    existing = (
+        "# Notes\n"
+        "<!-- tokenjam:pothole:sig1 -->\nOLD BODY\n<!-- /tokenjam:pothole:sig1 -->\n"
+        "tail\n"
+    )
+    out = pa.render_note_content(existing, {"title": "T", "signature": "sig1"}, "sig1")
+    assert "OLD BODY" not in out, "the pre-rename block must be replaced, not orphaned"
+    assert out.count("sig1 -->") == 2, "exactly one block for this signature"
+    # The rewrite normalises the file to the current marker, so a file only
+    # ever needs to survive one re-apply to stop being legacy.
+    assert "tokenjam:relearn:sig1" in out
+    assert "pothole" not in out
+
+
+def test_legacy_marked_file_is_an_allowed_note_target(tmp_path):
+    # A prior apply's file stays re-appliable even when it is not a .md.
+    target = tmp_path / "hook.py"
+    assert pa._is_allowed_note_target(target, LEGACY_HOOK) is True
+    assert pa._is_allowed_note_target(target, "import os\n") is False

--- a/tokenjam/api/routes/analytics.py
+++ b/tokenjam/api/routes/analytics.py
@@ -288,20 +288,29 @@ async def get_analytics(
             "sessions": int(row[3] or 0) if row else 0,
         }
 
-    kpis = _kpi_totals(kpi_where, kpi_params)
-
-    # Per-bucket series for ALL FOUR KPI metrics (the sparklines, #217). One
-    # query, server-side — the UI zero-fills across the window and never
-    # aggregates per-bucket in JS (single compute path).
-    kpi_series_sql = (
+    # KPI window totals AND the per-bucket KPI series (the sparklines, #217) in a
+    # SINGLE scan over the window, instead of two sequential scans over the same
+    # WHERE. `GROUP BY ROLLUP(b)` returns every per-bucket row PLUS one grand
+    # total super-aggregate row (bucket IS NULL) whose COUNT(DISTINCT session_id)
+    # is recomputed window-wide — so a session spanning buckets is counted once,
+    # byte-identical to the standalone totals query. start_time is NOT NULL
+    # (schema), so the only null-bucket row is the ROLLUP super-aggregate; on an
+    # empty window ROLLUP emits no rows and the zero default below stands (same
+    # as the ungrouped totals query returning zeros). The UI zero-fills across
+    # the window and never aggregates per-bucket in JS (single compute path).
+    kpi_rollup_sql = (
         "SELECT " + _bucket_expr(bucket) + " AS b, " + _kpi_cols
-        + " FROM spans WHERE " + kpi_where + " GROUP BY b ORDER BY b"
+        + " FROM spans WHERE " + kpi_where + " GROUP BY ROLLUP(b) ORDER BY b"
     )
-    kpi_series = [
-        {"bucket": int(r[0]), "spend": float(r[1] or 0.0), "tokens": int(r[2] or 0),
-         "events": int(r[3] or 0), "sessions": int(r[4] or 0)}
-        for r in conn.execute(kpi_series_sql, kpi_params).fetchall()
-    ]
+    kpis = {"spend": 0.0, "tokens": 0, "events": 0, "sessions": 0}
+    kpi_series: list[dict] = []
+    for r in conn.execute(kpi_rollup_sql, kpi_params).fetchall():
+        vals = {"spend": float(r[1] or 0.0), "tokens": int(r[2] or 0),
+                "events": int(r[3] or 0), "sessions": int(r[4] or 0)}
+        if r[0] is None:  # grand-total super-aggregate row
+            kpis = vals
+        else:
+            kpi_series.append({"bucket": int(r[0]), **vals})
 
     # Period-over-period delta vs the prior equal-length window (#217), same
     # convention as the Cost/Overview --compare headline. Computed server-side.

--- a/tokenjam/cli/cmd_serve.py
+++ b/tokenjam/cli/cmd_serve.py
@@ -24,6 +24,15 @@ def _port_in_use(host: str, port: int) -> bool:
     # socket and get misread as a port conflict.
     family = socket.AF_INET6 if ":" in host else socket.AF_INET
     with socket.socket(family, socket.SOCK_STREAM) as sock:
+        # Match uvicorn's own bind semantics, which set SO_REUSEADDR. Without
+        # it, a port left in TIME_WAIT by a just-Ctrl-C'd server reads as
+        # bound here even though uvicorn WOULD bind it — so the pre-flight
+        # check, added to give a CLEARER error (issue #509), was stricter than
+        # the real bind and manufactured a false "already in use" that blocked
+        # a legitimate quick restart. A genuinely live listener still fails to
+        # bind (SO_REUSEADDR does not let two sockets both LISTEN on one port),
+        # so real conflicts are still caught.
+        sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
         try:
             sock.bind((host, port))
         except OSError:

--- a/tokenjam/core/optimize/cost_proposals.py
+++ b/tokenjam/core/optimize/cost_proposals.py
@@ -1561,16 +1561,25 @@ def _verbosity_to_proposals(finding: Any, persona: str = "unknown") -> list[Cost
     )]
 
 
-def _resend_to_proposals(finding: Any) -> list[CostProposal]:
+def _resend_to_proposals(finding: Any, persona: str = "unknown") -> list[CostProposal]:
     """One window-wide card for the ``resend`` (context re-send) finding.
 
-    Advise-only: the fix is a workflow change (``/compact``, or an SDK-side
-    ``cache_control`` placement) the user makes in their own harness/code,
-    not a file tokenjam can write into — same class of surface as ``cache``/
-    ``trim``. ``ResendFinding.estimate_basis`` already documents the
-    discounted, doubly-conservative derivation (repeat-share lower bound x
-    the corpus-measured 68.3% avoidable fraction); this adapter carries it
-    verbatim rather than re-deriving or re-stating it.
+    Advise-only, and persona-gated like every other lever-bearing adapter (it
+    was the one that wasn't). Two levers exist and they are NOT interchangeable:
+
+    * ``/compact`` / a fresh session cuts the re-sent volume and is available
+      to EVERYONE — it is always the lead fix.
+    * an SDK-side ``cache_control`` breakpoint is the SDK/API developer's
+      ADDITIONAL lever. A Claude Code (or other agent-harness) window never
+      constructs the request itself, so that snippet is not theirs to paste —
+      showing it to them is the same wrong-audience defect the cache family
+      already avoids via ``_persona_gated_cache_fields``. Suppress it for a
+      ``claude-code`` persona and lead with ``/compact`` alone.
+
+    ``ResendFinding.estimate_basis`` documents the discounted derivation; this
+    adapter carries it verbatim. The caveat is carried ONCE via ``caveat=`` and
+    deliberately NOT folded into ``advise_text`` — doing both printed it twice
+    on the card (the description and the caveat line rendered the same sentence).
     """
     if finding is None:
         return []
@@ -1587,7 +1596,9 @@ def _resend_to_proposals(finding: Any) -> list[CostProposal]:
     )
     fix_compaction = str(getattr(finding, "fix_compaction", "") or "")
     fix_cache_control = str(getattr(finding, "fix_cache_control", "") or "")
-    advise = " ".join(p for p in (fix_compaction, str(getattr(finding, "caveat", "") or "")) if p)
+    # The cache_control snippet is the SDK lever only; a claude-code window
+    # can't paste it, so suppress it there and let /compact stand alone.
+    cache_snippet = "" if persona == "claude-code" else fix_cache_control
     return [CostProposal(
         kind="cost",
         analyzer="resend",
@@ -1602,9 +1613,9 @@ def _resend_to_proposals(finding: Any) -> list[CostProposal]:
             "repeat_share_median": getattr(finding, "repeat_share_median", None),
             "repeat_share_p90": getattr(finding, "repeat_share_p90", None),
         },
-        advise_text=advise.strip(),
-        suggestion=fix_cache_control,
-        one_paste_fix=fix_cache_control or fix_compaction,
+        advise_text=fix_compaction,
+        suggestion=cache_snippet,
+        one_paste_fix=cache_snippet or fix_compaction,
         estimated_recoverable_usd=getattr(finding, "estimated_recoverable_usd", None),
         estimated_recoverable_tokens=getattr(finding, "estimated_recoverable_tokens", None),
         estimate_basis=str(getattr(finding, "estimate_basis", "") or ""),
@@ -1812,7 +1823,7 @@ def cost_proposals_from_report(
         (lambda f: _script_to_proposals(f, persona=persona), findings.get("script")),
         (lambda f: _reuse_to_proposals(f, persona=persona), findings.get("reuse")),
         (lambda f: _verbosity_to_proposals(f, persona=persona), findings.get("verbosity")),
-        (_resend_to_proposals, findings.get("resend")),
+        (lambda f: _resend_to_proposals(f, persona=persona), findings.get("resend")),
     )
     for adapter, finding in adapters:
         try:

--- a/tokenjam/core/optimize/relearn_apply.py
+++ b/tokenjam/core/optimize/relearn_apply.py
@@ -501,9 +501,15 @@ def render_note_content(existing: str, cluster: dict, signature: str) -> str:
     """Idempotent: replaces a prior block for this exact signature (re-apply),
     else appends one — creating the shared section header on first use."""
     block = _note_block(cluster, signature)
+    # Matches this signature's block in ANY marker generation, so a note
+    # written pre-rename is REPLACED here rather than left in place while a
+    # second block is appended below (anti-pattern #21: strip every legacy
+    # marker, write exactly one fresh block). `block` always carries the
+    # current marker, so a legacy file normalises itself on first re-apply.
+    any_marker = "|".join(re.escape(p) for p in TOKENJAM_MARKER_PREFIXES)
     marker_re = re.compile(
-        rf"<!-- tokenjam:relearn:{re.escape(signature)} -->.*?"
-        rf"<!-- /tokenjam:relearn:{re.escape(signature)} -->",
+        rf"<!-- (?:{any_marker}){re.escape(signature)} -->.*?"
+        rf"<!-- /(?:{any_marker}){re.escape(signature)} -->",
         re.DOTALL,
     )
     if marker_re.search(existing):
@@ -874,18 +880,46 @@ def _write_target(target: Path, content: str) -> None:
         target.write_text(content, encoding="utf-8")
 
 
+# --- Ownership markers ---------------------------------------------------------
+
+# Every artifact this module writes carries one of these, and "is this file
+# ours?" is asked in three places: the note-target allowlist, the overwrite
+# guard, and the note block's idempotency regex.
+#
+# ``pothole`` is the pre-rename spelling of the same feature. Files written by
+# those versions are still live on users' machines, and keying only on the
+# CURRENT marker made every one of them read as a stranger's file: re-apply
+# refused with "wasn't written by TokenJam", and a rung-1 note re-apply appended
+# a duplicate block instead of replacing the old one. Root CLAUDE.md
+# anti-pattern #21 is exactly this failure (the zshrc OTEL marker drifted at an
+# earlier rename with no migration) — match a STABLE set that includes every
+# legacy spelling, and let the write normalise the file to the current form.
+#
+# Append here, never replace: dropping an entry silently orphans that
+# generation of files all over again.
+TOKENJAM_MARKER_PREFIXES = ("tokenjam:relearn:", "tokenjam:pothole:")
+
+
+def _carries_tokenjam_marker(pre_image: str | None) -> bool:
+    """True when this file is a TokenJam artifact, in any marker generation."""
+    if pre_image is None:
+        return False
+    return any(prefix in pre_image for prefix in TOKENJAM_MARKER_PREFIXES)
+
+
 # --- Rung 1: note target allowlist (must-fix #2) -------------------------------
 
 def _is_allowed_note_target(target: Path, pre_image: str | None) -> bool:
     """A rung-1 note may only land on: (a) a ``*.md`` file (covers
     ``CLAUDE.md``, the intended target — any Markdown doc is a reasonable
-    note home), or (b) a file that ALREADY carries a ``tokenjam:relearn:``
-    marker (a prior legitimate apply — the same rung 2/3 re-apply allowance).
-    Anything else (a ``.py``, ``.zshrc``, etc.) is refused outright, closing
-    the "rung=1 + arbitrary target_path corrupts any file" gap."""
+    note home), or (b) a file that ALREADY carries a TokenJam marker in any
+    generation (a prior legitimate apply — the same rung 2/3 re-apply
+    allowance). Anything else (a ``.py``, ``.zshrc``, etc.) is refused
+    outright, closing the "rung=1 + arbitrary target_path corrupts any file"
+    gap."""
     if target.suffix.lower() == ".md":
         return True
-    return pre_image is not None and "tokenjam:relearn:" in pre_image
+    return _carries_tokenjam_marker(pre_image)
 
 
 # --- Write plan (shared by dry-run preview and the real apply) ----------------
@@ -949,7 +983,7 @@ def _build_write_plan(cluster: dict, target_path: str) -> dict[str, Any]:
             )
         new_content = render_note_content(pre_image or "", cluster, signature)
     else:
-        if pre_image is not None and "tokenjam:relearn:" not in pre_image:
+        if pre_image is not None and not _carries_tokenjam_marker(pre_image):
             raise RelearnApplyRefused(
                 f"{target} already exists and wasn't written by TokenJam — refusing to "
                 f"overwrite it. Choose a different target path."

--- a/tokenjam/ui/index.html
+++ b/tokenjam/ui/index.html
@@ -1554,7 +1554,13 @@ code.md-code {
   </div>
   <a href="#/review" class="nav-link" data-view="review" data-lens="improve"><span class="icon">&#9745;</span> Review inbox</a>
   <a href="#/dashboard" class="nav-link" data-view="dashboard" data-lens="improve"><span class="icon">&#9678;</span> Dashboard</a>
-  <a href="#/status" class="nav-link" data-view="status" data-lens="improve"><span class="icon">&bull;</span> Status</a>
+  <!-- One Sessions entry, not two. The old "Status" link (#/status) and this
+       one rendered the SAME StatusView for their bare route, so the sidebar
+       advertised two items that were one page. This #/sessions link is the one
+       kept: session rows deep-link to #/sessions/<id>, and the active-highlight
+       keys on data-view === route.view, so only data-view="sessions" lights up
+       while a session detail is open. #/status survives as a silent route alias
+       for old bookmarks. -->
   <a href="#/sessions" class="nav-link" data-view="sessions" data-lens="improve"><span class="icon">&#9707;</span> Sessions</a>
   <a href="#/traces" class="nav-link" data-view="traces" data-lens="observe"><span class="icon">&diamond;</span> Traces</a>
   <a href="#/cost" class="nav-link" data-view="cost" data-lens="observe"><span class="icon">$</span> Cost</a>
@@ -2694,10 +2700,10 @@ function StatusView({ params }) {
   };
 
   return html`
-    <div class="page-title">Status</div>
+    <div class="page-title">Sessions</div>
     <div style="font-size:12px;color:var(--text-dim);margin:-14px 0 18px;font-family:'Geist Mono',monospace">
       ${agentId
-        ? html`Filtered to <span class="mono">${agentId}</span> · <a href="#/status" style="color:var(--brand)">show all</a>`
+        ? html`Filtered to <span class="mono">${agentId}</span> · <a href="#/sessions" style="color:var(--brand)">show all</a>`
         : 'Two zones — coding sessions (bounded work) and SDK services (unbounded telemetry).'}
     </div>
 
@@ -4497,7 +4503,7 @@ function SessionDetailView({ sessionId }) {
 
   useEffect(() => { load(); const t = setInterval(load, 5000); return () => clearInterval(t); }, [load]);
 
-  const backBtn = html`<button class="btn btn-back" onClick=${() => location.hash = '#/status'}>← Back to status</button>`;
+  const backBtn = html`<button class="btn btn-back" onClick=${() => location.hash = '#/sessions'}>← Back to sessions</button>`;
 
   if (error) return html`<div>${backBtn}<div class="empty">Session not found.<code>${sessionId}</code></div></div>`;
   if (!data) return html`<div>${backBtn}<div class="empty">Loading session...</div></div>`;
@@ -4886,7 +4892,7 @@ function RunDetailView({ runId }) {
 
   useEffect(() => { load(); const t = setInterval(load, 5000); return () => clearInterval(t); }, [load]);
 
-  const backBtn = html`<button class="btn btn-back" onClick=${() => location.hash = '#/status'}>← Back to status</button>`;
+  const backBtn = html`<button class="btn btn-back" onClick=${() => location.hash = '#/sessions'}>← Back to sessions</button>`;
 
   if (error) return html`<div>${backBtn}<div class="empty">Run not found.<code>${runId}</code></div></div>`;
   if (!data) return html`<div>${backBtn}<div class="empty">Loading run...</div></div>`;
@@ -8935,13 +8941,16 @@ function App() {
     // #/overview bookmarks/links fall through to the Dashboard.
     case 'overview':
     case 'dashboard': return html`<${DashboardView} params=${p} />`;
-    case 'status': return html`<${StatusView} params=${p} />`;
-    case 'traces':
-      if (route.param) return html`<${TraceDetailView} traceId=${route.param} />`;
-      return html`<${TracesListView} params=${p} />`;
+    // #/status is a legacy alias kept for old bookmarks — its sidebar entry was
+    // removed (it duplicated Sessions, which renders the same StatusView). New
+    // navigation uses #/sessions; do not re-add a Status nav link.
+    case 'status':
     case 'sessions':
       if (route.param) return html`<${SessionDetailView} sessionId=${route.param} />`;
       return html`<${StatusView} params=${p} />`;
+    case 'traces':
+      if (route.param) return html`<${TraceDetailView} traceId=${route.param} />`;
+      return html`<${TracesListView} params=${p} />`;
     case 'runs':
       if (route.param) return html`<${RunDetailView} runId=${route.param} />`;
       return html`<${StatusView} params=${p} />`;

--- a/tokenjam/ui/index.html
+++ b/tokenjam/ui/index.html
@@ -43,7 +43,7 @@
   --text-faint: rgba(237,237,237,0.4);
   --accent: #ededed;            /* monochrome intensity (active/hover/focus) */
   --accent-rgb: 255,255,255;     /* for rgba() tints */
-  --brand: #3d8eff;              /* brand blue — logo + LLM category fill only */
+  --brand: #3d8eff;              /* brand blue — logo, LLM category fill, primary buttons */
   --warn: #f5a623;
   --error: #ee0000;
   --success: #0ce490;
@@ -1478,7 +1478,11 @@ code.md-code {
 .cur-addbar { display:flex; align-items:center; gap:14px; margin-top:16px; flex-wrap:wrap; }
 .cur-btn { font-size:13px; padding:9px 16px; border-radius:6px; border:1px solid var(--border); background:var(--surface); color:var(--text); cursor:pointer; font-family:'Geist Mono',monospace; }
 .cur-btn:hover:not(:disabled) { border-color:var(--accent); }
-.cur-btn.primary { background:rgba(var(--accent-rgb),0.16); border-color:rgba(var(--accent-rgb),0.4); color:var(--accent); }
+/* The primary action is brand-blue on white text (inbox mockup). The rest of
+   the chrome stays monochrome, so this fill is what marks the ONE action a
+   surface wants you to take. */
+.cur-btn.primary { background:var(--brand); border-color:var(--brand); color:#fff; }
+.cur-btn.primary:hover:not(:disabled) { background:#2f7ae8; border-color:#2f7ae8; }
 .cur-btn:disabled { opacity:.4; cursor:not-allowed; }
 .cur-tally { border:1px solid var(--border); border-radius:9px; background:var(--surface); padding:16px 18px; margin:0; cursor:pointer; transition:border-color .15s; }
 .cur-tally.empty { cursor:default; }
@@ -1504,6 +1508,8 @@ code.md-code {
 .cur-cwd { font-size:12px; color:var(--text-faint); margin:0 2px; line-height:1.5; }
 .cur-cwd code { color:var(--text-dim); }
 .cur-listbox { max-height:380px; overflow-y:auto; border:1px solid var(--border); border-radius:9px; background:var(--surface); }
+/* The last row's divider would otherwise double up against the box border. */
+.cur-listbox > .sz-runrow:last-child { border-bottom:none; }
 .rev-note { margin:0; }
 .rev-state { margin-left:auto; font-size:10.5px; text-transform:uppercase; letter-spacing:.04em; border-radius:4px; padding:3px 9px; border:1px solid var(--border); }
 .rev-state.staged { color:var(--warn); border-color:rgba(245,166,35,.4); }
@@ -7878,14 +7884,25 @@ function RecurringMistakeRow({ cluster, checked, onToggle, onExpand, suppressed 
     <div class="cur-row" style="display:flex;align-items:flex-start;gap:10px;padding:12px 14px;border-bottom:1px solid var(--border)" key=${cluster.signature}>
       <input type="checkbox" style="margin-top:3px" checked=${checked} onChange=${onToggle} />
       <div style="flex:1;min-width:0">
-        <span class="sz-link" onClick=${onExpand} style="font-weight:500">${cluster.title}</span>
+        ${/* Still clickable (cursor + hover underline come from sz-link), but
+              rendered in body text: the row already names its action in the
+              "Review →" link, so blue on every title made the list read as a
+              wall of links. */ ''}
+        <span class="sz-link" onClick=${onExpand} style="font-weight:500;color:var(--text)">${cluster.title}</span>
         <span class="badge badge-warning" style="margin-left:6px" title=${(cluster.family_key || '') + ' · rung ' + cluster.rung}>${relearnBadge(cluster)}</span>
         <div class="dim" style="font-size:12px;margin-top:3px">Recurred in ${cluster.sessions} session${cluster.sessions === 1 ? '' : 's'}${lastSeenTs ? ' · last seen ' + lastSeenTs.slice(0, 16).replace('T', ' ') : ''}</div>
       </div>
       <div style="text-align:right;flex-shrink:0">
-        <div class="mono" style="color:var(--accent);font-weight:600">${est.big} <span class="estimated-tag" title=${cluster.monthly_rate_basis || 'occurrences x a conservative per-turn token cost, extrapolated to a 30-day rate — review before applying'}>est.</span></div>
-        ${est.sub ? html`<div class="dim" style="font-size:11px">${est.sub}</div>` : null}
-        <div class="dim" style="font-size:10px;text-transform:uppercase;letter-spacing:.03em">est. / mo</div>
+        ${/* One caption, not two: the `est.` pill and an "EST. / MO" line both
+              asserted "estimated", stacking four lines in this column. Matches
+              the cost cards' single "est. / mo · <tokens>" caption so both tabs
+              read alike. The basis stays on hover. */ ''}
+        <div class="mono" style="color:var(--accent);font-weight:600" title=${cluster.monthly_rate_basis || 'occurrences x a conservative per-turn token cost, extrapolated to a 30-day rate — review before applying'}>${est.big}</div>
+        <div class="dim" style="font-size:11px">est. / mo${est.sub ? ' · ' + est.sub : ''}</div>
+        ${/* The row's only affordance used to be the title styled as a link,
+              so the constructive action was invisible next to a prominent
+              bulk Dismiss. Name the verb. */ ''}
+        <div class="sz-link" style="font-size:12px;margin-top:6px" onClick=${onExpand}>Review →</div>
       </div>
     </div>`;
 }
@@ -7893,7 +7910,13 @@ function RecurringMistakeRow({ cluster, checked, onToggle, onExpand, suppressed 
 // The card's Approve flow: preview -> (optional active-session warning ->
 // "apply anyway") -> write. Scope + target are ALWAYS human-editable before
 // Approve (§7 — repo-identity is noisy; never trust the suggestion blindly).
-function RelearnApplyModal({ cluster, onClose, onApplied }) {
+// `queuePos` ({ index, total }) and `onNext` are set only when the modal was
+// opened from the toolbar's "Review N checked" queue. Approving stays strictly
+// one-at-a-time even then — each fix needs its own scope/target confirmation
+// (requirement #9), so the queue only automates *getting to* the next card,
+// never the approval itself. onClose abandons the whole queue; onNext leaves
+// the current card untouched and opens the following one.
+function RelearnApplyModal({ cluster, onClose, onApplied, queuePos, onNext }) {
   const [scope, setScope] = useState('project');
   const [target, setTarget] = useState('');
   const [busy, setBusy] = useState(false);
@@ -7944,8 +7967,9 @@ function RelearnApplyModal({ cluster, onClose, onApplied }) {
       <div class="cur-modal" onClick=${e => e.stopPropagation()}>
         <div class="cur-modal-head">
           <span class="cur-modal-title">${cluster.title}</span>
+          ${queuePos ? html`<span class="dim" style="font-size:11.5px;margin-left:6px">${queuePos.index} of ${queuePos.total}</span>` : null}
           <span class=${'rev-state ' + (result ? 'applied' : 'staged')} style="margin-left:6px">${result ? 'applied' : 'pending'}</span>
-          <button class="cur-modal-x" onClick=${onClose} title="Close">✕</button>
+          <button class="cur-modal-x" onClick=${onClose} title=${queuePos ? 'Stop reviewing' : 'Close'}>✕</button>
         </div>
         <div class="cur-modal-body">
           <div style="font-size:12.5px;margin-bottom:10px">
@@ -8002,9 +8026,14 @@ function RelearnApplyModal({ cluster, onClose, onApplied }) {
         <div class="cur-modal-foot">
           ${cluster.advise_only ? html`<span class="dim" style="font-size:12px">Nothing to approve: this recommendation is yours to apply.</span>`
             : !result ? html`
-            <button class="cur-btn primary" disabled=${busy} onClick=${() => doApprove(false)}>${busy ? 'Applying…' : 'Approve →'}</button>
+            ${/* States the write's consequence BEFORE it happens. The body
+                  below only reports git-commit vs backup after the fact, and
+                  this is the last point at which the user can decline. */ ''}
+            <button class="cur-btn primary" disabled=${busy} onClick=${() => doApprove(false)}
+              title="Writes this fix at its rung: git-committed, or backed up if the target is not a git repo; you confirm the scope and target first">${busy ? 'Applying…' : 'Approve →'}</button>
           ` : html`<span class="dim" style="font-size:12px">Applied. Manage enforcement/revert from the Applied section below.</span>`}
-          <button class="cur-btn" style="margin-left:auto" onClick=${onClose}>Close</button>
+          ${queuePos && onNext ? html`<button class="cur-btn" style="margin-left:auto" onClick=${onNext} title="Leave this one as-is and open the next checked row">Next →</button>` : null}
+          <button class="cur-btn" style=${queuePos && onNext ? '' : 'margin-left:auto'} onClick=${onClose}>${queuePos ? 'Stop reviewing' : 'Close'}</button>
         </div>
       </div>
     </div>`;
@@ -8071,12 +8100,22 @@ function AppliedItemRow({ rec, onChanged, suppressed }) {
   const revertUrl = isRelearn ? `/relearn/${rec.id}/revert` : `/relearn/cost-applied/${rec.id}/revert`;
 
   return html`
-    <div class="sz-runrow" style="align-items:flex-start;flex-direction:column;gap:6px;padding:10px 0;border-bottom:1px solid var(--border)">
+    ${/* Horizontal padding matches the cost cards' 14px so the row's text and
+          its right-aligned state chip never sit flush against the panel edge. */ ''}
+    <div class="sz-runrow" style="align-items:flex-start;flex-direction:column;gap:6px;padding:10px 14px;border-bottom:1px solid var(--border)">
       <div style="display:flex;align-items:center;gap:8px;width:100%;flex-wrap:wrap">
         <span style="font-weight:500">${rec.title}</span>
         ${!isRelearn ? html`<span class="badge badge-info">${(COST_BADGE_BY_ANALYZER[rec.analyzer] || rec.analyzer || '').toUpperCase()}</span>` : null}
-        <span class=${'rev-state ' + (rec.state === 'reverted' ? 'reverted' : 'applied')}>${rec.state}</span>
-        ${isEnforcement && rec.state === 'applied' ? html`<span class="dim" style="font-size:11px">· enforcement ${enforcement && enforcement.enabled ? 'ENABLED' : 'disabled'}</span>` : null}
+        ${/* The chip only earns its space when the state is NOT the tab's own
+              default: every row here is applied, so "APPLIED" is noise, while
+              "REVERTED" is the one thing that distinguishes a row. */ ''}
+        ${rec.state !== 'applied' ? html`<span class=${'rev-state ' + (rec.state === 'reverted' ? 'reverted' : 'applied')}>${rec.state}</span>` : null}
+        ${/* NOT a restatement of "applied": applied means the hook file was
+              written, enabled means it is wired into settings.json and actually
+              intercepting tool calls. An applied-but-disabled hook is inert,
+              and this label is the only place that surfaces it — so the
+              disabled case gets the warn colour, being the surprising one. */ ''}
+        ${isEnforcement && rec.state === 'applied' ? html`<span class="dim" style=${'font-size:11px;margin-left:auto' + (enforcement && enforcement.enabled ? '' : ';color:var(--warn)')} title=${enforcement && enforcement.enabled ? 'wired into settings.json; intercepts matching tool calls' : 'the hook file exists but is not wired into settings.json, so it does nothing yet'}>enforcement ${enforcement && enforcement.enabled ? 'ENABLED' : 'disabled'}</span>` : null}
         ${(usd != null || toks != null) ? html`
           <span class="mono" style="margin-left:auto;color:var(--success);font-weight:600">
             +${(!suppressed && usd != null) ? fmtUsd(usd) : (toks != null ? '~' + fmtTokens(toks) + ' tok' : fmtUsd(usd))}
@@ -8287,7 +8326,9 @@ function CostProposalCard({ prop, busy, focused, onMark, onDismiss, onChanged, s
       `) : html`
         <div style="display:flex;gap:12px;align-items:center;margin-top:12px">
           <button class="cur-btn primary" disabled=${busy} onClick=${() => onMark(prop)}>${busy ? 'Marking…' : 'Mark applied'}</button>
-          <span class="sz-link" onClick=${() => onDismiss(prop.signature)}>Dismiss</span>
+          ${/* Dismiss is the secondary, discarding action — plain text, so the
+                blue belongs to the one action the card is asking for. */ ''}
+          <span class="sz-link" style="color:var(--text)" onClick=${() => onDismiss(prop.signature)}>Dismiss</span>
         </div>
       `}
       ${prop.apply_capable ? html`<div style="margin-top:8px"><span class="sz-link" onClick=${() => onDismiss(prop.signature)}>Dismiss</span></div>` : null}
@@ -8317,7 +8358,7 @@ function CostProposalCard({ prop, busy, focused, onMark, onDismiss, onChanged, s
 // shows per row), never a live re-measurement of what happened afterward. A
 // bounded verify redesign is a separate, later product decision — see
 // c0316aba before building one.
-function InboxStatTiles({ openItems, appliedEstimates, appliedCount, suppressed }) {
+function InboxStatTiles({ openItems, appliedEstimates, appliedCount, lastAppliedAt, suppressed }) {
   // monthlyUsdForDisplay excludes resend/TRIM's structural (not-a-savings-
   // claim) dollar figure from this tile the same way estMonthlyLine does for
   // the individual rows. appliedEstimates needs no equivalent call here — its
@@ -8343,17 +8384,27 @@ function InboxStatTiles({ openItems, appliedEstimates, appliedCount, suppressed 
       ${openItems.length > 0 ? html`
         <div class="opt-section" style="flex:1;min-width:260px;padding:12px 14px;border:1px solid var(--border);border-radius:8px;border-color:rgba(var(--accent-rgb,120,120,255),0.35)">
           <div class="dim" style="font-size:11px;text-transform:uppercase;letter-spacing:.03em">Estimated recoverable <span class="dim" style="font-weight:400">/ mo</span></div>
-          <div style="font-size:24px;font-weight:600;color:var(--accent);margin-top:4px">
+          <div style="font-size:24px;font-weight:600;color:var(--accent);margin-top:4px" title="sum of each open item's est./mo figure — review before applying">
             ${leadWithUsd ? fmtUsd(totalUsd) : '~' + fmtTokens(totalToks) + ' tok'}
-            <span class="estimated-tag" title="sum of each open item's est./mo figure — review before applying">est.</span>
           </div>
           <div class="dim" style="font-size:12px;margin-top:2px">across ${openItems.length} open item${openItems.length === 1 ? '' : 's'} · review before applying</div>
         </div>
       ` : null}
       <div class="opt-section" style="flex:1;min-width:260px;padding:12px 14px;border:1px solid var(--border);border-radius:8px">
         <div class="dim" style="font-size:11px;text-transform:uppercase;letter-spacing:.03em;color:var(--success)">Fixes applied</div>
-        <div style="font-size:24px;font-weight:600;color:var(--success);margin-top:4px">${appliedBig}${appliedCount > 0 ? html` <span class="estimated-tag" title="each fix's own estimate at the moment it was applied — never re-measured afterward">est.</span>` : null}</div>
-        <div class="dim" style="font-size:12px;margin-top:2px">${appliedCount} fix${appliedCount === 1 ? '' : 'es'} applied. estimates only, savings are not measured after the fact.</div>
+        ${/* The green belongs to the label, not the figure: the number reads as
+              a plain fact, matching the blue tile where the figure is also
+              body-coloured rather than tinted. */ ''}
+        <div style="font-size:24px;font-weight:600;margin-top:4px" title="each fix's own estimate at the moment it was applied — never re-measured afterward">${appliedBig}</div>
+        ${/* The sub-line never restates the number above it. When the big
+              figure is an estimate, the line dates it to apply time (the same
+              honesty the old "not re-measured" carried, without leading with a
+              negation). When the big figure is only the count fallback there is
+              no claim to qualify, so the line spends itself on recency instead
+              of apologising for a missing estimate. */ ''}
+        <div class="dim" style="font-size:12px;margin-top:2px">${appliedBig === String(appliedCount)
+          ? html`most recent ${daysAgoLabel(lastAppliedAt) || 'unknown'}`
+          : html`across ${appliedCount} applied fix${appliedCount === 1 ? '' : 'es'} · estimated when applied`}</div>
       </div>
     </div>`;
 }
@@ -8372,6 +8423,8 @@ function ReviewInboxView({ params }) {
   const [dismissed, setDismissed] = useState(() => loadDismissedRelearns());
   const [checked, setChecked] = useState(() => new Set());
   const [modalSig, setModalSig] = useState(null);
+  const [reviewQueue, setReviewQueue] = useState([]);
+  const [reviewTotal, setReviewTotal] = useState(0);
   const [refreshing, setRefreshing] = useState(false);
   const [applied, setApplied] = useState([]);
   const [appliedSigs, setAppliedSigs] = useState(() => new Set());   // hide from pending immediately
@@ -8459,7 +8512,19 @@ function ReviewInboxView({ params }) {
     finally { setMarking(null); }
   }, [loadCost]);
 
-  const visible = (d.clusters || []).filter(c => !dismissed.has(c.signature) && !appliedSigs.has(c.signature));
+  // `appliedSigs` is session-local (it hides a row the instant you approve it,
+  // before the ledger refetches) and starts EMPTY on every page load, so on its
+  // own it let already-applied clusters return as open proposals after a
+  // reload. Approving one then tried to rewrite the hook its own earlier
+  // approval created, and only relearn_apply's file-ownership guard stopped the
+  // double write. Seed from the server ledger too, exactly as the cost side
+  // does with costAppliedSigs. A reverted fix is deliberately NOT filtered: it
+  // is open again by definition.
+  const appliedSigsAll = new Set([
+    ...appliedSigs,
+    ...(applied || []).filter(r => r.state !== 'reverted').map(r => r.signature),
+  ]);
+  const visible = (d.clusters || []).filter(c => !dismissed.has(c.signature) && !appliedSigsAll.has(c.signature));
   const toggle = sig => setChecked(s => { const n = new Set(s); n.has(sig) ? n.delete(sig) : n.add(sig); return n; });
   const dismissChecked = () => {
     // Only the selected rows that are actually listed: a stale signature left in
@@ -8495,6 +8560,23 @@ function ReviewInboxView({ params }) {
   const toggleAll = () => setChecked(
     prev => nextSelectAllSelection(visible.map(c => c.signature), prev));
   const modalCluster = modalSig ? (d.clusters || []).find(c => c.signature === modalSig) : null;
+  // Review queue: the signatures still to visit AFTER the open one. Opening a
+  // single row leaves it empty, so the modal shows no queue chrome.
+  const startReview = (sigs) => {
+    if (!sigs.length) return;
+    setModalSig(sigs[0]);
+    setReviewQueue(sigs.slice(1));
+    setReviewTotal(sigs.length);
+  };
+  const nextInReview = () => {
+    const [next, ...rest] = reviewQueue;
+    setModalSig(next || null);
+    setReviewQueue(rest);
+  };
+  const endReview = () => { setModalSig(null); setReviewQueue([]); };
+  const queuePos = reviewTotal > 1 && modalSig
+    ? { index: reviewTotal - reviewQueue.length, total: reviewTotal }
+    : null;
   const costAppliedSigs = new Set((costApplied || []).filter(r => r.state !== 'reverted').map(r => r.signature));
   const visibleCost = (costProps || []).filter(p => !dismissed.has(p.signature) && !costAppliedSigs.has(p.signature));
 
@@ -8538,18 +8620,25 @@ function ReviewInboxView({ params }) {
   const appliedOpenCount = combinedApplied.filter(r => r.state !== 'reverted').length;
   // Each non-reverted applied item's own estimate (requirement #7's honest
   // "Fixes applied" tile — never a live re-measurement).
-  const appliedEstimates = combinedApplied
-    .filter(r => r.state !== 'reverted')
-    .map(appliedEstimate);
+  const appliedOpen = combinedApplied.filter(r => r.state !== 'reverted');
+  const appliedEstimates = appliedOpen.map(appliedEstimate);
+  // combinedApplied is sorted newest-first, so the head is the most recent.
+  const lastAppliedAt = appliedOpen.length ? appliedOpen[0].applied_at : null;
 
   return html`
     <div style="display:flex;align-items:baseline;justify-content:space-between;gap:12px;flex-wrap:wrap">
       <div class="page-title" style="margin-bottom:0">Inbox</div>
-      <span class="sz-link" onClick=${doRefresh}>⟳ ${refreshing || d.status === 'computing' || costStatus === 'computing' ? 'scanning…' : 'Rescan now'}</span>
+      ${/* Scan provenance belongs beside the control that re-runs it, not in a
+            per-tab header: it describes the whole inbox, and the Rescan link is
+            already the one place that reports scan state. */ ''}
+      <span style="display:flex;align-items:baseline;gap:12px;flex-wrap:wrap">
+        ${d.computedAt ? html`<span class="dim" style="font-size:12px">last scanned ${d.computedAt.slice(0, 16).replace('T', ' ')} UTC${d.sessionsScanned != null ? ' · ' + d.sessionsScanned + ' sessions scanned' : ''}</span>` : null}
+        <span class="sz-link" onClick=${doRefresh}>⟳ ${refreshing || d.status === 'computing' || costStatus === 'computing' ? 'scanning…' : 'Rescan now'}</span>
+      </span>
     </div>
     <div class="sz-note">Waste you're paying for more than once: mistakes your agents keep repeating, and cost fixes ready to apply.</div>
 
-    <${InboxStatTiles} openItems=${openItems} appliedEstimates=${appliedEstimates} appliedCount=${appliedOpenCount} suppressed=${suppressed} />
+    <${InboxStatTiles} openItems=${openItems} appliedEstimates=${appliedEstimates} appliedCount=${appliedOpenCount} lastAppliedAt=${lastAppliedAt} suppressed=${suppressed} />
 
     <div class="tab-bar" role="tablist">
       <button class="tab ${tab === 'mistakes' ? 'active' : ''}" role="tab" aria-selected=${tab === 'mistakes'} onClick=${() => setTab('mistakes')}>Recurring mistakes (${visible.length})</button>
@@ -8558,34 +8647,47 @@ function ReviewInboxView({ params }) {
     </div>
 
     ${tab === 'mistakes' ? html`
-      <div class="cur-listhead">
-        <span>
-          ${d.computedAt ? html`<span class="dim" style="font-size:12px">last scanned ${d.computedAt.slice(0, 16).replace('T', ' ')} UTC${d.sessionsScanned != null ? ' · ' + d.sessionsScanned + ' sessions scanned' : ''}</span>` : null}
-          ${d.status === 'computing' ? html` · <span style="color:var(--warn)">scanning…</span>` : null}
-        </span>
-        <span style="display:flex;align-items:center;gap:8px">
-          <${SelectAllCheckbox} total=${visible.length} selected=${selectedCount} onToggle=${toggleAll} />
-          <button class="cur-btn" disabled=${selectedCount === 0} onClick=${dismissChecked}>${selectedCount ? `Dismiss ${selectedCount} checked` : 'Dismiss checked'}</button>
-        </span>
-      </div>
+      ${/* Kept to one line. The rows name their own action ("Review →") and the
+            modal shows scope + target before anything is written, so the only
+            non-inferable facts are the two consequences: Approve writes to
+            disk, Dismiss is local. The detail that was here (rung, git-commit
+            vs backup) lives on the Approve step itself, where it applies. */ ''}
+      <div class="sz-note" style="margin:12px 0 10px"><b>Approve</b> writes the fix to disk. <b>Dismiss</b> only hides a row in this browser.</div>
+      ${/* Select-all sits directly above the list it governs, labelled — an
+            unlabelled checkbox floating in the metadata line read as chrome.
+            The two bulk actions sit BELOW the scroll box, where you land after
+            reading the rows you are acting on. */ ''}
+      <label style="display:flex;align-items:center;gap:8px;margin:0 2px 6px;font-size:12.5px;cursor:pointer;width:fit-content">
+        <${SelectAllCheckbox} total=${visible.length} selected=${selectedCount} onToggle=${toggleAll} />
+        <span class="dim">Select all${selectedCount ? ` · ${selectedCount} selected` : ''}</span>
+      </label>
       <div class="cur-listbox">
         ${d.error ? html`<div class="dim" style="padding:32px 16px;text-align:center;color:var(--error)">Couldn't load proposals: ${d.error}</div>` : null}
         ${!d.error && d.loading ? html`<div class="dim" style="padding:32px 16px;text-align:center">Loading…</div>` : null}
         ${!d.error && !d.loading && d.status === 'never_run' ? html`<div class="dim" style="padding:32px 16px;text-align:center">No scan has run yet. Click <span class="sz-link" onClick=${doRefresh}>Rescan now</span> to kick one off.</div>` : null}
         ${!d.error && !d.loading && d.status !== 'never_run' && visible.length === 0 ? html`<div class="dim" style="padding:32px 16px;text-align:center">No pending fixes. The last scan found nothing recurring enough to propose (or you've dismissed/applied everything).</div>` : null}
-        ${!d.error && !d.loading ? topRelearn.map(c => html`<${RecurringMistakeRow} key=${c.signature} cluster=${c} checked=${checked.has(c.signature)} onToggle=${() => toggle(c.signature)} onExpand=${() => setModalSig(c.signature)} suppressed=${suppressed} />`) : null}
+        ${!d.error && !d.loading ? topRelearn.map(c => html`<${RecurringMistakeRow} key=${c.signature} cluster=${c} checked=${checked.has(c.signature)} onToggle=${() => toggle(c.signature)} onExpand=${() => startReview([c.signature])} suppressed=${suppressed} />`) : null}
         <${CollapsedTailRow} tail=${tailRelearn} suppressed=${suppressed} itemLabel="recurring mistakes"
           onDismissAll=${() => dismissMany(tailRelearn.map(c => c.signature))}
-          renderItem=${c => html`<${RecurringMistakeRow} key=${c.signature} cluster=${c} checked=${checked.has(c.signature)} onToggle=${() => toggle(c.signature)} onExpand=${() => setModalSig(c.signature)} suppressed=${suppressed} />`} />
+          renderItem=${c => html`<${RecurringMistakeRow} key=${c.signature} cluster=${c} checked=${checked.has(c.signature)} onToggle=${() => toggle(c.signature)} onExpand=${() => startReview([c.signature])} suppressed=${suppressed} />`} />
       </div>
-      <div class="sz-note" style="margin-top:8px">Click a row for its evidence, proposed fix, and to Approve. <b>Approve</b> writes that fix (git-committed, or backed up if the target is not a git repo) at its rung; you confirm the scope and target first. <b>Dismiss</b> hides a row locally (this browser only; it is not sent to the server).</div>
+      <div style="display:flex;gap:10px;align-items:center;margin-top:10px">
+        <button class="cur-btn primary" disabled=${selectedCount === 0}
+          onClick=${() => startReview(selectedVisible.map(c => c.signature))}
+          title="Open each checked row in turn; you still approve them one at a time">${selectedCount ? `Review ${selectedCount} checked` : 'Review checked'}</button>
+        <button class="cur-btn" disabled=${selectedCount === 0} onClick=${dismissChecked}
+          title="Hides these rows locally: this browser only; it is not sent to the server, so clearing site data brings them back">${selectedCount ? `Dismiss ${selectedCount} checked` : 'Dismiss checked'}</button>
+      </div>
     ` : null}
 
     ${tab === 'advisories' ? html`
-      ${(costDegraded || costStatus === 'computing') ? html`
+      ${/* No "scanning…" here: the header's Rescan link already reports that
+            state for the whole inbox, and it read as two separate scans. The
+            degraded warning stays, being the one thing that link cannot say:
+            the last refresh FAILED and these rows are the last good result. */ ''}
+      ${costDegraded ? html`
         <div class="dim" style="font-size:12px;margin-bottom:8px">
-          ${costDegraded ? html`<span style="color:var(--warn)" title=${costLastError || ''}>⚠ the last refresh failed; showing the last good result</span>` : null}
-          ${costStatus === 'computing' ? html`<span style="color:var(--warn)">scanning…</span>` : null}
+          <span style="color:var(--warn)" title=${costLastError || ''}>⚠ the last refresh failed; showing the last good result</span>
         </div>` : null}
       <div>
         ${costStatus === 'never_run' && visibleCost.length === 0 ? html`<div class="dim" style="padding:32px 16px;text-align:center">No scan has run yet. Click <span class="sz-link" onClick=${doRefresh}>Rescan now</span> to kick one off.</div>` : null}
@@ -8606,7 +8708,7 @@ function ReviewInboxView({ params }) {
       </div>
     ` : null}
 
-    <${RelearnApplyModal} cluster=${modalCluster} onClose=${() => setModalSig(null)} onApplied=${onApplied} />
+    <${RelearnApplyModal} cluster=${modalCluster} onClose=${endReview} onApplied=${onApplied} queuePos=${queuePos} onNext=${reviewQueue.length ? nextInReview : null} />
   `;
 }
 

--- a/tokenjam/ui/index.html
+++ b/tokenjam/ui/index.html
@@ -8227,13 +8227,16 @@ function CostProposalCard({ prop, busy, focused, onMark, onDismiss, onChanged, s
   // Workspace-apply state (subagent rubric / script / reuse / verbosity): a
   // target path + a dry-run diff before the real, reversible write — routed
   // through the same human-gated relearn apply path.
-  const [target, setTarget] = useState('');
+  // Pre-fill from the backend's resolved path when it has one (a registered
+  // project); empty means the project was never onboarded per-project, and the
+  // block below explains the two exits rather than just erroring on Apply.
+  const [target, setTarget] = useState(prop.target_path || '');
   const [wbusy, setWbusy] = useState(false);
   const [werr, setWerr] = useState(null);
   const [preview, setPreview] = useState(null);
 
   const applyWorkspace = async (go) => {
-    if (!target.trim()) { setWerr('enter a CLAUDE.md path to write the note into'); return; }
+    if (!target.trim()) { setWerr('Paste a project CLAUDE.md path above, or run `tj onboard --add-project` from that repo so tokenjam can fill it in.'); return; }
     setWbusy(true); setWerr(null);
     try {
       const r = await apiPostOrDetail('/relearn/cost-proposals/apply-workspace',
@@ -8320,9 +8323,21 @@ function CostProposalCard({ prop, busy, focused, onMark, onDismiss, onChanged, s
       ` : html`
         <div class="opt-section" style="margin:10px 0 0">
           <div class="opt-title" style="font-size:12.5px">Apply the sizing note <span class="dim" style="font-weight:400">· writes a reversible rung-1 note; confirm the target first</span></div>
+          ${/* The sizing rubric is project-scoped, so it needs a specific
+                project CLAUDE.md. When tokenjam couldn't resolve one
+                (prop.target_path empty), the project was never registered
+                per-project, so say so and give the two real exits instead of
+                an empty box that only errors on Apply. */ ''}
+          ${!prop.target_path ? html`
+            <div class="sz-note" style="margin-top:6px;font-size:12px">
+              tokenjam doesn't know this project's path, so it can't choose the <code>CLAUDE.md</code> for you. Two ways forward:
+              <div style="margin-top:4px">1. paste the project's <code>CLAUDE.md</code> path below and apply it directly, or</div>
+              <div style="margin-top:2px">2. run <code>tj onboard --add-project</code> from that repo to register it; tokenjam then knows the path and can target it for you.</div>
+            </div>
+          ` : null}
           <div style="display:flex;gap:8px;margin-top:6px;flex-wrap:wrap">
             <input class="rename-input" style="flex:1;min-width:280px" value=${target}
-              placeholder="/absolute/path/to/CLAUDE.md" onInput=${e => setTarget(e.target.value)} />
+              placeholder="/absolute/path/to/project/CLAUDE.md" onInput=${e => setTarget(e.target.value)} />
             <button class="cur-btn" disabled=${wbusy} onClick=${() => applyWorkspace(false)}>${wbusy ? 'working…' : 'Preview note'}</button>
             <button class="cur-btn primary" disabled=${wbusy} onClick=${() => applyWorkspace(true)}>Apply note →</button>
           </div>

--- a/tokenjam/ui/index.html
+++ b/tokenjam/ui/index.html
@@ -8236,7 +8236,11 @@ function CostProposalCard({ prop, busy, focused, onMark, onDismiss, onChanged, s
   const [preview, setPreview] = useState(null);
 
   const applyWorkspace = async (go) => {
-    if (!target.trim()) { setWerr('Paste a project CLAUDE.md path above, or run `tj onboard --add-project` from that repo so tokenjam can fill it in.'); return; }
+    // The buttons are disabled while the path is empty, so this is only a
+    // defensive guard — it never sets a red error, because "no path yet" is
+    // not a mistake the user made. The always-visible guidance block explains
+    // what to do; a red line after a click would just repeat it, alarmingly.
+    if (!target.trim()) return;
     setWbusy(true); setWerr(null);
     try {
       const r = await apiPostOrDetail('/relearn/cost-proposals/apply-workspace',
@@ -8330,16 +8334,21 @@ function CostProposalCard({ prop, busy, focused, onMark, onDismiss, onChanged, s
                 an empty box that only errors on Apply. */ ''}
           ${!prop.target_path ? html`
             <div class="sz-note" style="margin-top:6px;font-size:12px">
-              tokenjam doesn't know this project's path, so it can't choose the <code>CLAUDE.md</code> for you. Two ways forward:
+              tokenjam doesn't know this project's path yet, so it can't choose the <code>CLAUDE.md</code> for you. Two ways forward:
               <div style="margin-top:4px">1. paste the project's <code>CLAUDE.md</code> path below and apply it directly, or</div>
-              <div style="margin-top:2px">2. run <code>tj onboard --add-project</code> from that repo to register it; tokenjam then knows the path and can target it for you.</div>
+              <div style="margin-top:4px;display:flex;align-items:center;gap:8px;flex-wrap:wrap">
+                <span>2. register the project once so tokenjam fills it in for you: run this from that repo</span>
+                <span style="display:inline-flex;align-items:center;gap:6px">
+                  <code>tj onboard --add-project</code><${CopySnippetButton} text="tj onboard --add-project" />
+                </span>
+              </div>
             </div>
           ` : null}
           <div style="display:flex;gap:8px;margin-top:6px;flex-wrap:wrap">
             <input class="rename-input" style="flex:1;min-width:280px" value=${target}
               placeholder="/absolute/path/to/project/CLAUDE.md" onInput=${e => setTarget(e.target.value)} />
-            <button class="cur-btn" disabled=${wbusy} onClick=${() => applyWorkspace(false)}>${wbusy ? 'working…' : 'Preview note'}</button>
-            <button class="cur-btn primary" disabled=${wbusy} onClick=${() => applyWorkspace(true)}>Apply note →</button>
+            <button class="cur-btn" disabled=${wbusy || !target.trim()} onClick=${() => applyWorkspace(false)}>${wbusy ? 'working…' : 'Preview note'}</button>
+            <button class="cur-btn primary" disabled=${wbusy || !target.trim()} onClick=${() => applyWorkspace(true)}>Apply note →</button>
           </div>
           ${preview ? html`<pre class="rev-diff" style="margin:8px 0 0;white-space:pre-wrap;font-size:11.5px">${preview}</pre>` : null}
           ${werr ? html`<div style="color:var(--error);font-size:12px;margin-top:6px">${werr}</div>` : null}

--- a/tokenjam/ui/index.html
+++ b/tokenjam/ui/index.html
@@ -1601,17 +1601,62 @@ const API_KEY = apiKeyMeta ? apiKeyMeta.getAttribute('content') : null;
 const writeTokenMeta = document.querySelector('meta[name="tj-write-token"]');
 const WRITE_TOKEN = writeTokenMeta ? writeTokenMeta.getAttribute('content') : null;
 
-async function api(path, params = {}) {
+// --- GET response cache ---
+// The App hard-unmounts each view on navigation, so returning to a page
+// refetches every section from scratch (the expensive /analytics "Spend by
+// model" pivot, the Recoverable panel, etc. all flash-reload). A small
+// module-level cache serves navigation-return reads instantly.
+//
+// Scope: safe idempotent READS only, and only the heavy / slow-changing
+// endpoints below — never the fast live pollers (/status, /traces, /alerts,
+// /drift, /budget, /sessions/*, /runs/*, /expectations), nor the Review inbox's
+// 8s /relearn proposal polls, which keep hitting the network on every poll
+// exactly as before (a short-TTL cache would defeat their fast refresh). Any
+// mutation (apiPost / *OrDetail) clears the whole cache, so a read never lingers
+// stale after a write. Force-bypass with api(path, params, { noCache: true })
+// for polls that must be fresh even on a cacheable endpoint (the Cost view's
+// 30s poll uses this).
+const API_CACHE_TTL_MS = 45000;
+const CACHEABLE_READ_PREFIXES = [
+  '/analytics', '/cost', '/optimize', '/recommendations',
+  '/relearn/applied',
+  '/summarize/backups', '/summarize/candidates',
+  '/summarize/staged', '/summarize/capabilities',
+];
+const apiCache = new Map(); // key -> { at: epochMs, promise: Promise<data> }
+const isCacheableRead = (path) => CACHEABLE_READ_PREFIXES.some(p => path.startsWith(p));
+function clearApiCache() { apiCache.clear(); }
+
+async function api(path, params = {}, opts = {}) {
   const qs = new URLSearchParams();
   for (const [k, v] of Object.entries(params)) {
     if (v != null && v !== '') qs.set(k, v);
   }
   const url = '/api/v1' + path + (qs.toString() ? '?' + qs : '');
+  const cacheable = isCacheableRead(path);
+  const key = 'GET ' + url;
+  if (cacheable && !opts.noCache) {
+    const hit = apiCache.get(key);
+    // Fresh (< TTL) -> return immediately; stale/miss -> fall through and fetch
+    // (await-on-stale). In-flight requests are shared via the stored promise.
+    if (hit && (Date.now() - hit.at) < API_CACHE_TTL_MS) return hit.promise;
+  }
   const headers = {};
   if (API_KEY) headers['Authorization'] = 'Bearer ' + API_KEY;
-  const resp = await fetch(url, { headers });
-  if (!resp.ok) throw new Error(`API ${resp.status}`);
-  return resp.json();
+  const promise = fetch(url, { headers }).then(resp => {
+    if (!resp.ok) throw new Error(`API ${resp.status}`);
+    return resp.json();
+  });
+  if (cacheable) {
+    // Store even on a noCache fetch so the cache stays warm for the next
+    // navigation-return; evict on failure so errors are never cached.
+    apiCache.set(key, { at: Date.now(), promise });
+    promise.catch(() => {
+      const cur = apiCache.get(key);
+      if (cur && cur.promise === promise) apiCache.delete(key);
+    });
+  }
+  return promise;
 }
 
 async function apiPost(path, body) {
@@ -1621,6 +1666,8 @@ async function apiPost(path, body) {
   const resp = await fetch('/api/v1' + path, {
     method: 'POST', headers, body: JSON.stringify(body),
   });
+  // Any mutation invalidates cached reads so stale data never lingers.
+  clearApiCache();
   if (!resp.ok) throw new Error(`API ${resp.status}`);
   return resp.json();
 }
@@ -1635,6 +1682,8 @@ async function apiPostOrDetail(path, body) {
   const resp = await fetch('/api/v1' + path, {
     method: 'POST', headers, body: JSON.stringify(body),
   });
+  // Any mutation invalidates cached reads so stale data never lingers.
+  clearApiCache();
   let data = null;
   try { data = await resp.json(); } catch (e) { /* no/empty body */ }
   if (!resp.ok) {
@@ -5608,22 +5657,22 @@ function CostView({ params }) {
   const [st, setSt] = useState({ loading: true, error: null, rows: [], total: 0,
     totalTokens: 0, framing: null, costResp: null, compare: null, cacheResp: null });
 
-  const load = useCallback(async () => {
+  const load = useCallback(async (opts = {}) => {
     setSt(s => ({ ...s, loading: s.rows.length === 0, error: null }));
     try {
       const tableGroup = groupBy === 'total' ? 'day' : groupBy;
       // One /cost call returns the grouped table `rows` + the daily `series`
       // (per date+agent+model) the chart needs + framing + totals (#113).
-      const d = await api('/cost', { since, group_by: tableGroup, agent_id: agentId || undefined });
+      const d = await api('/cost', { since, group_by: tableGroup, agent_id: agentId || undefined }, opts);
       let compare = null;
       try {
-        compare = await api('/cost/compare', { since, compare: 'previous', agent_id: agentId || undefined });
+        compare = await api('/cost/compare', { since, compare: 'previous', agent_id: agentId || undefined }, opts);
       } catch (_) { compare = null; }
       // Cache-savings series (#212). Best-effort: a failure here must not blank
       // the cost screen, so it falls back to null (card renders nothing).
       let cacheResp = null;
       try {
-        cacheResp = await api('/cost/cache', { since, agent_id: agentId || undefined });
+        cacheResp = await api('/cost/cache', { since, agent_id: agentId || undefined }, opts);
       } catch (_) { cacheResp = null; }
       const totalTokens = d.total_tokens != null
         ? d.total_tokens
@@ -5635,7 +5684,8 @@ function CostView({ params }) {
     }
   }, [since, groupBy, agentId]);
 
-  useEffect(() => { load(); const t = setInterval(load, 30000); return () => clearInterval(t); }, [load]);
+  // Poll bypasses the GET cache so the 30s refresh always hits the network.
+  useEffect(() => { load(); const t = setInterval(() => load({ noCache: true }), 30000); return () => clearInterval(t); }, [load]);
 
   const { loading, error, rows, total, totalTokens, framing, costResp, compare, cacheResp } = st;
   const useTokens = !!framing && (framing.pricing_mode === 'subscription' || framing.pricing_mode === 'local');
@@ -8787,6 +8837,9 @@ function DashboardView({ params }) {
 
   useEffect(() => {
     load();
+    // The live tiles (/status, /traces, /alerts, /drift) are excluded from the
+    // GET cache, so each poll refetches them fresh; the slow /cost, /optimize and
+    // /relearn reads honor the short cache TTL (refresh within ~45s).
     const timer = setInterval(() => { if (document.visibilityState === 'visible') load(); }, 30000);
     const onVis = () => { if (document.visibilityState === 'visible') load(); };
     document.addEventListener('visibilitychange', onVis);

--- a/tokenjam/ui/index.html
+++ b/tokenjam/ui/index.html
@@ -8963,8 +8963,57 @@ const VIEW_LENS = {
 };
 
 // ============================
-// App Router
+// App Router — keep-alive
 // ============================
+// Each PRIMARY sidebar view mounts once and then STAYS mounted; navigation
+// toggles visibility (display:none) instead of unmounting, so a view's
+// component state + already-fetched data survive navigation and returning to a
+// page is instant with no re-fetch spinner. The registry is the single source
+// of truth for view → component wiring (it replaced the switch-and-unmount
+// router). Detail/param views (session/trace/run detail) are NOT kept alive —
+// they mount fresh per id via detailNodeFor (a brief load on drill-in is
+// expected and fine).
+const PRIMARY_VIEWS = [
+  ['dashboard', DashboardView],
+  ['review',    ReviewInboxView],
+  ['sessions',  StatusView],
+  ['traces',    TracesListView],
+  ['cost',      CostView],
+  ['analytics', AnalyticsView],
+  ['alerts',    AlertsView],
+  ['drift',     DriftView],
+  ['optimize',  OptimizeView],
+  ['summarize', SummarizeView],
+  ['budget',    BudgetView],
+];
+const PRIMARY_KEYS = new Set(PRIMARY_VIEWS.map(([k]) => k));
+const EMPTY_PARAMS = new URLSearchParams();
+const WARM_STAGGER_MS = 120;   // gap between mounting each warmed-on-boot view
+
+// Map a raw route to the keep-alive primary key that frames it. #/overview is a
+// retired alias for the Dashboard; #/status and #/runs are silent aliases for
+// Sessions (they render the same StatusView); #/optimize/summarize is the
+// Summarize sub-view. Anything else is its own view key.
+function primaryKeyFor(route) {
+  const v = route.view;
+  if (v === 'overview') return 'dashboard';
+  if (v === 'status' || v === 'runs') return 'sessions';
+  if (v === 'optimize' && route.param === 'summarize') return 'summarize';
+  return v;
+}
+
+// Detail overlay for an id-keyed drill-in (mounts fresh per id), else null.
+// Only session/trace/run detail are id-keyed; summarize is a kept-alive
+// sub-view (in PRIMARY_VIEWS), not a per-id detail.
+function detailNodeFor(route) {
+  const id = route.param;
+  if (!id) return null;
+  if (route.view === 'sessions' || route.view === 'status') return html`<${SessionDetailView} sessionId=${id} />`;
+  if (route.view === 'traces') return html`<${TraceDetailView} traceId=${id} />`;
+  if (route.view === 'runs') return html`<${RunDetailView} runId=${id} />`;
+  return null;
+}
+
 function App() {
   const [route, setRoute] = useState(getRoute());
 
@@ -9010,37 +9059,65 @@ function App() {
     });
   }, [route.view, route.param]);
 
-  const p = route.params;
-  switch (route.view) {
-    // Improve lens home — the self-improve loop's Approve stage (SPEC.md §12).
-    case 'review': return html`<${ReviewInboxView} params=${p} />`;
-    // Overview retired — the Dashboard's triage band subsumes it. Lingering
-    // #/overview bookmarks/links fall through to the Dashboard.
-    case 'overview':
-    case 'dashboard': return html`<${DashboardView} params=${p} />`;
-    // #/status is a legacy alias kept for old bookmarks — its sidebar entry was
-    // removed (it duplicated Sessions, which renders the same StatusView). New
-    // navigation uses #/sessions; do not re-add a Status nav link.
-    case 'status':
-    case 'sessions':
-      if (route.param) return html`<${SessionDetailView} sessionId=${route.param} />`;
-      return html`<${StatusView} params=${p} />`;
-    case 'traces':
-      if (route.param) return html`<${TraceDetailView} traceId=${route.param} />`;
-      return html`<${TracesListView} params=${p} />`;
-    case 'runs':
-      if (route.param) return html`<${RunDetailView} runId=${route.param} />`;
-      return html`<${StatusView} params=${p} />`;
-    case 'cost': return html`<${CostView} params=${p} />`;
-    case 'analytics': return html`<${AnalyticsView} params=${p} />`;
-    case 'alerts': return html`<${AlertsView} params=${p} />`;
-    case 'drift': return html`<${DriftView} params=${p} />`;
-    case 'optimize':
-      if (route.param === 'summarize') return html`<${SummarizeView} params=${p} />`;
-      return html`<${OptimizeView} params=${p} />`;
-    case 'budget': return html`<${BudgetView} params=${p} />`;
-    default: return html`<div class="empty">Page not found.</div>`;
+  const primaryKey = primaryKeyFor(route);
+  const detail = detailNodeFor(route);
+
+  // Per-view params: only the ACTIVE primary view receives the live route
+  // params; hidden views keep their last params so a param meant for one view
+  // never perturbs another. The active view thus reacts to its OWN route param
+  // change (a filter/preset in the hash → its load() deps change → refetch),
+  // while a hidden view stays put until it's re-activated (then it revalidates
+  // in the background, still showing its last data — never a spinner). Written
+  // during render as a plain memo of "last params seen while active".
+  const paramsByView = useRef({});
+  if (!detail && PRIMARY_KEYS.has(primaryKey)) {
+    paramsByView.current[primaryKey] = route.params;
   }
+
+  // Warm-all-on-boot: start with ONLY the active view mounted so the first
+  // paint isn't slowed by the others, then progressively mount the rest
+  // (hidden) after first paint — staggered via requestIdleCallback so boot
+  // doesn't fire every endpoint at once (a thundering herd). Once mounted, a
+  // view stays mounted (keep-alive), so its on-mount fetch + poll keep its data
+  // warm for an instant first visit.
+  const [mounted, setMounted] = useState(() => new Set([primaryKey]));
+  const mountedRef = useRef(mounted);
+  mountedRef.current = mounted;
+
+  // If the user navigates to a view before warming has reached it, mount it now.
+  useEffect(() => {
+    if (PRIMARY_KEYS.has(primaryKey) && !mountedRef.current.has(primaryKey)) {
+      setMounted(prev => { const n = new Set(prev); n.add(primaryKey); return n; });
+    }
+  }, [primaryKey]);
+
+  useEffect(() => {
+    const idle = window.requestIdleCallback || (cb => setTimeout(cb, 1));
+    let cancelled = false;
+    let i = 0;
+    const pump = () => {
+      if (cancelled || i >= PRIMARY_VIEWS.length) return;
+      const k = PRIMARY_VIEWS[i++][0];
+      setMounted(prev => (prev.has(k) ? prev : new Set(prev).add(k)));
+      setTimeout(() => idle(pump), WARM_STAGGER_MS);
+    };
+    idle(pump);
+    return () => { cancelled = true; };
+  }, []);
+
+  // Keep-alive stack: every mounted primary view renders, but only the active
+  // one is visible; the rest are display:none (kept mounted, state intact). A
+  // detail drill-in (mounted fresh, keyed by id) overlays the hidden stack.
+  return html`
+    ${PRIMARY_VIEWS.map(([key, Comp]) => {
+      if (!mounted.has(key)) return null;
+      const isActive = !detail && key === primaryKey;
+      const vp = paramsByView.current[key] || EMPTY_PARAMS;
+      return html`<div key=${key} class="view-pane" style=${isActive ? '' : 'display:none'}><${Comp} params=${vp} /></div>`;
+    })}
+    ${detail ? html`<div key=${'detail:' + route.view + ':' + route.param} class="view-pane">${detail}</div>` : null}
+    ${!detail && !PRIMARY_KEYS.has(primaryKey) ? html`<div class="empty">Page not found.</div>` : null}
+  `;
 }
 
 render(html`<${App} />`, document.getElementById('app'));

--- a/tokenjam/ui/index.html
+++ b/tokenjam/ui/index.html
@@ -1552,8 +1552,8 @@ code.md-code {
     <button type="button" class="lens-btn active" data-lens="improve">Improve</button>
     <button type="button" class="lens-btn" data-lens="observe">Observe</button>
   </div>
-  <a href="#/review" class="nav-link" data-view="review" data-lens="improve"><span class="icon">&#9745;</span> Review inbox</a>
   <a href="#/dashboard" class="nav-link" data-view="dashboard" data-lens="improve"><span class="icon">&#9678;</span> Dashboard</a>
+  <a href="#/review" class="nav-link" data-view="review" data-lens="improve"><span class="icon">&#9745;</span> Review inbox</a>
   <!-- One Sessions entry, not two. The old "Status" link (#/status) and this
        one rendered the SAME StatusView for their bare route, so the sidebar
        advertised two items that were one page. This #/sessions link is the one


### PR DESCRIPTION
## Summary

This started as a Review-inbox density fix and grew into a broader Lens UI pass with two themes: (1) polish and correctness fixes across the inbox, nav, and serve path; (2) a real performance pass that makes dashboard navigation instant and stops every page from reloading when you switch away and back.

## Performance — navigation & loading

- **Keep-alive router.** Primary nav views now mount once and stay mounted; navigation toggles visibility instead of unmounting the view. Returning to a page is instant and never re-runs its fetches, because the view's state and data survive navigation. Detail drill-ins (session / trace by id) still mount fresh per id.
- **Warm on boot.** After the dashboard's first paint, the remaining views are progressively mounted in the background (staggered via `requestIdleCallback`) so every page is already warm on first visit, instead of loading on arrival.
- **Render stale immediately.** A view that already has data never flips back to a loading skeleton on a background poll or refresh; the spinner only appears on a genuine first load.
- **`api()` response cache.** GET-only, ~45s stale-while-revalidate, cleared on any mutation, and scoped to the heavy / slow-changing endpoints (`/analytics`, `/cost*`, `/optimize`, ...). Fast-polling live views (status, traces, review inbox) are intentionally left uncached so they stay fresh.
- **Analytics endpoint latency.** `get_analytics` folds its KPI-totals and per-bucket-series scans into a single `GROUP BY ROLLUP` pass (from 4–5 serial scans over `spans` down to 3). Output is verified byte-for-byte identical across metric × dimension shapes.

## Review inbox & navigation polish

- Reduce inbox cards to the mockup and stop re-offering fixes that have already been applied.
- Recognise the pre-rename marker as TokenJam's own (relearn apply).
- Collapse the duplicate Status / Sessions nav into a single Sessions page; `#/status` stays as a silent route alias for old bookmarks.
- Sizing-note apply is guidance-first (no error-after-click), and the apply card now explains the unregistered-project case.
- Order the sidebar: Dashboard, then Review inbox, then Sessions.

## Backend / serve

- Persona-gate the resend advisory's `cache_control` snippet in the optimize output.
- Set `SO_REUSEADDR` on the serve port pre-check so a quick restart no longer trips on a stale bind.

## Verification

- Offline-UI, Lens-regression, and analytics suites pass locally (unit + integration); the Lens regression assertions were adapted to the keep-alive structure with their intent preserved.
- Keep-alive verified in a real browser: all primary view panes mount, exactly one is visible at a time, no loading skeleton appears on return, and the sidebar order is confirmed live.
- The analytics coalesce is proven output-equivalent (byte-for-byte) against the pre-change endpoint.
