### PR TITLE
Price waste estimates honestly across the Optimize surface

### DIFF
--- a/tests/integration/test_api.py
+++ b/tests/integration/test_api.py
@@ -768,7 +768,9 @@ async def test_budget_framing_reflects_configured_subscription_plan(db):
     assert framing["pricing_mode"] == "subscription"
     assert framing["plan_tier"] == "max_5x"
     assert framing["plan_label"] == "Max 5x plan"
-    assert framing["display_rule"] == "suppress_dollars_for_subscription_share"
+    # Dollars are shown by default (assume API pricing), qualified as a
+    # list-price equivalent — never suppressed for a subscription plan.
+    assert framing["display_rule"] == "show_dollars_with_qualifier"
 
 
 async def test_get_alerts_returns_list(client):

--- a/tests/integration/test_cli.py
+++ b/tests/integration/test_cli.py
@@ -202,7 +202,10 @@ def test_status_subscription_plan_shows_no_raw_dollar_line(runner, db):
     assert "$0.00" not in result.output
     assert "$0.000000" not in result.output
     assert "Cost today:     0.0% of cycle" in result.output
-    assert "Subscription plan" in result.output
+    # The generic "Subscription plan — flat-fee billing" note was superseded
+    # by compute_framing's list-price-equivalent qualifier, which now fires
+    # unconditionally for subscription mode (see cmd_status._framing_note).
+    assert "list-price equivalent, not an amount billed" in result.output
 
 
 def test_status_api_plan_keeps_raw_dollar_line(runner, db, config):

--- a/tests/unit/test_cmd_cost.py
+++ b/tests/unit/test_cmd_cost.py
@@ -79,7 +79,11 @@ def test_subscription_plan_suppresses_raw_dollars(db):
     # render_dollar's "X% of cycle" framing (the COST column may wrap it, so
     # match the distinctive token rather than the whole phrase).
     assert "cycle" in result.output
-    assert "Subscription plan" in result.output  # honesty note surfaced
+    # The generic "Subscription plan — flat-fee billing" note was superseded
+    # by compute_framing's list-price-equivalent qualifier, which now fires
+    # unconditionally for subscription mode (not just mixed subscription/API
+    # windows) so the honesty note is never a bare mode label.
+    assert "list-price equivalent, not an amount billed" in result.output
 
 
 def test_unknown_plan_keeps_dollars_with_qualifier(db):

--- a/tests/unit/test_context_resend.py
+++ b/tests/unit/test_context_resend.py
@@ -209,9 +209,15 @@ def test_estimated_recoverable_tokens_uses_avoidable_fraction(db):
     assert finding.estimated_recoverable_tokens < finding.repeat_tokens
 
 
-def test_estimated_recoverable_usd_prices_uncached_share_at_rate_delta(db):
-    """Fully-uncached session: uncached_fraction == 1.0, so usd is exactly
-    repeat_tokens x (input - cache-read rate) x AVOIDABLE_FRACTION_OF_REPEAT."""
+def test_cost_of_waste_is_observed_and_never_the_recoverable_figure(db):
+    """The gross cost of re-sent context is an OBSERVATION on its own field.
+
+    It used to be absent entirely while `estimated_recoverable_usd` carried the
+    cache_control-adoption delta. Now the two are separate quantities: the gross
+    is priced per token class at what it really billed (cache reads at the
+    cache-read rate, the still-uncached repeat at the input rate) and is never
+    the same number as the recoverable one.
+    """
     _seed_session(db, "heavy", [1000, 1000, 1000, 1000], cache_ratio=0.0,
                   provider="anthropic", model="claude-haiku-4-5")
     _seed_session(db, "pad1", [500])
@@ -219,27 +225,32 @@ def test_estimated_recoverable_usd_prices_uncached_share_at_rate_delta(db):
     finding = _run(db, _config())
 
     rates = get_rates("anthropic", "claude-haiku-4-5")
+    # Fully uncached, so the whole repeat volume bills at the input rate and
+    # there are no cache reads to add.
     heavy_repeat_tokens = 3000  # sum=4000, max=1000
-    expected_usd = round(
-        heavy_repeat_tokens / 1_000_000
-        * (rates.input_per_mtok - rates.cache_read_per_mtok)
-        * AVOIDABLE_FRACTION_OF_REPEAT,
-        6,
-    )
-    assert finding.estimated_recoverable_usd == pytest.approx(expected_usd)
-
-
-def test_fully_cached_session_recovers_no_usd_but_still_tokens(db):
-    """Same repeat_share/repeat_tokens as the uncached case, but already
-    100% cached: the cache_control-adoption dollar opportunity must be
-    absent (already captured), even though the compaction token estimate
-    still applies. This is what stops the analyzer double-counting
-    cache_efficacy's own recoverable figure."""
-    _seed_session(db, "cached", [1000, 1000, 1000, 1000], cache_ratio=1.0)
-    _seed_session(db, "pad1", [500])  # single-turn: contributes 0 repeat
-    _seed_session(db, "pad2", [500])  # single-turn: contributes 0 repeat
-    finding = _run(db, _config())
+    expected_gross = round(heavy_repeat_tokens / 1_000_000 * rates.input_per_mtok, 6)
+    assert finding.cost_of_waste_usd == pytest.approx(expected_gross)
+    assert finding.cost_of_waste_basis
+    # No subagent anywhere in the window, so nothing measures the offloadable
+    # share and no recoverable dollar figure is claimed at all.
+    assert finding.offloadable_share is None
     assert finding.estimated_recoverable_usd is None
+    assert finding.cost_of_waste_usd != finding.estimated_recoverable_usd
+
+
+def test_cost_of_waste_prices_cache_reads_at_the_cache_read_rate(db):
+    """A fully-cached session still cost real money to re-send — just a tenth
+    of the uncached rate. A zero here would read as "re-reading is free"."""
+    _seed_session(db, "cached", [1000, 1000, 1000, 1000], cache_ratio=1.0,
+                  provider="anthropic", model="claude-haiku-4-5")
+    _seed_session(db, "pad1", [500])
+    _seed_session(db, "pad2", [500])
+    finding = _run(db, _config())
+    rates = get_rates("anthropic", "claude-haiku-4-5")
+    # Every cache read IS re-sent context: 4 turns x 1000 cached tokens.
+    assert finding.cost_of_waste_usd == pytest.approx(
+        round(4000 / 1_000_000 * rates.cache_read_per_mtok, 6)
+    )
     assert finding.estimated_recoverable_tokens > 0
 
 
@@ -250,7 +261,77 @@ def test_recoverable_usd_none_when_no_priced_model(db):
     _seed_session(db, "pad2", [500])
     finding = _run(db, _config())
     assert finding.estimated_recoverable_usd is None
+    assert finding.cost_of_waste_usd is None
     assert finding.estimated_recoverable_tokens is not None
+
+
+# --------------------------------------------------------------------------
+# The offload lever: measured from this corpus's own sub_agent_id telemetry
+# --------------------------------------------------------------------------
+
+def _seed_offload_corpus(db):
+    """One delegating session (which measures the offloadable share) plus one
+    context-heavy in-thread session (where the saving is then claimed)."""
+    start = datetime(2026, 5, 10, tzinfo=UTC)
+    db.upsert_session(make_session(session_id="delegator", plan_tier="api"))
+    for i in range(4):
+        db.insert_span(make_llm_span(
+            session_id="delegator", provider="anthropic", model="claude-opus-4-8",
+            input_tokens=1000, cache_tokens=1000, output_tokens=100,
+            cost_usd=0.01, start_time=start + timedelta(minutes=i),
+        ))
+    for i in range(4):
+        db.insert_span(make_llm_span(
+            session_id="delegator", provider="anthropic", model="claude-opus-4-8",
+            input_tokens=1000, cache_tokens=0, output_tokens=100,
+            cost_usd=0.01, sub_agent_id="researcher",
+            start_time=start + timedelta(minutes=10 + i),
+        ))
+    # Context-heavy main-thread session: prompt grows past
+    # MIN_SESSION_CONTEXT_TOKENS, so offloading has something to remove.
+    db.upsert_session(make_session(session_id="inthread", plan_tier="api"))
+    for i in range(5):
+        db.insert_span(make_llm_span(
+            session_id="inthread", provider="anthropic", model="claude-opus-4-8",
+            input_tokens=20_000, cache_tokens=20_000 * i, output_tokens=500,
+            cost_usd=0.5, start_time=start + timedelta(hours=1, minutes=i),
+        ))
+    _seed_session(db, "pad1", [500])
+
+
+def test_offloadable_share_is_measured_from_sub_agent_id(db):
+    """The avoidable fraction comes from the user's own delegation behaviour,
+    not from the cross-corpus 68.3% constant the token claim still uses."""
+    _seed_offload_corpus(db)
+    finding = _run(db, _config())
+    assert finding.offloadable_share is not None
+    assert 0.0 < finding.offloadable_share < 1.0
+    assert finding.offloadable_share != pytest.approx(AVOIDABLE_FRACTION_OF_REPEAT)
+
+
+def test_recoverable_usd_is_offload_plus_rightsize_and_excludes_gross(db):
+    _seed_offload_corpus(db)
+    finding = _run(db, _config())
+    assert finding.offload_recoverable_usd is not None
+    assert finding.rightsize_recoverable_usd is not None
+    assert finding.estimated_recoverable_usd == pytest.approx(
+        round(finding.offload_recoverable_usd + finding.rightsize_recoverable_usd, 6)
+    )
+    # The whole point of the split: the recoverable claim is a small fraction
+    # of what re-sending actually cost, and the gross never leaks into it.
+    assert finding.cost_of_waste_usd > finding.estimated_recoverable_usd
+
+
+def test_no_delegating_session_means_no_offload_claim(db):
+    """Nothing to measure the share from, so nothing is claimed — never a
+    fraction invented to fill the gap."""
+    _seed_session(db, "heavy", [1000, 1000, 1000, 1000])
+    _seed_session(db, "pad1", [500])
+    _seed_session(db, "pad2", [500])
+    finding = _run(db, _config())
+    assert finding.offloadable_share is None
+    assert finding.estimated_recoverable_usd is None
+    assert any("offload lever" in n for n in finding.notes)
 
 
 # --------------------------------------------------------------------------

--- a/tests/unit/test_context_resend.py
+++ b/tests/unit/test_context_resend.py
@@ -265,6 +265,58 @@ def test_recoverable_usd_none_when_no_priced_model(db):
     assert finding.estimated_recoverable_tokens is not None
 
 
+def _seed_mixed_model_session(db, session_id, sizes, models, *, cache_ratio=0.0, start=None):
+    """Like `_seed_session` but each turn can carry its OWN (provider, model)
+    instead of one model for the whole session."""
+    start = start or datetime(2026, 5, 10, tzinfo=UTC)
+    db.upsert_session(make_session(session_id=session_id, plan_tier="api"))
+    for i, (size, (provider, model)) in enumerate(zip(sizes, models)):
+        cache_tok = int(size * cache_ratio)
+        input_tok = size - cache_tok
+        db.insert_span(make_llm_span(
+            session_id=session_id, provider=provider, model=model,
+            input_tokens=input_tok, cache_tokens=cache_tok, output_tokens=50,
+            cost_usd=0.01, start_time=start + timedelta(minutes=i),
+        ))
+
+
+def test_cost_of_waste_prices_each_turn_at_its_own_model_not_the_dominant_one(db):
+    """A session that mixes models must price EACH turn's re-sent volume at
+    THAT turn's own model's rate, not at whichever model dominated the turn
+    count. Two opus turns ($5/MTok) and two haiku turns ($1/MTok), tied on
+    turn count, all uncached and equally sized -- the correct figure prices
+    each turn's own uncached-repeat share at its own rate."""
+    _seed_mixed_model_session(db, "mixed", [1000, 1000, 1000, 1000], [
+        ("anthropic", "claude-opus-4-8"), ("anthropic", "claude-opus-4-8"),
+        ("anthropic", "claude-haiku-4-5"), ("anthropic", "claude-haiku-4-5"),
+    ])
+    _seed_session(db, "pad1", [500])
+    _seed_session(db, "pad2", [500])
+    finding = _run(db, _config())
+
+    opus = get_rates("anthropic", "claude-opus-4-8")
+    haiku = get_rates("anthropic", "claude-haiku-4-5")
+    # sum=4000, max=1000 (tie) -> repeat_tokens=3000, split evenly across the
+    # 4 equally-sized turns: 750 uncached-repeat tokens per turn.
+    per_turn_uncached_repeat = 750
+    expected = (
+        2 * (per_turn_uncached_repeat / 1_000_000 * opus.input_per_mtok)
+        + 2 * (per_turn_uncached_repeat / 1_000_000 * haiku.input_per_mtok)
+    )
+    # What pricing the WHOLE session at a single dominant model (a tie here,
+    # but the old code's Counter.most_common(1) picks one) would have given --
+    # strictly higher than the correct mixed figure since it prices some
+    # cheap-model volume at the expensive rate (or vice versa; either way it
+    # cannot equal the correctly split figure for these two distinct rates).
+    all_opus_estimate = 3000 / 1_000_000 * opus.input_per_mtok
+    all_haiku_estimate = 3000 / 1_000_000 * haiku.input_per_mtok
+
+    assert finding.cost_of_waste_usd == pytest.approx(round(expected, 6))
+    assert finding.cost_of_waste_usd != pytest.approx(round(all_opus_estimate, 6))
+    assert finding.cost_of_waste_usd != pytest.approx(round(all_haiku_estimate, 6))
+    assert all_haiku_estimate < finding.cost_of_waste_usd < all_opus_estimate
+
+
 # --------------------------------------------------------------------------
 # The offload lever: measured from this corpus's own sub_agent_id telemetry
 # --------------------------------------------------------------------------
@@ -320,6 +372,57 @@ def test_recoverable_usd_is_offload_plus_rightsize_and_excludes_gross(db):
     # The whole point of the split: the recoverable claim is a small fraction
     # of what re-sending actually cost, and the gross never leaks into it.
     assert finding.cost_of_waste_usd > finding.estimated_recoverable_usd
+
+
+def _seed_recoverable_corpus(db, first_turn_model):
+    """Same shape as `_seed_offload_corpus`, except the FIRST main-thread turn
+    of the in-thread session -- the one with the largest re-read tail, since
+    it's the one read back by every later turn -- uses `first_turn_model`
+    while every later turn stays on the expensive model."""
+    start = datetime(2026, 5, 10, tzinfo=UTC)
+    db.upsert_session(make_session(session_id="delegator", plan_tier="api"))
+    for i in range(4):
+        db.insert_span(make_llm_span(
+            session_id="delegator", provider="anthropic", model="claude-opus-4-8",
+            input_tokens=1000, cache_tokens=1000, output_tokens=100,
+            cost_usd=0.01, start_time=start + timedelta(minutes=i),
+        ))
+    for i in range(4):
+        db.insert_span(make_llm_span(
+            session_id="delegator", provider="anthropic", model="claude-opus-4-8",
+            input_tokens=1000, cache_tokens=0, output_tokens=100,
+            cost_usd=0.01, sub_agent_id="researcher",
+            start_time=start + timedelta(minutes=10 + i),
+        ))
+    db.upsert_session(make_session(session_id="inthread", plan_tier="api"))
+    models = [first_turn_model] + ["claude-opus-4-8"] * 4
+    for i, model in enumerate(models):
+        db.insert_span(make_llm_span(
+            session_id="inthread", provider="anthropic", model=model,
+            input_tokens=20_000, cache_tokens=20_000 * i, output_tokens=500,
+            cost_usd=0.5, start_time=start + timedelta(hours=1, minutes=i),
+        ))
+    _seed_session(db, "pad1", [500])
+
+
+def test_offload_recoverable_prices_each_turn_at_its_own_model(db):
+    """Changing ONLY the first main-thread turn's model (the one with the
+    largest re-read tail) must move the offload-recoverable figure --
+    otherwise it is still being priced off whichever model dominates the turn
+    count (4 opus turns vs. 1 other), not per turn. Under the old
+    dominant-model-only code this comparison would be a no-op: the dominant
+    model stays opus in both runs, so the figure would not move at all."""
+    _seed_recoverable_corpus(db, "claude-opus-4-8")
+    all_opus = _run(db, _config())
+
+    cheap_db = InMemoryBackend()
+    _seed_recoverable_corpus(cheap_db, "claude-haiku-4-5")
+    mixed = _run(cheap_db, _config())
+
+    assert all_opus.offload_recoverable_usd is not None
+    assert mixed.offload_recoverable_usd is not None
+    # A cheaper first-turn model must pull the recoverable figure DOWN.
+    assert mixed.offload_recoverable_usd < all_opus.offload_recoverable_usd
 
 
 def test_no_delegating_session_means_no_offload_claim(db):

--- a/tests/unit/test_cost_proposals.py
+++ b/tests/unit/test_cost_proposals.py
@@ -1080,13 +1080,23 @@ def test_resend_suppresses_cache_control_snippet_for_claude_code():
     # The durable subagent-offload rule leads, not /compact.
     assert prop.advise_text.startswith(SUBAGENT_OFFLOAD_FIX)
     assert "Run /compact." in prop.advise_text   # kept, but only as secondary relief
-    assert prop.one_paste_fix == SUBAGENT_OFFLOAD_FIX
+    # The one-paste artifact is the SECOND half of the compound fix: the agent
+    # file's model + reasoning-effort pin. The offload rule is a WRITE, carried
+    # on `proposed_fix` and applied rather than pasted.
+    assert "model:" in prop.one_paste_fix
+    assert "reasoning_effort:" in prop.one_paste_fix
 
 
-def test_resend_claude_code_offers_apply_capable_subagent_offload_write():
+def test_resend_claude_code_offers_apply_capable_compound_write():
     # Durable claude-code lever: a rung-1 CLAUDE.md rule, apply-capable via the
     # same `_persona_gated_write_fields` machinery script/reuse/verbosity use.
-    from tokenjam.core.optimize.analyzers.context_resend import SUBAGENT_OFFLOAD_FIX
+    # ONE card carries BOTH halves of the lever — offload the context-heavy
+    # work, and right-size what you offload it to — so this consolidates the
+    # resend and subagent recommendations instead of adding a card.
+    from tokenjam.core.optimize.analyzers.context_resend import (
+        RIGHTSIZE_FIX_TEMPLATE,
+        SUBAGENT_OFFLOAD_FIX,
+    )
     from tokenjam.core.optimize.cost_proposals import _resend_to_proposals
 
     prop = _resend_to_proposals(_resend_finding(), persona="claude-code")[0]
@@ -1094,7 +1104,29 @@ def test_resend_claude_code_offers_apply_capable_subagent_offload_write():
     assert prop.apply_capable is True
     assert prop.rung == 1
     assert prop.scope == "project"
-    assert prop.proposed_fix == SUBAGENT_OFFLOAD_FIX
+    assert SUBAGENT_OFFLOAD_FIX in prop.proposed_fix
+    assert RIGHTSIZE_FIX_TEMPLATE in prop.proposed_fix
+
+
+def test_resend_cost_of_waste_is_carried_but_never_the_recoverable_figure():
+    # The gross observation rides its own fields and must never be confused
+    # with — or summed into — what the fix returns.
+    from tokenjam.core.optimize.cost_proposals import (
+        _resend_to_proposals,
+        estimated_recoverable_rollup,
+    )
+
+    finding = _resend_finding()
+    finding.cost_of_waste_usd = 4_200.0
+    finding.cost_of_waste_tokens = 9_800_000_000
+    prop = _resend_to_proposals(finding, persona="claude-code")[0]
+
+    assert prop.cost_of_waste_usd == 4_200.0
+    assert prop.estimated_recoverable_usd == 0.5
+    # The Review inbox headline reads only the recoverable fields.
+    rollup = estimated_recoverable_rollup([prop])
+    assert rollup["estimated_recoverable_usd"] == 0.5
+    assert rollup["estimated_recoverable_tokens"] == 6_830
 
 
 def test_resend_sdk_persona_gets_no_write_and_leads_with_compact():
@@ -1117,16 +1149,14 @@ def test_resend_mixed_persona_offers_write_and_keeps_snippet():
 
     prop = _resend_to_proposals(_resend_finding(), persona="mixed")[0]
     assert prop.apply_capable is True
-    assert prop.proposed_fix == SUBAGENT_OFFLOAD_FIX
+    assert SUBAGENT_OFFLOAD_FIX in prop.proposed_fix
     assert "cache_control" in prop.suggestion
-    # Pin the one-paste slot too, so neither side of the mixed branch can drift
-    # silently: the SDK snippet is what a "mixed" window pastes (it is the only
-    # copyable artifact here -- the subagent-offload rule is a WRITE, carried on
-    # `proposed_fix` above and applied, not pasted), while a claude-code-only
-    # window has no snippet and falls back to the offload text.
-    assert prop.one_paste_fix == prop.suggestion
-    assert "cache_control" in prop.one_paste_fix
-    assert prop.one_paste_fix != SUBAGENT_OFFLOAD_FIX
+    # Both sides of the mixed branch are pinned so neither can drift silently:
+    # the SDK share keeps its cache_control snippet on `suggestion`, while the
+    # one-paste slot carries the claude-code share's right-sizing frontmatter
+    # (the offload rule itself is a WRITE on `proposed_fix`, applied not pasted).
+    assert "reasoning_effort:" in prop.one_paste_fix
+    assert "cache_control" not in prop.one_paste_fix
 
 
 def test_resend_keeps_cache_control_snippet_for_sdk():
@@ -1144,14 +1174,13 @@ def test_resend_caveat_is_not_duplicated():
     # The caveat is carried once via `caveat=`, and must NOT also be folded into
     # advise_text — doing both printed the same sentence twice on the card
     # (description paragraph + caveat line render the joined fields).
-    from tokenjam.core.optimize.analyzers.context_resend import SUBAGENT_OFFLOAD_FIX
     from tokenjam.core.optimize.cost_proposals import _resend_to_proposals
 
     prop = _resend_to_proposals(_resend_finding(), persona="claude-code")[0]
     assert prop.caveat == "conservative lower bound"
     assert "conservative lower bound" not in prop.advise_text
     assert prop.advise_text == (
-        SUBAGENT_OFFLOAD_FIX + " Immediate relief in an already-full session: Run /compact."
+        prop.proposed_fix + " Immediate relief in an already-full session: Run /compact."
     )
 
 

--- a/tests/unit/test_deadweight.py
+++ b/tests/unit/test_deadweight.py
@@ -81,6 +81,18 @@ def _invoking_session(root: Path, project: str, session_id: str, cwd: str, tool_
     ])
 
 
+def _multi_call_session(root: Path, project: str, session_id: str, cwd: str, calls: int) -> None:
+    """A session with ``calls`` sequential user/assistant turns -- each
+    assistant turn is one API request, so a configured server's tool schemas
+    ride in the `tools` array of every one of them (see the per-session
+    cache-read multiplier in ``compute_deadweight_finding``)."""
+    records: list[dict] = []
+    for i in range(calls):
+        records.append(_user_prompt(f"turn {i}", cwd=cwd))
+        records.append(_assistant(f"ok {i}", cwd=cwd))
+    _write_transcript(root, project, session_id, records)
+
+
 def _deferred_session(root: Path, project: str, session_id: str, cwd: str, tool_name: str) -> None:
     """A session whose transcript shows the deferred-tools listing naming
     ``tool_name`` — the server's schema was NOT fully loaded this session."""
@@ -479,6 +491,41 @@ def test_partial_deferral_blends_the_two_constants(tmp_path):
     expected = round((5 * FULL_SCHEMA_TAX_TOKENS + 5 * DEFERRED_SCHEMA_TAX_TOKENS) / 10)
     assert dead.estimated_tax_tokens_per_session == expected
     assert dead.estimated_tax_tokens_per_session < FULL_SCHEMA_TAX_TOKENS
+
+
+def test_schema_tax_scales_with_actual_calls_per_session(tmp_path):
+    """The schema tax must price EVERY call in a session, not just charge the
+    full/deferred constant once -- later calls in the same session re-send
+    the schema and are billed at the cache-read rate, not re-charged at input
+    rate. A mixed population (light single-call sessions + one heavy
+    multi-call session) proves this uses each session's OWN actual call
+    count, never a global mean/median applied uniformly."""
+    from tokenjam.core.pricing import get_rates
+
+    root = tmp_path / "root"
+    project_dir = root / "-repo-a"
+    _write_mcp_json(project_dir, {"apollo": {}})
+    for i in range(MIN_SESSIONS_DEADWEIGHT - 1):
+        _plain_session(root, "-repo-a", f"s-light-{i}", str(project_dir))
+    _multi_call_session(root, "-repo-a", "s-heavy", str(project_dir), calls=10)
+
+    finding = compute_deadweight_finding(_SINCE, _UNTIL, projects_root=root)
+    dead = finding.dead_servers[0]
+    assert dead.sessions_present == MIN_SESSIONS_DEADWEIGHT
+
+    rates = get_rates("anthropic", "claude-opus-4-8")
+    ratio = rates.cache_read_per_mtok / rates.input_per_mtok
+    light_tax = FULL_SCHEMA_TAX_TOKENS  # single call -> multiplier == 1
+    heavy_tax = round(FULL_SCHEMA_TAX_TOKENS * (1.0 + (10 - 1) * ratio))
+    expected_window = light_tax * (MIN_SESSIONS_DEADWEIGHT - 1) + heavy_tax
+
+    assert heavy_tax > FULL_SCHEMA_TAX_TOKENS
+    assert dead.estimated_tax_tokens_window == expected_window
+    # The heavy session's real cost is folded in, not diluted by an averaged
+    # call count applied uniformly to every session.
+    assert dead.estimated_tax_tokens_window > light_tax * MIN_SESSIONS_DEADWEIGHT
+    assert "cache-read rate" in dead.tax_construction
+    assert "5-minute cache TTL" in dead.tax_construction
 
 
 # --- C2: context tax table --------------------------------------------------

--- a/tests/unit/test_deadweight.py
+++ b/tests/unit/test_deadweight.py
@@ -450,6 +450,43 @@ def test_invoked_server_is_never_flagged_dead(tmp_path):
     assert finding.dead_servers == []
 
 
+# --- Sidechain/subagent transcripts must not become extra top-level sessions -
+
+def test_sidechain_subagent_transcript_is_not_counted_as_a_top_level_session(tmp_path):
+    """A `subagents/agent-*.jsonl` sidechain transcript lives nested under its
+    parent session's own directory (core/transcript.py) but must not be
+    discovered as an independent top-level "session" -- otherwise a session
+    that happens to spawn a subagent spuriously inflates sessions_present (and
+    thus can push a server across the dead-weight threshold, or inflate the
+    schema tax) purely because of where the subagent's JSONL file lives on
+    disk, not because of any real additional session."""
+    root = tmp_path / "root"
+    project_dir = root / "-repo-a"
+    _write_mcp_json(project_dir, {"apollo": {}})
+    for i in range(MIN_SESSIONS_DEADWEIGHT - 1):
+        _plain_session(root, "-repo-a", f"s{i}", str(project_dir))
+
+    # A sidechain transcript nested under s0's own subagents/ dir. If it were
+    # (mis)discovered as its own top-level session, sessions_present would
+    # reach MIN_SESSIONS_DEADWEIGHT and flip apollo to dead.
+    sidechain_path = root / "-repo-a" / "s0" / "subagents" / "agent-child1.jsonl"
+    sidechain_path.parent.mkdir(parents=True, exist_ok=True)
+    sidechain_path.write_text(
+        "\n".join(json.dumps(r) for r in [
+            _user_prompt("subagent task", cwd=str(project_dir)),
+            _assistant("working...", cwd=str(project_dir)),
+        ]),
+        encoding="utf-8",
+    )
+
+    finding = compute_deadweight_finding(_SINCE, _UNTIL, projects_root=root)
+
+    assert finding.sessions_scanned == MIN_SESSIONS_DEADWEIGHT - 1
+    assert finding.dead_servers == []
+    row = next(s for s in finding.servers if s.name == "apollo")
+    assert row.sessions_present == MIN_SESSIONS_DEADWEIGHT - 1
+
+
 # --- Deferred-tools suppression ---------------------------------------------
 
 def test_deferred_listing_suppresses_full_tax_claim(tmp_path):
@@ -491,6 +528,61 @@ def test_partial_deferral_blends_the_two_constants(tmp_path):
     expected = round((5 * FULL_SCHEMA_TAX_TOKENS + 5 * DEFERRED_SCHEMA_TAX_TOKENS) / 10)
     assert dead.estimated_tax_tokens_per_session == expected
     assert dead.estimated_tax_tokens_per_session < FULL_SCHEMA_TAX_TOKENS
+
+
+def test_mixed_deferral_prices_each_call_by_its_own_load_state(tmp_path):
+    """A server deferred at the start of a session but actually invoked partway
+    through (schema now fully loaded -- a deferred tool's own listing says
+    calling it directly "will fail... use ToolSearch to load their schema
+    before calling them", so a successful invocation is positive evidence the
+    schema was already loaded by that call) must have the calls BEFORE the
+    invocation priced at the deferred base and the calls FROM the invocation
+    onward priced at the full base -- never the whole session at the low
+    deferred base just because it was deferred at some point."""
+    from tokenjam.core.pricing import get_rates
+
+    root = tmp_path / "root"
+    project_dir = root / "-repo-a"
+    _write_mcp_json(project_dir, {"apollo": {}})
+    reminder = (
+        "<system-reminder>\n"
+        "The following deferred tools are now available via ToolSearch. "
+        "Their schemas are NOT loaded — calling them directly will fail "
+        "with InputValidationError. Use ToolSearch to load their schema "
+        "before calling them:\n"
+        "mcp__apollo__apollo_contacts_search\n"
+        "</system-reminder>"
+    )
+    _write_transcript(root, "-repo-a", "s-mixed", [
+        _user_prompt(reminder, cwd=str(project_dir)),
+        _assistant("thinking...", cwd=str(project_dir)),                  # call 1: deferred
+        _user_prompt("continue", cwd=str(project_dir)),
+        _assistant("still deferred", cwd=str(project_dir)),               # call 2: deferred
+        _user_prompt("use the tool", cwd=str(project_dir)),
+        _assistant(                                                        # call 3: loads + invokes
+            "calling it now",
+            tools=[{"id": "t1", "name": "mcp__apollo__apollo_contacts_search", "input": {}}],
+            cwd=str(project_dir),
+        ),
+        _user_prompt("result", cwd=str(project_dir)),
+        _assistant("done", cwd=str(project_dir)),                         # call 4: full
+    ])
+
+    finding = compute_deadweight_finding(_SINCE, _UNTIL, projects_root=root)
+    row = next(s for s in finding.servers if s.name == "apollo")
+
+    rates = get_rates("anthropic", "claude-opus-4-8")
+    ratio = rates.cache_read_per_mtok / rates.input_per_mtok
+    expected_deferred = round(DEFERRED_SCHEMA_TAX_TOKENS * (1.0 + (2 - 1) * ratio))
+    expected_full = round(FULL_SCHEMA_TAX_TOKENS * (1.0 + (2 - 1) * ratio))
+
+    assert row.invocations == 1
+    assert row.dead is False
+    assert row.estimated_tax_tokens_window == expected_deferred + expected_full
+    # Strictly more than the old bug (whole session priced at the deferred
+    # base just because it was deferred at some point).
+    old_buggy_estimate = round(DEFERRED_SCHEMA_TAX_TOKENS * (1.0 + (4 - 1) * ratio))
+    assert row.estimated_tax_tokens_window > old_buggy_estimate
 
 
 def test_schema_tax_scales_with_actual_calls_per_session(tmp_path):

--- a/tests/unit/test_framing.py
+++ b/tests/unit/test_framing.py
@@ -8,7 +8,6 @@ import pytest
 from tokenjam.core.framing import (
     DISPLAY_SHOW_DOLLARS,
     DISPLAY_SHOW_DOLLARS_WITH_QUALIFIER,
-    DISPLAY_SUPPRESS_SUBSCRIPTION,
     DISPLAY_SUPPRESS_UNKNOWN,
     DISPLAY_TOKENS_ONLY,
     Framing,
@@ -155,6 +154,9 @@ def test_compute_framing_api_with_unknown_qualifier():
 
 
 def test_compute_framing_subscription():
+    # Standing product decision: dollars are shown by default (assume API
+    # pricing), even for an all-subscription window — never suppressed in
+    # favour of a token-share-only figure.
     f = compute_framing(
         _Config(),
         WindowSummary(total_cost_usd=148.0, total_tokens=2_000_000, sessions=20,
@@ -164,8 +166,10 @@ def test_compute_framing_subscription():
     assert f.plan_tier == "max_5x"
     assert f.plan_label == "Max 5x plan"
     assert f.plan_monthly_usd == 100.0
-    assert f.display_rule == DISPLAY_SUPPRESS_SUBSCRIPTION
+    assert f.display_rule == DISPLAY_SHOW_DOLLARS_WITH_QUALIFIER
     assert f.subscription_share_pct == 100.0
+    assert f.qualifier_text is not None
+    assert "list-price equivalent, not an amount billed" in f.qualifier_text
 
 
 def test_compute_framing_subscription_mixed_window_qualifier():
@@ -175,7 +179,7 @@ def test_compute_framing_subscription_mixed_window_qualifier():
                       plan_tier_mix={"max_5x": 17, "api": 3}),
     )
     assert f.pricing_mode == "subscription"
-    assert f.display_rule == DISPLAY_SUPPRESS_SUBSCRIPTION
+    assert f.display_rule == DISPLAY_SHOW_DOLLARS_WITH_QUALIFIER
     assert f.qualifier_text is not None
     assert "subscription-billed" in f.qualifier_text
     assert f.subscription_share_pct == 85.0

--- a/tests/unit/test_onboard_backfill_scope.py
+++ b/tests/unit/test_onboard_backfill_scope.py
@@ -12,6 +12,7 @@ the real `tj backfill claude-code` command.
 from __future__ import annotations
 
 import json
+from datetime import datetime, timedelta, timezone
 from pathlib import Path
 
 import pytest
@@ -19,6 +20,15 @@ from click.testing import CliRunner
 
 import tokenjam.core.backfill as backfill_mod
 from tokenjam.cli.cmd_onboard import DEFAULT_BACKFILL_DAYS, cmd_onboard
+
+# `sess-recent` must stay well inside the default 30-day backfill window no
+# matter when the suite runs. A hardcoded absolute timestamp is a time bomb:
+# once wall-clock time passes `<that date> + DEFAULT_BACKFILL_DAYS`, the
+# session falls out of scope and every assertion below starts failing with
+# no code change involved. Anchor it relative to "now" instead.
+_RECENT_SESSION_TS = (
+    datetime.now(tz=timezone.utc) - timedelta(days=5)
+).strftime("%Y-%m-%dT%H:%M:%S.000Z")
 
 
 def _make_session_file(root: Path, session_id: str, cwd: str, ts: str) -> Path:
@@ -64,7 +74,7 @@ def _isolated_claude_code_with_history(monkeypatch, tmp_path):
         "tokenjam.cli.cmd_onboard._try_apply_declared_plans", lambda *a, **k: None,
     )
     _make_session_file(projects_root, "sess-recent", "/Users/me/proj",
-                      "2026-06-25T10:00:00.000Z")
+                      _RECENT_SESSION_TS)
     _make_session_file(projects_root, "sess-old", "/Users/me/proj",
                       "2020-01-01T10:00:00.000Z")
     return projects_root
@@ -200,7 +210,7 @@ def test_default_window_actually_filters_old_session(
 ):
     res = _run_claude_code(tmp_path)
     assert res.exit_code == 0, res.output
-    # Only the recent (2026-06-25) session is within a 30-day-from-now window;
+    # Only the recent (5-days-ago) session is within a 30-day-from-now window;
     # the 2020 session must be excluded from the backfilled total.
     assert "1 total session" in res.output
 

--- a/tests/unit/test_optimize_reuse.py
+++ b/tests/unit/test_optimize_reuse.py
@@ -151,9 +151,11 @@ def test_cluster_surfaced_and_savings_math(db):
     assert c.tool_signature == ("read", "edit", "run")
     assert c.cache_reuse_recoverable_usd == pytest.approx(0.80)
     assert c.script_replacement_recoverable_usd == pytest.approx(1.00)
-    # Aggregate uses the conservative cache-reuse number.
-    assert finding.estimated_recoverable_usd == pytest.approx(0.80)
-    assert finding.estimated_recoverable_tokens == c.cache_reuse_recoverable_tokens
+    # Aggregate uses the script-replacement premise (a template removes the
+    # planning call entirely) — the more conservative cache-reuse premise
+    # (avg cost x (reps - 1)) stays available per-cluster, never deleted.
+    assert finding.estimated_recoverable_usd == pytest.approx(1.00)
+    assert finding.estimated_recoverable_tokens == c.script_replacement_recoverable_tokens
 
 
 def test_below_repetition_threshold_dropped(db):

--- a/tests/unit/test_optimize_subagent.py
+++ b/tests/unit/test_optimize_subagent.py
@@ -168,9 +168,13 @@ def test_over_powered_subagent_carries_quantified_estimate():
 
 def test_over_provisioned_only_subagent_has_no_estimate():
     """A subagent flagged only over_provisioned (a NON-premium model handed a
-    large context) contributes nothing to the estimate — its recoverable is a
-    prompt-size cut we don't size — so the finding stays unranked (estimate
-    None), honestly, rather than inventing a number (#101)."""
+    large context) contributes nothing to the estimate when its dispatch
+    cohort (same calling agent + model) is too small to have a meaningful
+    median baseline — one subagent is a cohort of one, well under
+    MIN_COHORT_SESSIONS — so the finding stays unranked (estimate None),
+    honestly, rather than inventing a baseline (#101). See
+    test_over_provisioned_estimate_prices_context_excess_over_cohort_median
+    for the case where a real cohort baseline exists."""
     db = InMemoryBackend()
     try:
         ctx, now = _ctx(db, window_cost_usd=1.0)
@@ -186,6 +190,53 @@ def test_over_provisioned_only_subagent_has_no_estimate():
         assert f.flagged[0].flags == ["over_provisioned"]
         assert f.estimated_recoverable_usd is None
         assert f.estimated_recoverable_tokens is None
+    finally:
+        db.close()
+
+
+def test_over_provisioned_estimate_prices_context_excess_over_cohort_median():
+    """With a real dispatch cohort (>= MIN_COHORT_SESSIONS same-agent,
+    same-model subagents), an over_provisioned outlier's context excess over
+    the cohort's own median is priced at the cache-read rate (context arrives
+    overwhelmingly as cache reads) -- never against zero context, never a
+    made-up target size."""
+    from tokenjam.core.pricing import get_rates
+
+    db = InMemoryBackend()
+    try:
+        ctx, now = _ctx(db, window_cost_usd=1.0)
+        # 4 ordinary same-shape dispatches: modest context, well under the
+        # over_provisioned threshold -> form the cohort's baseline.
+        for i in range(4):
+            db.insert_span(make_llm_span(
+                model="claude-sonnet-4-6", provider="anthropic",
+                input_tokens=10_000, output_tokens=500, cost_usd=0.05,
+                session_id=f"s-peer-{i}", sub_agent_id=f"peer{i}", start_time=now,
+            ))
+        # The outlier: same agent + model, huge context, tiny output ->
+        # over_provisioned, with 4 like-shaped peers to baseline against.
+        db.insert_span(make_llm_span(
+            model="claude-sonnet-4-6", provider="anthropic",
+            input_tokens=80_000, output_tokens=100, cost_usd=0.30,
+            session_id="s-outlier", sub_agent_id="outlier", start_time=now,
+        ))
+
+        run_subagent(ctx)
+        f = ctx.report.findings["subagent"]
+
+        outlier = next(r for r in f.flagged if r.sub_agent_id == "outlier")
+        assert outlier.flags == ["over_provisioned"]
+
+        # Cohort contexts: [10_000, 10_000, 10_000, 10_000, 80_000] -> median
+        # 10_000. Excess = 80_000 - 10_000 = 70_000, priced at the cache-read
+        # rate (never the fresh-input rate).
+        rates = get_rates("anthropic", "claude-sonnet-4-6")
+        expected_tokens = 70_000
+        expected_usd = expected_tokens / 1_000_000 * rates.cache_read_per_mtok
+
+        assert f.estimated_recoverable_tokens == expected_tokens
+        assert f.estimated_recoverable_usd == pytest.approx(expected_usd, abs=1e-9)
+        assert "cohort" in f.estimate_basis.lower()
     finally:
         db.close()
 

--- a/tests/unit/test_optimize_summarize.py
+++ b/tests/unit/test_optimize_summarize.py
@@ -74,7 +74,11 @@ def test_sums_per_call_tokens_drops_zero_saving(db, monkeypatch):
     f = _run(db)
     assert f.files == 2
     assert f.estimated_recoverable_tokens == 710
-    assert f.estimated_recoverable_usd is None       # tokens-only by design
+    # No session in this window is observed loading a repo-scoped "./CLAUDE.md"
+    # (its ancestor names match no agent_id-derived repo), so no dollar figure
+    # is attached — never a zero, never a rate borrowed from a file that did
+    # resolve.
+    assert f.estimated_recoverable_usd is None
     assert f.estimate_confidence == "heuristic"
     assert f.estimate_basis                          # explicit basis required by contract
     assert {c.path for c in f.candidates} == {"./CLAUDE.md", "./AGENTS.md"}
@@ -145,12 +149,18 @@ def test_summarize_in_click_choices_and_renderer():
 
 def test_render_summarize_lists_candidates_and_points_to_summarize_list(db, monkeypatch, capsys):
     """The finding renders through the CLI dispatch path, names the files, the
-    per-call token saving, and points at `tj summarize` -- never fabricates a
-    dollar figure (estimated_recoverable_usd stays None by design)."""
+    per-call token saving, and points at `tj summarize`.
+
+    These candidates resolve to no loading session, so there is no dollar
+    figure to show and none is fabricated. The inverse — that a resolvable file
+    DOES surface its dollars — is pinned by
+    `test_render_summarize_shows_the_window_dollar_figure_when_priced`.
+    """
     from tokenjam.cli.cmd_optimize import _render_summarize
 
     _patch_scan(monkeypatch, [_cand("./CLAUDE.md", 410), _cand("./AGENTS.md", 300)])
     finding = _run(db)
+    assert finding.estimated_recoverable_usd is None
 
     for mode in ("api", "subscription", "local", "unknown"):
         _render_summarize(finding, pricing_mode=mode, marker="①")
@@ -162,6 +172,73 @@ def test_render_summarize_lists_candidates_and_points_to_summarize_list(db, monk
     assert "tj summarize list" in out
     assert "tj summarize prep" in out
     assert "$" not in out  # no fabricated dollar figure
+
+
+# --- Always-on files save REPEATEDLY, so the figure is priced per window ------
+
+def test_global_scope_file_is_priced_across_every_session_in_the_window(
+    db, monkeypatch,
+):
+    """A `~/.claude` file is loaded by every session and re-read on every call
+    within one, so its reduction is worth reduction x sessions x (input rate +
+    later calls at the cache-read rate) — not a one-time figure."""
+    from tokenjam.core.pricing import get_rates
+
+    db.upsert_session(make_session(session_id="s1"))
+    db.upsert_session(make_session(session_id="s2"))
+    for sid in ("s1", "s2"):
+        for _ in range(3):
+            db.insert_span(make_llm_span(
+                session_id=sid, provider="anthropic", model="claude-haiku-4-5",
+                input_tokens=100, output_tokens=10,
+                start_time=utcnow() - timedelta(days=1),
+            ))
+    _patch_scan(monkeypatch, [_cand("~/.claude/CLAUDE.md", 1_000, scope="global")])
+
+    since, until = _window()
+    report = build_report(db=db, config=TjConfig(version="1"),
+                          since=since, until=until, findings=["summarize"])
+    f = report.findings["summarize"]
+
+    rates = get_rates("anthropic", "claude-haiku-4-5")
+    # 2 sessions x 3 calls each: one send at the input rate, two re-reads.
+    expected = (
+        1_000
+        * (rates.input_per_mtok / 1_000_000)
+        * (1 + (rates.cache_read_per_mtok / rates.input_per_mtok) * 2)
+        * 2
+    )
+    assert f.sessions_examined == 2
+    assert f.calls_per_session == 3.0
+    assert f.candidates[0].sessions_loading == 2
+    assert f.estimated_recoverable_usd == pytest.approx(round(expected, 6))
+    assert f.rate_basis
+    # Strictly more than a single send: the saving recurs, it is not one-time.
+    assert f.estimated_recoverable_usd > 1_000 * rates.input_per_mtok / 1_000_000
+
+
+def test_render_summarize_shows_the_window_dollar_figure_when_priced(
+    db, monkeypatch, capsys,
+):
+    from tokenjam.cli.cmd_optimize import _render_summarize
+
+    db.upsert_session(make_session(session_id="s1"))
+    db.insert_span(make_llm_span(
+        session_id="s1", provider="anthropic", model="claude-haiku-4-5",
+        input_tokens=100, output_tokens=10, start_time=utcnow() - timedelta(days=1),
+    ))
+    _patch_scan(monkeypatch, [_cand("~/.claude/CLAUDE.md", 5_000_000, scope="global")])
+    since, until = _window()
+    report = build_report(db=db, config=TjConfig(version="1"),
+                          since=since, until=until, findings=["summarize"])
+    finding = report.findings["summarize"]
+    assert finding.estimated_recoverable_usd
+
+    _render_summarize(finding, pricing_mode="api", marker="①")
+    out = capsys.readouterr().out
+    assert "$" in out
+    # Rich soft-wraps, so match on a fragment that survives a line break.
+    assert "session(s) in this" in out
 
 
 def test_render_summarize_empty_state_names_the_reason(db, monkeypatch, capsys):

--- a/tests/unit/test_optimize_summarize.py
+++ b/tests/unit/test_optimize_summarize.py
@@ -217,6 +217,60 @@ def test_global_scope_file_is_priced_across_every_session_in_the_window(
     assert f.estimated_recoverable_usd > 1_000 * rates.input_per_mtok / 1_000_000
 
 
+def test_project_scope_file_is_priced_against_its_own_repos_calls_per_session(
+    db, monkeypatch,
+):
+    """A project-scope candidate must price against its OWN repo's average
+    calls-per-session -- never the window-wide blend across every other
+    repo/agent in the window, which can differ sharply from this repo's own
+    session behavior.
+
+    Repo A: one session, 5 calls (a heavy call-count repo). Repo B: four
+    sessions, one call each (a light one). The window-wide average
+    (9 calls / 5 sessions = 1.8, rounds to 2) is nowhere near repo A's own
+    average (5.0) -- pricing repo A's file against the blend would understate
+    its recoverable figure.
+    """
+    from tokenjam.core.pricing import get_rates
+
+    db.upsert_session(make_session(session_id="a1", agent_id="claude-code-repo-a"))
+    for i in range(5):
+        db.insert_span(make_llm_span(
+            session_id="a1", agent_id="claude-code-repo-a",
+            provider="anthropic", model="claude-haiku-4-5",
+            input_tokens=100, output_tokens=10,
+            start_time=utcnow() - timedelta(days=1, minutes=i),
+        ))
+    for i in range(4):
+        sid = f"b{i}"
+        db.upsert_session(make_session(session_id=sid, agent_id="claude-code-repo-b"))
+        db.insert_span(make_llm_span(
+            session_id=sid, agent_id="claude-code-repo-b",
+            provider="anthropic", model="claude-haiku-4-5",
+            input_tokens=100, output_tokens=10,
+            start_time=utcnow() - timedelta(days=1),
+        ))
+
+    _patch_scan(monkeypatch, [_cand("repo-a/CLAUDE.md", 1_000, scope="repo")])
+    since, until = _window()
+    report = build_report(db=db, config=TjConfig(version="1"),
+                          since=since, until=until, findings=["summarize"])
+
+    f = report.findings["summarize"]
+    candidate = f.candidates[0]
+    rates = get_rates("anthropic", "claude-haiku-4-5")
+    ratio = rates.cache_read_per_mtok / rates.input_per_mtok
+
+    assert candidate.sessions_loading == 1  # only repo-a's own session matches
+    # Repo A's own average is 5 calls/session -> 4 rereads, never the
+    # window-wide blend's rounded 2 calls/session -> 1 reread.
+    expected = 1_000 * (rates.input_per_mtok / 1_000_000) * (1 + ratio * 4)
+    wrong_window_blend = 1_000 * (rates.input_per_mtok / 1_000_000) * (1 + ratio * 1)
+    assert candidate.est_usd_saved == pytest.approx(round(expected, 6))
+    assert candidate.est_usd_saved != pytest.approx(round(wrong_window_blend, 6))
+    assert candidate.est_usd_saved > wrong_window_blend
+
+
 def test_render_summarize_shows_the_window_dollar_figure_when_priced(
     db, monkeypatch, capsys,
 ):

--- a/tests/unit/test_rate_profile.py
+++ b/tests/unit/test_rate_profile.py
@@ -1,0 +1,151 @@
+"""Unit tests for `core/optimize/rate_profile.py`'s blended rate derivation.
+
+Each rate must be weighted by its OWN matching token class: the input rate by
+observed input-token volume, the cache-read ratio by observed cache-read-token
+volume -- never by output or cache-write volume, which have nothing to do with
+either priced rate.
+"""
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+
+from tokenjam.core.db import InMemoryBackend
+from tokenjam.core.optimize.rate_profile import blended_rate_profile
+from tokenjam.core.pricing import get_rates
+from tests.factories import make_llm_span, make_session
+
+UTC = timezone.utc
+
+
+def _db():
+    backend = InMemoryBackend()
+    return backend
+
+
+def _window():
+    since = datetime(2026, 5, 1, tzinfo=UTC)
+    until = datetime(2026, 5, 30, tzinfo=UTC)
+    return since, until
+
+
+def test_input_rate_weighted_by_input_tokens_not_output_volume():
+    """Model A carries almost all the INPUT volume; Model B carries almost all
+    the OUTPUT volume (with a much higher input rate). Weighting by a combined
+    input+output+cache+cache_write total (the old behavior) would give the two
+    models roughly EQUAL weight and drag the blended input rate toward the
+    midpoint -- even though nearly none of the actual input volume came from
+    Model B. Weighting by input volume alone must keep the blend close to
+    Model A's own rate.
+    """
+    db = _db()
+    db.upsert_session(make_session(session_id="s1"))
+    start = datetime(2026, 5, 10, tzinfo=UTC)
+    # Model A: claude-opus-4-8 ($5/MTok input) — nearly all the input volume.
+    db.insert_span(make_llm_span(
+        session_id="s1", provider="anthropic", model="claude-opus-4-8",
+        input_tokens=1_000_000, output_tokens=1, cache_tokens=0,
+        start_time=start,
+    ))
+    # Model B: claude-fable-5 ($10/MTok input) — nearly all the output volume,
+    # negligible input volume.
+    db.insert_span(make_llm_span(
+        session_id="s1", provider="anthropic", model="claude-fable-5",
+        input_tokens=1, output_tokens=1_000_000, cache_tokens=0,
+        start_time=start + timedelta(minutes=1),
+    ))
+
+    since, until = _window()
+    profile = blended_rate_profile(db.conn, since=since, until=until)
+
+    rate_a = get_rates("anthropic", "claude-opus-4-8")
+    rate_b = get_rates("anthropic", "claude-fable-5")
+    assert profile is not None
+    # Must land close to Model A's own rate (its ~1M input tokens dwarf
+    # Model B's 1), not the ~7.5 midpoint an output-inclusive weighting would
+    # have produced from two roughly-equal combined totals.
+    assert abs(profile.input_rate_per_token - rate_a.input_per_mtok / 1_000_000) < (
+        0.05 * rate_a.input_per_mtok / 1_000_000
+    )
+    midpoint = (rate_a.input_per_mtok + rate_b.input_per_mtok) / 2 / 1_000_000
+    assert abs(profile.input_rate_per_token - midpoint) > abs(
+        profile.input_rate_per_token - rate_a.input_per_mtok / 1_000_000
+    )
+
+
+def test_cache_read_ratio_weighted_by_cache_read_tokens_not_output_volume():
+    """Model A carries all the CACHE-READ volume (Anthropic ratio 0.1). Model B
+    carries a huge OUTPUT volume but a rate table entry with NO cache-read
+    price (defaults to 0.0 -- e.g. a provider row with no cache_read_per_mtok
+    set). Weighting the ratio by a combined total would drag it toward 0
+    purely because Model B's output volume swamped the combined denominator,
+    even though Model B contributed zero cache-read evidence. Weighting by
+    cache-read volume alone must keep the observed 0.1 ratio intact.
+    """
+    db = _db()
+    db.upsert_session(make_session(session_id="s1"))
+    start = datetime(2026, 5, 10, tzinfo=UTC)
+    # Model A: claude-opus-4-8 -- input + cache-read volume, ratio 0.1.
+    db.insert_span(make_llm_span(
+        session_id="s1", provider="anthropic", model="claude-opus-4-8",
+        input_tokens=100_000, output_tokens=1, cache_tokens=100_000,
+        start_time=start,
+    ))
+    # Model B: gemini-2-5-pro -- huge output volume, no cache-read price
+    # (defaults to 0.0), no cache reads of its own.
+    db.insert_span(make_llm_span(
+        session_id="s1", provider="google", model="gemini-2-5-pro",
+        input_tokens=1, output_tokens=1_000_000, cache_tokens=0,
+        start_time=start + timedelta(minutes=1),
+    ))
+
+    since, until = _window()
+    profile = blended_rate_profile(db.conn, since=since, until=until)
+
+    assert profile is not None
+    # The observed ratio must stay at Model A's own 0.1 -- not dragged toward
+    # 0 by Model B's unrelated output volume.
+    assert abs(profile.cache_read_ratio - 0.100) < 0.01
+
+
+def test_cache_read_ratio_falls_back_to_input_weighting_when_no_cache_reads_observed():
+    """A window with input volume but literally zero cache-read tokens still
+    resolves a ratio (derived from the SAME observed models' own rates,
+    weighted by input volume instead) rather than returning None outright."""
+    db = _db()
+    db.upsert_session(make_session(session_id="s1"))
+    start = datetime(2026, 5, 10, tzinfo=UTC)
+    db.insert_span(make_llm_span(
+        session_id="s1", provider="anthropic", model="claude-opus-4-8",
+        input_tokens=100_000, output_tokens=1_000, cache_tokens=0,
+        start_time=start,
+    ))
+
+    since, until = _window()
+    profile = blended_rate_profile(db.conn, since=since, until=until)
+
+    assert profile is not None
+    rate_a = get_rates("anthropic", "claude-opus-4-8")
+    assert abs(
+        profile.cache_read_ratio - rate_a.cache_read_per_mtok / rate_a.input_per_mtok
+    ) < 1e-9
+
+
+def test_single_model_input_rate_and_ratio_match_its_own_rates():
+    db = _db()
+    db.upsert_session(make_session(session_id="s1"))
+    start = datetime(2026, 5, 10, tzinfo=UTC)
+    db.insert_span(make_llm_span(
+        session_id="s1", provider="anthropic", model="claude-sonnet-5",
+        input_tokens=10_000, output_tokens=2_000, cache_tokens=5_000,
+        cache_write_tokens=1_000, start_time=start,
+    ))
+
+    since, until = _window()
+    profile = blended_rate_profile(db.conn, since=since, until=until)
+
+    rates = get_rates("anthropic", "claude-sonnet-5")
+    assert profile is not None
+    assert profile.input_rate_per_token == rates.input_per_mtok / 1_000_000
+    assert abs(
+        profile.cache_read_ratio - rates.cache_read_per_mtok / rates.input_per_mtok
+    ) < 1e-9

--- a/tests/unit/test_relearn.py
+++ b/tests/unit/test_relearn.py
@@ -24,6 +24,7 @@ from tokenjam.core.optimize.analyzers.relearn import (
     extract_failures_for_session,
     is_already_codified,
 )
+from tokenjam.core.pricing import get_rates
 
 
 # --- Fixture builders (mirrors test_transcript.py) ----------------------------
@@ -888,59 +889,122 @@ def test_single_timestamp_corpus_floors_the_window_to_one_day(tmp_path):
 
 
 class _FakeSpanConn:
-    """Minimal stand-in for a DuckDB connection: `_blended_dollar_rate` only
-    ever calls `.execute(sql, params).fetchall()` on it, so this returns
-    canned `(provider, model, cost, tokens)` rows regardless of the SQL text."""
-    def __init__(self, rows):
-        self._rows = rows
+    """Minimal stand-in for a DuckDB connection.
 
-    def execute(self, _sql, _params):
+    Relearn issues two different queries per cluster — the rate blend
+    (``provider, model, tokens``) and the per-session prompt timeline the
+    re-read tail is measured on (``session_id, start_time, prompt_size``) — so
+    this dispatches on the SQL text rather than returning one canned shape to
+    both.
+    """
+    def __init__(self, rate_rows, timeline_rows=()):
+        self._rate_rows = rate_rows
+        self._timeline_rows = list(timeline_rows)
+        self._rows: list = []
+
+    def execute(self, sql, _params):
+        self._rows = self._timeline_rows if "start_time" in sql else self._rate_rows
         return self
 
     def fetchall(self):
         return self._rows
 
 
-def test_blended_dollar_rate_names_the_models_it_derived_from():
-    from tokenjam.core.optimize.analyzers.relearn import _blended_dollar_rate
+def test_blended_rate_profile_names_the_models_it_derived_from():
+    from tokenjam.core.optimize.rate_profile import blended_rate_profile
 
-    conn = _FakeSpanConn([("anthropic", "claude-sonnet-5", 3.0, 1_000_000)])
-    rate, basis = _blended_dollar_rate(conn, {"s1", "s2"})
+    conn = _FakeSpanConn([("anthropic", "claude-sonnet-5", 1_000_000)])
+    profile = blended_rate_profile(conn, session_ids={"s1", "s2"})
 
-    assert rate == pytest.approx(3.0 / 1_000_000)
-    assert "anthropic/claude-sonnet-5" in basis
-    assert "blended" in basis
-
-
-def test_blended_dollar_rate_never_invents_a_rate_with_no_conn_or_sessions():
-    from tokenjam.core.optimize.analyzers.relearn import _blended_dollar_rate
-
-    assert _blended_dollar_rate(None, {"s1"}) == (None, "")
-    assert _blended_dollar_rate(_FakeSpanConn([]), set()) == (None, "")
+    rates = get_rates("anthropic", "claude-sonnet-5")
+    assert profile.input_rate_per_token == pytest.approx(rates.input_per_mtok / 1_000_000)
+    assert profile.cache_read_ratio == pytest.approx(
+        rates.cache_read_per_mtok / rates.input_per_mtok
+    )
+    assert "anthropic/claude-sonnet-5" in profile.basis
 
 
-def test_blended_dollar_rate_degrades_on_query_failure_never_raises():
-    from tokenjam.core.optimize.analyzers.relearn import _blended_dollar_rate
+def test_blended_rate_profile_never_invents_a_rate_with_no_conn_or_sessions():
+    from tokenjam.core.optimize.rate_profile import blended_rate_profile
+
+    assert blended_rate_profile(None, session_ids={"s1"}) is None
+    assert blended_rate_profile(_FakeSpanConn([]), session_ids=set()) is None
+
+
+def test_blended_rate_profile_degrades_on_query_failure_never_raises():
+    from tokenjam.core.optimize.rate_profile import blended_rate_profile
 
     class _RaisingConn:
         def execute(self, _sql, _params):
             raise RuntimeError("boom")
 
-    assert _blended_dollar_rate(_RaisingConn(), {"s1"}) == (None, "")
+    assert blended_rate_profile(_RaisingConn(), session_ids={"s1"}) is None
 
 
 def test_monthly_usd_derived_when_conn_has_priced_spans(tmp_path):
     # End-to-end: analyze_relearns(conn=...) stamps a cluster's
-    # estimated_monthly_usd from the blended rate observed across its own
+    # estimated_monthly_usd from the input rate observed across its own
     # sessions, not a hardcoded or invented one.
     for i in range(MIN_RECURRING_SESSIONS):
         _cwd_confusion_session(tmp_path, f"-Users-test-usd{i}", f"usd-{i}")
     sessions = [(f"usd-{i}", f"repo{i}") for i in range(MIN_RECURRING_SESSIONS)]
-    conn = _FakeSpanConn([("anthropic", "claude-sonnet-5", 3.0, 1_000_000)])
+    conn = _FakeSpanConn([("anthropic", "claude-sonnet-5", 1_000_000)])
 
     finding = analyze_relearns(sessions, projects_root=tmp_path, distill_enabled=False, conn=conn)
 
     cluster = finding.clusters[0]
-    expected_rate = 3.0 / 1_000_000
+    expected_rate = get_rates("anthropic", "claude-sonnet-5").input_per_mtok / 1_000_000
     assert cluster.estimated_monthly_usd == round(cluster.estimated_monthly_tokens * expected_rate, 6)
     assert "claude-sonnet-5" in cluster.monthly_rate_basis
+    assert finding.estimated_monthly_usd == pytest.approx(cluster.estimated_monthly_usd)
+
+
+def test_occurrence_is_worth_its_re_read_tail_not_just_one_turn(tmp_path):
+    """A failure's text is re-sent on every later call in the same context
+    window, so an occurrence is worth more than its 1,500 raw tokens — and the
+    1,500 constant itself is unchanged."""
+    from tokenjam.core.optimize.analyzers.relearn import GROUNDED_TOKENS_PER_OCCURRENCE
+
+    for i in range(MIN_RECURRING_SESSIONS):
+        _cwd_confusion_session(tmp_path, f"-Users-test-tail{i}", f"tail-{i}")
+    sessions = [(f"tail-{i}", f"repo{i}") for i in range(MIN_RECURRING_SESSIONS)]
+    # Twenty later calls in each session, prompt growing monotonically (no
+    # compaction), all timestamped after the seeded failures.
+    timeline = [
+        (f"tail-{i}", datetime(2030, 1, 1, tzinfo=timezone.utc) + timedelta(minutes=n),
+         1000 * (n + 1))
+        for i in range(MIN_RECURRING_SESSIONS)
+        for n in range(20)
+    ]
+    conn = _FakeSpanConn([("anthropic", "claude-sonnet-5", 1_000_000)], timeline)
+
+    finding = analyze_relearns(sessions, projects_root=tmp_path, distill_enabled=False, conn=conn)
+    cluster = finding.clusters[0]
+
+    assert GROUNDED_TOKENS_PER_OCCURRENCE == 1_500
+    assert cluster.tail_calls_median == 20
+    assert cluster.tail_multiplier > 1.0
+    assert cluster.gross_recoverable_tokens > (
+        cluster.occurrences * GROUNDED_TOKENS_PER_OCCURRENCE
+    )
+
+
+def test_compaction_truncates_the_re_read_tail(tmp_path):
+    """The tail stops where the context collapses: past a `/compact` the
+    failure text is no longer being re-sent, so those calls are not charged."""
+    for i in range(MIN_RECURRING_SESSIONS):
+        _cwd_confusion_session(tmp_path, f"-Users-test-comp{i}", f"comp-{i}")
+    sessions = [(f"comp-{i}", f"repo{i}") for i in range(MIN_RECURRING_SESSIONS)]
+    base = datetime(2030, 1, 1, tzinfo=timezone.utc)
+    # Five growing calls, then a collapse, then fifteen more: only the five
+    # before the collapse re-read the failure.
+    sizes = [1000 * (n + 1) for n in range(5)] + [100] + [1000 * (n + 1) for n in range(15)]
+    timeline = [
+        (f"comp-{i}", base + timedelta(minutes=n), size)
+        for i in range(MIN_RECURRING_SESSIONS)
+        for n, size in enumerate(sizes)
+    ]
+    conn = _FakeSpanConn([("anthropic", "claude-sonnet-5", 1_000_000)], timeline)
+
+    finding = analyze_relearns(sessions, projects_root=tmp_path, distill_enabled=False, conn=conn)
+    assert finding.clusters[0].tail_calls_median == 5

--- a/tests/unit/test_relearn.py
+++ b/tests/unit/test_relearn.py
@@ -892,10 +892,10 @@ class _FakeSpanConn:
     """Minimal stand-in for a DuckDB connection.
 
     Relearn issues two different queries per cluster — the rate blend
-    (``provider, model, tokens``) and the per-session prompt timeline the
-    re-read tail is measured on (``session_id, start_time, prompt_size``) — so
-    this dispatches on the SQL text rather than returning one canned shape to
-    both.
+    (``provider, model, input_tokens, cache_tokens``) and the per-session
+    prompt timeline the re-read tail is measured on (``session_id,
+    start_time, prompt_size``) — so this dispatches on the SQL text rather
+    than returning one canned shape to both.
     """
     def __init__(self, rate_rows, timeline_rows=()):
         self._rate_rows = rate_rows
@@ -913,7 +913,7 @@ class _FakeSpanConn:
 def test_blended_rate_profile_names_the_models_it_derived_from():
     from tokenjam.core.optimize.rate_profile import blended_rate_profile
 
-    conn = _FakeSpanConn([("anthropic", "claude-sonnet-5", 1_000_000)])
+    conn = _FakeSpanConn([("anthropic", "claude-sonnet-5", 1_000_000, 1_000_000)])
     profile = blended_rate_profile(conn, session_ids={"s1", "s2"})
 
     rates = get_rates("anthropic", "claude-sonnet-5")
@@ -948,7 +948,7 @@ def test_monthly_usd_derived_when_conn_has_priced_spans(tmp_path):
     for i in range(MIN_RECURRING_SESSIONS):
         _cwd_confusion_session(tmp_path, f"-Users-test-usd{i}", f"usd-{i}")
     sessions = [(f"usd-{i}", f"repo{i}") for i in range(MIN_RECURRING_SESSIONS)]
-    conn = _FakeSpanConn([("anthropic", "claude-sonnet-5", 1_000_000)])
+    conn = _FakeSpanConn([("anthropic", "claude-sonnet-5", 1_000_000, 1_000_000)])
 
     finding = analyze_relearns(sessions, projects_root=tmp_path, distill_enabled=False, conn=conn)
 
@@ -976,7 +976,7 @@ def test_occurrence_is_worth_its_re_read_tail_not_just_one_turn(tmp_path):
         for i in range(MIN_RECURRING_SESSIONS)
         for n in range(20)
     ]
-    conn = _FakeSpanConn([("anthropic", "claude-sonnet-5", 1_000_000)], timeline)
+    conn = _FakeSpanConn([("anthropic", "claude-sonnet-5", 1_000_000, 1_000_000)], timeline)
 
     finding = analyze_relearns(sessions, projects_root=tmp_path, distill_enabled=False, conn=conn)
     cluster = finding.clusters[0]
@@ -1004,7 +1004,7 @@ def test_compaction_truncates_the_re_read_tail(tmp_path):
         for i in range(MIN_RECURRING_SESSIONS)
         for n, size in enumerate(sizes)
     ]
-    conn = _FakeSpanConn([("anthropic", "claude-sonnet-5", 1_000_000)], timeline)
+    conn = _FakeSpanConn([("anthropic", "claude-sonnet-5", 1_000_000, 1_000_000)], timeline)
 
     finding = analyze_relearns(sessions, projects_root=tmp_path, distill_enabled=False, conn=conn)
     assert finding.clusters[0].tail_calls_median == 5

--- a/tests/unit/test_rollup_subagent_downsize_dedup.py
+++ b/tests/unit/test_rollup_subagent_downsize_dedup.py
@@ -10,6 +10,7 @@ cache family, applied to downsize/subagent.
 """
 from __future__ import annotations
 
+from dataclasses import replace
 from datetime import timedelta
 
 import pytest
@@ -129,3 +130,82 @@ def test_rollup_counts_the_subagent_tokens_exactly_once(db):
     assert rollup["estimated_recoverable_tokens"] <= SESSION_TOKENS
     # The dollar side can only ever claim the session's real spend back.
     assert rollup["estimated_recoverable_usd"] <= MAIN_COST + SUB_COST
+
+
+# --- resend's compound offload claim vs the subagent card --------------------
+# Same class of guard, third pair. `resend` prices the re-read tail that
+# offloading main-thread work removes, plus the right-sizing delta on that same
+# offloaded material. Both are computed over `sub_agent_id IS NULL` spans in
+# context-heavy sessions, so they can never reach the spans `subagent` prices
+# (which are `sub_agent_id IS NOT NULL` by construction) nor the small
+# structural sessions `downsize` flags.
+
+def test_resend_offload_claim_never_reaches_subagent_or_downsize_spans(db):
+    from tokenjam.core.optimize.analyzers.context_resend import (
+        MIN_SESSION_CONTEXT_TOKENS,
+    )
+
+    start = utcnow() - timedelta(days=2)
+    # A delegating session, so the offloadable share is measurable at all.
+    for i in range(3):
+        db.insert_span(make_llm_span(
+            agent_id="claude-code-x", model="claude-opus-4-7", provider="anthropic",
+            input_tokens=1_000, cache_tokens=500, output_tokens=100, cost_usd=0.05,
+            session_id="deleg", sub_agent_id=None, start_time=start + timedelta(minutes=i),
+        ))
+    for i in range(3):
+        db.insert_span(make_llm_span(
+            agent_id="claude-code-x", model="claude-opus-4-7", provider="anthropic",
+            input_tokens=2_000, output_tokens=100, cost_usd=0.10,
+            session_id="deleg", sub_agent_id="researcher",
+            start_time=start + timedelta(minutes=10 + i),
+        ))
+    # A context-heavy in-thread session where the offload saving is claimed.
+    heavy_main_cost = 0.0
+    for i in range(4):
+        db.insert_span(make_llm_span(
+            agent_id="claude-code-x", model="claude-opus-4-7", provider="anthropic",
+            input_tokens=MIN_SESSION_CONTEXT_TOKENS,
+            cache_tokens=MIN_SESSION_CONTEXT_TOKENS * i,
+            output_tokens=500, cost_usd=1.0,
+            session_id="heavy", sub_agent_id=None,
+            start_time=start + timedelta(hours=1, minutes=i),
+        ))
+        heavy_main_cost += 1.0
+    db.insert_span(make_llm_span(
+        agent_id="claude-code-x", model="claude-opus-4-7", provider="anthropic",
+        input_tokens=100, output_tokens=10, cost_usd=0.01,
+        session_id="pad", sub_agent_id=None, start_time=start,
+    ))
+
+    since, until = _window()
+    report = build_report(db=db, config=TjConfig(version="1"), since=since, until=until,
+                          findings=["resend", "subagent"])
+    resend = report.findings["resend"]
+    assert resend.estimated_recoverable_usd is not None
+
+    # The claim is bounded by what the main thread actually spent: it prices a
+    # tail and a rate delta on main-thread material, never the subagent spans
+    # the `subagent` card already claims.
+    assert resend.estimated_recoverable_usd <= heavy_main_cost + 0.15
+    # And it is strictly smaller than the observed cost of the same re-sending.
+    assert resend.cost_of_waste_usd > resend.estimated_recoverable_usd
+
+    proposals = cost_proposals_from_report(report)
+    resend_card = next(p for p in proposals if p.analyzer == "resend")
+    assert resend_card.cost_of_waste_usd == resend.cost_of_waste_usd
+
+    # cost-of-waste is structurally excluded from the headline: the rollup reads
+    # only the `estimated_*` fields, so the gross can never inflate it. Pinned
+    # by removing the recoverable figures and watching the rollup go to zero
+    # while the gross is still sitting on the card.
+    rollup = estimated_recoverable_rollup(proposals)
+    assert rollup["estimated_recoverable_usd"] == pytest.approx(
+        sum(p.estimated_recoverable_usd or 0.0 for p in proposals)
+    )
+    stripped = [
+        replace(p, estimated_recoverable_usd=None, estimated_recoverable_tokens=None)
+        for p in proposals
+    ]
+    assert any(p.cost_of_waste_usd for p in stripped)
+    assert estimated_recoverable_rollup(stripped)["estimated_recoverable_usd"] == 0.0

--- a/tokenjam/cli/cmd_optimize.py
+++ b/tokenjam/cli/cmd_optimize.py
@@ -2124,10 +2124,13 @@ def _render_summarize(
     silently dropped from plain-text `tj optimize` output and only reachable
     via `--json`.
 
-    Tokens-only by design (see core/optimize/analyzers/summarize.py):
-    `estimated_recoverable_usd` is intentionally None — there's no per-file
-    call telemetry to amortize a dollar figure over — so this renderer never
-    fabricates one, only the per-call token reduction.
+    The token figure is per CALL; the dollar figure is per WINDOW, because
+    these files are always-on context and the reduction is realized on every
+    session that loads them (see core/optimize/analyzers/summarize.py). The
+    dollar line only appears when the analyzer could observe how many sessions
+    actually load the files — it is never fabricated from a default rate — and
+    it goes through `render_savings` so a subscription/local plan sees the same
+    framing every other analyzer gives it.
     """
     console.print(_finding_header(marker, "Summarize:"))
     if not finding.candidates:
@@ -2143,6 +2146,17 @@ def _render_summarize(
         f"summarizable, ~[bold]{format_tokens(tokens)}[/bold] per call "
         f"[dim](aggregate {finding.reduction_pct}% prose reduction)[/dim]"
     )
+    recoverable_usd = getattr(finding, "estimated_recoverable_usd", None)
+    if recoverable_usd:
+        savings = render_savings(
+            recoverable_usd, tokens, Framing(pricing_mode=pricing_mode),
+        )
+        if savings != "—":
+            console.print(
+                f"       [green]~{savings}[/green] across the "
+                f"[bold]{finding.sessions_examined}[/bold] session(s) in this "
+                f"window that re-send these files on every call"
+            )
     for c in finding.candidates[:5]:
         console.print(
             f"       [dim]{c.path}[/dim]  [dim]({c.scope})[/dim]  "

--- a/tokenjam/core/framing.py
+++ b/tokenjam/core/framing.py
@@ -11,10 +11,11 @@ This module *reads* plan-tier / pricing-mode; it does not define them. The
 canonical derivation lives on ``SessionRecord.pricing_mode`` and the
 ``SUBSCRIPTION_PLAN_TIERS`` frozenset in :mod:`tokenjam.otel.semconv`.
 
-Honesty discipline (see CLAUDE.md Critical Rule 14): subscription users never
-see a raw dollar figure that includes subscription traffic without
-qualification; local users see tokens only; unknown-plan users see dollars with
-an "may overstate" qualifier.
+Honesty discipline (see CLAUDE.md Critical Rule 14): every user is assumed to
+be on API pricing, so dollar figures are shown by default — subscription
+users see them qualified as a list-price equivalent (never an amount billed);
+local users see tokens only (no marginal cost to price); unknown-plan users
+see dollars with a "may overstate" qualifier.
 """
 from __future__ import annotations
 
@@ -385,25 +386,28 @@ def compute_framing(
             + RECONFIGURE_HINT
         )
     elif mode == "subscription":
-        display_rule = DISPLAY_SUPPRESS_SUBSCRIPTION
-        if api_sessions > 0:
-            # Scope-neutral wording ("of sessions", not "this window"): the
-            # /cost route now frames off the user's full session history (#177)
-            # while the CLI / compare callers still pass a window-scoped mix —
-            # the phrasing must read truthfully for both.
-            #
-            # It must also be true about HOW the dollars are derived. This used
-            # to claim they "reflect API traffic only", which no query in the
-            # product does: `plan_tier` lives on `sessions`, every cost
-            # aggregate reads `spans`, and nothing joins the two — so dollars
-            # price ALL traffic at API list rates. That is the right number
-            # (it is what the waste would cost at list price), but it is a
-            # list-price equivalent, not an amount anyone was billed.
-            qualifier = (
-                f"{sub_pct:.1f}% of sessions are subscription-billed. Dollar "
-                f"figures price all traffic at API list rates, so they are a "
-                f"list-price equivalent, not an amount billed."
-            )
+        # Standing product decision: assume every user is on API pricing and
+        # show dollars, because a dollar figure is the unit users actually
+        # reason in — token counts don't translate into a decision. Dollars
+        # price ALL traffic (subscription and API alike) at API list rates,
+        # so they are always shown WITH the qualifier below, never suppressed
+        # in favour of a token-share-only figure. `DISPLAY_SUPPRESS_SUBSCRIPTION`
+        # stays defined for any caller that still wants to detect "this window
+        # is subscription-dominant" from `pricing_mode`, but `display_rule` no
+        # longer resolves to it.
+        display_rule = DISPLAY_SHOW_DOLLARS_WITH_QUALIFIER
+        # It must be true about HOW the dollars are derived. This used to
+        # claim they "reflect API traffic only", which no query in the
+        # product does: `plan_tier` lives on `sessions`, every cost
+        # aggregate reads `spans`, and nothing joins the two — so dollars
+        # price ALL traffic at API list rates. That is the right number
+        # (it is what the waste would cost at list price), but it is a
+        # list-price equivalent, not an amount anyone was billed.
+        qualifier = (
+            f"{sub_pct:.1f}% of sessions are subscription-billed. Dollar "
+            f"figures price all traffic at API list rates, so they are a "
+            f"list-price equivalent, not an amount billed."
+        )
     elif mode == "local":
         display_rule = DISPLAY_TOKENS_ONLY
         qualifier = "Local inference — no marginal cost."

--- a/tokenjam/core/optimize/analyzers/context_resend.py
+++ b/tokenjam/core/optimize/analyzers/context_resend.py
@@ -371,8 +371,11 @@ def _measure_offloadable_share(by_session: dict[str, list[TurnComposition]]) -> 
     return min(delegated / total, 1.0)
 
 
-def _resend_tail_tokens(main_turns: list[TurnComposition]) -> int:
-    """Token-turns of re-reading the main thread pays for its own material.
+def _resend_tail_tokens_per_turn(main_turns: list[TurnComposition]) -> list[int]:
+    """Per-turn tail-token contribution — same computation as
+    ``_resend_tail_tokens``, kept ungrouped so each turn's own contribution can
+    be priced at that turn's own model's rate rather than one rate applied to
+    the session-wide sum.
 
     For each turn, the material it introduces is re-read by every later
     main-thread turn until the next compaction — a turn whose prompt collapses
@@ -380,7 +383,7 @@ def _resend_tail_tokens(main_turns: list[TurnComposition]) -> int:
     what a ``/compact`` or a context reset looks like in the data. Counting
     past that boundary would claim a cost the user never paid.
 
-    Returns the sum of ``introduced x tail_length``, i.e. tokens billed as
+    Returns, per turn, ``introduced x tail_length``, i.e. tokens billed as
     cache reads purely because the work stayed on the parent thread.
     """
     n = len(main_turns)
@@ -399,10 +402,16 @@ def _resend_tail_tokens(main_turns: list[TurnComposition]) -> int:
         if collapsed:
             next_boundary = i
 
-    return sum(
+    return [
         _introduced_tokens(turn) * max(boundary_after[i] - i - 1, 0)
         for i, turn in enumerate(main_turns)
-    )
+    ]
+
+
+def _resend_tail_tokens(main_turns: list[TurnComposition]) -> int:
+    """Window-scoped total of ``_resend_tail_tokens_per_turn`` — kept for
+    callers (and tests) that only need the session's aggregate tail."""
+    return sum(_resend_tail_tokens_per_turn(main_turns))
 
 
 def _capture_flags(config) -> tuple[bool, bool, bool]:
@@ -488,31 +497,38 @@ def run(ctx: AnalyzerContext) -> None:
 
         if repeat_tokens <= 0:
             continue
-        rates = get_rates(provider, model)
-        if rates is None or rates.input_per_mtok <= 0:
-            continue  # unpriced model: contributes to no dollar figure at all
 
-        # COST OF WASTE (observed). Every cache read IS re-sent context by
-        # definition, billed at the cache-read rate; the still-uncached share
-        # of the repeat volume billed at the full input rate. Nothing
-        # discounted, nothing projected — this is what it cost, not what a fix
-        # returns. NEVER summed with the recoverable figures below.
-        total_new_input = sum(t.new_input_tokens for t in session_turns)
-        reread_tokens = sum(t.reread_tokens for t in session_turns)
-        uncached_fraction = (total_new_input / s_sum) if s_sum else 0.0
-        uncached_repeat_tokens = repeat_tokens * uncached_fraction
-        waste_usd_total += (
-            reread_tokens / 1_000_000 * rates.cache_read_per_mtok
-            + uncached_repeat_tokens / 1_000_000 * rates.input_per_mtok
-        )
-        waste_tokens_total += reread_tokens + round(uncached_repeat_tokens)
-        any_waste_priced = True
+        # COST OF WASTE (observed), priced per TURN at that turn's OWN model's
+        # rate — a session that mixes models (e.g. opus for some turns, haiku
+        # for others) must not have every turn priced at whichever model
+        # happened to dominate the turn count. `repeat_tokens` is inherently a
+        # session-level quantity (it comes from the sum-vs-max prompt-size
+        # comparison, not a per-turn one), so its uncached share is allocated
+        # across turns in proportion to each turn's own `new_input_tokens` —
+        # the same proportion the old single blended fraction expressed in
+        # aggregate, just applied per turn instead of once. Every cache read
+        # IS re-sent context by definition, billed at that turn's cache-read
+        # rate; the still-uncached share billed at that turn's input rate.
+        # Nothing discounted, nothing projected — this is what it cost, not
+        # what a fix returns. NEVER summed with the recoverable figures below.
+        for t in session_turns:
+            turn_rates = get_rates(t.provider or "unknown", t.model)
+            if turn_rates is None or turn_rates.input_per_mtok <= 0:
+                continue  # this turn's model unpriced: contributes no dollar figure
+            uncached_repeat = repeat_tokens * (t.new_input_tokens / s_sum) if s_sum else 0.0
+            waste_usd_total += (
+                t.reread_tokens / 1_000_000 * turn_rates.cache_read_per_mtok
+                + uncached_repeat / 1_000_000 * turn_rates.input_per_mtok
+            )
+            waste_tokens_total += t.reread_tokens + round(uncached_repeat)
+            any_waste_priced = True
 
         # RECOVERABLE (the compound offload + right-size lever). Main-thread
         # turns only, and only in sessions whose context is heavy enough for
         # the lever to exist — see MIN_SESSION_CONTEXT_TOKENS for why that also
-        # keeps this disjoint from `downsize`.
-        if offloadable_share is None or rates.cache_read_per_mtok <= 0:
+        # keeps this disjoint from `downsize`. Priced per turn at that turn's
+        # own model's rate, same reasoning as cost-of-waste above.
+        if offloadable_share is None:
             continue
         main_turns = [t for t in session_turns if not t.sub_agent_id]
         if len(main_turns) < 2:
@@ -522,20 +538,25 @@ def run(ctx: AnalyzerContext) -> None:
 
         # The tail that offloading removes: material re-read by later
         # main-thread turns purely because the work stayed in the thread.
-        offloadable_tail = _resend_tail_tokens(main_turns) * offloadable_share
-        offload_usd_total += offloadable_tail / 1_000_000 * rates.cache_read_per_mtok
+        for t, tail_tokens in zip(main_turns, _resend_tail_tokens_per_turn(main_turns)):
+            turn_rates = get_rates(t.provider or "unknown", t.model)
+            if turn_rates is None or turn_rates.cache_read_per_mtok <= 0:
+                continue
+            offloadable_tail = tail_tokens * offloadable_share
+            offload_usd_total += offloadable_tail / 1_000_000 * turn_rates.cache_read_per_mtok
 
-        # Right-sizing stacks independently: the same offloaded material still
-        # has to be read once by whatever runs it, so pricing it at the cheaper
-        # same-family model's input rate instead of this one's is a second,
-        # non-overlapping cut. Skipped when no cheaper alternative is priced.
-        offloaded_material = sum(_introduced_tokens(t) for t in main_turns) * offloadable_share
-        offload_tokens_total += round(offloadable_tail + offloaded_material)
-        alt = lookup_downgrade(provider, model)
-        alt_rates = get_rates(provider, alt) if alt else None
-        if alt_rates is not None:
-            rate_gap = max(0.0, rates.input_per_mtok - alt_rates.input_per_mtok)
-            rightsize_usd_total += offloaded_material / 1_000_000 * rate_gap
+            # Right-sizing stacks independently: the same offloaded material
+            # still has to be read once by whatever runs it, so pricing it at
+            # the cheaper same-family model's input rate instead of this
+            # turn's is a second, non-overlapping cut. Skipped when no
+            # cheaper alternative is priced for this turn's own model.
+            offloaded_material = _introduced_tokens(t) * offloadable_share
+            offload_tokens_total += round(offloadable_tail + offloaded_material)
+            alt = lookup_downgrade(t.provider or "unknown", t.model)
+            alt_rates = get_rates(t.provider or "unknown", alt) if alt else None
+            if alt_rates is not None:
+                rate_gap = max(0.0, turn_rates.input_per_mtok - alt_rates.input_per_mtok)
+                rightsize_usd_total += offloaded_material / 1_000_000 * rate_gap
 
     if total_sum <= 0:
         finding.notes.append(

--- a/tokenjam/core/optimize/analyzers/context_resend.py
+++ b/tokenjam/core/optimize/analyzers/context_resend.py
@@ -33,13 +33,27 @@ UNDERESTIMATE of the true repeat share, never an overestimate.
 
 Honesty discipline (CLAUDE.md Rule 14 / anti-pattern #22): `repeat_share`
 itself is a measured token-share, not a savings claim; it is shown
-regardless of pricing or caching state. The full repeat share is NOT claimed
-as recoverable (the benchmark explicitly warns against this: 93.8% re-sent is
-a different, larger number than the 68.3% of Anthropic spend the SAME corpus
-found actually avoidable once caching was added). `estimated_recoverable_*`
-below is discounted by AVOIDABLE_FRACTION_OF_REPEAT, and the dollar figure is
-additionally scoped to only the currently-uncached share of the repeated
-volume; see that constant's docstring and RESEND_ESTIMATE_BASIS for why.
+regardless of pricing or caching state.
+
+**Two dollar figures live on this finding and they are NEVER summed.**
+
+`cost_of_waste_usd` is an OBSERVATION, not a saving: what the re-sent volume
+actually cost over the window, priced per token class at the rates it really
+billed at (cache reads at the cache-read rate, uncached repeat at the input
+rate). Nothing is projected and nothing is discounted, because nothing is
+being claimed — this answers "what did re-sending context cost me", which is
+a question the data answers exactly. It is deliberately much larger than the
+recoverable figure, and publishing it AS a saving would fail the product's
+"if I apply the fix, do I actually save this?" bar outright: multi-turn
+conversation inherently re-sends context (the floor is not zero), subagent
+offload MOVES context rather than deleting it, and compaction only helps
+forward and costs a summarization call of its own.
+
+`estimated_recoverable_usd` is what the fix actually returns, and is derived
+from THIS user's corpus, not from a cross-corpus constant. The lever is a
+compound one — offload context-heavy in-thread work to a subagent AND
+right-size that subagent — and both halves are measured here; see
+`_offload_recoverable` and RESEND_ESTIMATE_BASIS.
 """
 from __future__ import annotations
 
@@ -54,6 +68,7 @@ from tokenjam.core.context_diagnostic import (
     compute_context_diagnostic,
     load_turn_compositions,
 )
+from tokenjam.core.optimize.analyzers.model_downgrade import lookup_downgrade
 from tokenjam.core.optimize.registry import register
 from tokenjam.core.optimize.types import AnalyzerContext
 from tokenjam.core.pricing import get_rates
@@ -74,14 +89,51 @@ MIN_TURNS_FOR_SIGNAL = 6
 # a 68.3% reduction cross-checked against one real ground-truth case (see
 # benchmarks/RESULTS.md, "1. Caching recommendations"). That 68.3% is a
 # DIFFERENT metric from the 93.8% repeat-share above (dollars vs tokens,
-# Anthropic-only vs all-providers); it is not a nested fraction of it. It is
-# used here only as the best available proxy for "not every re-sent token
-# converts to a recoverable saving" (cache lookback limits, TTL expiry, and
-# prefix instability all eat into the theoretical maximum; see
-# cache_efficacy.py's A2/A3 root causes for the mechanisms), so both
-# recoverable claims below are discounted by it rather than claiming the
-# full structural repeat share as recoverable.
+# Anthropic-only vs all-providers); it is not a nested fraction of it.
+#
+# It is a calibration constant from ANOTHER corpus, so it prices the TOKENS
+# claim only — the cache_control / compaction lever, whose mechanism is
+# cross-corpus by nature. The DOLLAR claim no longer inherits it: the offload
+# lever's avoidable fraction is measured from the user's own `sub_agent_id`
+# telemetry instead (see `_measure_offloadable_share`), because that lever's
+# realisable share is a property of how THIS user already works, not of a
+# benchmark suite.
 AVOIDABLE_FRACTION_OF_REPEAT = 0.683
+
+# --- The offload lever, measured -------------------------------------------
+# Claude Code's durable fix for repeated context is not caching and not
+# `/compact`: it is keeping context-heavy work OFF the long-lived parent
+# thread. A subagent's tool outputs live in the subagent's own context, so
+# they are never re-billed on any later parent call. The saving is the tail
+# that never happens:
+#
+#     saving_offload  ~ introduced_tokens x tail_calls x cache_read_rate
+#     saving_rightsize ~ offloaded_tokens x (premium_rate - right_sized_rate)
+#
+# and the two COMPOUND — moving the work off the parent thread does not stop
+# the subagent that now does it from running on a cheaper model.
+#
+# Scope, and why it is disjoint from every other analyzer's claim (Critical
+# Rule 27 — two analyzers claiming `estimated_recoverable_*` must draw from
+# disjoint spans). This claim is computed over MAIN-THREAD turns only
+# (`sub_agent_id IS NULL`), so it cannot overlap `subagent`, which filters to
+# `sub_agent_id IS NOT NULL`. And it only counts sessions whose accumulated
+# main-thread context exceeds MIN_SESSION_CONTEXT_TOKENS, which no `downsize`
+# candidate can be: that analyzer's structural gate is input < 5K tokens for
+# the whole session.
+
+#: A session only has an offload lever once its main-thread context is big
+#: enough for re-reading it to cost real money. Same threshold
+#: `subagent_rightsizing.CONTEXT_HEAVY_TOKENS` uses for the same idea, and
+#: an order of magnitude above `downsize`'s 5K structural ceiling, which is
+#: what keeps the two claims disjoint by construction.
+MIN_SESSION_CONTEXT_TOKENS = 50_000
+
+#: A prompt whose size falls to at most this share of the previous turn's has
+#: had its context reset (a `/compact`, a resume, a fresh window). Material
+#: introduced before that point is not re-read after it, so the tail stops
+#: there rather than running to end-of-session.
+COMPACTION_PROMPT_DROP_RATIO = 0.5
 
 RESEND_HONESTY_CAVEAT = (
     "Structural token-share, not a savings claim: a conservative lower bound "
@@ -97,14 +149,34 @@ RESEND_ESTIMATE_BASIS = (
     "token-weighted across sessions. TOKENS claim (compaction lever): "
     "repeat_tokens x 68.3% avoidable-fraction (see AVOIDABLE_FRACTION_OF_REPEAT "
     "docstring); cache-agnostic, since compaction cuts gross token volume "
-    "regardless of caching state. USD claim (cache_control-adoption lever): "
-    "the CURRENTLY-UNCACHED share of that repeat volume only "
-    "(repeat_tokens x new_input_tokens/prompt_tokens for the session), priced "
-    "at the dominant model's (input - cache-read) rate delta x 68.3%; "
-    "already-cached repeat volume already has its caching benefit, so "
-    "re-claiming it here would double-count cache_efficacy's own recoverable "
-    "estimate. Both are heuristic: reviewed against this repo's own benchmark "
-    "corpus, not measured on this user's own data."
+    "regardless of caching state, and cross-corpus calibrated rather than "
+    "measured here. USD claim (subagent-offload + right-sizing lever, measured "
+    "on YOUR data): for each main-thread turn of a context-heavy session, the "
+    "material it introduces (uncached input + output) is re-read by every later "
+    "main-thread turn until the next compaction, billed at the cache-read rate "
+    "— that tail is what offloading the work to a subagent removes, because a "
+    "subagent's tool output never enters the parent context. Only the share of "
+    "that volume you demonstrably CAN offload is claimed, and that share is "
+    "measured from your own sub_agent_id telemetry (how much of the "
+    "context-introducing volume already runs in subagents, in the sessions "
+    "where you delegate at all) rather than inherited from a benchmark. "
+    "Right-sizing stacks on top: the same offloaded volume priced at the "
+    "cheaper same-family model's input rate instead of the premium one. "
+    "Computed over main-thread spans only, so it never overlaps the subagent "
+    "analyzer's own claim."
+)
+
+RESEND_COST_OF_WASTE_BASIS = (
+    "OBSERVED, not recoverable: what re-sent context actually cost over the "
+    "window, priced per token class at the rates it really billed at — cache "
+    "reads at the cache-read rate, the still-uncached share of the repeat "
+    "volume at the input rate. Nothing here is projected or discounted because "
+    "nothing is being claimed. Do NOT read this as a saving: multi-turn work "
+    "inherently re-sends context (the floor is not zero), offloading to a "
+    "subagent moves context rather than deleting it, and compaction only helps "
+    "forward and costs a summarization call of its own. The figure the fix "
+    "actually returns is estimated_recoverable_usd, which is much smaller and "
+    "derived separately."
 )
 
 COMPACTION_FIX = (
@@ -135,6 +207,17 @@ SUBAGENT_OFFLOAD_FIX = (
     "with. Where available, pair this with a hook that warns once context "
     "crosses a size threshold, as a second, automated nudge toward the same "
     "behavior."
+)
+
+#: The second half of the compound lever. Offloading decides WHERE the work
+#: runs; this decides what it runs ON. Both are settable in the same agent
+#: file's frontmatter, so the two land as one artifact rather than two cards.
+RIGHTSIZE_FIX_TEMPLATE = (
+    "Then right-size what you offload to. A subagent doing broad reads and "
+    "returning a short conclusion rarely needs the premium tier: pin both its "
+    "model and its reasoning effort in its own definition file so every future "
+    "dispatch inherits them instead of defaulting to whatever the parent runs "
+    "on."
 )
 
 # Cap on evidence rows carried in the finding payload; aggregates are over ALL
@@ -183,12 +266,33 @@ class ResendFinding:
     # session had a model to name in the snippet.
     fix_compaction:        str = COMPACTION_FIX
     fix_subagent_offload:  str = SUBAGENT_OFFLOAD_FIX
+    fix_rightsize:         str = RIGHTSIZE_FIX_TEMPLATE
     fix_cache_control:     str = ""
     caveat:            str = RESEND_HONESTY_CAVEAT
     estimate_basis:    str = ""
     estimate_confidence: str = "heuristic"
     estimated_recoverable_tokens: int | None = None
     estimated_recoverable_usd:    float | None = None
+    # COST OF WASTE — an observation, never a saving, and NEVER summed with
+    # `estimated_recoverable_usd` anywhere. See the module docstring and
+    # `RESEND_COST_OF_WASTE_BASIS`. `None` when no turn in the window carried a
+    # priced model (a zero would read as "re-sending context is free").
+    cost_of_waste_usd:      float | None = None
+    cost_of_waste_tokens:   int = 0
+    cost_of_waste_basis:    str = RESEND_COST_OF_WASTE_BASIS
+    # The two halves of the compound recoverable claim, kept visible so the
+    # headline is never a black box. They ARE summed into
+    # `estimated_recoverable_usd` — unlike cost-of-waste, these price the same
+    # fix and are independent of one another (moving work off the parent thread
+    # does not stop it from also running on a cheaper model).
+    offload_recoverable_usd:   float | None = None
+    rightsize_recoverable_usd: float | None = None
+    #: Share of context-introducing volume this user already routes through
+    #: subagents, in the sessions where they delegate at all — the measured
+    #: replacement for the inherited 68.3% constant on the dollar claim.
+    #: `None` when no session in the window delegates, in which case no
+    #: offload dollar figure is claimed.
+    offloadable_share:         float | None = None
     notes: list[str] = field(default_factory=list)
 
 
@@ -226,6 +330,78 @@ def _cache_control_snippet(model: str, tokens: int) -> str:
             "text": "<the stable prefix you resend every turn>",
             "cache_control": {"type": "ephemeral"},
         }, indent=2)
+    )
+
+
+def _introduced_tokens(turn: TurnComposition) -> int:
+    """Material this turn ADDS to the conversation, and that every later turn
+    in the same context window therefore re-reads: uncached input (a tool
+    result, a pasted file, a user message) plus the assistant's own output.
+    Cache reads are excluded — those are the re-reading, not the material."""
+    return turn.new_input_tokens + turn.output_tokens
+
+
+def _measure_offloadable_share(by_session: dict[str, list[TurnComposition]]) -> float | None:
+    """Share of context-introducing volume this user already routes through
+    subagents, measured across the sessions where they delegate at all.
+
+    This is the corpus-measured replacement for inheriting a cross-corpus
+    constant. Telemetry carries ``sub_agent_id``, so in-thread and offloaded
+    work are directly comparable: sessions that already lean on subagents show
+    what fraction of the material is offloadable IN PRACTICE for this user's
+    kind of work. Sessions that never delegate are excluded from the
+    measurement (they have nothing to measure) but are exactly where the
+    saving is then claimed.
+
+    ``None`` when no session in the window delegates — nothing to measure, so
+    nothing is claimed rather than a fraction being invented.
+    """
+    delegated = 0
+    total = 0
+    for turns in by_session.values():
+        if not any(t.sub_agent_id for t in turns):
+            continue
+        for turn in turns:
+            introduced = _introduced_tokens(turn)
+            total += introduced
+            if turn.sub_agent_id:
+                delegated += introduced
+    if total <= 0 or delegated <= 0:
+        return None
+    return min(delegated / total, 1.0)
+
+
+def _resend_tail_tokens(main_turns: list[TurnComposition]) -> int:
+    """Token-turns of re-reading the main thread pays for its own material.
+
+    For each turn, the material it introduces is re-read by every later
+    main-thread turn until the next compaction — a turn whose prompt collapses
+    to at most ``COMPACTION_PROMPT_DROP_RATIO`` of the previous one's, which is
+    what a ``/compact`` or a context reset looks like in the data. Counting
+    past that boundary would claim a cost the user never paid.
+
+    Returns the sum of ``introduced x tail_length``, i.e. tokens billed as
+    cache reads purely because the work stayed on the parent thread.
+    """
+    n = len(main_turns)
+    prompt_sizes = [t.new_input_tokens + t.reread_tokens for t in main_turns]
+    # boundary_after[i] = index of the first compaction boundary strictly after
+    # turn i, or n when the context survives to the end of the session.
+    boundary_after = [n] * n
+    next_boundary = n
+    for i in range(n - 1, -1, -1):
+        boundary_after[i] = next_boundary
+        collapsed = (
+            i >= 1
+            and prompt_sizes[i - 1] > 0
+            and prompt_sizes[i] <= prompt_sizes[i - 1] * COMPACTION_PROMPT_DROP_RATIO
+        )
+        if collapsed:
+            next_boundary = i
+
+    return sum(
+        _introduced_tokens(turn) * max(boundary_after[i] - i - 1, 0)
+        for i, turn in enumerate(main_turns)
     )
 
 
@@ -273,11 +449,20 @@ def run(ctx: AnalyzerContext) -> None:
         ctx.report.findings["resend"] = finding
         return
 
+    # Measured on this user's own telemetry, not inherited: how much of the
+    # context-introducing volume already runs in subagents where they delegate
+    # at all. `None` means the corpus can't answer it, so no dollar claim.
+    offloadable_share = _measure_offloadable_share(by_session)
+
     total_sum = 0
     total_max = 0
     examples: list[ResendSessionExample] = []
-    priced_usd_total = 0.0
-    any_priced = False
+    waste_usd_total = 0.0
+    waste_tokens_total = 0
+    any_waste_priced = False
+    offload_usd_total = 0.0
+    rightsize_usd_total = 0.0
+    offload_tokens_total = 0
 
     for sid, session_turns in by_session.items():
         prompt_sizes = [t.new_input_tokens + t.reread_tokens for t in session_turns]
@@ -303,26 +488,54 @@ def run(ctx: AnalyzerContext) -> None:
 
         if repeat_tokens <= 0:
             continue
-        # Dollar opportunity, cache_control-adoption lever: scoped to the
-        # CURRENTLY-UNCACHED share of this session's prompt volume only. See
-        # RESEND_ESTIMATE_BASIS for why already-cached repeat volume is
-        # excluded (double-counting cache_efficacy's own recoverable figure).
+        rates = get_rates(provider, model)
+        if rates is None or rates.input_per_mtok <= 0:
+            continue  # unpriced model: contributes to no dollar figure at all
+
+        # COST OF WASTE (observed). Every cache read IS re-sent context by
+        # definition, billed at the cache-read rate; the still-uncached share
+        # of the repeat volume billed at the full input rate. Nothing
+        # discounted, nothing projected — this is what it cost, not what a fix
+        # returns. NEVER summed with the recoverable figures below.
         total_new_input = sum(t.new_input_tokens for t in session_turns)
+        reread_tokens = sum(t.reread_tokens for t in session_turns)
         uncached_fraction = (total_new_input / s_sum) if s_sum else 0.0
         uncached_repeat_tokens = repeat_tokens * uncached_fraction
-        if uncached_repeat_tokens <= 0:
-            continue
-        rates = get_rates(provider, model)
-        if rates is None or rates.cache_read_per_mtok <= 0:
-            continue  # unpriced / no caching dimension for this model
-        rate_delta = max(0.0, rates.input_per_mtok - rates.cache_read_per_mtok)
-        if rate_delta <= 0:
-            continue
-        priced_usd_total += (
-            uncached_repeat_tokens / 1_000_000 * rate_delta
-            * AVOIDABLE_FRACTION_OF_REPEAT
+        waste_usd_total += (
+            reread_tokens / 1_000_000 * rates.cache_read_per_mtok
+            + uncached_repeat_tokens / 1_000_000 * rates.input_per_mtok
         )
-        any_priced = True
+        waste_tokens_total += reread_tokens + round(uncached_repeat_tokens)
+        any_waste_priced = True
+
+        # RECOVERABLE (the compound offload + right-size lever). Main-thread
+        # turns only, and only in sessions whose context is heavy enough for
+        # the lever to exist — see MIN_SESSION_CONTEXT_TOKENS for why that also
+        # keeps this disjoint from `downsize`.
+        if offloadable_share is None or rates.cache_read_per_mtok <= 0:
+            continue
+        main_turns = [t for t in session_turns if not t.sub_agent_id]
+        if len(main_turns) < 2:
+            continue
+        if max((t.new_input_tokens + t.reread_tokens for t in main_turns), default=0) < MIN_SESSION_CONTEXT_TOKENS:
+            continue
+
+        # The tail that offloading removes: material re-read by later
+        # main-thread turns purely because the work stayed in the thread.
+        offloadable_tail = _resend_tail_tokens(main_turns) * offloadable_share
+        offload_usd_total += offloadable_tail / 1_000_000 * rates.cache_read_per_mtok
+
+        # Right-sizing stacks independently: the same offloaded material still
+        # has to be read once by whatever runs it, so pricing it at the cheaper
+        # same-family model's input rate instead of this one's is a second,
+        # non-overlapping cut. Skipped when no cheaper alternative is priced.
+        offloaded_material = sum(_introduced_tokens(t) for t in main_turns) * offloadable_share
+        offload_tokens_total += round(offloadable_tail + offloaded_material)
+        alt = lookup_downgrade(provider, model)
+        alt_rates = get_rates(provider, alt) if alt else None
+        if alt_rates is not None:
+            rate_gap = max(0.0, rates.input_per_mtok - alt_rates.input_per_mtok)
+            rightsize_usd_total += offloaded_material / 1_000_000 * rate_gap
 
     if total_sum <= 0:
         finding.notes.append(
@@ -345,7 +558,28 @@ def run(ctx: AnalyzerContext) -> None:
     finding.estimated_recoverable_tokens = round(
         AVOIDABLE_FRACTION_OF_REPEAT * finding.repeat_tokens
     )
-    finding.estimated_recoverable_usd = round(priced_usd_total, 6) if any_priced else None
+    finding.cost_of_waste_usd = round(waste_usd_total, 6) if any_waste_priced else None
+    finding.cost_of_waste_tokens = waste_tokens_total
+    finding.offloadable_share = (
+        round(offloadable_share, 4) if offloadable_share is not None else None
+    )
+    if offloadable_share is not None and offload_tokens_total > 0:
+        finding.offload_recoverable_usd = round(offload_usd_total, 6)
+        finding.rightsize_recoverable_usd = round(rightsize_usd_total, 6)
+        # The two halves compound: offloading decides where the work runs,
+        # right-sizing decides what it runs on. Neither cancels the other, so
+        # they sum — unlike cost-of-waste, which never enters this figure.
+        finding.estimated_recoverable_usd = round(
+            offload_usd_total + rightsize_usd_total, 6
+        )
+    else:
+        finding.notes.append(
+            "No dollar figure for the offload lever: this window has no "
+            "session that both delegates to a subagent (nothing to measure "
+            "your offloadable share from) and carries enough main-thread "
+            "context for offloading to pay. The token figure above still "
+            "stands."
+        )
     finding.estimate_basis = RESEND_ESTIMATE_BASIS
 
     heaviest = finding.examples[0] if finding.examples else None

--- a/tokenjam/core/optimize/analyzers/deadweight.py
+++ b/tokenjam/core/optimize/analyzers/deadweight.py
@@ -491,6 +491,17 @@ def _split_reminder_sources(blob: str) -> dict[str, int]:
 class _SessionSignal:
     mcp_invocations: dict[str, int] = field(default_factory=dict)
     deferred_servers: set[str] = field(default_factory=set)
+    #: server name -> assistant-turn ordinal (1-indexed, matches
+    #: ``assistant_turns`` at the moment) of that server's FIRST tool_use in
+    #: this session — the earliest point with POSITIVE evidence the schema was
+    #: fully loaded. A deferred tool's own listing states calling it directly
+    #: "will fail ... use ToolSearch to load their schema before calling
+    #: them", so a successful invocation implies the schema was already loaded
+    #: by that turn. A server never invoked in this session (every dead-weight
+    #: candidate, by definition) has no entry here and is conservatively
+    #: treated as deferred for its whole presence — matching the "never claim
+    #: the full tax for a deferred call without evidence" discipline.
+    first_invocation_turn: dict[str, int] = field(default_factory=dict)
     reminder_chars_by_source: dict[str, int] = field(default_factory=dict)
     #: assistant-turn model -> turn count, for pricing the token tax at a
     #: representative model's input rate (see ``_dominant_model``).
@@ -548,6 +559,10 @@ def _analyze_session(records: list[dict[str, Any]]) -> _SessionSignal:
                 server = _mcp_server_from_tool_name(str(block.get("name") or ""))
                 if server:
                     signal.mcp_invocations[server] = signal.mcp_invocations.get(server, 0) + 1
+                    # `assistant_turns` was already incremented above for THIS
+                    # record, so this is the 1-indexed ordinal of the call
+                    # that's doing the invoking.
+                    signal.first_invocation_turn.setdefault(server, signal.assistant_turns)
 
     return signal
 
@@ -732,6 +747,16 @@ def compute_deadweight_finding(
 
     session_paths: list[tuple[str, Path]] = []
     for path in sorted(root.rglob("*.jsonl")):
+        # Subagent/sidechain transcripts live at
+        # `<parent-session-dir>/subagents/agent-<id>.jsonl` (core/transcript.py)
+        # -- nested under `root`, so a plain rglob picks them up too. Counting
+        # one as its own top-level "session" would double the call count fed
+        # into the per-session schema-tax multiplier below (and, for a
+        # user-scoped server, spuriously inflate `sessions_present` toward the
+        # dead-weight threshold) purely because the parent session happened to
+        # spawn a subagent -- never the parent session's own ACTUAL call count.
+        if path.parent.name == "subagents":
+            continue
         try:
             mtime = datetime.fromtimestamp(path.stat().st_mtime, tz=timezone.utc)
         except OSError:
@@ -771,12 +796,17 @@ def compute_deadweight_finding(
         deferred_sessions = 0
         example_sessions: list[str] = []
         model_counts: dict[str, int] = {}
-        # (deferred_here, actual_call_count) per present session — each
-        # session's OWN call count feeds its own cache-read multiplier below;
-        # never a global mean/median (call-count distribution is severely
+        # (deferred_calls, full_calls) per present session — each session's
+        # OWN call count feeds its own cache-read multiplier below; never a
+        # global mean/median (call-count distribution is severely
         # right-skewed, and the affected population is only sessions where
-        # this server was present).
-        session_presence: list[tuple[bool, int]] = []
+        # this server was present). Split per CALL, not once per session: a
+        # server deferred early in a session and then actually invoked later
+        # (schema fully loaded from that call on, per the deferred listing's
+        # own "use ToolSearch to load their schema before calling them")
+        # must not have every call in that session priced at the low
+        # deferred base — only the calls before the load point.
+        session_presence: list[tuple[int, int]] = []
         for session_id, signal in per_session.items():
             deferred_here = server.name in signal.deferred_servers
             present = deferred_here or server.scope == "user" or (
@@ -792,7 +822,18 @@ def compute_deadweight_finding(
                 example_sessions.append(session_id)
             for model, count in signal.models.items():
                 model_counts[model] = model_counts.get(model, 0) + count
-            session_presence.append((deferred_here, max(signal.assistant_turns, 1)))
+
+            total_calls = max(signal.assistant_turns, 1)
+            if deferred_here:
+                load_turn = signal.first_invocation_turn.get(server.name)
+                # No invocation ever seen for this server in this session
+                # (true for every dead-weight candidate, by definition): no
+                # positive evidence the schema was ever fully loaded here, so
+                # stay conservative and treat the whole session as deferred.
+                deferred_calls = min(load_turn - 1, total_calls) if load_turn else total_calls
+            else:
+                deferred_calls = 0
+            session_presence.append((max(deferred_calls, 0), total_calls - max(deferred_calls, 0)))
 
         dead = sessions_present >= min_sessions and invocations == 0
         non_deferred = max(sessions_present - deferred_sessions, 0)
@@ -819,14 +860,23 @@ def compute_deadweight_finding(
         # models.toml), not re-charged at full input rate again. Computed per
         # session from that session's own call count and summed for the
         # window total; tax_per_session below is the resulting average, for
-        # display only — never the basis for tax_window itself.
+        # display only — never the basis for tax_window itself. A session
+        # whose deferred/full split changes partway through prices each
+        # segment separately: the segment's own first call at the full
+        # per-call base (the content just changed, so nothing is cached yet
+        # for it), later calls in that SAME segment at the cache-read rate.
         tax_window = 0
         total_calls = 0
-        for deferred_here, calls in session_presence:
-            base = DEFERRED_SCHEMA_TAX_TOKENS if deferred_here else FULL_SCHEMA_TAX_TOKENS
-            multiplier = 1.0 + (calls - 1) * cache_read_ratio
-            tax_window += round(base * multiplier)
-            total_calls += calls
+        for deferred_calls, full_calls in session_presence:
+            if deferred_calls > 0:
+                tax_window += round(
+                    DEFERRED_SCHEMA_TAX_TOKENS * (1.0 + (deferred_calls - 1) * cache_read_ratio)
+                )
+            if full_calls > 0:
+                tax_window += round(
+                    FULL_SCHEMA_TAX_TOKENS * (1.0 + (full_calls - 1) * cache_read_ratio)
+                )
+            total_calls += deferred_calls + full_calls
         tax_per_session = round(tax_window / sessions_present) if sessions_present else 0
         avg_calls_per_session = (total_calls / sessions_present) if sessions_present else 1.0
 

--- a/tokenjam/core/optimize/analyzers/deadweight.py
+++ b/tokenjam/core/optimize/analyzers/deadweight.py
@@ -80,21 +80,27 @@ MIN_SESSIONS_DEADWEIGHT = 5
 #: (mirrors relearn.py's MAX_EXAMPLE_SESSIONS convention).
 MAX_EXAMPLE_SESSIONS = 3
 
-#: Full MCP-connector schema-injection tax, per server, when its tool schemas
+#: Full MCP-connector schema-injection tax, PER CALL, when its tool schemas
 #: are loaded (not deferred) — a documented community/founder-research figure
 #: (~25K tokens/call for an attached MCP connector's injected tool
 #: definitions; see .claude/context/research/evidence/
 #: subscription-vs-cost-framing.md and feature-context-diagnostic.md), NOT a
 #: live per-call measurement — the on-disk transcript carries no per-schema
 #: token count (see core/context_diagnostic.py's MCP_INJECTION_PARK_NOTE).
-#: `estimated`, conservative, cited in the card footnote.
+#: `estimated`, conservative, cited in the card footnote. The server's tool
+#: definitions ride in the `tools` array of EVERY call in the session, not
+#: just the first — this is the FIRST call's token count; subsequent calls in
+#: the same session re-send it too but are priced at the cache-read rate, not
+#: this rate again (see the per-session multiplier in the tax loop below).
 FULL_SCHEMA_TAX_TOKENS = 25_000
 
 #: When a session's transcript shows this server's tools in a DEFERRED
-#: listing (ToolSearch-style), its schemas are NOT loaded that turn — only a
+#: listing (ToolSearch-style), its schemas are NOT loaded that call — only a
 #: short name+description line per tool appears in the listing.
 #: Conservative estimate: ~10 tools x ~40 tokens/line for a typically-sized
-#: server. Never used to claim the full tax for a deferred session.
+#: server. Never used to claim the full tax for a deferred call. Like
+#: FULL_SCHEMA_TAX_TOKENS, this is the first call's count; the same
+#: per-session multiplier applies to later calls.
 DEFERRED_SCHEMA_TAX_TOKENS = 400
 
 #: Chars-per-token conversion for text measured directly off transcripts
@@ -489,6 +495,12 @@ class _SessionSignal:
     #: assistant-turn model -> turn count, for pricing the token tax at a
     #: representative model's input rate (see ``_dominant_model``).
     models: dict[str, int] = field(default_factory=dict)
+    #: Total assistant turns in the session — each is one API request, so this
+    #: is the session's ACTUAL call count (mirrors context_diagnostic.py's
+    #: one-``TurnComposition``-per-turn convention). A configured MCP server's
+    #: tool schemas ride in the ``tools`` array of every one of these calls,
+    #: not just the first — see the per-call multiplier in the tax loop below.
+    assistant_turns: int = 0
 
 
 def _analyze_session(records: list[dict[str, Any]]) -> _SessionSignal:
@@ -526,6 +538,7 @@ def _analyze_session(records: list[dict[str, Any]]) -> _SessionSignal:
                     reminder_measured = True
 
         if role == "assistant":
+            signal.assistant_turns += 1
             model = message.get("model")
             if isinstance(model, str) and model:
                 signal.models[model] = signal.models.get(model, 0) + 1
@@ -551,27 +564,47 @@ def _tax_construction_note(
     non_deferred: int, deferred_sessions: int, sessions_present: int,
     *, model: str = "", input_per_mtok: float | None = None,
     usd_per_session: float | None = None,
+    avg_calls_per_session: float = 1.0,
+    cache_read_ratio: float = 0.0,
 ) -> str:
     if sessions_present == 0:
         return ""
     if deferred_sessions == 0:
         note = (
-            f"{FULL_SCHEMA_TAX_TOKENS:,} tok/session (full schema injection), "
-            f"cited estimate, not a live per-call measurement."
+            f"{FULL_SCHEMA_TAX_TOKENS:,} tok on the first call (full schema "
+            f"injection), cited estimate, not a live per-call measurement."
         )
     elif non_deferred == 0:
         note = (
-            f"{DEFERRED_SCHEMA_TAX_TOKENS:,} tok/session; ToolSearch deferred "
-            f"this server's schemas in every observed session (name and "
-            f"description line only, never the full schema tax)."
+            f"{DEFERRED_SCHEMA_TAX_TOKENS:,} tok on the first call; ToolSearch "
+            f"deferred this server's schemas in every observed session (name "
+            f"and description line only, never the full schema tax)."
         )
     else:
         note = (
-            f"{FULL_SCHEMA_TAX_TOKENS:,} tok/session when fully loaded "
-            f"({non_deferred} of {sessions_present} sessions) blended with "
-            f"{DEFERRED_SCHEMA_TAX_TOKENS:,} tok/session when ToolSearch defers "
+            f"{FULL_SCHEMA_TAX_TOKENS:,} tok on the first call when fully "
+            f"loaded ({non_deferred} of {sessions_present} sessions) blended "
+            f"with {DEFERRED_SCHEMA_TAX_TOKENS:,} tok when ToolSearch defers "
             f"this server's schemas ({deferred_sessions} of {sessions_present} "
-            f"sessions); never claims the full tax for a deferred session."
+            f"sessions); never claims the full tax for a deferred call."
+        )
+    if cache_read_ratio > 0:
+        note += (
+            f" The schema rides in the `tools` array of every call in the "
+            f"session, not just the first: priced at the input rate once, "
+            f"then at the cache-read rate (~{cache_read_ratio * 100:.0f}% of "
+            f"input) on every later call (avg {avg_calls_per_session:.1f} "
+            f"call(s)/session across these sessions, from each session's own "
+            f"actual call count, never a global mean/median). Simplification: "
+            f"assumes every call in a session lands inside Anthropic's "
+            f"5-minute cache TTL; a call after a longer gap would instead "
+            f"re-write the schema at the higher cache-write rate for that "
+            f"call, so this understates sessions with long gaps between calls."
+        )
+    else:
+        note += (
+            " Charged once per session (no cache-read rate available for "
+            "the priced model to compound later calls against)."
         )
     return note + " " + _pricing_note(model, input_per_mtok, usd_per_session)
 
@@ -605,9 +638,13 @@ class ServerDeadweight:
     deferred_sessions:                int
     dead:                             bool
     estimated_tax_tokens_per_session: int
-    #: Window-scoped total (this server's per-session tax x sessions_present
-    #: it was present in over the ANALYZED window) — NO projection folded in.
-    #: A caller wanting a forward-looking figure applies the shared, centrally-
+    #: Window-scoped total: the SUM of each present session's own tax (first
+    #: call at input rate + that session's own later calls at the cache-read
+    #: rate — see the per-session multiplier in `compute_deadweight_finding`),
+    #: never `estimated_tax_tokens_per_session x sessions_present` (that would
+    #: silently substitute the average call count for every session's actual
+    #: one). NO projection folded in. A caller wanting a forward-looking
+    #: figure applies the shared, centrally-
     #: computed 30-day-pace ratio (`cost_proposals.compute_projection_ratio`)
     #: on top of this, exactly like every other cost analyzer's window field
     #: (the "Recoverable-savings contract", CLAUDE.md). See #273: this field
@@ -734,6 +771,12 @@ def compute_deadweight_finding(
         deferred_sessions = 0
         example_sessions: list[str] = []
         model_counts: dict[str, int] = {}
+        # (deferred_here, actual_call_count) per present session — each
+        # session's OWN call count feeds its own cache-read multiplier below;
+        # never a global mean/median (call-count distribution is severely
+        # right-skewed, and the affected population is only sessions where
+        # this server was present).
+        session_presence: list[tuple[bool, int]] = []
         for session_id, signal in per_session.items():
             deferred_here = server.name in signal.deferred_servers
             present = deferred_here or server.scope == "user" or (
@@ -749,37 +792,49 @@ def compute_deadweight_finding(
                 example_sessions.append(session_id)
             for model, count in signal.models.items():
                 model_counts[model] = model_counts.get(model, 0) + count
+            session_presence.append((deferred_here, max(signal.assistant_turns, 1)))
 
         dead = sessions_present >= min_sessions and invocations == 0
         non_deferred = max(sessions_present - deferred_sessions, 0)
-        tax_per_session = (
-            round(
-                (non_deferred * FULL_SCHEMA_TAX_TOKENS + deferred_sessions * DEFERRED_SCHEMA_TAX_TOKENS)
-                / sessions_present
-            )
-            if sessions_present else 0
-        )
-        # Window-scoped total -- this server's per-session tax times the
-        # sessions it was present in over since..until. No projection: #273
-        # deleted the fixed 90-day multiplier that used to live here.
-        tax_window = tax_per_session * sessions_present
 
         # Price the token tax through core/pricing.py at the dominant model
         # observed across this server's present sessions -- never a
-        # hardcoded rate. usd stays None when no priced model was seen.
+        # hardcoded rate. usd/cache_read_ratio stay at their no-op defaults
+        # when no priced model was seen.
         priced_model = _dominant_model(model_counts)
         input_per_mtok: float | None = None
-        usd_per_session: float | None = None
-        usd_window: float | None = None
+        cache_read_ratio = 0.0
         if priced_model:
             provider = provider_for_model(priced_model) or "unknown"
             rates = get_rates(provider, priced_model)
             if rates is not None and rates.input_per_mtok > 0:
                 input_per_mtok = rates.input_per_mtok
-                usd_per_session = round(tax_per_session / 1_000_000 * input_per_mtok, 6)
-                usd_window = round(tax_window / 1_000_000 * input_per_mtok, 6)
+                cache_read_ratio = rates.cache_read_per_mtok / rates.input_per_mtok
             else:
                 priced_model = ""  # no rate available -- don't claim a model we can't price
+
+        # The schema rides in the `tools` array of EVERY call in a session,
+        # not just once — after the first call it's re-billed as a cache read
+        # (~10% of input rate for every Anthropic model in pricing/
+        # models.toml), not re-charged at full input rate again. Computed per
+        # session from that session's own call count and summed for the
+        # window total; tax_per_session below is the resulting average, for
+        # display only — never the basis for tax_window itself.
+        tax_window = 0
+        total_calls = 0
+        for deferred_here, calls in session_presence:
+            base = DEFERRED_SCHEMA_TAX_TOKENS if deferred_here else FULL_SCHEMA_TAX_TOKENS
+            multiplier = 1.0 + (calls - 1) * cache_read_ratio
+            tax_window += round(base * multiplier)
+            total_calls += calls
+        tax_per_session = round(tax_window / sessions_present) if sessions_present else 0
+        avg_calls_per_session = (total_calls / sessions_present) if sessions_present else 1.0
+
+        usd_per_session: float | None = None
+        usd_window: float | None = None
+        if input_per_mtok is not None:
+            usd_per_session = round(tax_per_session / 1_000_000 * input_per_mtok, 6)
+            usd_window = round(tax_window / 1_000_000 * input_per_mtok, 6)
 
         row = ServerDeadweight(
             name=server.name,
@@ -795,6 +850,8 @@ def compute_deadweight_finding(
                 non_deferred, deferred_sessions, sessions_present,
                 model=priced_model, input_per_mtok=input_per_mtok,
                 usd_per_session=usd_per_session,
+                avg_calls_per_session=avg_calls_per_session,
+                cache_read_ratio=cache_read_ratio,
             ),
             fix=(
                 f"Remove or project-scope the `{server.name}` MCP server "

--- a/tokenjam/core/optimize/analyzers/model_downgrade.py
+++ b/tokenjam/core/optimize/analyzers/model_downgrade.py
@@ -400,6 +400,32 @@ def analyze_model_downgrade(
         # they don't compute their own monthly figure. Two bases, two
         # explicitly-named surfaces: Overview/Optimize stay window-scoped,
         # the Review inbox is always monthly. Never mix the two on one card.
+        #
+        # Deliberately session-scoped, not turn-scoped: `audit_opus_quota`
+        # below also computes a cheap-segment / mechanical-stretch dollar
+        # counterfactual (`audit.actual_cost_usd`/`alternative_cost_usd`),
+        # but that is a DIFFERENT metric on a DIFFERENT dataclass
+        # (`OpusQuotaAudit`, not `DowngradeFinding`) for a DIFFERENT,
+        # deliberately separate surface (`tj quota-audit` / GET
+        # /api/v1/quota-audit) — verified by tracing every call site of
+        # `audit_opus_quota` (cli/data_access.py, cli/cmd_quota_audit.py,
+        # api/routes/quota_audit.py); `run()` above never calls it, so it
+        # never reaches `ctx.report.downgrade` today. Three reasons this
+        # candidate figure was NOT folded in here: (1) `audit_opus_quota`'s
+        # own docstring and its "Secondary API-only implied-dollar
+        # counterfactual" comment both say its dollar pair is explicitly
+        # NEVER a headline — the audit's headline is
+        # `percent_quota_misallocated`, a quota-weighted PERCENT, because the
+        # subscription majority is on flat-rate plans a dollar figure
+        # mis-targets; (2) it is scoped to PREMIUM-tier turns only
+        # (`is_premium_tier`), never the full `DOWNGRADE_CANDIDATES` ladder
+        # this function covers (sonnet->haiku, openai, google); folding it in
+        # would silently narrow what "downsize recoverable" means on windows
+        # with no premium-tier usage at all. (3) merging two independently
+        # -scoped estimate methodologies onto one contract field is a
+        # product decision beyond a bug fix — see CLAUDE.md anti-pattern #18
+        # (a ticket's Where: line is the scope boundary, not an "approved
+        # design" narrative to redesign a whole subsystem from).
         estimated_recoverable_usd=round(savings_window, 6),
         estimated_recoverable_tokens=candidate_tokens,
         estimate_basis=(
@@ -680,7 +706,10 @@ def audit_opus_quota(
 
     # Secondary API-only implied-dollar counterfactual, aggregated over the
     # flagged premium turns and priced at each session's dominant premium model's
-    # cheaper alternative (never the headline).
+    # cheaper alternative (never the headline). Deliberately never folded into
+    # `analyze_model_downgrade`'s `DowngradeFinding.estimated_recoverable_usd`
+    # (the `tj optimize` downsize card) — see the comment on that assignment
+    # for why the two stay separate.
     for agg in aggs.values():
         provider, model = agg.dominant_model()
         alt = lookup_downgrade(provider, model) if provider else None

--- a/tokenjam/core/optimize/analyzers/plan_reuse.py
+++ b/tokenjam/core/optimize/analyzers/plan_reuse.py
@@ -294,16 +294,24 @@ def run(ctx: AnalyzerContext) -> None:
             skeleton_session_id=by_recency[0].session_id,
         ))
 
-    # Rank by the conservative (cache-reuse) recoverable amount, descending.
+    # Cluster listing order (independent of the finding-level headline basis
+    # below): rank by the conservative cache-reuse amount, descending.
     surfaced.sort(key=lambda c: c.cache_reuse_recoverable_usd, reverse=True)
 
     finding.clusters = surfaced
     if surfaced:
+        # Headline uses the script-replacement premise (a template/skill
+        # removes the planning call entirely: avg cost x reps) rather than
+        # the more conservative cache-reuse premise (avg cost x (reps - 1)) —
+        # both are legitimate readings of the same measured cluster, and the
+        # conservative figure stays available per-cluster as
+        # cache_reuse_recoverable_usd/_tokens. See REUSE_ESTIMATE_BASIS for
+        # which premise this total rests on.
         finding.estimated_recoverable_usd = round(
-            sum(c.cache_reuse_recoverable_usd for c in surfaced), 6
+            sum(c.script_replacement_recoverable_usd for c in surfaced), 6
         )
         finding.estimated_recoverable_tokens = sum(
-            c.cache_reuse_recoverable_tokens for c in surfaced
+            c.script_replacement_recoverable_tokens for c in surfaced
         )
 
     ctx.report.findings["reuse"] = finding

--- a/tokenjam/core/optimize/analyzers/relearn.py
+++ b/tokenjam/core/optimize/analyzers/relearn.py
@@ -52,6 +52,7 @@ from tokenjam.core import distill as distill_mod
 from tokenjam.core.method_spine import build_method_spine
 from tokenjam.core.optimize.clustering import group_by_key, mask_variables, recurring
 from tokenjam.core.optimize.projection import build_projection_basis
+from tokenjam.core.optimize.rate_profile import RateProfile, blended_rate_profile
 from tokenjam.core.optimize.registry import register
 from tokenjam.core.optimize.types import AnalyzerContext
 from tokenjam.core.transcript import build_session_story, resolve_projects_root
@@ -75,12 +76,48 @@ MAX_DISTILL_CLUSTERS = 20
 MIN_DISTILL_CLUSTER_SESSIONS = MIN_RECURRING_SESSIONS
 DISTILL_MODEL = "haiku"
 
+# --- Per-occurrence re-read tail ---------------------------------------------
+# A failure does not cost one turn's tokens once. Its text lands in the
+# conversation and is re-sent on every LATER call that still carries it, so an
+# occurrence at call index k of a session whose context survives `tail` more
+# calls actually bills
+#
+#     GROUNDED_TOKENS_PER_OCCURRENCE x input_rate
+#   + GROUNDED_TOKENS_PER_OCCURRENCE x tail x cache_read_rate
+#
+# Everything below is expressed in INPUT-TOKEN EQUIVALENTS so the token figure
+# and the dollar figure stay proportional to one another (the existing
+# recoverable contract prices one against the other, and the write budget nets
+# a rule's standing cost against the token side). A re-read token bills at the
+# cache-read rate — exactly 0.100 x the input rate for every Anthropic model in
+# pricing/models.toml — so one occurrence is worth
+#
+#     1 + cache_read_ratio x tail
+#
+# input-token equivalents rather than 1. That ratio is measured from the
+# cluster's own models, never assumed.
+
+#: A prompt whose size falls to at most this share of the previous turn's has
+#: had its context window reset — a `/compact`, a resume, or a fresh window.
+#: The tail STOPS there: the failure text is no longer in what gets re-sent.
+#: Without this the multiplier assumes a failure is re-read for the rest of the
+#: session, which is measurably wrong on long automated-harness sessions (the
+#: ones that dominate a corpus by call count) and inflates the aggregate.
+COMPACTION_PROMPT_DROP_RATIO = 0.5
+
 ESTIMATE_BASIS = (
     "occurrences x a conservative per-turn token cost (one re-issued tool "
-    "call + re-narration) — never the inflated whole-session footprint; "
-    "reported NET of what the proposed fix costs to keep (a CLAUDE.md rule is "
-    "re-sent on every future session, a hook is not); review the example "
-    "sessions before applying a fix"
+    "call + re-narration) — never the inflated whole-session footprint — "
+    "then x the occurrence's own re-read tail: a failure's text is re-sent on "
+    "every later call that still carries it, billed at the cache-read rate, so "
+    "one occurrence is worth 1 + cache_read_ratio x tail input-token "
+    "equivalents. The tail is truncated at the first compaction (a prompt-size "
+    "collapse), not run to end-of-session, and the cluster takes the MEDIAN of "
+    "its occurrences' multipliers rather than the mean — a handful of very long "
+    "uncompacted sessions otherwise dominate. Reported NET of what the proposed "
+    "fix costs to keep (a CLAUDE.md rule is re-sent on every future session, a "
+    "hook is not); a cluster with no derived fix claims nothing at all. Review "
+    "the example sessions before applying a fix"
 )
 HONESTY_CAVEAT = (
     "Structural failure-signature clustering, not a quality judgment. "
@@ -812,6 +849,14 @@ class RelearnCluster:
     estimated_monthly_tokens:     int = 0
     estimated_monthly_usd:        float | None = None
     monthly_rate_basis:           str = ""
+    #: The measured re-read tail behind the figures above: the MEDIAN number of
+    #: later calls that still carried one of this cluster's occurrences before
+    #: the context was compacted away, and the input-token-equivalent
+    #: multiplier that follows from it (`1 + cache_read_ratio x tail`). Carried
+    #: so a reader can see WHY an occurrence is worth more than its 1,500
+    #: tokens; 0 / 1.0 when no tail could be measured.
+    tail_calls_median:            int = 0
+    tail_multiplier:              float = 1.0
     # Net-of-standing-cost accounting (`core/optimize/write_budget.py`). The
     # four `estimated_*` fields above are reported NET of what the proposed
     # artifact costs to KEEP: a rung-1 CLAUDE.md rule is re-sent on every
@@ -866,6 +911,12 @@ class RelearnFinding:
     # Sum of every cluster's `estimated_monthly_tokens` — the Review inbox
     # headline's token-basis total when it can't lead with dollars.
     estimated_monthly_tokens: int | None = None
+    # Sum of every cluster's `estimated_monthly_usd`. ``None`` when no cluster
+    # could be priced at all (no DB connection, no priced spans, no model with
+    # pricing data) — a zero would read as "this waste is free", which it is
+    # not (CLAUDE.md anti-pattern #22). Clusters with no derived fix contribute
+    # nothing here by construction: they claim zero on every basis.
+    estimated_monthly_usd: float | None = None
 
 
 def _snippet(failure: FailureEpisode) -> str:
@@ -937,50 +988,89 @@ def _monthly_scale(window_days: float | None) -> float:
     return 30.0 / window_days
 
 
-def _blended_dollar_rate(conn: Any, session_ids: set[str]) -> tuple[float | None, str]:
-    """Best-effort $/token blended rate observed across THIS cluster's own
-    sessions' LLM spans, weighted by tokens actually billed.
+def _prompt_timelines(conn: Any, session_ids: set[str]) -> dict[str, list[tuple[Any, int]]]:
+    """``session_id -> [(start_time, prompt_size), ...]`` in wall-clock order.
 
-    Returns ``(None, "")`` when there's no DB connection or no priced spans
-    for these sessions — this never invents a rate (CLAUDE.md anti-pattern
-    #22); the caller falls back to a tokens-only figure in that case. The
-    basis string names every (provider, model) that contributed so the
-    derivation is inspectable rather than a black box (behavioral requirement
-    #2's "never invent a rate silently").
+    ``prompt_size`` is ``input_tokens + cache_tokens``, the same per-turn
+    quantity ``analyzers/context_resend.py`` measures repeat share on. It is
+    what a compaction collapses, which is how the tail knows where to stop.
+    Best-effort: an unavailable DB just means no timeline and no tail.
     """
     if conn is None or not session_ids:
-        return None, ""
+        return {}
     ids = sorted(session_ids)
     placeholders = ", ".join(f"${i + 1}" for i in range(len(ids)))
     try:
         rows = conn.execute(
-            f"SELECT provider, model, "
-            f"COALESCE(SUM(cost_usd), 0.0), "
-            f"COALESCE(SUM(input_tokens + output_tokens + cache_tokens + cache_write_tokens), 0) "
-            f"FROM spans WHERE session_id IN ({placeholders}) AND model IS NOT NULL "
-            f"GROUP BY provider, model",
+            f"SELECT session_id, start_time, "
+            f"COALESCE(input_tokens, 0) + COALESCE(cache_tokens, 0) "
+            f"FROM spans WHERE session_id IN ({placeholders}) "
+            f"AND name = 'gen_ai.llm.call' AND start_time IS NOT NULL "
+            f"ORDER BY session_id, start_time",
             ids,
         ).fetchall()
     except Exception:
-        return None, ""
-    total_cost = 0.0
-    total_tokens = 0
-    models: list[str] = []
-    for provider, model, cost, tokens in rows:
-        tokens = int(tokens or 0)
-        if tokens <= 0:
+        return {}
+    out: dict[str, list[tuple[Any, int]]] = {}
+    for session_id, start_time, prompt_size in rows:
+        out.setdefault(str(session_id), []).append((start_time, int(prompt_size or 0)))
+    return out
+
+
+def _tail_calls(timeline: list[tuple[Any, int]], failure_ts: Any) -> int:
+    """How many later calls still re-read a failure that landed at ``failure_ts``.
+
+    Walks forward from the first call after the failure and stops at the first
+    COMPACTION boundary — a turn whose prompt collapses to at most
+    ``COMPACTION_PROMPT_DROP_RATIO`` of the previous turn's. Past that point the
+    failure text is no longer in the window being re-sent, so counting those
+    calls would claim a cost the user never paid.
+    """
+    if failure_ts is None or not timeline:
+        return 0
+    tail = 0
+    previous_size: int | None = None
+    for start_time, prompt_size in timeline:
+        if start_time is None or start_time <= failure_ts:
+            previous_size = prompt_size
             continue
-        total_cost += float(cost or 0.0)
-        total_tokens += tokens
-        models.append(f"{provider}/{model}")
-    if total_tokens <= 0:
-        return None, ""
-    rate = total_cost / total_tokens
-    basis = (
-        f"blended ${rate * 1_000_000:.2f}/MTok observed across this cluster's "
-        f"own sessions: {', '.join(sorted(set(models)))}"
-    )
-    return rate, basis
+        if (
+            previous_size is not None
+            and previous_size > 0
+            and prompt_size <= previous_size * COMPACTION_PROMPT_DROP_RATIO
+        ):
+            break
+        tail += 1
+        previous_size = prompt_size
+    return tail
+
+
+def _tail_multiplier(
+    failures: list[FailureEpisode],
+    timelines: dict[str, list[tuple[Any, int]]],
+    profile: RateProfile | None,
+) -> tuple[float, int]:
+    """``(multiplier, median_tail_calls)`` in input-token equivalents.
+
+    The MEDIAN of the per-occurrence multipliers, not the mean: a corpus's call
+    volume is dominated by long automated-harness sessions, whose uncompacted
+    tails drag a mean far above what a typical occurrence actually costs.
+    Returns ``(1.0, 0)`` — one occurrence, no tail — whenever the tail cannot be
+    measured, which is the conservative direction (never invent a multiplier).
+    """
+    if profile is None or not timelines:
+        return 1.0, 0
+    tails = [
+        _tail_calls(timelines.get(f.session_id, []), _parse_failure_ts(f.ts))
+        for f in failures
+    ]
+    tails = [t for t in tails if t > 0]
+    if not tails:
+        return 1.0, 0
+    import statistics
+
+    median_tail = int(statistics.median(tails))
+    return 1.0 + profile.cache_read_ratio * median_tail, median_tail
 
 
 def build_proposals(
@@ -1030,6 +1120,7 @@ def build_proposals(
     is unaffected either way — only the apply path is.
     """
     from tokenjam.core.optimize.relearn_apply import default_target_path, slugify
+    from tokenjam.core.optimize.write_budget import REASON_PLACEHOLDER, is_placeholder_fix
 
     repo_cwd_map = repo_cwd_map or {}
     write_offered = persona in {"claude-code", "mixed"}
@@ -1081,11 +1172,43 @@ def build_proposals(
             except Exception:
                 suggested_target = ""   # never let a bad path computation sink the proposal
 
-        recoverable_tokens = occurrences * GROUNDED_TOKENS_PER_OCCURRENCE
+        # A cluster with no derived fix claims NOTHING, on any basis. 1387 of
+        # 2311 occurrences in a real corpus match no known family and fall back
+        # to the generic "review examples" text — attaching a dollar figure to
+        # those would put a number on a card whose fix the user cannot apply,
+        # which is the "would this be a quiet lie in the user's favour?" test
+        # (CLAUDE.md anti-pattern #22) failing outright. The write budget
+        # already refuses to WRITE a placeholder; this is the same verdict
+        # applied to the CLAIM, so it holds for every persona rather than only
+        # for the windows that reach the write path at all.
+        has_real_fix = not is_placeholder_fix(fix)
+
+        # A placeholder cluster is priced at the bare per-occurrence cost with
+        # no tail — the raw observation stays inspectable on the `gross_*`
+        # fields, and the two round-trip queries the tail needs are skipped for
+        # a cluster that will claim nothing anyway.
+        profile = blended_rate_profile(conn, session_ids=sessions) if has_real_fix else None
+        timelines = _prompt_timelines(conn, sessions) if profile is not None else {}
+        multiplier, median_tail = _tail_multiplier(cluster.failures, timelines, profile)
+
+        # Input-token EQUIVALENTS: the head token at the input rate plus each
+        # re-read at the cache-read rate, expressed on the head's basis so the
+        # token and dollar figures stay proportional. See the constants above.
         scale = _monthly_scale(window_days)
-        monthly_tokens = round(recoverable_tokens * scale)
-        rate, rate_basis = _blended_dollar_rate(conn, sessions)
-        monthly_usd = round(monthly_tokens * rate, 6) if rate is not None else None
+        gross_tokens = round(occurrences * GROUNDED_TOKENS_PER_OCCURRENCE * multiplier)
+        gross_monthly_tokens = round(gross_tokens * scale)
+        gross_monthly_usd = (
+            round(gross_monthly_tokens * profile.input_rate_per_token, 6)
+            if profile is not None else None
+        )
+        # The CLAIM, as distinct from the observation above.
+        recoverable_tokens = gross_tokens if has_real_fix else 0
+        monthly_tokens = gross_monthly_tokens if has_real_fix else 0
+        monthly_usd = gross_monthly_usd if has_real_fix else None
+        rate_basis = "" if profile is None else (
+            f"{profile.basis}; x{multiplier:.2f} for a median re-read tail of "
+            f"{median_tail} later call(s) per occurrence"
+        )
 
         proposals.append(RelearnCluster(
             signature=cluster.signature,
@@ -1106,12 +1229,16 @@ def build_proposals(
             estimated_monthly_tokens=monthly_tokens,
             estimated_monthly_usd=monthly_usd,
             monthly_rate_basis=rate_basis,
+            tail_calls_median=median_tail,
+            tail_multiplier=round(multiplier, 4),
             # Pre-net figures, kept inspectable. `_apply_write_budget` nets the
             # four `estimated_*` fields above in place, so nothing downstream
             # can read a gross figure by accident.
-            gross_recoverable_tokens=recoverable_tokens,
-            gross_monthly_tokens=monthly_tokens,
-            gross_monthly_usd=monthly_usd,
+            gross_recoverable_tokens=gross_tokens,
+            gross_monthly_tokens=gross_monthly_tokens,
+            gross_monthly_usd=gross_monthly_usd,
+            write_offered=has_real_fix,
+            write_blocked_reason="" if has_real_fix else REASON_PLACEHOLDER,
         ))
 
     proposals.sort(key=lambda p: p.sessions, reverse=True)
@@ -1349,6 +1476,8 @@ def analyze_relearns(
     )
     total_tokens = sum(p.estimated_recoverable_tokens for p in proposals)
     total_monthly_tokens = sum(p.estimated_monthly_tokens for p in proposals) if proposals else None
+    priced = [p.estimated_monthly_usd for p in proposals if p.estimated_monthly_usd is not None]
+    total_monthly_usd = round(sum(priced), 6) if priced else None
 
     return RelearnFinding(
         clusters=proposals,
@@ -1360,6 +1489,7 @@ def analyze_relearns(
         min_sessions=min_sessions,
         window_days=window_days,
         estimated_monthly_tokens=total_monthly_tokens,
+        estimated_monthly_usd=total_monthly_usd,
     )
 
 

--- a/tokenjam/core/optimize/analyzers/subagent_rightsizing.py
+++ b/tokenjam/core/optimize/analyzers/subagent_rightsizing.py
@@ -27,6 +27,7 @@ other runtimes carry NULL and are ignored here.
 """
 from __future__ import annotations
 
+import statistics
 from dataclasses import dataclass, field
 from typing import Any
 
@@ -49,6 +50,14 @@ CONTEXT_HEAVY_TOKENS = 50_000
 # of shape — the absolute saving isn't worth a recommendation.
 MIN_FLAG_COST_USD = 0.05
 
+# A dispatch cohort (same calling agent + same model — the "like-shaped
+# dispatches" peer group) needs at least this many subagents before its
+# median context size is a meaningful baseline. Mirrors output_verbosity.py's
+# MIN_COHORT_SESSIONS (same config knob, OptimizeConfig.min_cohort_sessions —
+# kept as a literal default here too, same convention as every other
+# analyzer's module-local default constant).
+MIN_COHORT_SESSIONS = 5
+
 # Cap on how many rows the finding payload carries (a single session can spawn
 # 100+ subagents). Aggregates below are computed over ALL rows; only the
 # rendered/serialised lists are capped, top-by-cost.
@@ -60,18 +69,24 @@ SUBAGENT_HONESTY_CAVEAT = (
     "subagents before changing how you dispatch them or which model they use."
 )
 
-# estimate_basis for the savings contract (#111). The quantified estimate is
-# the token-cost delta of routing each over_powered subagent (premium model,
-# little output) to its cheaper same-family model over the SAME tokens — a
-# model-swap counterfactual with no token-count change and no quality claim.
-# over_provisioned is deliberately excluded: its recoverable is a prompt-size
-# reduction we can't size honestly, so it never inflates this number.
+# estimate_basis for the savings contract (#111). Two quantified components:
+# over_powered is the token-cost delta of routing each flagged subagent
+# (premium model, little output) to its cheaper same-family model over the
+# SAME tokens — a model-swap counterfactual with no token-count change and no
+# quality claim. over_provisioned is the context EXCESS over its dispatch
+# cohort's own median (same calling agent + model — the like-shaped peer
+# group, mirrors output_verbosity.py's per-task-shape median), priced at the
+# cache-read rate (context arrives overwhelmingly as cache reads). Neither
+# invents a target size or a rate: a subagent with no cheaper alternative, no
+# pricing data, or no cohort baseline (fewer than min_cohort_sessions
+# like-shaped peers) contributes nothing to that component.
 SUBAGENT_ESTIMATE_BASIS = (
     "over_powered subagents priced at their cheaper same-family model over the "
-    "same tokens: a model-swap delta, structural fit only, no quality "
-    "validation; review before re-dispatching. over_provisioned spend is "
-    "flagged but not counted here (its recoverable prompt-size cut isn't "
-    "quantifiable). No guaranteed saving."
+    "same tokens (a model-swap delta, structural fit only) plus "
+    "over_provisioned subagents priced on their context excess over their "
+    "dispatch cohort's own median (same calling agent + model), at the "
+    "cache-read rate; no quality validation, review before re-dispatching. "
+    "No guaranteed saving."
 )
 
 
@@ -92,6 +107,10 @@ class SubagentRow:
     # same-family alternative; defaulted for round-trip of pre-provider payloads.
     provider:           str = "unknown"
     flags:              list[str] = field(default_factory=list)
+    # The dispatching agent — with `model`, defines the "like-shaped dispatch"
+    # cohort the over_provisioned estimate baselines against (see
+    # `_dispatch_cohort_key`). Defaulted for round-trip of older payloads.
+    agent_id:           str = ""
 
 
 @dataclass
@@ -108,9 +127,12 @@ class SubagentRightsizingFinding:
     flagged:     list[SubagentRow] = field(default_factory=list)  # candidates
     confidence:  str = "structural"
     caveat:      str = SUBAGENT_HONESTY_CAVEAT
-    # Recoverable-savings contract (#111). Candidate-only in v1: we report the
-    # spend sitting in flagged subagents (flagged_cost_usd) rather than assert a
-    # guaranteed recovery, so the precise estimate stays None.
+    # Recoverable-savings contract (#111): the quantified sum of the
+    # over_powered model-swap delta plus the over_provisioned context-excess
+    # estimate (see SUBAGENT_ESTIMATE_BASIS). None only when neither component
+    # priced anything (e.g. no flagged subagent had a priced alternative or a
+    # usable cohort baseline) — flagged_cost_usd above still reports the raw
+    # spend sitting in every flagged row regardless.
     estimated_recoverable_usd:    float | None = None
     estimated_recoverable_tokens: int | None   = None
     estimate_basis:               str          = SUBAGENT_ESTIMATE_BASIS
@@ -155,6 +177,7 @@ def _compute_rows(
     where = " AND ".join(clauses)
     rows = conn.execute(
         f"SELECT session_id, sub_agent_id, "
+        f"FIRST(agent_id) AS agent_id, "
         f"arg_max(model, COALESCE(input_tokens, 0) + COALESCE(output_tokens, 0)) AS model, "
         f"arg_max(provider, COALESCE(input_tokens, 0) + COALESCE(output_tokens, 0)) AS provider, "
         f"COUNT(*) FILTER (WHERE name = 'gen_ai.llm.call') AS llm_calls, "
@@ -171,7 +194,7 @@ def _compute_rows(
     ).fetchall()
 
     result: list[SubagentRow] = []
-    for (sid, said, model, provider, llm_calls, tool_calls,
+    for (sid, said, row_agent_id, model, provider, llm_calls, tool_calls,
          in_tok, out_tok, cache_tok, cache_w_tok, cost) in rows:
         in_tok = int(in_tok or 0)
         out_tok = int(out_tok or 0)
@@ -188,6 +211,7 @@ def _compute_rows(
         result.append(SubagentRow(
             session_id=str(sid),
             sub_agent_id=str(said),
+            agent_id=str(row_agent_id or ""),
             model=model,
             llm_calls=int(llm_calls or 0),
             tool_calls=int(tool_calls or 0),
@@ -227,8 +251,9 @@ def _over_powered_recoverable(rows: list[SubagentRow]) -> tuple[float, int]:
     token mix and take the POSITIVE cost delta — a pure model-swap
     counterfactual, no token-count change and no quality claim. A subagent with
     no cheaper alternative or no pricing data contributes nothing (we refuse to
-    invent a number). ``over_provisioned`` is intentionally excluded: reducing an
-    over-large prompt is a real saving but not one we can size honestly here.
+    invent a number). ``over_provisioned`` is priced separately, by
+    :func:`_over_provisioned_recoverable` — see that function for why it needs
+    the full row population, not just the flagged rows.
 
     Returns ``(recoverable_usd, recoverable_tokens)`` where the token figure is
     the quota (input + output + cache) sitting in the priced over_powered
@@ -258,12 +283,80 @@ def _over_powered_recoverable(rows: list[SubagentRow]) -> tuple[float, int]:
     return recoverable_usd, recoverable_tokens
 
 
+def _dispatch_cohort_key(r: SubagentRow) -> tuple[str, str]:
+    """The "like-shaped dispatch" peer group for a subagent: same calling
+    agent + same model. Mirrors output_verbosity.py's per-task-shape cohort —
+    the closest defensible like-for-like grouping available here (a subagent
+    dispatch carries no tool-call-sequence signature the way a whole session
+    does, so agent + model is the shape signal this analyzer already has)."""
+    return (r.agent_id, r.model)
+
+
+def _over_provisioned_recoverable(
+    rows: list[SubagentRow], *, min_cohort_sessions: int = MIN_COHORT_SESSIONS,
+) -> tuple[float, int]:
+    """Recoverable estimate over the over_provisioned subagents.
+
+    Mirrors output_verbosity.py's cohort-median shape. Groups ALL subagents
+    (not just the flagged ones — a flagged row's baseline is built from its
+    unflagged peers too) into "like-shaped dispatch" cohorts (same calling
+    agent + same model, see :func:`_dispatch_cohort_key`), takes each
+    cohort's MEDIAN received context (input + cache tokens — the same
+    aggregate the ``over_provisioned`` flag itself gates on), and for every
+    flagged row with a usable cohort baseline (at least ``min_cohort_sessions``
+    members, median > 0) prices ``received_context - cohort_median`` at the
+    CACHE-READ rate: context arrives overwhelmingly as cache reads (~95% of
+    window token volume, measured), never the full input rate a fresh prompt
+    would cost. Never prices the excess against zero context (every dispatch
+    needs some baseline) and never invents a target size: a cohort below the
+    size bar, a flagged row already at or below its cohort's median, or a
+    model with no pricing data contributes nothing (we refuse to invent a
+    number).
+
+    Returns ``(recoverable_usd, recoverable_tokens)`` — the token figure is
+    the context excess itself, comparable to the model-downgrade/over_powered
+    token framing above.
+    """
+    contexts_by_cohort: dict[tuple[str, str], list[int]] = {}
+    for r in rows:
+        contexts_by_cohort.setdefault(_dispatch_cohort_key(r), []).append(
+            r.input_tokens + r.cache_tokens
+        )
+
+    cohort_medians: dict[tuple[str, str], float] = {
+        key: statistics.median(contexts)
+        for key, contexts in contexts_by_cohort.items()
+        if len(contexts) >= min_cohort_sessions
+    }
+
+    recoverable_usd = 0.0
+    recoverable_tokens = 0
+    for r in rows:
+        if "over_provisioned" not in r.flags:
+            continue
+        median = cohort_medians.get(_dispatch_cohort_key(r))
+        if median is None or median <= 0:
+            continue
+        excess = int(round((r.input_tokens + r.cache_tokens) - median))
+        if excess <= 0:
+            continue
+        rates = get_rates(r.provider, r.model)
+        if rates is None:
+            continue
+        recoverable_usd += excess / 1_000_000 * rates.cache_read_per_mtok
+        recoverable_tokens += excess
+    return recoverable_usd, recoverable_tokens
+
+
 @register("subagent")
 def run(ctx: AnalyzerContext) -> None:
     """Registry entry point. Attaches the finding to ctx.report.findings."""
     optimize_cfg = getattr(ctx.config, "optimize", None)
     min_flag_cost_usd = getattr(
         optimize_cfg, "min_flag_cost_usd", MIN_FLAG_COST_USD,
+    )
+    min_cohort_sessions = getattr(
+        optimize_cfg, "min_cohort_sessions", MIN_COHORT_SESSIONS,
     )
     rows = _compute_rows(
         ctx.conn, ctx.since, ctx.until, ctx.agent_id,
@@ -283,12 +376,20 @@ def run(ctx: AnalyzerContext) -> None:
     )
 
     # Quantified recoverable estimate (#101 / savings contract #111): the
-    # model-swap delta over the over_powered subagents. Computed over ALL flagged
-    # rows (not just the TOP_N rendered) so the ranked-report share reflects the
-    # full window. None when nothing over_powered had a priced cheaper
-    # alternative — the finding then renders unranked (honest empty estimate),
-    # exactly like it did before it could quantify anything.
-    recoverable_usd, recoverable_tokens = _over_powered_recoverable(flagged)
+    # model-swap delta over the over_powered subagents (computed over ALL
+    # flagged rows, not just the TOP_N rendered, so the ranked-report share
+    # reflects the full window) plus the context-excess-over-cohort-median
+    # delta over the over_provisioned subagents (needs the FULL row
+    # population, not just flagged, to build each dispatch cohort's
+    # baseline — see `_over_provisioned_recoverable`). None when neither
+    # component priced anything — the finding then renders unranked (honest
+    # empty estimate), exactly like it did before either could quantify.
+    op_usd, op_tokens = _over_powered_recoverable(flagged)
+    ctx_usd, ctx_tokens = _over_provisioned_recoverable(
+        rows, min_cohort_sessions=min_cohort_sessions,
+    )
+    recoverable_usd = op_usd + ctx_usd
+    recoverable_tokens = op_tokens + ctx_tokens
     est_usd = round(recoverable_usd, 8) if recoverable_tokens > 0 else None
     est_tokens = recoverable_tokens if recoverable_tokens > 0 else None
 

--- a/tokenjam/core/optimize/analyzers/summarize.py
+++ b/tokenjam/core/optimize/analyzers/summarize.py
@@ -15,12 +15,29 @@ break the empty-window overlay invariant (#211) — a dead window must show no
 recoverable waste. The filesystem scan is skipped entirely until the window shows
 activity.
 
-Honesty discipline (Critical Rule 14 + `core/summarize/estimate.py`): the figure
-we can stand behind from a file alone is **tokens**. A per-call dollar amount at
-default rates is noise, and the meaningful *amortized* dollar needs a real
-per-file call count (telemetry) we don't have — so `estimated_recoverable_usd`
-is left `None` (the contract's "no estimate available for this state"), and the
-usage-ranked/amortized path is deferred. Every user-visible string says
+**The saving RECURS; it is not a one-time figure.** Every file in the catalog
+is always-on context: re-sent at the head of every session that loads it, and
+re-read on every call within that session. Compressing it therefore pays on
+each of those, so the recoverable figure is priced the same way each of the
+other cost analyzers' is — over the analyzed window, at the rates the tokens
+actually bill at (first call of a session at the input rate, later calls at the
+cache-read rate, which is 0.100x the input rate for every Anthropic model in
+`pricing/models.toml`). See `_price_reduction`.
+
+This is also the ONE analyzer whose fix has a NEGATIVE standing cost: it
+shrinks the always-loaded footprint that the rule-writing analyzers (`relearn`,
+`script`, `reuse`, `resend`) grow. `write_budget.measured_agent_file_tokens`
+reads this finding as the denominator of their write budget, which is why
+`summarize` is deliberately not a `COST_ANALYZERS` member — see the note there.
+
+Honesty discipline (Critical Rule 14 + `core/summarize/estimate.py`): a dollar
+figure is only attached where the load count is OBSERVED. A global-scope file
+(`~/.claude/...`) is loaded by every session in the window, which telemetry
+counts directly; a project-scope file is loaded only by its own repo's
+sessions, matched through the same `agent_id` -> repo derivation
+`analyzers/relearn.py` uses. A file whose loading sessions cannot be identified
+contributes tokens only and NO dollars — never a zero, never a rate borrowed
+from a file that did resolve (anti-pattern #22). Every user-visible string says
 "estimated" / "review before applying" — never "saves you"; the mandatory
 `caveat` names summary's one risk (meaning may change, structure won't).
 """
@@ -28,12 +45,20 @@ from __future__ import annotations
 
 import logging
 from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
 
+from tokenjam.core.optimize.rate_profile import RateProfile, blended_rate_profile
 from tokenjam.core.optimize.registry import register
 from tokenjam.core.optimize.types import AnalyzerContext
 from tokenjam.core.summarize.detect import CHARS_PER_TOKEN
 
 logger = logging.getLogger(__name__)
+
+#: Prefix Claude Code backfill stamps on a session's ``agent_id``
+#: (``core/backfill.py`` ``_agent_id_from_cwd``). Stripping it yields the repo
+#: directory name, which is what a project-scope candidate path is matched on.
+_CC_AGENT_PREFIX = "claude-code-"
 
 # Surfaced verbatim next to the recoverable figure (contract requires an explicit
 # basis; states the filesystem/per-call basis so it isn't mistaken for a
@@ -41,9 +66,15 @@ logger = logging.getLogger(__name__)
 SUMMARIZE_ESTIMATE_BASIS = (
     "Per-call prompt-token reduction from a read-only filesystem scan of catalog "
     "prompt files (CLAUDE.md / AGENTS.md / globals); prose is summarized, structure "
-    "kept verbatim. Realized on every call that sends the cached prompt — NOT "
-    "multiplied by this window's calls (that amortized figure needs per-file usage "
-    "telemetry). Advisory; review each rewrite before applying."
+    "kept verbatim. These files are ALWAYS-ON context, so the reduction is "
+    "realized repeatedly, not once: it is priced over the analyzed window as "
+    "reduction x (sessions that load the file) x (first call at the input rate + "
+    "each later call in that session at the cache-read rate), on the same window "
+    "basis as the other cost analyzers. Load counts are observed from telemetry "
+    "— a global-scope file against every session in the window, a project-scope "
+    "file against its own repo's sessions only. A file whose loading sessions "
+    "cannot be identified carries tokens and no dollars. Advisory; review each "
+    "rewrite before applying."
 )
 
 # Mandatory caveat (Rule 14) — carried as the dataclass default like the other
@@ -65,6 +96,12 @@ class SummarizeCandidate:
     est_tokens_saved: int
     total_chars: int = 0     # source size (feeds the aggregate reduction %)
     reduction_pct: int = 0   # per-file prose reduction %, computed server-side (no JS chars/4)
+    #: How many of the window's sessions actually load this file, and what the
+    #: reduction is worth across them. ``est_usd_saved`` is ``None`` when the
+    #: loading sessions could not be identified or no model was priced — a
+    #: zero would read as "compressing this file is worth nothing".
+    sessions_loading: int = 0
+    est_usd_saved: float | None = None
 
 
 @dataclass
@@ -88,6 +125,13 @@ class SummarizeFinding:
     #   avg_reduction_pct = mean of the per-file reduction %s
     reduction_pct: int | None = None
     avg_reduction_pct: int | None = None
+    # The observed inputs behind `estimated_recoverable_usd`, carried so the
+    # figure is inspectable rather than a black box: how many sessions the
+    # window held, how many calls each made on average (every one of which
+    # re-sends these files), and which models the rate blend came from.
+    sessions_examined: int = 0
+    calls_per_session: float | None = None
+    rate_basis: str = ""
 
 
 def _src_tokens(total_chars: int) -> int:
@@ -100,6 +144,104 @@ def _reduction_pct(est_tokens_saved: int, total_chars: int) -> int:
     """Per-file prose reduction % (saved ÷ source tokens), on the shared basis."""
     src = _src_tokens(total_chars)
     return round(est_tokens_saved / src * 100) if src > 0 else 0
+
+
+@dataclass(frozen=True)
+class _LoadProfile:
+    """How often the window's sessions would re-send an always-on prompt file.
+
+    ``sessions_total`` is every session in the window (what a global-scope file
+    is loaded by); ``sessions_by_repo`` narrows that for a project-scope file.
+    ``calls_per_session`` is the average number of LLM calls a session makes —
+    the first sends the file at the input rate, each later one re-reads it at
+    the cache-read rate.
+    """
+
+    sessions_total: int
+    sessions_by_repo: dict[str, int]
+    calls_per_session: float
+    rates: RateProfile
+
+
+def _load_profile(ctx: AnalyzerContext) -> _LoadProfile | None:
+    """Observed session and call counts for the window, per repo.
+
+    ``None`` when the window carries no LLM call or no priced model — the
+    finding then reports tokens with no dollars rather than inventing a load
+    count. Never raises: a DB hiccup degrades to the tokens-only shape.
+    """
+    rates = blended_rate_profile(
+        ctx.conn, since=ctx.since, until=ctx.until, agent_id=ctx.agent_id,
+    )
+    if rates is None:
+        return None
+    clauses = ["name = 'gen_ai.llm.call'", "start_time >= $1", "start_time < $2"]
+    params: list[Any] = [ctx.since, ctx.until]
+    if ctx.agent_id:
+        clauses.append(f"agent_id = ${len(params) + 1}")
+        params.append(ctx.agent_id)
+    try:
+        rows = ctx.conn.execute(
+            "SELECT agent_id, COUNT(DISTINCT session_id), COUNT(*) "
+            "FROM spans WHERE " + " AND ".join(clauses) + " GROUP BY agent_id",
+            params,
+        ).fetchall()
+    except Exception:
+        logger.debug("summarize analyzer: load-profile query failed", exc_info=True)
+        return None
+
+    sessions_by_repo: dict[str, int] = {}
+    sessions_total = 0
+    calls_total = 0
+    for agent_id, sessions, calls in rows:
+        sessions = int(sessions or 0)
+        sessions_total += sessions
+        calls_total += int(calls or 0)
+        label = str(agent_id or "")
+        if label.startswith(_CC_AGENT_PREFIX):
+            label = label[len(_CC_AGENT_PREFIX):]
+        if label:
+            sessions_by_repo[label] = sessions_by_repo.get(label, 0) + sessions
+    if sessions_total <= 0:
+        return None
+    return _LoadProfile(
+        sessions_total=sessions_total,
+        sessions_by_repo=sessions_by_repo,
+        calls_per_session=calls_total / sessions_total,
+        rates=rates,
+    )
+
+
+def _sessions_loading(path: str, scope: str, profile: _LoadProfile) -> int:
+    """How many of the window's sessions send this file at the head of every call.
+
+    A global-scope file lives under ``~/.claude`` and is loaded by every
+    session. A project/repo/path-scoped one is loaded only by sessions in its
+    own repo, matched by walking the file's ancestor directory names against
+    the repo labels telemetry recorded. An unmatched path returns 0, which
+    leaves the file tokens-only rather than charging it to every session.
+    """
+    if scope == "global":
+        return profile.sessions_total
+    ancestors = {parent.name for parent in Path(path).parents if parent.name}
+    return sum(
+        count for repo, count in profile.sessions_by_repo.items() if repo in ancestors
+    )
+
+
+def _price_reduction(tokens_saved: int, sessions: int, profile: _LoadProfile) -> float | None:
+    """What removing ``tokens_saved`` from an always-on file is worth over the
+    window: the reduction, on each loading session, sent once at the input rate
+    and re-read on that session's every later call at the cache-read rate.
+
+    ``None`` when no session loads the file — the saving is real but this
+    window carries no evidence of its size, and a zero would misreport that as
+    "worth nothing".
+    """
+    if sessions <= 0 or tokens_saved <= 0:
+        return None
+    rereads = max(round(profile.calls_per_session) - 1, 0)
+    return profile.rates.cost_of(float(tokens_saved), rereads) * sessions
 
 
 @register("summarize")
@@ -135,24 +277,43 @@ def run(ctx: AnalyzerContext) -> None:
         ctx.report.findings["summarize"] = finding
         return
 
-    finding.candidates = [
-        SummarizeCandidate(
+    # Observed load counts + blended rates for the window. `None` (dead or
+    # unpriced window) leaves every candidate tokens-only, exactly as before.
+    profile = _load_profile(ctx)
+
+    candidates: list[SummarizeCandidate] = []
+    for c in scan.candidates:
+        if c.est_tokens_saved <= 0:
+            continue
+        sessions = _sessions_loading(c.path, c.scope, profile) if profile else 0
+        candidates.append(SummarizeCandidate(
             path=c.path,
             kind="prompt" if c.is_prompt else "other",
             scope=c.scope,
             est_tokens_saved=c.est_tokens_saved,
             total_chars=c.total_chars,
             reduction_pct=_reduction_pct(c.est_tokens_saved, c.total_chars),
-        )
-        for c in scan.candidates
-        if c.est_tokens_saved > 0
-    ]
+            sessions_loading=sessions,
+            est_usd_saved=(
+                _price_reduction(c.est_tokens_saved, sessions, profile)
+                if profile else None
+            ),
+        ))
+    finding.candidates = candidates
     finding.files = len(finding.candidates)
     if finding.candidates:
         finding.estimated_recoverable_tokens = sum(
             c.est_tokens_saved for c in finding.candidates
         )
-        # estimated_recoverable_usd intentionally left None — see module docstring.
+        priced = [c.est_usd_saved for c in finding.candidates if c.est_usd_saved is not None]
+        # None, not 0.0, when nothing resolved: "no session in this window was
+        # observed loading these files" is a different statement from
+        # "compressing them is worth nothing" (anti-pattern #22).
+        finding.estimated_recoverable_usd = round(sum(priced), 6) if priced else None
+        if profile is not None:
+            finding.sessions_examined = profile.sessions_total
+            finding.calls_per_session = round(profile.calls_per_session, 2)
+            finding.rate_basis = profile.rates.basis
         # Prose-reduction %s, computed here so the UI has a single compute path:
         #   reduction_pct     = token-weighted aggregate (saved ÷ source tokens)
         #   avg_reduction_pct = mean of the per-file reduction %s

--- a/tokenjam/core/optimize/analyzers/summarize.py
+++ b/tokenjam/core/optimize/analyzers/summarize.py
@@ -151,14 +151,19 @@ class _LoadProfile:
     """How often the window's sessions would re-send an always-on prompt file.
 
     ``sessions_total`` is every session in the window (what a global-scope file
-    is loaded by); ``sessions_by_repo`` narrows that for a project-scope file.
-    ``calls_per_session`` is the average number of LLM calls a session makes —
-    the first sends the file at the input rate, each later one re-reads it at
-    the cache-read rate.
+    is loaded by); ``sessions_by_repo``/``calls_by_repo`` narrow that for a
+    project-scope file. ``calls_per_session`` is the window-WIDE average number
+    of LLM calls a session makes — the first sends the file at the input rate,
+    each later one re-reads it at the cache-read rate. A project-scope file
+    must price against its OWN repo's average, not this blend across every
+    other repo/agent in the window (see ``_repo_calls_per_session``); this
+    field stays window-wide because it's also what a global-scope file
+    legitimately prices against.
     """
 
     sessions_total: int
     sessions_by_repo: dict[str, int]
+    calls_by_repo: dict[str, int]
     calls_per_session: float
     rates: RateProfile
 
@@ -191,22 +196,26 @@ def _load_profile(ctx: AnalyzerContext) -> _LoadProfile | None:
         return None
 
     sessions_by_repo: dict[str, int] = {}
+    calls_by_repo: dict[str, int] = {}
     sessions_total = 0
     calls_total = 0
     for agent_id, sessions, calls in rows:
         sessions = int(sessions or 0)
+        calls = int(calls or 0)
         sessions_total += sessions
-        calls_total += int(calls or 0)
+        calls_total += calls
         label = str(agent_id or "")
         if label.startswith(_CC_AGENT_PREFIX):
             label = label[len(_CC_AGENT_PREFIX):]
         if label:
             sessions_by_repo[label] = sessions_by_repo.get(label, 0) + sessions
+            calls_by_repo[label] = calls_by_repo.get(label, 0) + calls
     if sessions_total <= 0:
         return None
     return _LoadProfile(
         sessions_total=sessions_total,
         sessions_by_repo=sessions_by_repo,
+        calls_by_repo=calls_by_repo,
         calls_per_session=calls_total / sessions_total,
         rates=rates,
     )
@@ -229,10 +238,44 @@ def _sessions_loading(path: str, scope: str, profile: _LoadProfile) -> int:
     )
 
 
-def _price_reduction(tokens_saved: int, sessions: int, profile: _LoadProfile) -> float | None:
+def _repo_calls_per_session(path: str, scope: str, profile: _LoadProfile) -> float:
+    """This candidate's own repo's average calls-per-session, on the SAME
+    ancestor-matching basis ``_sessions_loading`` uses.
+
+    A global-scope file legitimately spans every session in the window, so it
+    keeps the window-wide average. A project-scope file uses only its own
+    repo's observed call rate — blending in every other repo/agent in the
+    window would over- or under-state the recoverable figure whenever that
+    repo's actual session behavior differs from the window average. Falls
+    back to the window-wide average only when the repo match carries no
+    session evidence (in practice unreachable from ``_price_reduction``, which
+    already returns ``None`` for a zero-session candidate before this is
+    consulted).
+    """
+    if scope == "global":
+        return profile.calls_per_session
+    ancestors = {parent.name for parent in Path(path).parents if parent.name}
+    matched_sessions = sum(
+        count for repo, count in profile.sessions_by_repo.items() if repo in ancestors
+    )
+    if matched_sessions <= 0:
+        return profile.calls_per_session
+    matched_calls = sum(
+        count for repo, count in profile.calls_by_repo.items() if repo in ancestors
+    )
+    return matched_calls / matched_sessions
+
+
+def _price_reduction(
+    tokens_saved: int, sessions: int, calls_per_session: float, rates: RateProfile,
+) -> float | None:
     """What removing ``tokens_saved`` from an always-on file is worth over the
     window: the reduction, on each loading session, sent once at the input rate
     and re-read on that session's every later call at the cache-read rate.
+
+    ``calls_per_session`` is the candidate's OWN repo's average (see
+    ``_repo_calls_per_session``) for a project-scope file, or the window-wide
+    average for a global-scope one — never a blend of the two.
 
     ``None`` when no session loads the file — the saving is real but this
     window carries no evidence of its size, and a zero would misreport that as
@@ -240,8 +283,8 @@ def _price_reduction(tokens_saved: int, sessions: int, profile: _LoadProfile) ->
     """
     if sessions <= 0 or tokens_saved <= 0:
         return None
-    rereads = max(round(profile.calls_per_session) - 1, 0)
-    return profile.rates.cost_of(float(tokens_saved), rereads) * sessions
+    rereads = max(round(calls_per_session) - 1, 0)
+    return rates.cost_of(float(tokens_saved), rereads) * sessions
 
 
 @register("summarize")
@@ -295,7 +338,10 @@ def run(ctx: AnalyzerContext) -> None:
             reduction_pct=_reduction_pct(c.est_tokens_saved, c.total_chars),
             sessions_loading=sessions,
             est_usd_saved=(
-                _price_reduction(c.est_tokens_saved, sessions, profile)
+                _price_reduction(
+                    c.est_tokens_saved, sessions,
+                    _repo_calls_per_session(c.path, c.scope, profile), profile.rates,
+                )
                 if profile else None
             ),
         ))

--- a/tokenjam/core/optimize/cost_proposals.py
+++ b/tokenjam/core/optimize/cost_proposals.py
@@ -68,11 +68,25 @@ COST_CORRELATIONAL_CAVEAT = (
 #: savings and previously had no adapter here, silently excluding it from the
 #: Review inbox's Cost-advisories tab.
 #:
-#: ``summarize`` (prompt summarization) is deliberately NOT here — it is the
-#: one cost analyzer with its own dedicated review surface (the curate/diff
-#: screen driven by ``core/summarize/``'s prepare/check/apply lifecycle,
-#: which needs a multi-step rewrite-and-verify flow this single-card adapter
-#: shape can't represent), not an oversight to fix later.
+#: ``summarize`` (prompt summarization) is deliberately NOT here, and stays out
+#: now that it carries a dollar figure of its own. Three reasons, decided
+#: rather than inherited:
+#:
+#:   1. It has its own dedicated review surface — the curate/diff screen driven
+#:      by ``core/summarize/``'s prepare/check/apply lifecycle, a multi-step
+#:      rewrite-and-verify flow this single-card adapter shape cannot represent.
+#:      An inbox card would either duplicate that surface or link away from the
+#:      inbox to it, and neither is a card.
+#:   2. It is the BUDGET, not a peer. ``write_budget.measured_agent_file_tokens``
+#:      reads the summarize finding to size how much permanent rule-writing every
+#:      OTHER analyzer in this table is allowed to propose. Listing it here would
+#:      make the analyzer that sets the budget also compete for it, and a user who
+#:      dismissed the card would silently be dismissing the counterweight that
+#:      stops the rule-writers from growing the files it wants compressed.
+#:   3. The standing product constraint is to consolidate cards, not add them.
+#:      Its saving is already visible in the Overview waste band (registry-driven
+#:      off the presence of ``estimated_recoverable_usd``), so it is not hidden —
+#:      only absent from this one surface.
 COST_ANALYZERS = (
     "downsize", "cache", "cache-recommend", "trim", "subagent", "deadweight",
     "script", "reuse", "verbosity", "resend",
@@ -195,6 +209,17 @@ class CostProposal:
     # labeled. ``None`` when the finding produced no estimate for this item.
     estimated_recoverable_usd:    float | None = None
     estimated_recoverable_tokens: int | None   = None
+    # COST OF WASTE — what the flagged behaviour actually COST over the window,
+    # fully observed. Structurally separate from every `estimated_*` field
+    # above and MUST NEVER be summed with them, on any surface: those answer
+    # "what does the fix return", this answers "what did this cost me", and the
+    # second is legitimately much larger than the first (a floor of zero is not
+    # achievable — see `analyzers/context_resend.py`'s module docstring).
+    # `estimated_recoverable_rollup` reads only the `estimated_*` fields, so
+    # this never leaks into the Review inbox headline.
+    cost_of_waste_usd:            float | None = None
+    cost_of_waste_tokens:         int | None   = None
+    cost_of_waste_basis:          str          = ""
     # Monthly-basis fields (Review inbox stat tiles) — a SEPARATE, explicitly-
     # named basis from the two window fields above; see the "Recoverable-
     # savings contract" note in model_downgrade.py / CLAUDE.md. `downsize`
@@ -1693,8 +1718,80 @@ def _verbosity_to_proposals(finding: Any, persona: str = "unknown") -> list[Cost
     )]
 
 
-def _resend_to_proposals(finding: Any, persona: str = "unknown") -> list[CostProposal]:
+def _rightsize_target(subagent_finding: Any, config: Any) -> dict[str, Any]:
+    """The concrete agent file the compound offload card should name, if one
+    exists: the most expensive over-powered subagent that has its own
+    definition file, plus the cheaper model to pin in it.
+
+    Reuses ``_agent_model_plumbing`` — the same resolver the ``subagent`` card
+    already uses — rather than re-deriving a path, so the two cards can never
+    name different files for the same agent. Empty dict when the subagent
+    analyzer didn't run, nothing was flagged, or no flagged subagent has a
+    definition file; the card then states the right-sizing lever generically
+    instead of inventing an agent name.
+    """
+    if subagent_finding is None:
+        return {}
+    flagged = list(getattr(subagent_finding, "flagged", []) or [])
+    over_powered = [r for r in flagged if "over_powered" in (getattr(r, "flags", []) or [])]
+    if not over_powered:
+        return {}
+    try:
+        return _agent_model_plumbing(over_powered, config)
+    except Exception:
+        return {}
+
+
+def _compound_offload_fix(rightsize: dict[str, Any], fix_offload: str, fix_rightsize: str) -> str:
+    """The single rung-1 rule that carries BOTH halves of the compound lever.
+
+    One artifact, not two: the offload directive decides where context-heavy
+    work runs, the right-sizing directive decides what it runs on, and they
+    compound. Writing them as one block is what keeps this a consolidation of
+    the resend / subagent / downsize recommendations rather than a third card
+    on top of them.
+    """
+    parts = [fix_offload, fix_rightsize]
+    if rightsize:
+        parts.append(
+            f"Concretely: {rightsize['agent_name']} already runs oversized for "
+            f"the work it does — pin `model: {rightsize['proposed_model']}` in "
+            f"{rightsize['target_path']} and set its reasoning effort to match "
+            f"the task rather than inheriting the parent's."
+        )
+    return "\n\n".join(p for p in parts if p)
+
+
+def _rightsize_frontmatter_snippet(rightsize: dict[str, Any]) -> str:
+    """The copyable agent-file frontmatter for the right-sizing half.
+
+    Both keys live in the same ``.claude/agents/<name>.md`` frontmatter block,
+    so the second half of the compound fix is one paste, not two.
+    """
+    name = rightsize.get("agent_name") or "<subagent-name>"
+    model = rightsize.get("proposed_model") or "<cheaper-same-family-model>"
+    path = rightsize.get("target_path") or f".claude/agents/{name}.md"
+    return (
+        f"# {path} — frontmatter\n"
+        f"---\n"
+        f"name: {name}\n"
+        f"model: {model}\n"
+        f"reasoning_effort: low\n"
+        f"---"
+    )
+
+
+def _resend_to_proposals(
+    finding: Any, persona: str = "unknown",
+    subagent_finding: Any = None, config: Any = None,
+) -> list[CostProposal]:
     """One window-wide card for the ``resend`` (context re-send) finding.
+
+    This card is COMPOUND by design: it consolidates what resend and subagent
+    right-sizing would otherwise say on separate cards, because the two are one
+    behavioural change (offload context-heavy work to a subagent, and size that
+    subagent to the work) applied through one rung-1 rule. Consolidating rather
+    than adding is deliberate — the Review inbox does not grow.
 
     Persona-gated like every other lever-bearing adapter. Three levers exist
     and they are NOT interchangeable:
@@ -1737,25 +1834,39 @@ def _resend_to_proposals(finding: Any, persona: str = "unknown") -> list[CostPro
         f"earlier turn (conservative lower bound; independent of whether "
         f"caching is enabled)."
     )
+    cost_of_waste_usd = getattr(finding, "cost_of_waste_usd", None)
+    if cost_of_waste_usd is not None:
+        evidence += (
+            f" That re-sent volume cost {_money(float(cost_of_waste_usd))} over "
+            f"the window — an observation, not a recoverable amount; the fix "
+            f"below returns a much smaller figure."
+        )
     fix_compaction = str(getattr(finding, "fix_compaction", "") or "")
     fix_cache_control = str(getattr(finding, "fix_cache_control", "") or "")
     fix_subagent_offload = str(getattr(finding, "fix_subagent_offload", "") or "")
+    fix_rightsize = str(getattr(finding, "fix_rightsize", "") or "")
     # The cache_control snippet is the SDK lever only; a claude-code window
     # can't paste it, so suppress it there — unchanged from before.
     cache_snippet = "" if persona == "claude-code" else fix_cache_control
+    rightsize = _rightsize_target(subagent_finding, config)
 
     if persona in {"claude-code", "mixed"} and fix_subagent_offload:
-        advise = fix_subagent_offload
+        compound_fix = _compound_offload_fix(rightsize, fix_subagent_offload, fix_rightsize)
+        advise = compound_fix
         if fix_compaction:
             advise = advise + " Immediate relief in an already-full session: " + fix_compaction
         write_fields = _persona_gated_write_fields(
-            persona, fix_subagent_offload, rung=1, scope="project",
+            persona, compound_fix, rung=1, scope=rightsize.get("scope") or "project",
         )
         # resend's `suggestion` slot is reserved for the SDK cache_control
         # snippet above, not the write-fallback text the helper would add
         # for a "mixed" persona — drop it so the two don't collide.
         write_fields.pop("suggestion", None)
-        one_paste_fix = cache_snippet or fix_subagent_offload
+        # The second half of the compound fix: the agent-file frontmatter that
+        # pins model AND reasoning effort. Carried as the one-paste artifact
+        # because the rung-1 write lands in CLAUDE.md, and the apply machinery
+        # writes exactly one target per apply.
+        one_paste_fix = _rightsize_frontmatter_snippet(rightsize)
     else:
         advise = fix_compaction
         write_fields = {
@@ -1777,12 +1888,20 @@ def _resend_to_proposals(finding: Any, persona: str = "unknown") -> list[CostPro
             "repeat_share": float(repeat_share),
             "repeat_share_median": getattr(finding, "repeat_share_median", None),
             "repeat_share_p90": getattr(finding, "repeat_share_p90", None),
+            "offloadable_share": getattr(finding, "offloadable_share", None),
+            "offload_recoverable_usd": getattr(finding, "offload_recoverable_usd", None),
+            "rightsize_recoverable_usd": getattr(finding, "rightsize_recoverable_usd", None),
+            "rightsize_agent_name": rightsize.get("agent_name", ""),
+            "rightsize_target_path": rightsize.get("target_path", ""),
         },
         advise_text=advise,
         suggestion=cache_snippet,
         one_paste_fix=one_paste_fix,
         estimated_recoverable_usd=getattr(finding, "estimated_recoverable_usd", None),
         estimated_recoverable_tokens=getattr(finding, "estimated_recoverable_tokens", None),
+        cost_of_waste_usd=cost_of_waste_usd,
+        cost_of_waste_tokens=getattr(finding, "cost_of_waste_tokens", None) or None,
+        cost_of_waste_basis=str(getattr(finding, "cost_of_waste_basis", "") or ""),
         estimate_basis=str(getattr(finding, "estimate_basis", "") or ""),
         caveat=str(getattr(finding, "caveat", "") or COST_CORRELATIONAL_CAVEAT),
         **write_fields,
@@ -2142,7 +2261,17 @@ def cost_proposals_from_report(
         (lambda f: _script_to_proposals(f, persona=persona), _pick("script")),
         (lambda f: _reuse_to_proposals(f, persona=persona), _pick("reuse")),
         (lambda f: _verbosity_to_proposals(f, persona=persona), _pick("verbosity")),
-        (lambda f: _resend_to_proposals(f, persona=persona), _pick("resend")),
+        (
+            # The resend card is compound: it names the concrete over-powered
+            # subagent (from the `subagent` finding) that the offload rule
+            # should also right-size, so the two levers land as one card rather
+            # than two. Reading the sibling finding here, not in the analyzer,
+            # keeps `context_resend.py` free of a cross-analyzer dependency.
+            lambda f: _resend_to_proposals(
+                f, persona=persona, subagent_finding=_pick("subagent"), config=config,
+            ),
+            _pick("resend"),
+        ),
     )
     for adapter, finding in adapters:
         try:

--- a/tokenjam/core/optimize/rate_profile.py
+++ b/tokenjam/core/optimize/rate_profile.py
@@ -1,0 +1,125 @@
+"""Blended input rate + cache-read ratio, measured off observed spans.
+
+Two analyzers need to price the SAME shape of thing: a block of tokens that is
+sent once at the input rate and then re-read on later calls at the cache-read
+rate. ``relearn`` prices a failure's re-read tail that way; ``summarize``
+prices an always-on prompt file's per-session re-reads that way. Both need the
+two rates blended over whichever models the user actually ran, and neither may
+invent one when the data cannot supply it.
+
+Deliberately NOT derived from observed ``cost_usd``. An all-in blended $/token
+cannot tell an input token from a cache read, and the whole point here is to
+price those two classes differently. The rates come from
+``pricing/models.toml`` via :func:`tokenjam.core.pricing.get_rates`, weighted
+by the token volume each model actually carried.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+
+@dataclass(frozen=True)
+class RateProfile:
+    """The two rates a re-read block is billed at, blended over observed models.
+
+    ``input_rate_per_token`` prices the first send; ``cache_read_ratio``
+    (cache-read rate / input rate — exactly 0.100 for every Anthropic model in
+    ``pricing/models.toml``) prices every re-read of it. ``basis`` names the
+    models the blend came from so the derivation is never a black box.
+    """
+
+    input_rate_per_token: float
+    cache_read_ratio: float
+    basis: str
+
+    def cost_of(self, tokens: float, rereads: int) -> float:
+        """What ``tokens`` cost when sent once and re-read ``rereads`` times."""
+        return (
+            tokens
+            * self.input_rate_per_token
+            * (1.0 + self.cache_read_ratio * max(rereads, 0))
+        )
+
+
+def blended_rate_profile(
+    conn: Any,
+    *,
+    session_ids: set[str] | None = None,
+    since: Any = None,
+    until: Any = None,
+    agent_id: str | None = None,
+) -> RateProfile | None:
+    """Blend input + cache-read rates over the spans the filters select.
+
+    Pass ``session_ids`` to scope to an explicit set of sessions, or
+    ``since``/``until`` (plus an optional ``agent_id``) to scope to a window.
+    Returns ``None`` — never a default rate — when there is no connection, no
+    matching spans, or no model with pricing data; the caller then reports a
+    token figure with no dollars rather than a number borrowed from a model
+    the user never ran (CLAUDE.md anti-pattern #22).
+    """
+    if conn is None:
+        return None
+    clauses = ["model IS NOT NULL"]
+    params: list[Any] = []
+    if session_ids is not None:
+        if not session_ids:
+            return None
+        ids = sorted(session_ids)
+        placeholders = ", ".join(f"${i + 1}" for i in range(len(ids)))
+        clauses.append(f"session_id IN ({placeholders})")
+        params.extend(ids)
+    if since is not None:
+        clauses.append(f"start_time >= ${len(params) + 1}")
+        params.append(since)
+    if until is not None:
+        clauses.append(f"start_time < ${len(params) + 1}")
+        params.append(until)
+    if agent_id:
+        clauses.append(f"agent_id = ${len(params) + 1}")
+        params.append(agent_id)
+
+    try:
+        rows = conn.execute(
+            "SELECT provider, model, "
+            "COALESCE(SUM(input_tokens + output_tokens + cache_tokens "
+            "+ cache_write_tokens), 0) "
+            "FROM spans WHERE " + " AND ".join(clauses) + " GROUP BY provider, model",
+            params,
+        ).fetchall()
+    except Exception:
+        return None
+
+    from tokenjam.core.pricing import get_rates
+
+    weighted_input = 0.0
+    weighted_cache_read = 0.0
+    total_tokens = 0
+    models: list[str] = []
+    for provider, model, tokens in rows:
+        tokens = int(tokens or 0)
+        if tokens <= 0:
+            continue
+        rates = get_rates(str(provider or "unknown"), str(model))
+        if rates is None or rates.input_per_mtok <= 0:
+            continue
+        weighted_input += rates.input_per_mtok * tokens
+        weighted_cache_read += rates.cache_read_per_mtok * tokens
+        total_tokens += tokens
+        models.append(f"{provider}/{model}")
+    if total_tokens <= 0:
+        return None
+    input_per_mtok = weighted_input / total_tokens
+    if input_per_mtok <= 0:
+        return None
+    cache_read_ratio = min(weighted_cache_read / total_tokens / input_per_mtok, 1.0)
+    return RateProfile(
+        input_rate_per_token=input_per_mtok / 1_000_000,
+        cache_read_ratio=cache_read_ratio,
+        basis=(
+            f"${input_per_mtok:.2f}/MTok input, re-reads at "
+            f"{cache_read_ratio:.3f}x that, blended over the models actually "
+            f"observed: {', '.join(sorted(set(models)))}"
+        ),
+    )

--- a/tokenjam/core/optimize/rate_profile.py
+++ b/tokenjam/core/optimize/rate_profile.py
@@ -83,8 +83,7 @@ def blended_rate_profile(
     try:
         rows = conn.execute(
             "SELECT provider, model, "
-            "COALESCE(SUM(input_tokens + output_tokens + cache_tokens "
-            "+ cache_write_tokens), 0) "
+            "COALESCE(SUM(input_tokens), 0), COALESCE(SUM(cache_tokens), 0) "
             "FROM spans WHERE " + " AND ".join(clauses) + " GROUP BY provider, model",
             params,
         ).fetchall()
@@ -93,27 +92,55 @@ def blended_rate_profile(
 
     from tokenjam.core.pricing import get_rates
 
+    # Each rate is weighted by ITS OWN matching token class, not a shared
+    # combined total -- input tokens for the input rate, cache-read tokens for
+    # the cache-read ratio. Weighting either by output/cache-write volume (a
+    # token class the priced rate has nothing to do with) biases the blend
+    # whenever a corpus's model mix has different output/cache-write
+    # proportions than input/cache-read proportions.
     weighted_input = 0.0
+    input_tokens_total = 0
     weighted_cache_read = 0.0
-    total_tokens = 0
+    cache_read_tokens_total = 0
     models: list[str] = []
-    for provider, model, tokens in rows:
-        tokens = int(tokens or 0)
-        if tokens <= 0:
+    for provider, model, input_tokens, cache_read_tokens in rows:
+        input_tokens = int(input_tokens or 0)
+        cache_read_tokens = int(cache_read_tokens or 0)
+        if input_tokens <= 0 and cache_read_tokens <= 0:
             continue
         rates = get_rates(str(provider or "unknown"), str(model))
         if rates is None or rates.input_per_mtok <= 0:
             continue
-        weighted_input += rates.input_per_mtok * tokens
-        weighted_cache_read += rates.cache_read_per_mtok * tokens
-        total_tokens += tokens
+        if input_tokens > 0:
+            weighted_input += rates.input_per_mtok * input_tokens
+            input_tokens_total += input_tokens
+        if cache_read_tokens > 0:
+            weighted_cache_read += rates.cache_read_per_mtok * cache_read_tokens
+            cache_read_tokens_total += cache_read_tokens
         models.append(f"{provider}/{model}")
-    if total_tokens <= 0:
+    if input_tokens_total <= 0:
         return None
-    input_per_mtok = weighted_input / total_tokens
+    input_per_mtok = weighted_input / input_tokens_total
     if input_per_mtok <= 0:
         return None
-    cache_read_ratio = min(weighted_cache_read / total_tokens / input_per_mtok, 1.0)
+    # No cache reads observed at all: no cache-read volume to weight the ratio
+    # by, so fall back to the same models' rates weighted by INPUT volume
+    # instead -- still derived from pricing/models.toml for the models
+    # actually observed, never an invented number.
+    if cache_read_tokens_total > 0:
+        cache_read_per_mtok = weighted_cache_read / cache_read_tokens_total
+    else:
+        weighted_cache_read_by_input = 0.0
+        for provider, model, input_tokens, _cache_read_tokens in rows:
+            input_tokens = int(input_tokens or 0)
+            if input_tokens <= 0:
+                continue
+            rates = get_rates(str(provider or "unknown"), str(model))
+            if rates is None or rates.input_per_mtok <= 0:
+                continue
+            weighted_cache_read_by_input += rates.cache_read_per_mtok * input_tokens
+        cache_read_per_mtok = weighted_cache_read_by_input / input_tokens_total
+    cache_read_ratio = min(cache_read_per_mtok / input_per_mtok, 1.0)
     return RateProfile(
         input_rate_per_token=input_per_mtok / 1_000_000,
         cache_read_ratio=cache_read_ratio,

--- a/tokenjam/core/optimize/types.py
+++ b/tokenjam/core/optimize/types.py
@@ -51,8 +51,12 @@ REUSE_HONESTY_CAVEAT = (
 # Required `estimate_basis` for ReuseFinding (issue #115 AC8 / savings
 # contract). Must contain the word "review".
 REUSE_ESTIMATE_BASIS = (
-    "structurally repeated planning calls — cache-reuse number assumes future "
-    "re-plans skip the LLM call entirely; review templates before reusing"
+    "structurally repeated planning calls — the headline prices the "
+    "script-replacement premise (a template/skill removes the planning call "
+    "entirely: avg cost x reps); the more conservative cache-reuse premise "
+    "(a template only removes the re-plan delta: avg cost x (reps - 1)) "
+    "stays available on every cluster as cache_reuse_recoverable_usd/"
+    "_tokens; review templates before reusing"
 )
 
 

--- a/tokenjam/ui/index.html
+++ b/tokenjam/ui/index.html
@@ -6198,25 +6198,32 @@ function capitalize(name) {
   return name ? name.charAt(0).toUpperCase() + name.slice(1) : name;
 }
 
-// Mirror core/framing.render_savings: api/unknown → dollars; subscription →
-// token-share of the cycle; local → token count. The mode is server-decided.
+// Mirror core/framing's dollars-by-default rule: dollars unless the server
+// explicitly suppressed them (local inference, or an all-unknown plan mix —
+// see dollarsSuppressed below). Subscription no longer suppresses: dollars
+// price all traffic at API list rates and render with framing.qualifier_text
+// carrying the list-price-equivalent caveat. The `window_total_tokens`
+// token-share fallback stays for the rare case a payload only carries
+// `display_rule`-less legacy framing (pricing_mode-only fallback below).
 function fmtFramedSavings(usd, tokens, framing) {
-  const mode = framing ? framing.pricing_mode : 'api';
-  if (mode === 'subscription') {
+  if (dollarsSuppressed(framing)) {
     if (tokens == null) return '—';
-    if (framing.window_total_tokens > 0) return (100 * tokens / framing.window_total_tokens).toFixed(1) + '% of cycle tokens';
+    const mode = framing ? framing.pricing_mode : 'api';
+    if (mode === 'subscription' && framing.window_total_tokens > 0) {
+      return (100 * tokens / framing.window_total_tokens).toFixed(1) + '% of cycle tokens';
+    }
     return fmtTokens(tokens) + ' tokens';
   }
-  if (mode === 'local') return tokens == null ? '—' : fmtTokens(tokens) + ' tokens';
   return usd == null ? '—' : fmtCost(usd);
 }
 
 // Is the server telling us NOT to lead with dollars? Reads the explicit
 // server-side decision (`display_rule`, core/framing.py) rather than
-// re-deriving it, with a pricing_mode fallback for older payloads. True for a
-// subscription-dominant corpus (a dollar figure there covers only the
-// API-billed slice, so it understates), for local inference, and for an
-// unknown plan. Callers make TOKENS the headline in that case.
+// re-deriving it, with a pricing_mode fallback for older payloads. True for
+// local inference (no marginal cost to price) and an all-unknown plan mix.
+// Subscription is deliberately NOT in this set — dollars price all traffic at
+// API list rates and are shown with a list-price-equivalent qualifier.
+// Callers make TOKENS the headline only in the suppressed case.
 const DOLLARS_SUPPRESSED_RULES = new Set([
   'suppress_dollars_for_subscription_share', 'tokens_only', 'suppress_dollars_unknown',
 ]);


### PR DESCRIPTION
## Summary

This batches two PRs that both touch how the Optimize/Review-inbox surface prices waste and savings, so they land as a single merge instead of two:

1. **Dollar-default + independent analyzer fixes** (this branch, originally scoped alone):
   - Dollar figures now render by default on subscription-billed windows (API-list-price equivalent, with the honesty qualifier kept), instead of being suppressed in favor of token-only framing.
   - Deadweight's MCP schema tax now prices each session's *actual* call count instead of a session-flat charge.
   - Plan-reuse's headline switched to the script-replacement basis (the fuller, already-computed figure) instead of the more conservative cache-reuse-only basis; the conservative figure stays retrievable.
   - Subagent right-sizing now prices `over_provisioned` dispatches against a same-agent/same-model cohort median instead of contributing $0.
   - Model-downgrade's turn-stretch dollar fields were traced and confirmed to intentionally belong to a separate CLI/API surface (`quota-audit`) rather than the headline rollup — documented, left alone.

2. **Merged in from the sibling PR** (relearn / summarize / resend dollar attribution):
   - Relearn now attaches a USD figure to recurring-failure clusters instead of reporting $0, derived from each occurrence's measured re-read tail; generic/unclassified clusters are suppressed rather than priced.
   - Summarize now prices its context-compression candidates on the same 30-day, sessions-that-load basis as its sibling analyzers, instead of a one-time token-only figure.
   - Resend's cost-of-waste (fully observed) and recoverable (what the fix actually returns) are now separate fields that are never summed, with recoverable re-derived from a measured offload+right-size lever instead of an inherited cross-corpus constant.

3. **On top of the merge, 5 review-bot findings verified against the actual code and fixed** (all confirmed real, not style noise):
   - Deadweight: subagent sidechain transcripts were being counted as extra top-level sessions, inflating the schema-tax call count; excluded.
   - Deadweight: a session-wide deferred/full flag mispriced sessions that mixed both; now split into a deferred segment and a full segment, each priced on its own evidence (successful tool invocation as the signal that a deferred schema was loaded).
   - Shared rate-blend helper (`rate_profile.py`, used by relearn + summarize) was weighting the input rate and the cache-read rate by the wrong token classes (output/cache-write volume); now each rate is weighted by its own matching token class.
   - Resend priced every turn in a session at one dominant model's rate; now prices each turn at its own model's rate, so mixed-model sessions aren't mispriced.
   - Summarize priced project-scoped candidate files against the window-wide average calls-per-session instead of that file's own repo's average; now uses the repo-scoped average for project-scope files (global-scope files correctly keep the window-wide average).

## Verification

Full suite run on the final union tip (not just per-component CI):
```
pytest tests/unit/ tests/synthetic/ tests/agents/ tests/integration/
→ 3663 passed, 2 skipped, 0 failed
ruff check tokenjam/ → clean
mypy tokenjam/ → clean
```
(Baseline before the review-bot fixes: 3654 passed, 2 skipped — 9 new tests added, zero regressions.)

## Merge instructions

**Please merge this PR with "Create a merge commit" — do NOT squash or rebase.** The sibling PR (linked below) will auto-flip to Merged only if its current branch head stays an ancestor of `main` after this lands; squashing or rebasing rewrites history and stamps it OPEN with a stale diff instead.

Sibling PR riding along on this merge: the "relearn/summarize/resend dollar attribution" PR — please don't push any new commits to its branch before this merges, as that would break the ancestry check and strand it open.
