### PR TITLE
Apply persona gating consistently to model-swap, batch, and workspace-note proposals

### DIFF
--- a/tests/unit/test_cost_proposals.py
+++ b/tests/unit/test_cost_proposals.py
@@ -526,6 +526,10 @@ def _verbosity_finding(**overrides):
 
 
 def test_verbosity_proposal_shape_and_apply_fields():
+    """Unlike script/reuse, verbosity NEVER offers a write — for any persona,
+    including claude-code (see `_verbosity_to_proposals`'s docstring): a
+    cohort-scoped flag written as a global CLAUDE.md rule fails the
+    no-quality-tax gate outright, regardless of who would read it."""
     from tokenjam.core.optimize.cost_proposals import _verbosity_to_proposals
     props = _verbosity_to_proposals(_verbosity_finding(), persona="claude-code")
     assert len(props) == 1
@@ -536,16 +540,20 @@ def test_verbosity_proposal_shape_and_apply_fields():
     assert "6 session" in p.evidence
     assert p.estimated_recoverable_usd == 0.9
     assert p.estimated_recoverable_tokens == 9_000
-    assert p.advise_only is False
-    assert p.apply_capable is True
-    assert p.rung == 1
-    assert p.scope == "project"
-    # The remedy snippet + the concrete suggested cap both land in the note.
-    assert "concise" in p.proposed_fix.lower()
-    assert "800" in p.proposed_fix
+    assert p.advise_only is True
+    assert p.apply_capable is False
+    assert p.rung == 0
+    assert p.scope == ""
+    assert p.proposed_fix == ""
+    # The remedy snippet + the concrete suggested cap both land in the
+    # copy-pasteable suggestion, worded as a data point, never an
+    # enforceable cap.
+    assert "800" in p.suggestion
+    assert "not a limit to enforce" in p.suggestion
     # The honesty caveat (output length is not waste) rides along, never a
     # bare "you are wasting tokens" claim.
-    assert "not waste" in p.proposed_fix
+    assert "not waste" in p.suggestion
+    assert p.suggestion == p.advise_text
     assert p.baseline["apply_sessions"] == 6
 
 
@@ -570,14 +578,18 @@ def test_script_reuse_verbosity_wired_into_cost_analyzers_and_report_adapter():
     assert {"script", "reuse", "verbosity"} <= analyzers
 
 
-# --- Persona-gated fix modality (script / reuse / verbosity only) -----------
+# --- Persona-gated fix modality (script / reuse / verbosity) ----------------
 #
-# These three analyzers' only apply path is a rung-1 CLAUDE.md note or rung-2
+# script/reuse's apply path is a rung-1 CLAUDE.md note or rung-2
 # .claude/skills/<slug>/SKILL.md — an artifact nothing in an SDK service's
 # request path ever reads. An "sdk"/"unknown" persona must never see
 # apply_capable=True for them; the identical recommendation must still reach
 # them as a copy-pasteable `suggestion`. A "claude-code" window must be
 # byte-identical to before this gating existed.
+#
+# verbosity shares the sdk/unknown no-write behavior (parametrized in below)
+# but NEVER offers the write, for ANY persona including claude-code/mixed —
+# see the dedicated tests after the parametrized block.
 
 def _script_finding_for_persona_tests():
     return _workflow_finding()
@@ -644,7 +656,6 @@ def test_unknown_persona_is_gated_same_as_sdk(adapter_name, finder):
 @pytest.mark.parametrize("adapter_name,finder", [
     ("_script_to_proposals", _script_finding_for_persona_tests),
     ("_reuse_to_proposals", _reuse_finding_for_persona_tests),
-    ("_verbosity_to_proposals", _verbosity_finding_for_persona_tests),
 ])
 def test_claude_code_persona_is_byte_identical_to_pre_gating_shape(adapter_name, finder):
     """The exact fields these analyzers produced before persona gating
@@ -666,7 +677,6 @@ def test_claude_code_persona_is_byte_identical_to_pre_gating_shape(adapter_name,
 @pytest.mark.parametrize("adapter_name,finder", [
     ("_script_to_proposals", _script_finding_for_persona_tests),
     ("_reuse_to_proposals", _reuse_finding_for_persona_tests),
-    ("_verbosity_to_proposals", _verbosity_finding_for_persona_tests),
 ])
 def test_mixed_persona_offers_the_write_and_the_snippet(adapter_name, finder):
     """"mixed": both audiences are meaningfully represented and a single
@@ -684,6 +694,23 @@ def test_mixed_persona_offers_the_write_and_the_snippet(adapter_name, finder):
     assert p.advise_only is False
     assert p.proposed_fix
     assert p.suggestion == p.advise_text
+
+
+@pytest.mark.parametrize("persona", ["claude-code", "mixed", "sdk", "unknown"])
+def test_verbosity_never_offers_the_write_for_any_persona(persona):
+    """verbosity's write path is disabled outright, not persona-gated: the
+    finding's cohort-scoped flag would become a global CLAUDE.md rule if
+    written, for EVERY persona — see `_verbosity_to_proposals`."""
+    from tokenjam.core.optimize.cost_proposals import _verbosity_to_proposals
+    props = _verbosity_to_proposals(_verbosity_finding_for_persona_tests(), persona=persona)
+    assert len(props) == 1
+    p = props[0]
+    assert p.apply_capable is False
+    assert p.advise_only is True
+    assert p.rung == 0
+    assert p.scope == ""
+    assert p.proposed_fix == ""
+    assert p.suggestion == p.advise_text  # the recommendation still reaches everyone
 
 
 def test_cost_proposals_from_report_reads_persona_off_the_report():
@@ -705,8 +732,11 @@ def test_cost_proposals_from_report_reads_persona_off_the_report():
 
     rep.persona = "claude-code"
     by_analyzer = {p.analyzer: p for p in cost_proposals_from_report(rep)}
-    for name in ("script", "reuse", "verbosity"):
+    for name in ("script", "reuse"):
         assert by_analyzer[name].apply_capable is True
+    # verbosity never offers the write, even for claude-code — see
+    # test_verbosity_never_offers_the_write_for_any_persona.
+    assert by_analyzer["verbosity"].apply_capable is False
 
     # A report with no persona set at all (e.g. hand-built, pre-gating test
     # code) defaults to "unknown" -> the fail-safe, not "claude-code".
@@ -1174,6 +1204,140 @@ def test_downsize_agent_row_monthly_usd_matches_its_own_evidence_text():
     assert prop.estimated_monthly_usd == rows[0].projected_30d_delta_usd
     # The evidence paragraph's own "$X per 30 days" is the identical number.
     assert f"{prop.estimated_monthly_usd:,.2f}" in prop.evidence or f"{prop.estimated_monthly_usd:.4f}" in prop.evidence
+
+
+# --- Persona gating: downsize (window-wide + per-agent) ---------------------
+
+def _downsize_finding():
+    return DowngradeFinding(
+        candidate_sessions=4, total_sessions=10, actual_cost_usd=5.0,
+        alternative_cost_usd=2.0, monthly_savings_usd=3.0, percent_of_sessions=40.0,
+        examples=[], suggestions={"claude-opus-4-8": "claude-sonnet-5"},
+        estimated_recoverable_usd=3.0, percent_of_tokens=35.0,
+        estimate_basis="downsize basis",
+    )
+
+
+def test_downsize_window_wide_card_gives_claude_code_the_cc_lever_not_a_raw_swap():
+    """A claude-code window can't switch its own interactive model mid-
+    session, so the window-wide fallback card must not hand it the raw
+    "route to a cheaper model" instruction an SDK caller gets."""
+    from tokenjam.core.optimize.cost_proposals import _downsize_to_proposal
+
+    props = _downsize_to_proposal(_downsize_finding(), persona="claude-code")
+    assert len(props) == 1
+    p = props[0]
+    assert "switch your own interactive model" in p.advise_text
+    assert "route to a cheaper" not in p.advise_text.lower()
+    assert "tj route export" in p.advise_text
+    assert p.suggestion == ""  # the unusable model-swap snippet is dropped
+
+
+def test_downsize_window_wide_card_unchanged_for_sdk_and_unknown():
+    from tokenjam.core.optimize.cost_proposals import _downsize_to_proposal
+
+    for persona in ("sdk", "unknown"):
+        props = _downsize_to_proposal(_downsize_finding(), persona=persona)
+        p = props[0]
+        assert "Route the flagged structural-shaped work" in p.advise_text
+        assert p.suggestion  # the swap snippet is still there for a caller who can act on it
+
+
+def test_downsize_window_wide_card_mixed_gets_both():
+    from tokenjam.core.optimize.cost_proposals import _downsize_to_proposal
+
+    props = _downsize_to_proposal(_downsize_finding(), persona="mixed")
+    p = props[0]
+    assert "Route the flagged structural-shaped work" in p.advise_text  # sdk share
+    assert "switch your own interactive model" in p.advise_text          # cc share
+
+
+def test_downsize_agent_card_apply_blocked_gets_cc_lever_for_claude_code():
+    """A per-agent card with no registered source path (apply blocked) is
+    just as unreachable for a claude-code window as the window-wide card —
+    it must get the same CC-actionable lever appended."""
+    from tokenjam.core.optimize.analyzers.downsize_agents import build_agent_price_rows
+    from tokenjam.core.optimize.cost_proposals import _downsize_agent_proposals
+
+    candidates = [{
+        "session_id": f"s{i}", "agent_id": "claude-code", "provider": "anthropic",
+        "model": "claude-opus-4-7", "alt_model": "claude-haiku-4-5",
+        "input_tokens": 1, "output_tokens": 48, "cache_tokens": 3142, "cache_write_tokens": 6716,
+    } for i in range(32)]
+    rows = build_agent_price_rows(candidates, window_days=30.0)
+
+    class _Finding:
+        per_agent = rows
+        candidate_sessions = 32
+        suggestions: dict = {}
+
+    props = _downsize_agent_proposals(_Finding(), config=None, persona="claude-code")
+    assert len(props) == 1
+    p = props[0]
+    assert "Applying it here is not on offer" in p.advise_text
+    assert "switch your own interactive model" in p.advise_text
+
+    # sdk/unknown never get the CC lever appended.
+    for persona in ("sdk", "unknown"):
+        p2 = _downsize_agent_proposals(_Finding(), config=None, persona=persona)[0]
+        assert "switch your own interactive model" not in p2.advise_text
+
+
+# --- Persona gating: placement (batch) ---------------------------------------
+
+def _placement_finding():
+    from tokenjam.core.optimize.analyzers.batch_placement import (
+        BatchCandidate,
+        BatchPlacementFinding,
+    )
+
+    candidate = BatchCandidate(
+        agent_id="worker-svc", sessions=8, first_start="2026-07-01T00:00:00Z",
+        last_start="2026-07-15T00:00:00Z", median_gap_seconds=3600.0, gap_cv=0.1,
+        cost_usd=4.0, tokens=200_000, estimated_batch_saving_usd=2.0,
+    )
+    return BatchPlacementFinding(
+        candidates=[candidate], window_cost_usd=10.0, candidate_cost_usd=4.0,
+        percent_of_window_cost=40.0, estimated_recoverable_usd=2.0,
+        estimated_recoverable_tokens=200_000, estimate_basis="placement basis",
+    )
+
+
+def test_placement_suppressed_outright_for_claude_code_persona():
+    """Batch API is structurally unreachable from an interactive coding-agent
+    session (there's no application code of its own to move to a batch
+    lane) — the whole card must be gone, not just the dollar figure,
+    regardless of pricing_mode."""
+    from tokenjam.core.optimize.cost_proposals import _placement_to_proposals
+
+    for pricing_mode in ("api", "subscription"):
+        assert _placement_to_proposals(
+            _placement_finding(), pricing_mode=pricing_mode, persona="claude-code",
+        ) == []
+
+
+@pytest.mark.parametrize("persona", ["sdk", "mixed", "unknown"])
+def test_placement_unaffected_for_non_claude_code_personas(persona):
+    from tokenjam.core.optimize.cost_proposals import _placement_to_proposals
+
+    props = _placement_to_proposals(_placement_finding(), persona=persona)
+    assert len(props) == 1
+    assert props[0].analyzer == "placement"
+
+
+def test_placement_gated_by_report_persona_through_the_dispatcher():
+    from tokenjam.core.optimize.cost_proposals import cost_proposals_from_report
+
+    rep = _report()
+    rep.findings["placement"] = _placement_finding()
+
+    rep.persona = "claude-code"
+    analyzers = {p.analyzer for p in cost_proposals_from_report(rep)}
+    assert "placement" not in analyzers
+
+    rep.persona = "sdk"
+    analyzers = {p.analyzer for p in cost_proposals_from_report(rep)}
+    assert "placement" in analyzers
 
 
 def test_backfill_legacy_monthly_fields_fills_only_absent_keys():

--- a/tests/unit/test_optimize_verbosity.py
+++ b/tests/unit/test_optimize_verbosity.py
@@ -210,7 +210,10 @@ def test_surfaces_remedy_but_does_not_apply(db):
     _seed_session(db, "loud", output_tokens=3000, i=50)
     finding = _run(db)
     assert finding.remedy_snippet
-    assert "concise" in finding.remedy_snippet.lower()
+    # Soft guidance, not an enforceable "be concise" directive (a cohort-
+    # scoped flag written as a blanket rule fails the no-quality-tax gate).
+    assert "review" in finding.remedy_snippet.lower()
+    assert "rule to enforce" in finding.remedy_snippet.lower()
     assert finding.suggested_max_tokens == 300  # the cohort median baseline
 
 

--- a/tests/unit/test_relearn.py
+++ b/tests/unit/test_relearn.py
@@ -476,6 +476,57 @@ def test_single_repo_cluster_scopes_to_project(tmp_path):
     assert finding.clusters[0].repos == ["onerepo"]
 
 
+# --- Persona gating on the rung-1/rung-2 write --------------------------------
+# Mirrors cost_proposals._persona_gated_write_fields's gate on the SAME class
+# of surface (a CLAUDE.md/skill write): only claude-code/mixed get the write.
+# A workspace-having (non-OTel) cluster used to be apply-capable regardless of
+# persona — see test_relearn_otel.test_workspace_cluster_is_not_advise_only,
+# which now has to opt back into "claude-code" to isolate the workspace seam
+# from this gate.
+
+def _one_repo_sessions(tmp_path, label):
+    for i in range(MIN_RECURRING_SESSIONS):
+        _edit_before_read_session(tmp_path, f"-Users-test-{label}", f"{label}-{i}")
+    return [(f"{label}-{i}", label) for i in range(MIN_RECURRING_SESSIONS)]
+
+
+@pytest.mark.parametrize("persona", ["claude-code", "mixed"])
+def test_write_offered_cluster_advise_only_false_for_claude_code_and_mixed(tmp_path, persona):
+    sessions = _one_repo_sessions(tmp_path, f"wp-{persona}")
+    finding = analyze_relearns(
+        sessions, projects_root=tmp_path, distill_enabled=False, persona=persona,
+    )
+    assert len(finding.clusters) == 1
+    assert finding.clusters[0].advise_only is False
+
+
+@pytest.mark.parametrize("persona", ["sdk", "unknown"])
+def test_write_withheld_for_sdk_and_unknown_even_with_a_real_workspace(tmp_path, persona):
+    """A workspace-having cluster (a real repo, not an OTel service) still
+    gets no apply path for an sdk/unknown window — nothing in an SDK-only
+    service's request path reads a CLAUDE.md/skill note. The recommendation
+    (`proposed_fix`) is unaffected; only the apply path is withheld."""
+    sessions = _one_repo_sessions(tmp_path, f"nowrite-{persona}")
+    finding = analyze_relearns(
+        sessions, projects_root=tmp_path, distill_enabled=False, persona=persona,
+    )
+    assert len(finding.clusters) == 1
+    cluster = finding.clusters[0]
+    assert cluster.advise_only is True
+    assert cluster.suggested_target == ""
+    assert cluster.proposed_fix  # the recommendation itself is never dropped
+
+
+def test_default_persona_is_unknown_and_withholds_the_write(tmp_path):
+    """No explicit `persona` kwarg must never silently default to
+    claude-code — the conservative default matches every other
+    persona-gated adapter in cost_proposals.py."""
+    sessions = _one_repo_sessions(tmp_path, "default-persona")
+    finding = analyze_relearns(sessions, projects_root=tmp_path, distill_enabled=False)
+    assert len(finding.clusters) == 1
+    assert finding.clusters[0].advise_only is True
+
+
 def test_clean_sessions_produce_no_proposals(tmp_path):
     for i in range(5):
         _clean_session(tmp_path, "-Users-test-clean", f"clean-{i}")

--- a/tests/unit/test_relearn_otel.py
+++ b/tests/unit/test_relearn_otel.py
@@ -201,8 +201,14 @@ def test_workspace_cluster_is_not_advise_only(db):
         for sid in ("s1", "s2", "s3")
     ]
 
+    # persona="claude-code": isolates the workspace-vs-OTel seam under test
+    # from the SEPARATE persona write-gate (see test_relearn.py) — the write
+    # is only ever offered for a claude-code/mixed window regardless of
+    # workspace, so this test's default "unknown" persona would otherwise
+    # mask the very thing it's checking.
     proposals, _ = build_proposals(
         _raw_clusters(failures), advise_only_repos={"billing-svc"},
+        persona="claude-code",
     )
 
     assert len(proposals) == 1
@@ -230,8 +236,11 @@ def test_mixed_cluster_keeps_the_apply_path(db):
         ),
     ]
 
+    # persona="claude-code" — see the comment on test_workspace_cluster_is_
+    # not_advise_only above.
     proposals, _ = build_proposals(
         _raw_clusters(failures), advise_only_repos={"billing-svc"},
+        persona="claude-code",
     )
 
     assert proposals[0].advise_only is False

--- a/tokenjam/cli/cmd_onboard.py
+++ b/tokenjam/cli/cmd_onboard.py
@@ -1038,8 +1038,14 @@ def _run_relearn_first_fix(config: TjConfig, *, port: int, want_daemon: bool) ->
         # (`tj serve`'s relearn job) already runs the full distill-enabled
         # scan and will surface those in the Lens Review inbox on its own
         # schedule.
+        # persona="claude-code": `tj onboard` scanning the Claude Code
+        # transcript root is itself the claude-code persona's own onboarding
+        # flow (there is no window/conn here to classify from), so the write
+        # gate (see `build_proposals`) should stay open the way it always
+        # has for this call site.
         finding = compute_relearn_finding(
             projects_root=CLAUDE_CODE_PROJECTS_ROOT, distill_enabled=False,
+            persona="claude-code",
         )
     except Exception:
         return

--- a/tokenjam/core/optimize/analyzers/output_verbosity.py
+++ b/tokenjam/core/optimize/analyzers/output_verbosity.py
@@ -85,11 +85,20 @@ VERBOSITY_ESTIMATE_BASIS = (
     "net-negative once its own overhead is counted, so measure before claiming"
 )
 
-# Surfaced remedy (not applied). A terse system-prompt snippet the user can add,
-# paired with a max_tokens cap suggestion computed per candidate cohort.
+# Surfaced remedy (not applied, and never written into a workspace file — see
+# `cost_proposals._verbosity_to_proposals`). Deliberately SOFT: the flag is
+# cohort-scoped (this task shape, vs its own like-shaped peers) but a blanket
+# "be concise" instruction pasted into CLAUDE.md would apply GLOBAL terseness
+# pressure to every future task, including legitimately-verbose ones — the
+# analyzer's own honesty caveat above says output length is not waste. So this
+# names the cohort instead of asserting a rule, and states the tradeoff rather
+# than commanding brevity.
 VERBOSITY_REMEDY_SNIPPET = (
-    "Be concise. Answer in the fewest words that fully address the request; "
-    "omit restatement, preamble, and filler. Prefer lists over prose."
+    "This shape of task ran noticeably longer, output-wise, than similar "
+    "sessions recently. Worth a look: if a shorter answer would serve this "
+    "shape of task just as well, prefer it — but only when brevity doesn't "
+    "cost completeness, correctness, or clarity. A longer answer is often "
+    "the right one; this is a candidate to review, not a rule to enforce."
 )
 
 

--- a/tokenjam/core/optimize/analyzers/relearn.py
+++ b/tokenjam/core/optimize/analyzers/relearn.py
@@ -948,6 +948,7 @@ def build_proposals(
     advise_only_repos: set[str] | None = None,
     conn: Any | None = None,
     window_days: float | None = None,
+    persona: str = "unknown",
 ) -> tuple[list[RelearnCluster], int]:
     """Turn surviving raw clusters into ranked proposals. Returns
     ``(proposals, dropped_codified_count)``.
@@ -960,10 +961,21 @@ def build_proposals(
     OTel lane — see ``core/optimize/relearn_otel.py``). A cluster whose repos are
     all in that set is marked ``advise_only`` and gets NO suggested target: there
     is nothing to apply into, so the card must not imply an apply path exists.
+
+    ``persona`` gates the rung-1/rung-2 CLAUDE.md/skill write exactly like
+    ``cost_proposals._persona_gated_write_fields`` gates the script/reuse/
+    verbosity cards it shares that same write surface with: only a
+    ``"claude-code"``/``"mixed"`` window is offered the write. An
+    ``"sdk"``/``"unknown"`` window (the conservative default) never gets one
+    — nothing in an SDK-only service's request path reads a CLAUDE.md or a
+    ``.claude/skills/`` note, so offering it there is a write that visibly
+    succeeds and changes nothing. ``proposed_fix`` (the recommendation text)
+    is unaffected either way — only the apply path is.
     """
     from tokenjam.core.optimize.relearn_apply import default_target_path, slugify
 
     repo_cwd_map = repo_cwd_map or {}
+    write_offered = persona in {"claude-code", "mixed"}
     proposals: list[RelearnCluster] = []
     dropped = 0
     for cluster in clusters:
@@ -993,9 +1005,12 @@ def build_proposals(
         # `bool(advise_only_repos) and ...` defeats mypy's None-narrowing since
         # it's wrapped in a call; guarding on the name itself narrows it to
         # `set[str]` inside the genexpr while keeping identical truthiness.
+        # `not write_offered` folds in the persona gate above: even a
+        # workspace-having cluster gets no apply path for an sdk/unknown
+        # window.
         advise_only = bool(
             advise_only_repos and all(r in advise_only_repos for r in repos)
-        )
+        ) or not write_offered
         repo_cwd = "" if advise_only else (
             repo_cwd_map.get(repos[0], "") if len(repos) == 1 else ""
         )
@@ -1055,6 +1070,7 @@ def analyze_relearns(
     extra_failures: list[FailureEpisode] | None = None,
     advise_only_repos: set[str] | None = None,
     conn: Any | None = None,
+    persona: str = "unknown",
 ) -> RelearnFinding:
     """Full pipeline over an explicit session list — the pure core the
     registry entry point and the on-disk cache job both call. Never raises.
@@ -1070,6 +1086,8 @@ def analyze_relearns(
     ``conn`` (optional DuckDB connection) is forwarded to ``build_proposals``
     for the per-cluster blended-dollar-rate lookup (Review inbox monthly-$
     basis) — ``None`` keeps every cluster tokens-only, same as today.
+    ``persona`` is forwarded to ``build_proposals`` to gate the rung-1/rung-2
+    write — see its docstring.
     """
     all_failures: list[FailureEpisode] = []
     scanned = 0
@@ -1104,7 +1122,7 @@ def analyze_relearns(
     proposals, dropped = build_proposals(
         distilled, min_sessions=min_sessions, doc_text=codified_doc_text,
         repo_cwd_map=repo_cwd_map, advise_only_repos=advise_only_repos,
-        conn=conn, window_days=window_days,
+        conn=conn, window_days=window_days, persona=persona,
     )
     total_tokens = sum(p.estimated_recoverable_tokens for p in proposals)
     total_monthly_tokens = sum(p.estimated_monthly_tokens for p in proposals) if proposals else None
@@ -1178,6 +1196,7 @@ def compute_relearn_finding(
     distill_enabled: bool = True,
     min_sessions: int = MIN_RECURRING_SESSIONS,
     transcript_cache_dir: Path | None = None,
+    persona: str = "unknown",
 ) -> RelearnFinding:
     """Standalone entry point that doesn't need a full ``AnalyzerContext`` —
     used by the serve-time background cache job (``api/routes/relearn.py``)
@@ -1185,6 +1204,12 @@ def compute_relearn_finding(
     repo-name enrichment (``sessions.agent_id``); pass ``None`` and every
     session falls back to a ``"unknown"`` repo label — clustering itself needs
     no DB at all, it's a pure filesystem scan.
+
+    ``persona`` (default ``"unknown"``, the conservative no-write default —
+    see ``build_proposals``) is forwarded to gate the rung-1/rung-2 write.
+    ``run(ctx)`` below passes the report's own ``ctx.persona`` rather than
+    re-deriving it here, so a report never carries two different persona
+    classifications for the same window.
 
     Full-corpus by design: enumerates every on-disk Claude Code transcript
     (not window-scoped like the other analyzers — a relearn recurring across
@@ -1255,7 +1280,7 @@ def compute_relearn_finding(
         distill_enabled=distill_enabled, repo_cwd_map=repo_cwd_map,
         extra_failures=span_failures, advise_only_repos=advise_only_repos,
         min_sessions=min_sessions, transcript_cache_dir=transcript_cache_dir,
-        conn=conn,
+        conn=conn, persona=persona,
     )
 
 
@@ -1278,4 +1303,5 @@ def run(ctx: AnalyzerContext) -> None:
     ctx.report.findings["relearn"] = compute_relearn_finding(
         ctx.conn, ctx.since, min_sessions=min_sessions,
         transcript_cache_dir=default_cache_dir(ctx.config),
+        persona=ctx.persona,
     )

--- a/tokenjam/core/optimize/cost_proposals.py
+++ b/tokenjam/core/optimize/cost_proposals.py
@@ -20,13 +20,16 @@ NOT optional here:
     tokenjam cannot write into — those cards have NO apply path, exactly like
     an ``advise_only`` ``RelearnCluster`` (empty ``suggested_target``). A
     minority (``subagent``, the per-agent slice of ``downsize``, ``script``,
-    ``reuse``, ``verbosity``) DO have a workspace surface an orchestrating
-    agent reads before acting (a CLAUDE.md rubric, a model-id key, a new
-    skill note) and route through the same rung-gated
-    ``relearn_apply.apply_relearn_fix`` machinery the relearn lane uses
-    (``apply_capable=True``, ``rung``, ``scope``, ``proposed_fix``). Every
-    other card carries a recommendation and, where sensible, a copyable
-    config/code suggestion; the user applies it themselves.
+    ``reuse``) DO have a workspace surface an orchestrating agent reads
+    before acting (a CLAUDE.md rubric, a model-id key, a new skill note) and
+    route through the same rung-gated ``relearn_apply.apply_relearn_fix``
+    machinery the relearn lane uses (``apply_capable=True``, ``rung``,
+    ``scope``, ``proposed_fix``). ``verbosity`` shares that same class of
+    surface in principle but is deliberately kept advise-only for every
+    persona (see ``_verbosity_to_proposals``) — the finding is cohort-scoped
+    but the artifact would be global, which fails the no-quality-tax gate.
+    Every other card carries a recommendation and, where sensible, a
+    copyable config/code suggestion; the user applies it themselves.
   * **Estimated, never causal.** Every saving figure a cost finding carries is
     a heuristic ESTIMATE (house style, CLAUDE.md Rule 14). The adapter
     preserves the finding's own ``estimate_basis`` and labels the figure
@@ -114,6 +117,31 @@ SUBAGENT_RUBRIC_INTRO = (
     "the premium tier."
 )
 
+# The downsize card's claude-code CTA. Mirrors `cmd_optimize._render_downgrade_
+# cta`'s claude-code branch: an interactive CC session can't pass `--original`/
+# `--candidate` to swap its own model mid-turn, so "route to a cheaper model"
+# is not a fix this persona can act on. Used wherever the card would otherwise
+# hand a CC window the same generic model-swap text an SDK caller gets (see
+# ticket-level "no CC user gets a raw-model-swap CTA" requirement).
+_DOWNSIZE_CC_LEVER = (
+    "You can't switch your own interactive model mid-session, so this is not a "
+    "fix to paste into your own request the way an SDK caller would. The "
+    "actionable levers instead: `tj route export --target ccr` (or --target "
+    "litellm) to route future calls through a cheaper model, `tj optimize "
+    "subagent` to right-size subagent models and context, `/compact` to trim "
+    "context mid-session, or a CLAUDE.md/subagent directive telling this agent "
+    "to dispatch cheaper subagents for this shape of work."
+)
+
+# Appended (not substituted) for a "mixed" window: the swap text above already
+# applies to the sdk share, this just adds the claude-code share's own lever —
+# same "both, labeled" precedent as `_render_downgrade_cta`'s mixed branch.
+_DOWNSIZE_MIXED_CC_NOTE = (
+    " For the Claude Code sessions in this window: you can't switch your own "
+    "interactive model mid-session — use `tj route export`, `tj optimize "
+    "subagent`, or `/compact` instead."
+)
+
 
 @dataclass
 class CostProposal:
@@ -198,7 +226,9 @@ class CostProposal:
 # proposals. All tolerate a None/empty finding (returns []).
 # --------------------------------------------------------------------------- #
 
-def _downsize_to_proposal(finding: Any, config: Any = None) -> list[CostProposal]:
+def _downsize_to_proposal(
+    finding: Any, config: Any = None, persona: str = "unknown",
+) -> list[CostProposal]:
     """The model-over-sizing card(s).
 
     When the finding carries per-agent price rows, each agent gets its own card
@@ -212,10 +242,15 @@ def _downsize_to_proposal(finding: Any, config: Any = None) -> list[CostProposal
     maps each oversized model to its cheaper same-family alternative, and the
     delta-verify pass measures the model-mix cost delta across ALL flagged
     models, so one proposal listing them keeps that aggregate estimate coherent.
+
+    ``persona`` gates the CTA exactly like ``cmd_optimize._render_downgrade_
+    cta`` gates the CLI's: a ``"claude-code"`` window can't switch its own
+    interactive model, so it never gets the raw "route to a cheaper model"
+    instruction — see ``_DOWNSIZE_CC_LEVER``.
     """
     if finding is None or getattr(finding, "candidate_sessions", 0) <= 0:
         return []
-    per_agent = _downsize_agent_proposals(finding, config)
+    per_agent = _downsize_agent_proposals(finding, config, persona)
     if per_agent:
         return per_agent
     suggestions: dict[str, str] = dict(getattr(finding, "suggestions", {}) or {})
@@ -229,13 +264,20 @@ def _downsize_to_proposal(finding: Any, config: Any = None) -> list[CostProposal
         f"({model_list}); candidate sessions are {finding.percent_of_tokens:.0f}% "
         f"of the window's tokens."
     )
-    advise = (
-        "Route the flagged structural-shaped work to the cheaper same-family "
-        "model before it runs. Suggested swaps: "
-        + "; ".join(f"{m} → {alt}" for m, alt in sorted(suggestions.items()))
-        + ". " + str(getattr(finding, "caveat", "") or "")
-    ).strip()
+    caveat = str(getattr(finding, "caveat", "") or "")
     suggestion = "\n".join(f"{m} -> {alt}" for m, alt in sorted(suggestions.items()))
+    if persona == "claude-code":
+        advise = (_DOWNSIZE_CC_LEVER + " " + caveat).strip()
+        suggestion = ""
+    else:
+        advise = (
+            "Route the flagged structural-shaped work to the cheaper same-family "
+            "model before it runs. Suggested swaps: "
+            + "; ".join(f"{m} → {alt}" for m, alt in sorted(suggestions.items()))
+            + ". " + caveat
+        ).strip()
+        if persona == "mixed":
+            advise += _DOWNSIZE_MIXED_CC_NOTE
     return [CostProposal(
         kind="cost",
         analyzer="downsize",
@@ -360,12 +402,20 @@ def _model_swap_plumbing(row: Any, config: Any) -> dict[str, Any]:
     }
 
 
-def _downsize_agent_proposals(finding: Any, config: Any) -> list[CostProposal]:
+def _downsize_agent_proposals(
+    finding: Any, config: Any, persona: str = "unknown",
+) -> list[CostProposal]:
     """One card per agent, carrying that agent's own price arithmetic.
 
     Replaces the window-wide card when per-agent rows exist, so one source of
     over-sized spend produces exactly one card rather than an aggregate plus its
     own parts.
+
+    When the direct model-id swap is ``apply_capable`` (a registered, git-clean
+    source path — see ``_model_swap_plumbing``), the fix is a real write to
+    that agent's own config, not "switch your interactive model": it stays
+    persona-agnostic. Only the NON-apply-capable fallback text needs the
+    claude-code CTA, same reasoning as the window-wide card above.
     """
     proposals: list[CostProposal] = []
     for row in getattr(finding, "per_agent", []) or []:
@@ -402,6 +452,10 @@ def _downsize_agent_proposals(finding: Any, config: Any) -> list[CostProposal]:
             )
         elif plumbing.get("apply_blocked_reason"):
             advise += f" Applying it here is not on offer: {plumbing['apply_blocked_reason']}"
+            if persona == "claude-code":
+                advise += " " + _DOWNSIZE_CC_LEVER
+            elif persona == "mixed":
+                advise += _DOWNSIZE_MIXED_CC_NOTE
         proposals.append(CostProposal(
             kind="cost",
             analyzer="downsize",
@@ -461,7 +515,7 @@ def _downsize_agent_proposals(finding: Any, config: Any) -> list[CostProposal]:
 
 
 def _placement_to_proposals(
-    finding: Any, *, pricing_mode: str = "api",
+    finding: Any, *, pricing_mode: str = "api", persona: str = "unknown",
 ) -> list[CostProposal]:
     """One card for the batch-placement candidates (advise-only).
 
@@ -475,8 +529,17 @@ def _placement_to_proposals(
     (CLAUDE.md anti-pattern #22: never show a figure the reader can't act
     on). Without this the web Review inbox showed a batch-placement dollar
     figure the CLI deliberately suppresses for the same finding.
+
+    ``persona`` gates the WHOLE card, not just the dollar figure: the Batch
+    API is a synchronous-endpoint replacement in the user's own APPLICATION
+    code, and an interactive Claude Code session has no application code of
+    its own to move to a batch lane — the lever is structurally unreachable
+    for that persona regardless of ``pricing_mode``. A ``"claude-code"``
+    window gets nothing here (not even the advise-only/no-dollar branch);
+    ``"mixed"``/``"sdk"``/``"unknown"`` are unaffected — the sdk share of a
+    mixed window can still act on it.
     """
-    if finding is None:
+    if finding is None or persona == "claude-code":
         return []
     candidates = list(getattr(finding, "candidates", []) or [])
     if not candidates:
@@ -1304,9 +1367,13 @@ def _cluster_hash(value: Any) -> str:
 
 
 # --------------------------------------------------------------------------- #
-# Persona-gated fix modality — `script` / `reuse` / `verbosity` only.
+# Persona-gated fix modality — `script` / `reuse` only. (`verbosity` shares
+# the same write SURFACE — see its own module comment above `_verbosity_to_
+# proposals` — but never offers the write at all, for any persona: its
+# cohort-scoped flag would become a global CLAUDE.md rule if written, which
+# fails the no-quality-tax gate outright regardless of who reads it.)
 #
-# All three write the SAME class of artifact when apply-capable: a rung-1
+# Both write the SAME class of artifact when apply-capable: a rung-1
 # CLAUDE.md note or rung-2 `.claude/skills/<slug>/SKILL.md` file (see
 # `relearn_apply.default_target_path`). Nothing in an SDK-only service's
 # request path ever reads a CLAUDE.md or a `.claude/skills/` note — those are
@@ -1501,22 +1568,18 @@ def _verbosity_to_proposals(finding: Any, persona: str = "unknown") -> list[Cost
     """One proposal for the whole verbosity finding (unlike ``script``/
     ``reuse``, this is a single window-wide signal, not per-cluster).
 
-    Apply-capable at rung 1: a CLAUDE.md note carrying the finding's own
-    ``remedy_snippet`` plus its suggested ``max_tokens`` cap. This is the
-    least-grounded of the three analyzers by design (output length is not
-    waste), so the note leans on the finding's own honesty caveat rather than
-    asserting a saving. Left un-degraded to advise-only would strand the one
-    lever this analyzer already computes (the remedy snippet) with nowhere to
-    go; a workspace note is the same class of soft, orchestrator-read surface
-    the ``subagent`` rubric already uses, so this reuses that precedent
-    rather than inventing a new one.
-
-    The write is only actually offered for a ``"claude-code"``/``"mixed"``
-    ``persona`` — see ``_persona_gated_write_fields``. This is the sharpest
-    case of the three: the lever itself (``max_tokens``) is genuinely
-    SDK-actionable — an SDK caller can cap it in their own request — it is
-    only the CLAUDE.md *artifact* that is the wrong surface for them. Gating
-    still carries the cap as a ``suggestion`` so that lever isn't lost.
+    ALWAYS advise-only, regardless of ``persona`` — no rung-1 CLAUDE.md write
+    is ever offered here, unlike ``script``/``reuse`` which share the same
+    write machinery. A cohort-scoped flag (this task shape ran long vs its
+    OWN like-shaped peers) written as a global CLAUDE.md note would apply
+    blanket terseness pressure to every future task, including legitimately
+    verbose ones — the analyzer's own honesty caveat says output length is
+    not waste, so an enforced-looking file note fails that gate outright.
+    The recommendation is still carried as a copy-pasteable ``suggestion``
+    for every persona (never silently dropped), it just never becomes a
+    write. ``persona`` is accepted (and kept in the dispatcher's uniform
+    ``(f, persona=persona)`` call shape) but intentionally unused — see
+    above.
     """
     if finding is None:
         return []
@@ -1533,10 +1596,13 @@ def _verbosity_to_proposals(finding: Any, persona: str = "unknown") -> list[Cost
     )
     advise = remedy
     if max_tokens:
+        # A DATA POINT, not an enforceable cap — "keep responses under N
+        # tokens" reads as a rule once pasted anywhere; this states what
+        # similar sessions happened to do instead.
         advise += (
-            f" Suggested cap for this shape of task: keep responses under "
-            f"about {max_tokens:,} output tokens (the cohort baseline most "
-            f"sessions already sit under)."
+            f" For reference, similar sessions in this cohort typically "
+            f"finished under about {max_tokens:,} output tokens — a data "
+            f"point to weigh, not a limit to enforce."
         )
     advise = (advise + " " + caveat).strip()
     return [CostProposal(
@@ -1554,10 +1620,10 @@ def _verbosity_to_proposals(finding: Any, persona: str = "unknown") -> list[Cost
             "apply_sessions": total_candidates,
         },
         advise_text=advise,
+        suggestion=advise,
         estimated_recoverable_usd=getattr(finding, "estimated_recoverable_usd", None),
         estimated_recoverable_tokens=getattr(finding, "estimated_recoverable_tokens", None),
         estimate_basis=str(getattr(finding, "estimate_basis", "") or ""),
-        **_persona_gated_write_fields(persona, advise, rung=1, scope="project"),
     )]
 
 
@@ -1779,19 +1845,29 @@ def cost_proposals_from_report(
     so existing callers that don't know their caller's plan keep today's
     behaviour.
 
-    ``script`` / ``reuse`` / ``verbosity`` read ``report.persona`` (set once
-    by ``runner.build_report`` — see ``AnalyzerContext.persona``) to decide
-    whether their rung-1/rung-2 workspace write is offered at all — see
-    ``_persona_gated_write_fields``. The whole ``cache`` family (``cache`` /
-    ``cache_thrash`` / ``cache-recommend``) reads the same ``persona`` to
-    decide whether their cache_control instruction is shown at all — see
-    ``_persona_gated_cache_fields``; unlike script/reuse/verbosity there is no
-    write to gate, only the instruction text. A report built without a
+    ``script`` / ``reuse`` read ``report.persona`` (set once by ``runner.
+    build_report`` — see ``AnalyzerContext.persona``) to decide whether their
+    rung-1/rung-2 workspace write is offered at all — see
+    ``_persona_gated_write_fields``. ``verbosity`` reads the same finding
+    shape but never offers a write for ANY persona (see ``_verbosity_to_
+    proposals``) — a cohort-scoped flag written as a global CLAUDE.md rule
+    fails the no-quality-tax gate regardless of who would read it. The whole
+    ``cache`` family (``cache`` / ``cache_thrash`` / ``cache-recommend``)
+    reads the same ``persona`` to decide whether their cache_control
+    instruction is shown at all — see ``_persona_gated_cache_fields``; unlike
+    script/reuse there is no write to gate, only the instruction text.
+    ``downsize`` reads the same ``persona`` to swap its CTA for the
+    claude-code-actionable levers (``tj route export`` / ``tj optimize
+    subagent`` / ``/compact``) instead of a raw model-swap instruction that
+    persona can't act on — see ``_DOWNSIZE_CC_LEVER``. ``placement`` reads it
+    to suppress the card outright for a ``"claude-code"`` window: the Batch
+    API is a lever in the user's own application code, which an interactive
+    session doesn't have. A report built without a
     ``persona`` field (e.g. hand-constructed in a test) defaults to
-    ``"unknown"``, which keeps the script/reuse/verbosity write off (that
-    helper's conservative default) while leaving the cache family's
-    instruction on (that helper's conservative default runs the other way —
-    see its own docstring) — neither ever assumes ``"claude-code"``.
+    ``"unknown"``, which keeps the script/reuse write off (that helper's
+    conservative default) while leaving the cache family's instruction on
+    (that helper's conservative default runs the other way — see its own
+    docstring) — neither ever assumes ``"claude-code"``.
 
     ``window_days`` (default 30 — ``DEFAULT_COST_WINDOW_DAYS``, matching the
     daemon's own default look-back) is the monthly-basis extrapolation factor
@@ -1807,7 +1883,10 @@ def cost_proposals_from_report(
     persona = str(getattr(report, "persona", "") or "unknown")
     proposals: list[CostProposal] = []
     adapters = (
-        (lambda f: _downsize_to_proposal(f, config), getattr(report, "downgrade", None)),
+        (
+            lambda f: _downsize_to_proposal(f, config, persona=persona),
+            getattr(report, "downgrade", None),
+        ),
         (lambda f: _cache_to_proposals(f, persona=persona), findings.get("cache")),
         (lambda f: _cache_uncached_to_proposals(f, persona=persona), findings.get("cache")),
         (lambda f: _cache_thrash_to_proposals(f, persona=persona), findings.get("cache")),
@@ -1818,7 +1897,10 @@ def cost_proposals_from_report(
         ),
         (_trim_to_proposals, findings.get("trim")),
         (lambda f: _subagent_to_proposals(f, config), findings.get("subagent")),
-        (lambda f: _placement_to_proposals(f, pricing_mode=pricing_mode), findings.get("placement")),
+        (
+            lambda f: _placement_to_proposals(f, pricing_mode=pricing_mode, persona=persona),
+            findings.get("placement"),
+        ),
         (_deadweight_to_proposals, findings.get("deadweight")),
         (lambda f: _script_to_proposals(f, persona=persona), findings.get("script")),
         (lambda f: _reuse_to_proposals(f, persona=persona), findings.get("reuse")),

--- a/tokenjam/core/optimize/relearn_store.py
+++ b/tokenjam/core/optimize/relearn_store.py
@@ -233,8 +233,28 @@ def recompute_now(
                 transcript_cache_dir = default_cache_dir(config)
             except Exception:
                 transcript_cache_dir = None
+        # Full-corpus persona classification (relearn scans unbounded history
+        # like the finding itself, not a window) — same functions
+        # `runner.build_report` uses for `AnalyzerContext.persona`/
+        # `OptimizeReport.persona`, so the daemon's relearn cache gates its
+        # rung-1/rung-2 write by the same rule the rest of the product does.
+        persona = "unknown"
+        if conn is not None:
+            try:
+                from tokenjam.core.framing import (
+                    agent_persona_mix,
+                    config_declared_plan,
+                    dominant_persona,
+                )
+
+                persona = dominant_persona(
+                    agent_persona_mix(conn), declared_plan=config_declared_plan(config),
+                )
+            except Exception:
+                persona = "unknown"
         finding = compute_relearn_finding(
             conn, projects_root=projects_root, transcript_cache_dir=transcript_cache_dir,
+            persona=persona,
         )
         # cache_path, when omitted, resolves via `config` (honors --config /
         # storage.path, and a :memory:/"" storage.path never falls through to


### PR DESCRIPTION
## Summary
The downsize (model-oversizing) card told every persona to "switch models," even an interactive Claude Code session that has no such lever — it now gets the levers it can actually pull (routing config export, subagent right-sizing, `/compact`) instead.
The batch-placement card showed an api-billed Batch API dollar figure regardless of persona; it's now suppressed outright for an interactive coding-agent session, since there's no application code of its own to move to a batch lane.
The relearn detector's rung-1/rung-2 CLAUDE.md/skill write ignored persona entirely, unlike the other analyzers that share the same write surface (script/reuse) — it now gates the same way.
The verbosity remedy text read as an enforceable "be concise" rule despite the underlying signal being scoped to one task-shape cohort; it's reworded as a review prompt, and the write path is disabled outright for every persona (not just persona-gated), since a cohort-scoped flag written into a global file would apply blanket terseness pressure to unrelated future tasks.

## Test plan
[x] `pytest tests/unit/test_cost_proposals.py tests/unit/test_relearn.py tests/unit/test_relearn_otel.py tests/unit/test_optimize_verbosity.py` — new + existing coverage green
[x] `pytest tests/unit` — full unit suite (2941 passed, 2 skipped)
[x] `pytest tests/integration/test_cost_proposals_api.py tests/integration/test_relearn_api.py`
[x] `ruff check` / `mypy` on all touched modules

🤖 shipped by [shiploop](https://github.com/anshss/shiploop)