### PR TITLE
Hide no-lever analyzers from the Recoverable waste band on Claude Code windows

### DIFF
--- a/tests/unit/test_lens_ui_regression.py
+++ b/tests/unit/test_lens_ui_regression.py
@@ -2852,3 +2852,32 @@ def test_review_inbox_dollar_headline_ignores_framing_even_when_suppressed():
     assert headline_unit(priced_deadweight, founder_framing) == "dollars"
     assert headline_unit(resend_structural, founder_framing) == "tokens"
     assert headline_unit(unpriced_placement, founder_framing) == "tokens"
+
+
+# --- Recoverable-waste band drops no-lever analyzers for claude-code -------- #
+def test_recoverable_band_excludes_no_lever_analyzers_for_claude_code(html):
+    # cache / cache-recommend / placement / trim / verbosity / script have no
+    # actionable lever from the Claude Code CLI action surface (CLAUDE.md
+    # rules, hooks, MCP config, subagent definitions) — they must vanish from
+    # the Overview band entirely for a claude-code window, not render as a
+    # placeholder. Live-verified via a seeded `tj serve` + screenshot; this
+    # pins the JS source so a future edit can't silently regress it.
+    assert "const PERSONA_DISABLED_ANALYZERS" in html
+    start = html.index("const PERSONA_DISABLED_ANALYZERS")
+    end = html.index("};", start)
+    block = html[start:end]
+    assert "'claude-code'" in block
+    for name in ("cache", "cache-recommend", "placement", "trim", "verbosity", "script"):
+        assert f"'{name}'" in block
+
+
+def test_recoverable_tiles_filters_by_persona_before_ranking(html):
+    fn_start = html.index("function recoverableTiles(opt)")
+    fn_end = html.index("\nfunction ", fn_start + 1)
+    fn = html[fn_start:fn_end]
+    assert "PERSONA_DISABLED_ANALYZERS[opt.persona]" in fn
+    assert "disabled.has(k)" in fn
+    # Downsize + wave-2 findings + the not-ready fallback must all respect the
+    # gate (three separate call sites build `out`) so a persona-disabled
+    # analyzer never sneaks in through any of them.
+    assert fn.count("disabled.has(") >= 3

--- a/tokenjam/ui/index.html
+++ b/tokenjam/ui/index.html
@@ -6150,6 +6150,28 @@ const ANALYZER_META = {
   'budget-projection': { title: 'Budget projection', hint: 'Projected cycle spend vs ceiling' },
 };
 
+// Analyzers with no actionable lever for a given persona, keyed by
+// `opt.persona` (server-computed dominant persona for the window — see
+// core/framing.dominant_persona: "claude-code" | "sdk" | "mixed" | "unknown").
+// A Claude Code subscriber can only act through their CLI action surface
+// (CLAUDE.md rules, hooks, MCP server config, subagent definitions) — they
+// can't swap the interactive model per request or route to the Batch API.
+// Findings with no lever on that surface are excluded entirely from the
+// recoverable-waste band rather than shown as noise: cache/cache-recommend
+// (cache_control is set at the API-call site, not editable from the CLI),
+// placement (Batch API is unreachable from an interactive session), trim
+// (its remedy is a prompt-template edit outside the CLI surface), verbosity
+// (its only remedy is a blanket "produce less output" rule, which risks
+// degrading quality on tasks that legitimately need long output), and script
+// (its cluster-matching signature is too brittle to fire reliably on
+// heterogeneous coding sessions today). Only "claude-code" is gated — a
+// mixed/sdk/unknown window keeps the full set. This list intentionally
+// mirrors the equivalent server-side gate; keep the two in sync if either
+// changes.
+const PERSONA_DISABLED_ANALYZERS = {
+  'claude-code': new Set(['cache', 'cache-recommend', 'placement', 'trim', 'verbosity', 'script']),
+};
+
 // Fallback threshold values for the `placement` empty state, mirroring
 // analyzers/batch_placement.py's MIN_SESSIONS_FOR_CADENCE / MIN_GROUP_COST_USD
 // module defaults. Used only when the finding itself is absent from the
@@ -6296,18 +6318,27 @@ function classifyFinding(name, fd, skipped) {
 // wave-2 finding carrying the `estimated_recoverable_usd` contract field becomes
 // a tile (so a future `reuse` analyzer appears with no UI change).
 // cache-recommend / budget-projection lack the field → excluded by contract.
+// Persona-disabled analyzers (PERSONA_DISABLED_ANALYZERS) are dropped before
+// ranking, not shown as a placeholder — they vanish entirely from the band
+// so a claude-code window isn't crowded out by findings it can't act on, and
+// the tile that survives at rank 0 is guaranteed to carry a real lever.
 function recoverableTiles(opt) {
   if (!opt) return [];
+  const disabled = PERSONA_DISABLED_ANALYZERS[opt.persona] || new Set();
   const out = [];
   const skipped = new Set(opt.skipped_analyzers || []);
   const f = opt.findings || {};
   // Downsize always gets a tile — it runs unconditionally; a null typed slot
   // means "ran, no candidates", not "missing" (issue #126).
-  out.push({ name: 'downsize', ...classifyFinding('downsize', opt.downgrade, skipped) });
+  if (!disabled.has('downsize')) {
+    out.push({ name: 'downsize', ...classifyFinding('downsize', opt.downgrade, skipped) });
+  }
   Object.keys(f).forEach(k => {
+    if (disabled.has(k)) return;
     if (f[k] && 'estimated_recoverable_usd' in f[k]) out.push({ name: k, ...classifyFinding(k, f[k], skipped) });
   });
   skipped.forEach(k => {
+    if (disabled.has(k)) return;
     if (!(k in f) && k !== 'downsize') {
       out.push({ name: k, state: 'not_ready', hint: 'Not run on Overview — open the Optimize tab.' });
     }


### PR DESCRIPTION
## Summary
The Overview "Recoverable waste" band built a tile for any finding carrying `estimated_recoverable_usd`, with no regard for whether the window's dominant persona actually has a lever for that analyzer.
On a Claude Code window this let non-actionable findings (e.g. cache_control tuning, Batch API placement, prompt-template trimming, a blanket verbosity cap, a brittle call-pattern script match) dominate the band and crowd out findings a Claude Code user can actually act on.
The API payload already carries the window's dominant `persona`; the tile-building path now reads it and drops the no-lever analyzers entirely before ranking (no placeholder row), so the tile that leads is guaranteed to carry a real lever. Only the `claude-code` persona is filtered — sdk/mixed/unknown windows are unaffected.

## Test plan
[x] Seeded a local `tj serve` instance with a claude-code-dominant window carrying real (non-zero) `cache`, `batch placement`, and `verbosity` findings alongside a `downsize` candidate, and confirmed via the live-rendered Dashboard that the Recoverable waste band shows only `Reuse` / `Downsize` / `Summarize` / `Context resend` / `Deadweight` — the no-lever findings are gone and the top tile (`Reuse`) is actionable.
[x] Re-seeded the identical data under a non-Claude-Code (`sdk`) agent id and confirmed the same findings (`Cache`, `Batch placement`, `Verbosity`, `Cache recommend`, `Script`, `Trim`) reappear in full — the gate is persona-conditional, not a blanket removal.
[x] Verified no console errors from the change.

🤖 shipped by [shiploop](https://github.com/anshss/shiploop)