### PR TITLE
Lead the context-resend claude-code fix with a durable subagent-offload rule

### DIFF
--- a/tests/unit/test_cost_proposals.py
+++ b/tests/unit/test_cost_proposals.py
@@ -1000,16 +1000,56 @@ def _resend_finding():
 
 def test_resend_suppresses_cache_control_snippet_for_claude_code():
     # The cache_control snippet is the SDK lever. A Claude Code window never
-    # constructs the request, so it is not theirs to paste — the card must lead
-    # with /compact and show NO snippet, matching how the cache family gates.
+    # constructs the request, so it is not theirs to paste — show NO snippet,
+    # matching how the cache family gates.
+    from tokenjam.core.optimize.analyzers.context_resend import SUBAGENT_OFFLOAD_FIX
     from tokenjam.core.optimize.cost_proposals import _resend_to_proposals
 
     prop = _resend_to_proposals(_resend_finding(), persona="claude-code")[0]
     assert prop.suggestion == "", "cache_control snippet must be suppressed for claude-code"
     assert "cache_control" not in prop.suggestion
-    assert prop.advise_text.startswith("Run /compact.")
-    # The paste fallback is the compaction guidance, never the snippet.
-    assert prop.one_paste_fix == "Run /compact."
+    # The durable subagent-offload rule leads, not /compact.
+    assert prop.advise_text.startswith(SUBAGENT_OFFLOAD_FIX)
+    assert "Run /compact." in prop.advise_text   # kept, but only as secondary relief
+    assert prop.one_paste_fix == SUBAGENT_OFFLOAD_FIX
+
+
+def test_resend_claude_code_offers_apply_capable_subagent_offload_write():
+    # Durable claude-code lever: a rung-1 CLAUDE.md rule, apply-capable via the
+    # same `_persona_gated_write_fields` machinery script/reuse/verbosity use.
+    from tokenjam.core.optimize.analyzers.context_resend import SUBAGENT_OFFLOAD_FIX
+    from tokenjam.core.optimize.cost_proposals import _resend_to_proposals
+
+    prop = _resend_to_proposals(_resend_finding(), persona="claude-code")[0]
+    assert prop.advise_only is False
+    assert prop.apply_capable is True
+    assert prop.rung == 1
+    assert prop.scope == "project"
+    assert prop.proposed_fix == SUBAGENT_OFFLOAD_FIX
+
+
+def test_resend_sdk_persona_gets_no_write_and_leads_with_compact():
+    # The SDK branch is unchanged: no coding-agent harness reads a CLAUDE.md
+    # note there, so no write is offered and /compact remains the lead fix.
+    from tokenjam.core.optimize.cost_proposals import _resend_to_proposals
+
+    for persona in ("sdk", "unknown"):
+        prop = _resend_to_proposals(_resend_finding(), persona=persona)[0]
+        assert prop.advise_only is True
+        assert prop.apply_capable is False
+        assert prop.advise_text == "Run /compact."
+
+
+def test_resend_mixed_persona_offers_write_and_keeps_snippet():
+    # "mixed" carries both audiences: the claude-code share gets the write,
+    # the sdk share still gets its cache_control snippet (unchanged).
+    from tokenjam.core.optimize.analyzers.context_resend import SUBAGENT_OFFLOAD_FIX
+    from tokenjam.core.optimize.cost_proposals import _resend_to_proposals
+
+    prop = _resend_to_proposals(_resend_finding(), persona="mixed")[0]
+    assert prop.apply_capable is True
+    assert prop.proposed_fix == SUBAGENT_OFFLOAD_FIX
+    assert "cache_control" in prop.suggestion
 
 
 def test_resend_keeps_cache_control_snippet_for_sdk():
@@ -1027,12 +1067,15 @@ def test_resend_caveat_is_not_duplicated():
     # The caveat is carried once via `caveat=`, and must NOT also be folded into
     # advise_text — doing both printed the same sentence twice on the card
     # (description paragraph + caveat line render the joined fields).
+    from tokenjam.core.optimize.analyzers.context_resend import SUBAGENT_OFFLOAD_FIX
     from tokenjam.core.optimize.cost_proposals import _resend_to_proposals
 
     prop = _resend_to_proposals(_resend_finding(), persona="claude-code")[0]
     assert prop.caveat == "conservative lower bound"
     assert "conservative lower bound" not in prop.advise_text
-    assert prop.advise_text == "Run /compact."
+    assert prop.advise_text == (
+        SUBAGENT_OFFLOAD_FIX + " Immediate relief in an already-full session: Run /compact."
+    )
 
 
 def test_resend_persona_flows_through_the_report_dispatch():

--- a/tokenjam/core/optimize/analyzers/context_resend.py
+++ b/tokenjam/core/optimize/analyzers/context_resend.py
@@ -111,7 +111,30 @@ COMPACTION_FIX = (
     "Run /compact (or start a fresh session) once accumulated context crosses "
     "your working set. The repeated volume this finding measures is the same "
     "content being re-sent turn over turn: trimming it directly cuts future "
-    "prompt size, regardless of whether caching is on."
+    "prompt size, regardless of whether caching is on. This is a manual, "
+    "per-session action, so it never fixes the pattern going forward — treat "
+    "it as immediate relief for an already-full session, not the durable fix."
+)
+
+# The durable claude-code lever: a rung-1 CLAUDE.md rule (same write machinery
+# `script`/`reuse`/`verbosity` use via `cost_proposals._persona_gated_write_fields`)
+# so the context that would otherwise get re-sent every turn never accumulates
+# on the main thread in the first place. Unlike `/compact`, this persists
+# across sessions and is on the CC action surface (a workspace file an
+# orchestrating agent reads), which is why it leads for a claude-code window
+# instead of `/compact` (founder critique, 2026-07-25: a real CC user abandons
+# an over-full session and starts fresh rather than compacting it, so telling
+# them to compact isn't a useful recommendation).
+SUBAGENT_OFFLOAD_FIX = (
+    "Offload context-heavy sub-tasks (broad file reads, multi-file search, "
+    "long tool-output loops, exploratory investigation) to a subagent instead "
+    "of running them inline in the main thread. A subagent's own tool logs "
+    "and intermediate output stay in its own context; only its short "
+    "conclusion returns to the caller, so the material that keeps getting "
+    "re-sent turn over turn never accumulates on the main thread to begin "
+    "with. Where available, pair this with a hook that warns once context "
+    "crosses a size threshold, as a second, automated nudge toward the same "
+    "behavior."
 )
 
 # Cap on evidence rows carried in the finding payload; aggregates are over ALL
@@ -153,12 +176,14 @@ class ResendFinding:
     # re-pasted prompts/outputs) reused from context_diagnostic rather than
     # reimplemented (capture-gated; empty + a note when no capture toggle is on).
     recurring_examples: list[RecurringInclusion] = field(default_factory=list)
-    # Both fixes are always carried: the lever differs by persona (agent
-    # harness user: compaction; SDK user: cache_control), and the renderer
+    # All three fixes are always carried: the lever differs by persona
+    # (agent harness user: subagent-offload, with compaction as a secondary
+    # immediate-relief note; SDK user: cache_control), and the renderer
     # picks which to lead with. `fix_cache_control` is "" when no example
     # session had a model to name in the snippet.
-    fix_compaction:    str = COMPACTION_FIX
-    fix_cache_control: str = ""
+    fix_compaction:        str = COMPACTION_FIX
+    fix_subagent_offload:  str = SUBAGENT_OFFLOAD_FIX
+    fix_cache_control:     str = ""
     caveat:            str = RESEND_HONESTY_CAVEAT
     estimate_basis:    str = ""
     estimate_confidence: str = "heuristic"

--- a/tokenjam/core/optimize/cost_proposals.py
+++ b/tokenjam/core/optimize/cost_proposals.py
@@ -1564,17 +1564,28 @@ def _verbosity_to_proposals(finding: Any, persona: str = "unknown") -> list[Cost
 def _resend_to_proposals(finding: Any, persona: str = "unknown") -> list[CostProposal]:
     """One window-wide card for the ``resend`` (context re-send) finding.
 
-    Advise-only, and persona-gated like every other lever-bearing adapter (it
-    was the one that wasn't). Two levers exist and they are NOT interchangeable:
+    Persona-gated like every other lever-bearing adapter. Three levers exist
+    and they are NOT interchangeable:
 
-    * ``/compact`` / a fresh session cuts the re-sent volume and is available
-      to EVERYONE — it is always the lead fix.
+    * a rung-1 CLAUDE.md rule instructing offload of context-heavy sub-tasks
+      to subagents (``fix_subagent_offload``) is the DURABLE claude-code
+      lever: it persists across sessions and stops the repeated volume from
+      accumulating on the main thread in the first place. Apply-capable via
+      the same ``_persona_gated_write_fields`` machinery ``script`` /
+      ``reuse`` / ``verbosity`` already use, for a ``claude-code``/``mixed``
+      persona — see that helper.
+    * ``/compact`` / a fresh session is a MANUAL, per-session, transient
+      action available to everyone, but it fixes nothing going forward (a
+      real CC user who feels a session getting too full typically abandons
+      it and starts fresh anyway rather than compacting). It is carried only
+      as a secondary, immediate-relief note for an already-full session —
+      never the headline fix.
     * an SDK-side ``cache_control`` breakpoint is the SDK/API developer's
       ADDITIONAL lever. A Claude Code (or other agent-harness) window never
       constructs the request itself, so that snippet is not theirs to paste —
       showing it to them is the same wrong-audience defect the cache family
-      already avoids via ``_persona_gated_cache_fields``. Suppress it for a
-      ``claude-code`` persona and lead with ``/compact`` alone.
+      already avoids via ``_persona_gated_cache_fields``. Suppressed for a
+      ``claude-code`` persona, unchanged from before.
 
     ``ResendFinding.estimate_basis`` documents the discounted derivation; this
     adapter carries it verbatim. The caveat is carried ONCE via ``caveat=`` and
@@ -1596,9 +1607,31 @@ def _resend_to_proposals(finding: Any, persona: str = "unknown") -> list[CostPro
     )
     fix_compaction = str(getattr(finding, "fix_compaction", "") or "")
     fix_cache_control = str(getattr(finding, "fix_cache_control", "") or "")
+    fix_subagent_offload = str(getattr(finding, "fix_subagent_offload", "") or "")
     # The cache_control snippet is the SDK lever only; a claude-code window
-    # can't paste it, so suppress it there and let /compact stand alone.
+    # can't paste it, so suppress it there — unchanged from before.
     cache_snippet = "" if persona == "claude-code" else fix_cache_control
+
+    if persona in {"claude-code", "mixed"} and fix_subagent_offload:
+        advise = fix_subagent_offload
+        if fix_compaction:
+            advise = advise + " Immediate relief in an already-full session: " + fix_compaction
+        write_fields = _persona_gated_write_fields(
+            persona, fix_subagent_offload, rung=1, scope="project",
+        )
+        # resend's `suggestion` slot is reserved for the SDK cache_control
+        # snippet above, not the write-fallback text the helper would add
+        # for a "mixed" persona — drop it so the two don't collide.
+        write_fields.pop("suggestion", None)
+        one_paste_fix = cache_snippet or fix_subagent_offload
+    else:
+        advise = fix_compaction
+        write_fields = {
+            "advise_only": True, "apply_capable": False,
+            "rung": 0, "scope": "", "proposed_fix": "",
+        }
+        one_paste_fix = cache_snippet or fix_compaction
+
     return [CostProposal(
         kind="cost",
         analyzer="resend",
@@ -1613,13 +1646,14 @@ def _resend_to_proposals(finding: Any, persona: str = "unknown") -> list[CostPro
             "repeat_share_median": getattr(finding, "repeat_share_median", None),
             "repeat_share_p90": getattr(finding, "repeat_share_p90", None),
         },
-        advise_text=fix_compaction,
+        advise_text=advise,
         suggestion=cache_snippet,
-        one_paste_fix=cache_snippet or fix_compaction,
+        one_paste_fix=one_paste_fix,
         estimated_recoverable_usd=getattr(finding, "estimated_recoverable_usd", None),
         estimated_recoverable_tokens=getattr(finding, "estimated_recoverable_tokens", None),
         estimate_basis=str(getattr(finding, "estimate_basis", "") or ""),
         caveat=str(getattr(finding, "caveat", "") or COST_CORRELATIONAL_CAVEAT),
+        **write_fields,
     )]
 
 


### PR DESCRIPTION
## Summary
The context re-send advisory's claude-code branch led with `/compact` — a manual, per-session action a user typically abandons a full session for rather than running.
Replace the headline claude-code fix with an apply-capable, rung-1 CLAUDE.md rule (reusing the same `_persona_gated_write_fields` write machinery `script`/`reuse`/`verbosity` already use) that instructs offloading context-heavy sub-tasks to subagents, so the repeated context never accumulates on the main thread in the first place. `/compact` is kept only as a secondary, immediate-relief note for an already-full session.
The SDK `cache_control` lever and its persona gating are unchanged.

## Test plan
[x] `pytest tests/unit/test_cost_proposals.py tests/unit/test_context_resend.py tests/unit/test_optimize_resend_render.py` — all pass, plus new coverage for the apply-capable write on `claude-code`/`mixed` personas and the unchanged `sdk`/`unknown` behavior
[x] Full `pytest tests/unit` — 2928 passed, 2 skipped (pre-existing)

🤖 shipped by [shiploop](https://github.com/anshss/shiploop)