### PR TITLE
Put deadweight's recoverable estimate on the same window basis as every other cost analyzer

### DIFF
--- a/tests/unit/test_cost_proposals.py
+++ b/tests/unit/test_cost_proposals.py
@@ -231,7 +231,7 @@ def _dead_server(**overrides):
     fields = dict(
         name="apollo", scope="project", source="/repo/.mcp.json",
         sessions_present=10, invocations=0, deferred_sessions=0, dead=True,
-        estimated_tax_tokens_per_session=25_000, estimated_tax_tokens_90d=225_000,
+        estimated_tax_tokens_per_session=25_000, estimated_tax_tokens_window=225_000,
         tax_construction="25,000 tok/session (full schema injection), cited estimate.",
         fix="Remove or project-scope the `apollo` MCP server (/repo/.mcp.json); "
             "zero tool calls across 10 session(s) in this window.",
@@ -251,7 +251,7 @@ def _deadweight_finding(dead_servers=None, tax_table=None):
     return DeadweightFinding(
         sessions_scanned=10, configured_servers=1,
         servers=dead_servers, dead_servers=dead_servers, tax_table=tax_table,
-        estimated_recoverable_tokens=sum(s.estimated_tax_tokens_90d for s in dead_servers) or None,
+        estimated_recoverable_tokens=sum(s.estimated_tax_tokens_window for s in dead_servers) or None,
         estimate_basis="dead-server 90d tax sum",
     )
 
@@ -286,7 +286,7 @@ def test_deadweight_proposal_carries_priced_usd_from_server():
     server = _dead_server(
         priced_model="claude-opus-4-8",
         estimated_tax_usd_per_session=0.125,
-        estimated_tax_usd_90d=1.40625,
+        estimated_tax_usd_window=1.40625,
     )
     p = _deadweight_to_proposals(_deadweight_finding(dead_servers=[server]))[0]
     assert p.estimated_recoverable_usd == 1.40625
@@ -325,7 +325,7 @@ def test_deadweight_tax_table_never_becomes_a_second_proposal():
     from tokenjam.core.optimize.analyzers.deadweight import ContextTaxRow
     from tokenjam.core.optimize.cost_proposals import _deadweight_to_proposals
 
-    dead = _dead_server(name="apollo", estimated_tax_tokens_90d=225_000)
+    dead = _dead_server(name="apollo", estimated_tax_tokens_window=225_000)
     finding = _deadweight_finding(
         dead_servers=[dead],
         tax_table=[
@@ -908,42 +908,66 @@ def test_rollup_with_no_token_estimates_reports_zero_coverage():
     assert "floor, not a total" not in rollup["estimate_basis"]
 
 
-# --- Review inbox monthly-basis fields (behavioral requirement #1) ----------- #
+# --- Review inbox monthly-basis fields (#273: single central projection) ---- #
 
-def test_downsize_proposal_surfaces_its_own_monthly_projection():
-    # `downsize` already computes a 30-day projection (model_downgrade.py's
-    # `monthly_savings_usd`/`monthly_tokens_in_candidates`) — surfaced onto the
-    # proposal directly, never re-derived by the generic extrapolation below.
+def test_downsize_monthly_uses_the_same_central_projection_as_everyone_else():
+    # #273: downsize no longer self-projects into the shared monthly field
+    # (model_downgrade.py's own `monthly_savings_usd` used to be copied
+    # straight onto the proposal) — its estimated_monthly_usd now comes from
+    # the SAME central ratio every other analyzer's does, applied uniformly
+    # in `cost_proposals_from_report`.
     props = {p.analyzer: p for p in cost_proposals_from_report(_report())}
-    assert props["downsize"].estimated_monthly_usd == 3.0
-    assert props["downsize"].estimated_monthly_tokens == 0   # fixture's default
+    dsz = props["downsize"]
+    # `_report()`'s window (5 days, 10 sessions) is far below the projection
+    # guardrails (>=14 window days, >=8 active days, >=20 sessions), so no
+    # projection applies: the monthly figure equals the observed one.
+    assert dsz.estimated_monthly_usd == pytest.approx(dsz.estimated_recoverable_usd)
+    # The window-wide downsize card never sets a token estimate, so there is
+    # nothing to project a monthly token figure from either — no more
+    # silently claiming "0 monthly tokens" for an unmeasured quantity.
+    assert dsz.estimated_recoverable_tokens is None
+    assert dsz.estimated_monthly_tokens is None
 
 
-def test_non_downsize_proposals_get_generic_monthly_extrapolation():
-    # cache/trim carry no monthly figure of their own, so a report built over
-    # a NON-30-day window gets a generic `30/window_days` extrapolation of
-    # the window figure, applied once in `cost_proposals_from_report`. Assert
-    # the SCALING RELATIONSHIP to the adapter's own window figure (its exact
-    # dollar value is computed from `estimate_cache_recoverable`/pricing.py
-    # internals, not the fixture's finding-level field, which `_cache_to_
-    # proposals` doesn't read) — the `cache` finding also fans out into
-    # several signature-distinct cards, so select by signature.
-    at_default = {p.signature: p for p in cost_proposals_from_report(_report())}
+def test_thin_window_reports_observed_not_a_fabricated_projection():
+    # Below the guardrails (here: 10 window days < the 14-day floor), every
+    # analyzer's monthly figure is left AT its window figure — never scaled
+    # by a ratio computed from too little data.
     at_10d = {p.signature: p for p in cost_proposals_from_report(_report(), window_days=10.0)}
-    cache_default = at_default["cost:cache:anthropic:claude-sonnet-5"]
     cache_10d = at_10d["cost:cache:anthropic:claude-sonnet-5"]
-    assert cache_default.estimated_monthly_usd == pytest.approx(cache_default.estimated_recoverable_usd)
-    assert cache_10d.estimated_monthly_usd == pytest.approx(cache_default.estimated_recoverable_usd * 3.0)
-    trim_default = at_default["cost:trim:svc-a"]
-    trim_10d = at_10d["cost:trim:svc-a"]
-    assert trim_10d.estimated_monthly_usd == pytest.approx(trim_default.estimated_recoverable_usd * 3.0)
-    assert trim_10d.estimated_monthly_tokens == round(trim_default.estimated_recoverable_tokens * 3.0)
+    assert cache_10d.estimated_monthly_usd == pytest.approx(cache_10d.estimated_recoverable_usd)
+
+
+def test_projection_ratio_scales_every_cost_analyzer_the_same_way():
+    # A window that clears every guardrail (>=14 window days, >=8 active
+    # days, >=20 sessions): 10 active days over a 30-day window ->
+    # ratio = min(30/10, 3.0) = 3.0, floored no further since window_days<=30
+    # already yields 3.0. Every analyzer — including downsize — gets scaled
+    # by this SAME ratio; #273's whole point is that there is no longer a
+    # per-analyzer special case here.
+    rep = _report()
+    rep.window = WindowSummary(
+        since=MARKER, until=NOW, days=30, sessions=25, spans=100,
+        total_tokens=1, total_cost_usd=5.0, thin_data=False, active_days=10,
+    )
+    scaled = {p.signature: p for p in cost_proposals_from_report(rep, window_days=30.0)}
+
+    cache = scaled["cost:cache:anthropic:claude-sonnet-5"]
+    assert cache.estimated_monthly_usd == pytest.approx(cache.estimated_recoverable_usd * 3.0)
+
+    trim = scaled["cost:trim:svc-a"]
+    assert trim.estimated_monthly_usd == pytest.approx(trim.estimated_recoverable_usd * 3.0)
+    assert trim.estimated_monthly_tokens == round(trim.estimated_recoverable_tokens * 3.0)
+
+    downsize = scaled["cost:downsize"]
+    assert downsize.estimated_monthly_usd == pytest.approx(downsize.estimated_recoverable_usd * 3.0)
 
 
 def test_default_window_is_already_the_monthly_basis_no_scaling():
-    # `cost_proposals_from_report`'s default `window_days` (30.0) matches the
-    # daemon's own default look-back, so an un-scoped call needs no scaling:
-    # the monthly figure equals the window figure exactly.
+    # `cost_proposals_from_report`'s default `window_days` (30.0) still falls
+    # below `_report()`'s thin fixture window's guardrails, so an un-scoped
+    # call needs no scaling: the monthly figure equals the window figure
+    # exactly (the observed-only state, not a coincidental ratio of 1.0).
     by_sig = {p.signature: p for p in cost_proposals_from_report(_report())}
     cache = by_sig["cost:cache:anthropic:claude-sonnet-5"]
     assert cache.estimated_monthly_usd == pytest.approx(cache.estimated_recoverable_usd)
@@ -1142,14 +1166,19 @@ def test_read_cost_proposals_reports_error_state_before_any_success(tmp_path):
 
 # --- Real-data validation follow-ups: dollar-first headline, sort, formatting -
 
-def test_downsize_agent_row_monthly_usd_matches_its_own_evidence_text():
+def test_downsize_agent_row_leaves_monthly_to_the_central_projection():
     # Reproduces the founder's real "Model over-sizing in claude-code
     # (claude-opus-4-7 to claude-haiku-4-5)" card: a per-agent price row is
     # the path that produced it (_downsize_agent_proposals, not the window-
-    # wide aggregate _report() fixture above exercises). estimated_monthly_usd
-    # and the evidence string's own "$X per 30 days" figure both come from
-    # the SAME row.projected_30d_delta_usd — assert they never diverge, so a
-    # dollar-computable downsize card can never render a tokens-only headline.
+    # wide aggregate _report() fixture above exercises). #273: the adapter no
+    # longer self-projects `row.projected_30d_delta_usd` onto
+    # estimated_monthly_usd (that figure is `window_days`-based, computed
+    # inside model_downgrade.py — exactly the per-analyzer self-projection
+    # the approved design forbids for the shared field) — calling the
+    # adapter directly (bypassing `cost_proposals_from_report`'s central
+    # pass) leaves it unset. The evidence paragraph's own "$X per 30 days"
+    # arithmetic disclosure is untouched; it's a plain string built from the
+    # row, independent of this field.
     from tokenjam.core.optimize.analyzers.downsize_agents import build_agent_price_rows
     from tokenjam.core.optimize.cost_proposals import _downsize_agent_proposals
 
@@ -1169,11 +1198,12 @@ def test_downsize_agent_row_monthly_usd_matches_its_own_evidence_text():
     props = _downsize_agent_proposals(_Finding(), config=None)
     assert len(props) == 1
     prop = props[0]
-    assert prop.estimated_monthly_usd is not None
-    assert prop.estimated_monthly_usd > 0
-    assert prop.estimated_monthly_usd == rows[0].projected_30d_delta_usd
-    # The evidence paragraph's own "$X per 30 days" is the identical number.
-    assert f"{prop.estimated_monthly_usd:,.2f}" in prop.evidence or f"{prop.estimated_monthly_usd:.4f}" in prop.evidence
+    assert prop.estimated_monthly_usd is None
+    assert prop.estimated_recoverable_usd == rows[0].delta_usd
+    # The evidence paragraph's own "$X per 30 days" arithmetic line still
+    # cites the row's own projection, unaffected by the CostProposal field.
+    monthly = rows[0].projected_30d_delta_usd
+    assert f"{monthly:,.2f}" in prop.evidence or f"{monthly:.4f}" in prop.evidence
 
 
 def test_backfill_legacy_monthly_fields_fills_only_absent_keys():

--- a/tests/unit/test_deadweight.py
+++ b/tests/unit/test_deadweight.py
@@ -175,7 +175,7 @@ def test_detects_dead_server_at_threshold(tmp_path):
     assert dead.sessions_present == MIN_SESSIONS_DEADWEIGHT
     assert dead.invocations == 0
     assert dead.estimated_tax_tokens_per_session == FULL_SCHEMA_TAX_TOKENS
-    assert finding.estimated_recoverable_tokens == dead.estimated_tax_tokens_90d
+    assert finding.estimated_recoverable_tokens == dead.estimated_tax_tokens_window
     assert finding.estimated_recoverable_tokens > 0
 
 
@@ -199,8 +199,8 @@ def test_dead_server_prices_tax_in_usd_via_pricing_table(tmp_path):
     assert dead.estimated_tax_usd_per_session == round(
         dead.estimated_tax_tokens_per_session / 1_000_000 * rates.input_per_mtok, 6,
     )
-    assert dead.estimated_tax_usd_90d > 0
-    assert finding.estimated_recoverable_usd == dead.estimated_tax_usd_90d
+    assert dead.estimated_tax_usd_window > 0
+    assert finding.estimated_recoverable_usd == dead.estimated_tax_usd_window
     assert "Priced at claude-opus-4-8's input rate" in dead.tax_construction
 
 
@@ -221,7 +221,7 @@ def test_no_priced_model_leaves_usd_none(tmp_path):
 
     assert dead.priced_model == ""
     assert dead.estimated_tax_usd_per_session is None
-    assert dead.estimated_tax_usd_90d is None
+    assert dead.estimated_tax_usd_window is None
     assert finding.estimated_recoverable_usd is None
     assert "No dollar estimate" in dead.tax_construction
 
@@ -534,7 +534,7 @@ def test_dead_server_tax_not_double_counted_between_table_and_total(tmp_path):
     # The tax table's own MCP row and the recoverable total both derive from
     # the SAME per-server figure, but the total must equal exactly the dead
     # servers' sum -- never (tax table total) + (recoverable total).
-    assert finding.estimated_recoverable_tokens == dead.estimated_tax_tokens_90d
+    assert finding.estimated_recoverable_tokens == dead.estimated_tax_tokens_window
     assert mcp_row.total_tokens_window == dead.estimated_tax_tokens_per_session * dead.sessions_present
 
 
@@ -637,7 +637,7 @@ def test_render_deadweight_omits_dollars_when_no_model_was_priced(tmp_path, caps
         ])
 
     finding = compute_deadweight_finding(_SINCE, _UNTIL, projects_root=root)
-    assert finding.dead_servers[0].estimated_tax_usd_90d is None
+    assert finding.dead_servers[0].estimated_tax_usd_window is None
 
     _render_deadweight(finding, pricing_mode="api", marker="①")
     out = capsys.readouterr().out

--- a/tokenjam/api/routes/relearn.py
+++ b/tokenjam/api/routes/relearn.py
@@ -470,7 +470,16 @@ def get_cost_proposals(request: Request) -> dict[str, Any]:
         if rec.get("state") != "reverted"
     }
     open_proposals = [p for p in proposals if p.get("signature") not in applied_sigs]
-    rollup = cost_proposals_mod.estimated_recoverable_rollup(open_proposals)
+    # The window this batch of proposals was actually computed over (#273) —
+    # stored alongside them at recompute time, never re-derived here, so the
+    # rollup's projection ratio matches the data that produced these figures.
+    rollup_kwargs: dict[str, Any] = {}
+    if block:
+        if block.get("cost_window_days"):
+            rollup_kwargs["window_days"] = block["cost_window_days"]
+        rollup_kwargs["active_days"] = block.get("cost_active_days") or 0
+        rollup_kwargs["n_sessions"] = block.get("cost_n_sessions") or 0
+    rollup = cost_proposals_mod.estimated_recoverable_rollup(open_proposals, **rollup_kwargs)
     # Same plan-tier framing the cost-applied payload carries, so a dollar
     # figure rendered here never disagrees with its sibling surfaces.
     framing = _framing(request)

--- a/tokenjam/cli/cmd_optimize.py
+++ b/tokenjam/cli/cmd_optimize.py
@@ -2187,16 +2187,16 @@ def _render_deadweight(
             # Dollars only when a priced model was actually observed for this
             # server. None means no rate was available, and printing $0.00
             # there would read as "this costs nothing".
-            if pricing_mode == "api" and s.estimated_tax_usd_90d is not None:
+            if pricing_mode == "api" and s.estimated_tax_usd_window is not None:
                 tax = (
-                    f"~{format_tokens(s.estimated_tax_tokens_90d)} tokens / "
-                    f"{format_cost(s.estimated_tax_usd_90d)} over 90 days "
+                    f"~{format_tokens(s.estimated_tax_tokens_window)} tokens / "
+                    f"{format_cost(s.estimated_tax_usd_window)} in this window "
                     f"[dim](estimated, priced at {s.priced_model})[/dim]"
                 )
             else:
                 tax = (
-                    f"~{format_tokens(s.estimated_tax_tokens_90d)} tokens over "
-                    f"90 days [dim](estimated; no priced model observed for "
+                    f"~{format_tokens(s.estimated_tax_tokens_window)} tokens in "
+                    f"this window [dim](estimated; no priced model observed for "
                     f"this server, so no dollar figure)[/dim]"
                 )
             console.print(f"          [dim]tax[/dim] {tax}")

--- a/tokenjam/core/optimize/analyzers/deadweight.py
+++ b/tokenjam/core/optimize/analyzers/deadweight.py
@@ -605,7 +605,17 @@ class ServerDeadweight:
     deferred_sessions:                int
     dead:                             bool
     estimated_tax_tokens_per_session: int
-    estimated_tax_tokens_90d:         int
+    #: Window-scoped total (this server's per-session tax x sessions_present
+    #: it was present in over the ANALYZED window) — NO projection folded in.
+    #: A caller wanting a forward-looking figure applies the shared, centrally-
+    #: computed 30-day-pace ratio (`cost_proposals.compute_projection_ratio`)
+    #: on top of this, exactly like every other cost analyzer's window field
+    #: (the "Recoverable-savings contract", CLAUDE.md). See #273: this field
+    #: used to fold a fixed 90-day projection in directly, which made it
+    #: incomparable to every other analyzer's window-scoped figure and
+    #: silently corrupted the Review-inbox rollup's basis when summed
+    #: alongside them.
+    estimated_tax_tokens_window:      int
     tax_construction:                 str
     fix:                              str
     example_sessions:                 list[str] = field(default_factory=list)
@@ -614,7 +624,8 @@ class ServerDeadweight:
     #: ``None`` when no priced model was observed (never a fabricated rate).
     priced_model:                     str = ""
     estimated_tax_usd_per_session:    float | None = None
-    estimated_tax_usd_90d:            float | None = None
+    #: Window-scoped dollar total — see `estimated_tax_tokens_window` above.
+    estimated_tax_usd_window:         float | None = None
 
 
 @dataclass
@@ -650,13 +661,19 @@ def compute_deadweight_finding(
     until: datetime,
     *,
     projects_root: Path | str | None = None,
-    window_days: float | None = None,
     min_sessions: int = MIN_SESSIONS_DEADWEIGHT,
     cache_dir: Path | None = None,
 ) -> DeadweightFinding:
     """Full pipeline over a window of Claude Code transcripts. Never raises —
     a missing projects root, an unreadable transcript, or a malformed config
     file is skipped, not fatal.
+
+    Emits ``estimated_tax_tokens_window``/``estimated_tax_usd_window`` — the
+    tax OBSERVED over ``since``..``until``, with no internal projection
+    (#273). A forward-looking figure, when wanted, is the caller's job: the
+    Review-inbox rollup applies one shared, centrally-computed 30-day-pace
+    ratio on top of every cost analyzer's window figure alike, so a window
+    parameter has nothing left to do here.
 
     ``min_sessions`` overrides ``MIN_SESSIONS_DEADWEIGHT`` (config-overridable
     via ``core.config.OptimizeConfig.min_sessions_deadweight``); the module
@@ -706,11 +723,6 @@ def compute_deadweight_finding(
     if not configured:
         return finding
 
-    days = window_days if window_days and window_days > 0 else max(
-        (until - since).total_seconds() / 86400.0, 1.0,
-    )
-    projection_factor = 90.0 / days
-
     from tokenjam.core.pricing import get_rates, provider_for_model
 
     tax_rows: list[ContextTaxRow] = []
@@ -747,7 +759,10 @@ def compute_deadweight_finding(
             )
             if sessions_present else 0
         )
-        tax_90d = round(tax_per_session * sessions_present * projection_factor)
+        # Window-scoped total -- this server's per-session tax times the
+        # sessions it was present in over since..until. No projection: #273
+        # deleted the fixed 90-day multiplier that used to live here.
+        tax_window = tax_per_session * sessions_present
 
         # Price the token tax through core/pricing.py at the dominant model
         # observed across this server's present sessions -- never a
@@ -755,14 +770,14 @@ def compute_deadweight_finding(
         priced_model = _dominant_model(model_counts)
         input_per_mtok: float | None = None
         usd_per_session: float | None = None
-        usd_90d: float | None = None
+        usd_window: float | None = None
         if priced_model:
             provider = provider_for_model(priced_model) or "unknown"
             rates = get_rates(provider, priced_model)
             if rates is not None and rates.input_per_mtok > 0:
                 input_per_mtok = rates.input_per_mtok
                 usd_per_session = round(tax_per_session / 1_000_000 * input_per_mtok, 6)
-                usd_90d = round(tax_90d / 1_000_000 * input_per_mtok, 6)
+                usd_window = round(tax_window / 1_000_000 * input_per_mtok, 6)
             else:
                 priced_model = ""  # no rate available -- don't claim a model we can't price
 
@@ -775,7 +790,7 @@ def compute_deadweight_finding(
             deferred_sessions=deferred_sessions,
             dead=dead,
             estimated_tax_tokens_per_session=tax_per_session,
-            estimated_tax_tokens_90d=tax_90d,
+            estimated_tax_tokens_window=tax_window,
             tax_construction=_tax_construction_note(
                 non_deferred, deferred_sessions, sessions_present,
                 model=priced_model, input_per_mtok=input_per_mtok,
@@ -789,7 +804,7 @@ def compute_deadweight_finding(
             example_sessions=example_sessions,
             priced_model=priced_model,
             estimated_tax_usd_per_session=usd_per_session,
-            estimated_tax_usd_90d=usd_90d,
+            estimated_tax_usd_window=usd_window,
         )
         finding.servers.append(row)
         if sessions_present > 0:
@@ -841,15 +856,15 @@ def compute_deadweight_finding(
     # twice between the tax table and a dead-weight proposal.
     if finding.dead_servers:
         finding.estimated_recoverable_tokens = sum(
-            s.estimated_tax_tokens_90d for s in finding.dead_servers
+            s.estimated_tax_tokens_window for s in finding.dead_servers
         )
         priced = [
-            s.estimated_tax_usd_90d for s in finding.dead_servers
-            if s.estimated_tax_usd_90d is not None
+            s.estimated_tax_usd_window for s in finding.dead_servers
+            if s.estimated_tax_usd_window is not None
         ]
         basis = (
-            f"sum of each dead server's projected 90-day schema-injection tax "
-            f"({FULL_SCHEMA_TAX_TOKENS:,} tok/session full, "
+            f"sum of each dead server's schema-injection tax observed over "
+            f"this window ({FULL_SCHEMA_TAX_TOKENS:,} tok/session full, "
             f"{DEFERRED_SCHEMA_TAX_TOKENS:,} tok/session when deferred); the "
             f"tax table's own MCP-schema rows are informational only and "
             f"never double-count into this total."
@@ -900,7 +915,7 @@ def run(ctx: AnalyzerContext) -> None:
         optimize_cfg, "min_sessions_deadweight", MIN_SESSIONS_DEADWEIGHT,
     )
     ctx.report.findings["deadweight"] = compute_deadweight_finding(
-        ctx.since, ctx.until, window_days=ctx.window_days,
+        ctx.since, ctx.until,
         min_sessions=min_sessions,
         cache_dir=default_cache_dir(ctx.config),
     )

--- a/tokenjam/core/optimize/cost_proposals.py
+++ b/tokenjam/core/optimize/cost_proposals.py
@@ -153,6 +153,26 @@ class CostProposal:
     # to reimplement the arithmetic.
     estimated_monthly_usd:        float | None = None
     estimated_monthly_tokens:     int | None   = None
+    # Whether this proposal's waste RECURS at the user's own session pace
+    # (`"per_session"` — the shared, centrally-computed 30-day-pace ratio
+    # rescales it) or is a `"one_time"` fixed-occurrence / delete-this-
+    # artifact saving (never rescaled; its monthly figure always equals its
+    # window figure). See `compute_projection_ratio` and #273's approved
+    # design ("each analyzer declares scaling ... state the choice
+    # explicitly"). Defaulted here rather than repeated at every adapter's
+    # `CostProposal(...)` call site because EVERY current analyzer is
+    # `"per_session"`: downsize/cache/cache-recommend/resend/trim/subagent/
+    # script/reuse/verbosity/placement/deadweight's waste all recur every
+    # session (or call) the underlying condition persists — including the
+    # deadweight MCP tax, which keeps accruing every session the server stays
+    # configured even though ITS fix is a one-time config edit; the SAVING is
+    # what recurs, not the fix. `"one_time"` is reserved for a future
+    # analyzer whose estimate is a genuinely single fixed occurrence, which
+    # must set it explicitly at its own call site when it's added.
+    # (relearn's `RelearnCluster` estimates are a SEPARATE, unbounded-history
+    # system with no fixed window — not adapted into a `CostProposal` at all,
+    # so it carries no `scaling` field and is out of scope here.)
+    scaling:               str = "per_session"
     estimate_basis:       str = ""
     estimate_confidence:  str = COST_ESTIMATE_CONFIDENCE
     correlational:        bool = True
@@ -256,11 +276,17 @@ def _downsize_to_proposal(finding: Any, config: Any = None) -> list[CostProposal
         estimated_recoverable_usd=getattr(finding, "estimated_recoverable_usd", None),
         estimated_recoverable_tokens=getattr(finding, "estimated_recoverable_tokens", None),
         estimate_basis=str(getattr(finding, "estimate_basis", "") or ""),
-        # `downsize` already computes its own 30-day projection (model_downgrade.
-        # py's `monthly_savings_usd`/`monthly_tokens_in_candidates`) — surface it
-        # directly rather than re-deriving from the window figure.
-        estimated_monthly_usd=getattr(finding, "monthly_savings_usd", None),
-        estimated_monthly_tokens=getattr(finding, "monthly_tokens_in_candidates", None),
+        # `estimated_monthly_usd`/`estimated_monthly_tokens` are intentionally
+        # left unset here (#273): `model_downgrade.py`'s own
+        # `monthly_savings_usd`/`monthly_tokens_in_candidates` is a
+        # `30/window_days` projection computed inside the analyzer, which is
+        # exactly the per-analyzer self-projection the approved design
+        # forbids for the SHARED monthly basis — every analyzer's Review-inbox
+        # monthly figure must come from the ONE central ratio
+        # (`compute_projection_ratio`), applied uniformly in
+        # `cost_proposals_from_report`, or two analyzers' "monthly" figures
+        # are silently on different bases again. `monthly_savings_usd` itself
+        # is untouched and still backs the CLI's own `tj optimize` line.
     )]
 
 
@@ -436,17 +462,11 @@ def _downsize_agent_proposals(finding: Any, config: Any) -> list[CostProposal]:
             estimated_recoverable_usd=row.delta_usd,
             estimated_recoverable_tokens=row.total_tokens,
             estimate_basis=row.estimate_basis,
-            # `projected_30d_delta_usd` is this row's own 30-day projection
-            # (mirrors the window-wide card's `monthly_savings_usd`). No
-            # per-row monthly-token figure exists, so tokens are extrapolated
-            # by the SAME window->30d ratio the dollar figure already carries
-            # (`projected_30d_delta_usd / delta_usd`) rather than duplicating
-            # a window_days parameter down through this helper.
-            estimated_monthly_usd=row.projected_30d_delta_usd,
-            estimated_monthly_tokens=(
-                round(row.total_tokens * (row.projected_30d_delta_usd / row.delta_usd))
-                if row.delta_usd > 0 else None
-            ),
+            # `estimated_monthly_usd`/`estimated_monthly_tokens` are left
+            # unset here for the same reason as the window-wide downsize card
+            # above (#273): `row.projected_30d_delta_usd` is this row's own
+            # `window_days`-based self-projection, not the shared central
+            # ratio. The central function fills these in uniformly.
             agent_id=row.agent_id if row.agent_id != "unknown" else "",
             advise_only=not plumbing.get("apply_capable", False),
             apply_capable=bool(plumbing.get("apply_capable")),
@@ -1212,7 +1232,10 @@ def _deadweight_to_proposals(finding: Any) -> list[CostProposal]:
     ``estimated_recoverable_tokens`` / ``estimated_recoverable_usd``).
 
     ``estimated_recoverable_usd`` is carried straight off the analyzer's own
-    ``ServerDeadweight.estimated_tax_usd_90d`` — the analyzer already prices
+    ``ServerDeadweight.estimated_tax_usd_window`` — a WINDOW-scoped figure
+    with no projection folded in (#273: this used to be a fixed 90-day
+    projection, which made it incomparable to every other analyzer's window
+    figure and corrupted any sum across them). The analyzer already prices
     the token tax through ``core/pricing.py`` at the dominant model observed
     in that server's sessions (never a hardcoded rate; see
     ``deadweight._pricing_note``). Stays ``None`` when no priced model was
@@ -1276,12 +1299,9 @@ def _deadweight_to_proposals(finding: Any) -> list[CostProposal]:
             },
             advise_text=advise,
             suggestion=f"claude mcp remove {server.name} --scope {scope_flag}",
-            estimated_recoverable_tokens=server.estimated_tax_tokens_90d or None,
-            estimated_recoverable_usd=server.estimated_tax_usd_90d,
-            estimate_basis=(
-                server.tax_construction
-                + " Projected over a 90-day window from the sessions observed."
-            ),
+            estimated_recoverable_tokens=server.estimated_tax_tokens_window or None,
+            estimated_recoverable_usd=server.estimated_tax_usd_window,
+            estimate_basis=server.tax_construction,
             advise_only=not plumbing.get("apply_capable", False),
             apply_capable=bool(plumbing.get("apply_capable")),
             apply_kind=str(plumbing.get("apply_kind", "")),
@@ -1705,7 +1725,12 @@ def recompute_cost_proposals(
             return []
 
         try:
-            relearn_store.write_cost_proposals(proposals, config=config)
+            relearn_store.write_cost_proposals(
+                proposals, config=config,
+                window_days=effective_window_days,
+                active_days=int(getattr(report.window, "active_days", 0) or 0),
+                n_sessions=int(getattr(report.window, "sessions", 0) or 0),
+            )
             relearn_store.clear_cost_proposals_error(config=config)
         except Exception:
             pass
@@ -1755,6 +1780,88 @@ def trigger_background_cost_recompute(
     return True
 
 
+# --------------------------------------------------------------------------- #
+# The ONE central 30-day-pace projection (#273's approved design). Deleted
+# every per-analyzer self-projection (deadweight's old fixed 90-day factor,
+# downsize's own `monthly_savings_usd` feeding the shared field) in favor of
+# this single function, applied once here and again in
+# `estimated_recoverable_rollup` — never inside an analyzer — so every cost
+# analyzer's "monthly" figure is on the SAME basis and a sum across them
+# never silently mixes bases again.
+# --------------------------------------------------------------------------- #
+
+#: Guardrails: below any of these, the window's data is too thin to trust a
+#: forward projection from — show the observed figure, unscaled, instead.
+#: (Below this many days the window itself is barely wider than the ratio's
+#: own 30-day target, so a projection would mostly be noise.)
+MIN_WINDOW_DAYS_FOR_PROJECTION = 14
+#: Below this many distinct active days, the "sessions per active day" pace
+#: is estimated from too few data points to extrapolate honestly.
+MIN_ACTIVE_DAYS_FOR_PROJECTION = 8
+#: Below this many total sessions, there isn't enough volume for a pace
+#: figure to mean anything.
+MIN_SESSIONS_FOR_PROJECTION = 20
+#: Upper bound on the ratio — never claim more than 3x the observed window
+#: figure, however sparse the user's active days were.
+MAX_PROJECTION_RATIO = 3.0
+
+OBSERVED_LABEL = "observed"
+PROJECTED_LABEL = "per 30 days"
+
+
+def compute_projection_ratio(
+    window_days: float, active_days: int, n_sessions: int,
+) -> tuple[float | None, str]:
+    """The single ratio every cost analyzer's window figure is multiplied by
+    to get its 30-day-pace projection, and the label to render beside it.
+
+    ``r = clamp(30 / active_days, floor, MAX_PROJECTION_RATIO)`` where
+    ``active_days`` is the count of distinct calendar days in the window with
+    >=1 session (``WindowSummary.active_days``) — projecting on the user's
+    OWN observed pace, not a fixed multiplier on the window length (the bug
+    this replaces: a shrinking window inflated a fixed-days-over-window_days
+    ratio unboundedly). ``floor`` is ``1.0`` only when ``window_days <= 30``
+    (a real month's worth of pace can't be claimed to be LESS than what was
+    already observed over a sub-month window); a window LONGER than 30 days
+    may legitimately normalize DOWN below 1.0 — that's not a bug, it's
+    averaging a longer observation back down to a 30-day figure.
+
+    Returns ``(None, "observed")`` — no projection at all — when the window
+    is too thin to trust one: fewer than ``MIN_WINDOW_DAYS_FOR_PROJECTION``
+    days, fewer than ``MIN_ACTIVE_DAYS_FOR_PROJECTION`` active days, or fewer
+    than ``MIN_SESSIONS_FOR_PROJECTION`` sessions. A caller sees ``None`` and
+    renders the observed (window) figure labeled "observed in the last W
+    days" instead of "per 30 days" — never silently substitutes 1.0 for the
+    ratio and pretends that's a projection.
+
+    Deliberately NOT provided as an alternative basis: peak-single-day or a
+    p90-daily rate. Either cherry-picks the user's single worst day/week,
+    which is the first thing a skeptic attacks (#273's explicit prohibition)
+    — the mean pace over ALL active days is the only basis used here.
+    """
+    if (
+        window_days < MIN_WINDOW_DAYS_FOR_PROJECTION
+        or active_days < MIN_ACTIVE_DAYS_FOR_PROJECTION
+        or n_sessions < MIN_SESSIONS_FOR_PROJECTION
+    ):
+        return None, OBSERVED_LABEL
+    raw = 30.0 / active_days
+    ratio = min(raw, MAX_PROJECTION_RATIO)
+    if window_days <= 30:
+        ratio = max(ratio, 1.0)
+    return ratio, PROJECTED_LABEL
+
+
+def _effective_ratio(scaling: str, ratio: float | None) -> float:
+    """The ratio actually applied to ONE proposal: a `"one_time"` finding is
+    never rescaled regardless of the window's pace (its monthly figure always
+    equals its window figure), and a `None` ratio (guardrails blocked the
+    projection) means nothing is scaled either."""
+    if scaling == "one_time" or ratio is None:
+        return 1.0
+    return ratio
+
+
 def cost_proposals_from_report(
     report: Any, config: Any = None, *, pricing_mode: str = "api",
     window_days: float = 30.0,
@@ -1794,17 +1901,26 @@ def cost_proposals_from_report(
     see its own docstring) — neither ever assumes ``"claude-code"``.
 
     ``window_days`` (default 30 — ``DEFAULT_COST_WINDOW_DAYS``, matching the
-    daemon's own default look-back) is the monthly-basis extrapolation factor
-    (behavioral requirement #1): every proposal's ``estimated_monthly_usd``/
-    ``estimated_monthly_tokens`` that an adapter didn't already populate
-    (only ``downsize`` does, from its own 30-day projection) is stamped here
-    as ``window_figure * (30 / window_days)`` — one generic pass so no
-    adapter has to reimplement the arithmetic. A caller building a report
-    over a non-30-day window (e.g. ``tj optimize --since 7d``) still gets an
-    honest monthly figure rather than a raw window total mislabeled "/ mo".
+    daemon's own default look-back) feeds ``compute_projection_ratio`` along
+    with ``report.window.active_days``/``report.window.sessions`` (#273):
+    every proposal's ``estimated_monthly_usd``/``estimated_monthly_tokens``
+    is stamped here as ``window_figure * ratio`` — the SAME ratio for every
+    proposal, computed ONCE, respecting each proposal's own ``scaling``
+    (``"one_time"`` is never rescaled). No adapter sets these fields itself
+    any more (``downsize`` used to; #273 removed that self-projection so a
+    later scan over a non-default window can't leave it on a different basis
+    than everyone else). A caller building a report over a non-30-day window
+    (e.g. ``tj optimize --since 7d``) still gets an honest monthly figure
+    rather than a raw window total mislabeled "/ mo" — or, when the window is
+    too thin to trust a projection from (see ``compute_projection_ratio``'s
+    guardrails), the unscaled observed figure instead of an invented one.
     """
     findings = getattr(report, "findings", {}) or {}
     persona = str(getattr(report, "persona", "") or "unknown")
+    window = getattr(report, "window", None)
+    active_days = int(getattr(window, "active_days", 0) or 0)
+    n_sessions = int(getattr(window, "sessions", 0) or 0)
+    ratio, _label = compute_projection_ratio(window_days, active_days, n_sessions)
     proposals: list[CostProposal] = []
     adapters = (
         (lambda f: _downsize_to_proposal(f, config), getattr(report, "downgrade", None)),
@@ -1830,17 +1946,21 @@ def cost_proposals_from_report(
             proposals.extend(adapter(finding))
         except Exception:
             continue
-    return [_with_monthly_extrapolation(p, window_days) for p in proposals]
+    return [_with_rollup_projection(p, ratio) for p in proposals]
 
 
-def _with_monthly_extrapolation(proposal: CostProposal, window_days: float) -> CostProposal:
+def _with_rollup_projection(proposal: CostProposal, ratio: float | None) -> CostProposal:
     """Fill in ``estimated_monthly_usd``/``estimated_monthly_tokens`` from the
-    window figure when an adapter didn't already set one (see
-    ``cost_proposals_from_report``'s ``window_days`` docstring). Returns a NEW
-    ``CostProposal`` (``dataclasses.replace``) rather than mutating the one
-    the adapter built — every proposal here is otherwise treated as an
-    immutable, already-complete record."""
-    scale = (30.0 / window_days) if window_days and window_days > 0 else 1.0
+    window figure using the one shared ``ratio`` (``None`` when
+    ``compute_projection_ratio``'s guardrails blocked projection, in which
+    case the monthly figure equals the observed window figure unscaled).
+    Respects the proposal's own ``scaling`` — a ``"one_time"`` finding is
+    never rescaled regardless of ``ratio``. Returns a NEW ``CostProposal``
+    (``dataclasses.replace``) rather than mutating the one the adapter built
+    — every proposal here is otherwise treated as an immutable,
+    already-complete record. Only fills a field an adapter left ``None``; no
+    current adapter sets these itself (#273), but a future one may."""
+    scale = _effective_ratio(proposal.scaling, ratio)
     updates: dict[str, Any] = {}
     if proposal.estimated_monthly_usd is None and proposal.estimated_recoverable_usd is not None:
         updates["estimated_monthly_usd"] = round(proposal.estimated_recoverable_usd * scale, 6)
@@ -1892,6 +2012,8 @@ def estimated_recoverable_rollup(
     proposals: list[Any],
     *,
     window_days: int = DEFAULT_COST_WINDOW_DAYS,
+    active_days: int = 0,
+    n_sessions: int = 0,
 ) -> dict[str, Any]:
     """Sum ``estimated_recoverable_usd`` across ``proposals``, deduplicated by
     ``signature`` (a proposal's stable identity — see the ``CostProposal``
@@ -1917,6 +2039,20 @@ def estimated_recoverable_rollup(
     ``proposal_count``, and say so against ``deduplicated_proposal_count`` when
     coverage is partial: the token sum is a floor, not a total.
 
+    Both ``estimated_recoverable_usd``/``estimated_recoverable_tokens`` stay
+    the raw OBSERVED (window-scoped) sums — unchanged contract, so an
+    existing caller reading these two keys keeps seeing exactly what it saw
+    before. #273 adds a SEPARATE, single-basis 30-day projection alongside
+    them (never folded into the same field the window figure lives in, per
+    the Recoverable-savings contract): ``projected_usd_30d``/
+    ``projected_tokens_30d`` are each proposal's window figure multiplied by
+    the ONE ratio ``compute_projection_ratio(window_days, active_days,
+    n_sessions)`` computes (respecting each proposal's own ``scaling`` —
+    ``"one_time"`` is never rescaled), summed the same way. ``active_days``/
+    ``n_sessions`` default to 0 (guardrails always block the projection),
+    so a caller that doesn't yet know them gets the honest "observed" state
+    rather than a fabricated ratio.
+
     Tagged ``estimated`` — this is a heuristic figure, never a measured one.
     """
     seen: dict[str, dict[str, Any]] = {}
@@ -1927,12 +2063,18 @@ def estimated_recoverable_rollup(
             continue  # empty/duplicate signature never counts twice
         seen[sig] = row
 
+    ratio, label = compute_projection_ratio(window_days, active_days, n_sessions)
+
     contributing: list[dict[str, Any]] = []
     by_analyzer: dict[str, dict[str, Any]] = {}
     total_usd = 0.0
     total_tokens = 0
     token_proposal_count = 0
+    projected_usd = 0.0
+    projected_tokens = 0
     for row in seen.values():
+        scale = _effective_ratio(str(row.get("scaling") or "per_session"), ratio)
+
         # The token sum is counted INDEPENDENTLY of the dollar sum: the two
         # estimates are populated by different analyzers and a proposal can
         # carry either one alone. Folding tokens in only where a dollar
@@ -1941,6 +2083,7 @@ def estimated_recoverable_rollup(
         tokens = row.get("estimated_recoverable_tokens")
         if tokens is not None:
             total_tokens += int(tokens)
+            projected_tokens += round(int(tokens) * scale)
             token_proposal_count += 1
 
         usd = row.get("estimated_recoverable_usd")
@@ -1948,6 +2091,7 @@ def estimated_recoverable_rollup(
             continue
         usd = float(usd)
         total_usd += usd
+        projected_usd += usd * scale
         analyzer = str(row.get("analyzer") or "unknown")
         entry = by_analyzer.setdefault(analyzer, {"analyzer": analyzer, "count": 0, "usd": 0.0})
         entry["count"] += 1
@@ -1988,6 +2132,21 @@ def estimated_recoverable_rollup(
             f"proposal(s); the rest carry no token estimate, so it is a "
             f"floor, not a total."
         )
+    if ratio is not None:
+        disclosure = (
+            f"Projected to a 30-day month at your own pace: "
+            f"{n_sessions / active_days:.1f} sessions per active coding day, "
+            f"measured from {n_sessions} sessions across {active_days} active "
+            f"days in the last {window_days} days."
+        )
+    else:
+        disclosure = (
+            f"Observed in the last {window_days} days ({n_sessions} sessions "
+            f"across {active_days} active days) — not enough data to project "
+            f"a 30-day pace yet (needs >= {MIN_WINDOW_DAYS_FOR_PROJECTION} "
+            f"days, >= {MIN_ACTIVE_DAYS_FOR_PROJECTION} active days, and "
+            f">= {MIN_SESSIONS_FOR_PROJECTION} sessions)."
+        )
 
     return {
         "estimated_recoverable_usd": round(total_usd, 6),
@@ -1996,6 +2155,13 @@ def estimated_recoverable_rollup(
         "token_proposal_count": token_proposal_count,
         "deduplicated_proposal_count": deduplicated_proposal_count,
         "window_days": window_days,
+        "active_days": active_days,
+        "n_sessions": n_sessions,
+        "projection_ratio": ratio,
+        "projection_label": label,
+        "projected_usd_30d": round(projected_usd, 6),
+        "projected_tokens_30d": projected_tokens,
+        "disclosure": disclosure,
         "by_analyzer": sorted(by_analyzer.values(), key=lambda x: x["analyzer"]),
         "contributing": contributing,
         "estimate_confidence": COST_ESTIMATE_CONFIDENCE,

--- a/tokenjam/core/optimize/relearn_store.py
+++ b/tokenjam/core/optimize/relearn_store.py
@@ -110,10 +110,18 @@ def read_cost_proposals(
     computed AND no recompute has ever failed either (a genuinely fresh
     install). Shape: ``{"cost_computed_at": iso, "cost_proposals": [dict,
     ...], "cost_proposals_error": str | None, "cost_proposals_error_at": iso |
-    None}``. ``cost_proposals_error`` is the last recompute failure's message
-    (behavioral requirement #5) — present alongside a GOOD ``cost_proposals``
-    list when a later recompute failed after an earlier one had already
-    succeeded, so a transient failure never hides the last good result."""
+    None, "cost_window_days": int, "cost_active_days": int,
+    "cost_n_sessions": int}``. ``cost_proposals_error`` is the last recompute
+    failure's message (behavioral requirement #5) — present alongside a GOOD
+    ``cost_proposals`` list when a later recompute failed after an earlier one
+    had already succeeded, so a transient failure never hides the last good
+    result. The three ``cost_*`` count fields (#273) are the window's
+    active-day pace at the moment of the LAST successful recompute — the
+    inputs ``cost_proposals.estimated_recoverable_rollup`` needs to compute
+    its shared 30-day projection ratio centrally; ``0`` for a cache written
+    before they existed (a caller passes them straight to
+    ``compute_projection_ratio``, whose guardrails treat ``0`` as "not enough
+    data", never as a fabricated ratio)."""
     raw = read_cache(path, config=config)
     if raw is None:
         return None
@@ -126,6 +134,9 @@ def read_cost_proposals(
         "cost_proposals": raw.get("cost_proposals") or [],
         "cost_proposals_error": raw.get("cost_proposals_error"),
         "cost_proposals_error_at": raw.get("cost_proposals_error_at"),
+        "cost_window_days": raw.get("cost_window_days") or 0,
+        "cost_active_days": raw.get("cost_active_days") or 0,
+        "cost_n_sessions": raw.get("cost_n_sessions") or 0,
     }
 
 
@@ -167,11 +178,22 @@ def clear_cost_proposals_error(
 
 def write_cost_proposals(
     proposals: list[Any], path: Path | None = None, *, config: TjConfig | None = None,
+    window_days: int | None = None, active_days: int | None = None,
+    n_sessions: int | None = None,
 ) -> dict[str, Any]:
     """Write the cost proposals into the SAME cache file the relearn finding
     lives in, under a separate ``cost_proposals`` key, preserving the relearn
     ``finding`` block. ``proposals`` is a list of ``CostProposal`` (or plain
-    dicts). Atomic; best-effort on I/O error."""
+    dicts). Atomic; best-effort on I/O error.
+
+    ``window_days``/``active_days``/``n_sessions`` (#273) are the window this
+    recompute ran over, stored alongside the proposals so
+    ``estimated_recoverable_rollup`` can compute its shared 30-day projection
+    ratio the next time this cache is read — never recomputed ad hoc at read
+    time, since the window that produced these proposals may not be the
+    window a later reader assumes. ``None`` (the default) leaves any
+    previously-stored value untouched, so a caller that doesn't track these
+    yet (a legacy call site) doesn't silently zero out a real prior value."""
     from dataclasses import is_dataclass
 
     p = path or default_cache_path(config)
@@ -188,6 +210,12 @@ def write_cost_proposals(
     payload = dict(existing)
     payload["cost_proposals"] = serialised
     payload["cost_computed_at"] = datetime.now(timezone.utc).isoformat()
+    if window_days is not None:
+        payload["cost_window_days"] = window_days
+    if active_days is not None:
+        payload["cost_active_days"] = active_days
+    if n_sessions is not None:
+        payload["cost_n_sessions"] = n_sessions
     _atomic_write(p, payload)
     return payload
 

--- a/tokenjam/core/optimize/runner.py
+++ b/tokenjam/core/optimize/runner.py
@@ -68,7 +68,8 @@ def summarize_window(
         f"SELECT COUNT(*) AS spans, "
         f"COUNT(DISTINCT session_id) AS sessions, "
         f"COALESCE(SUM(COALESCE(input_tokens,0) + COALESCE(output_tokens,0) + COALESCE(cache_tokens,0) + COALESCE(cache_write_tokens,0)), 0) AS tokens, "
-        f"COALESCE(SUM(cost_usd), 0.0) AS cost "
+        f"COALESCE(SUM(cost_usd), 0.0) AS cost, "
+        f"COUNT(DISTINCT CAST(start_time AS DATE)) AS active_days "
         f"FROM spans WHERE {where}",
         params,
     ).fetchone()
@@ -76,6 +77,7 @@ def summarize_window(
     sessions = int(row[1] or 0)
     tokens = int(row[2] or 0)
     cost = float(row[3] or 0.0)
+    active_days = int(row[4] or 0)
     days = max((until - since).total_seconds() / 86400.0, 0.0)
     return WindowSummary(
         since=since,
@@ -86,6 +88,7 @@ def summarize_window(
         total_tokens=tokens,
         total_cost_usd=cost,
         thin_data=days < THIN_DATA_DAYS or sessions < 3,
+        active_days=active_days,
     )
 
 

--- a/tokenjam/core/optimize/types.py
+++ b/tokenjam/core/optimize/types.py
@@ -66,6 +66,14 @@ class WindowSummary:
     total_tokens: int
     total_cost_usd: float
     thin_data:   bool
+    #: Distinct calendar days within the window with >=1 session — the
+    #: user's own "active day" pace, the basis for the shared 30-day
+    #: projection ratio every cost analyzer's rollup uses (see
+    #: `cost_proposals.compute_projection_ratio`, #273). Defaults to 0 for a
+    #: hand-built `WindowSummary` (tests, older callers) — a 0 fails that
+    #: ratio's guardrail, so the projection is simply skipped rather than
+    #: dividing by zero or inventing a value.
+    active_days: int = 0
 
 
 @dataclass

--- a/tokenjam/ui/index.html
+++ b/tokenjam/ui/index.html
@@ -6511,8 +6511,8 @@ function OptimizeFinding({ name, opt, framing, hasProposal }) {
         : !(fd.dead_servers || []).length ? html`<div class="opt-line dim">${(fd.notes && fd.notes.length) ? fd.notes.join(' ') : `All ${fd.configured_servers} configured MCP server${fd.configured_servers !== 1 ? 's' : ''} were invoked at least once in this window.`}</div>`
         : html`
           <div class="opt-line">${fd.dead_servers.length} dead MCP server${fd.dead_servers.length !== 1 ? 's' : ''} of ${fd.configured_servers} configured <span class="dim">(schemas injected every session, never called)</span>.</div>
-          <table class="opt-table"><thead><tr><th>Server</th><th>Sessions</th><th>Invocations</th><th>Tax / 90d</th></tr></thead>
-            <tbody>${fd.dead_servers.map(s => html`<tr><td class="mono">${s.name} <span class="dim">(${s.scope} · ${s.source})</span></td><td>${s.sessions_present}</td><td>${s.invocations}</td><td>${s.estimated_tax_usd_90d != null ? fmtCost(s.estimated_tax_usd_90d) : ('~' + fmtTokens(s.estimated_tax_tokens_90d) + ' tokens')}</td></tr>`)}</tbody></table>
+          <table class="opt-table"><thead><tr><th>Server</th><th>Sessions</th><th>Invocations</th><th>Tax (window)</th></tr></thead>
+            <tbody>${fd.dead_servers.map(s => html`<tr><td class="mono">${s.name} <span class="dim">(${s.scope} · ${s.source})</span></td><td>${s.sessions_present}</td><td>${s.invocations}</td><td>${s.estimated_tax_usd_window != null ? fmtCost(s.estimated_tax_usd_window) : ('~' + fmtTokens(s.estimated_tax_tokens_window) + ' tokens')}</td></tr>`)}</tbody></table>
           ${fd.caveat ? html`<div class="opt-caveat">! ${fd.caveat}</div>` : null}`;
     }
   }


### PR DESCRIPTION
`deadweight` folded a fixed 90-day projection directly into its shared `estimated_recoverable_usd`/`estimated_recoverable_tokens` fields, while every other cost analyzer keeps that field strictly window-scoped (`downsize` keeps its own 30-day projection in a separate `monthly_savings_usd` field for exactly this reason — the "Recoverable-savings contract"). The inflated field wasn't comparable to the other analyzers and corrupted any sum across them; the projection also grew unboundedly as the window shrank (a 7-day window showed roughly 12.9x the true window-observed figure).

## Summary

`deadweight` now emits a pure window-scoped `estimated_tax_tokens_window` / `estimated_tax_usd_window` (renamed from the old `*_90d` fields), with no internal projection folded in.
Introduce one central, shared projection instead: `compute_projection_ratio` derives a 30-day-pace ratio from the window's own distinct active-session days (`WindowSummary.active_days`, now computed in `summarize_window`), capped at 3x and guardrailed against thin windows/session counts — below the guardrails it falls back to the observed figure, unscaled, with a disclosure string, rather than inventing a ratio from too little data.
Every cost-proposal adapter now defers its `estimated_monthly_usd`/`estimated_monthly_tokens` to this one central pass instead of self-projecting. `downsize` used to copy its own `window_days`-based projection onto the shared monthly field, which was a milder version of the same defect (a different analyzer landing on a different basis than everyone else) — it's now scaled by the same central ratio as every other analyzer.
`CostProposal` gains a `scaling` field (`"per_session"` | `"one_time"`), so a genuinely one-time saving is never rescaled by session pace. Every current analyzer's waste recurs per session/call, so the field defaults to `"per_session"`, documented inline with the reasoning.
`estimated_recoverable_rollup` carries the same ratio, plus `active_days`/`n_sessions`/`window_days` and a human-readable disclosure line, alongside its existing (unchanged) raw observed sum.

## Tests / Verification

Renamed and extended `tests/unit/test_deadweight.py` / `tests/unit/test_cost_proposals.py` for the field rename and the new central-ratio behavior (guardrail-blocked vs guardrail-passing windows, downsize's projection now matching everyone else's basis).
Full suite green: `pytest tests/unit/ tests/synthetic/ tests/agents/ tests/integration/` — 3566 passed, 2 skipped.
`ruff check` / `mypy` clean on every touched file.
Live-verified the fix with a real on-disk transcript scenario (a configured-but-never-called MCP server across 6 sessions spanning a 7-day window): the window figure is now exactly `6 x 25,000 = 150,000` tokens, not the old ~12.9x-inflated figure. Also verified the new projection end to end: a 30-day/10-active-day/25-session window yields ratio `3.0` with the disclosure line rendering real active-day/session/window values, and a thin window correctly falls back to the observed figure with the ratio reported as unavailable.

## What's NOT in this PR

`relearn`'s own `RelearnCluster.estimated_monthly_usd`/`estimated_monthly_tokens` (a structurally separate, unbounded-history system with no fixed window) is untouched — folding it into the same central ratio needs its own design pass for what "the window" even means for an unbounded corpus scan. Filed as a separate follow-up.

🤖 shipped by [shiploop](https://github.com/anshss/shiploop)