### PR TITLE
fix(transcript_cache): fingerprint equal-size in-place rewrites

### DIFF
--- a/tests/unit/test_transcript_cache.py
+++ b/tests/unit/test_transcript_cache.py
@@ -154,9 +154,33 @@ def test_concurrent_writers_never_corrupt_the_cache_file(tmp_path):
     cache_dir = tmp_path / "cache"
     cache_path = cache_dir / tc._cache_key(src)
 
-    tc._store(cache_path, src, 100, 1.0, [{"a": 1}])
-    tc._store(cache_path, src, 100, 1.0, [{"a": 2}])
+    tc._store(cache_path, src, 100, 1.0, "fp", [{"a": 1}])
+    tc._store(cache_path, src, 100, 1.0, "fp", [{"a": 2}])
 
     loaded = tc._load(cache_path)
     assert loaded is not None
     assert loaded["records"] == [{"a": 2}]
+
+
+def test_cache_invalidates_on_equal_size_inplace_rewrite_same_mtime(tmp_path):
+    """Equal-size in-place rewrite that preserves mtime must not stay warm."""
+    import os
+
+    src = tmp_path / "session.jsonl"
+    _write(src, [{"type": "user", "message": {"content": "aaa"}}])
+    cache_dir = tmp_path / "cache"
+
+    first = tc.cached_read_records(src, cache_dir)
+    assert first[0]["message"]["content"] == "aaa"
+
+    st = src.stat()
+    _write(src, [{"type": "user", "message": {"content": "bbb"}}])
+    # Preserve the previous mtime so size+mtime alone would spuriously hit.
+    os.utime(src, (st.st_atime, st.st_mtime))
+    st2 = src.stat()
+    assert st.st_size == st2.st_size
+    assert st.st_mtime == st2.st_mtime
+
+    second = tc.cached_read_records(src, cache_dir)
+    assert second[0]["message"]["content"] == "bbb"
+    assert second != first

--- a/tokenjam/core/transcript_cache.py
+++ b/tokenjam/core/transcript_cache.py
@@ -12,8 +12,9 @@ mtime-filter their session list, so a cache trusting the same signal adds no
 correctness risk beyond what they already accept.
 
 This module is the cache: one small JSON file per transcript under a cache
-directory, keyed on ``(path, size, mtime)`` — the exact staleness signal the
-callers already trust. A cache hit skips the original file's read + parse
+directory, keyed on ``(path, size, mtime, content fingerprint)`` — size/mtime match
+the analyzers' filter, with a cheap head/tail hash against equal-size
+in-place rewrites that preserve mtime. A cache hit skips the original file's read + parse
 entirely; a miss (cold entry, or a changed file) recomputes and rewrites
 atomically (temp file + rename), so a concurrent reader never observes a
 partial write.
@@ -69,12 +70,32 @@ def _cache_key(path: Path) -> str:
     return f"{digest}.json"
 
 
+def _content_fingerprint(path: Path, size: int, n: int = 64) -> str:
+    """Cheap head/tail hash so equal-size in-place rewrites invalidate cache.
+
+    Full-file hashing would defeat the point of the cache on multi-GB
+    corpora; sampling the first and last ``n`` bytes catches rewrites that
+    keep ``st_size`` (and sometimes ``st_mtime``) unchanged.
+    """
+    if size <= 0:
+        return hashlib.sha256(b"").hexdigest()[:16]
+    with path.open("rb") as fh:
+        head = fh.read(n)
+        if size > n:
+            fh.seek(max(0, size - n))
+            tail = fh.read(n)
+        else:
+            tail = b""
+    return hashlib.sha256(head + b"\0" + tail).hexdigest()[:16]
+
+
+
 def cached_read_records(path: Path, cache_dir: Path) -> list[dict[str, Any]]:
     """``read_records(path)``, transparently cached under ``cache_dir``.
 
-    Cache validity is ``(size, mtime)`` matching the live file's current
-    stat — the exact pair both analyzers already trust for their own mtime
-    filter. A stat failure (the transcript vanished mid-scan) degrades to
+    Cache validity is ``(size, mtime, fingerprint)``: size/mtime match the
+    live file's current stat (the pair both analyzers already trust),
+    plus a head/tail content fingerprint against equal-size rewrites. A stat failure (the transcript vanished mid-scan) degrades to
     ``[]``, matching ``read_records``'s own tolerant-of-missing-files
     contract rather than raising.
     """
@@ -85,6 +106,7 @@ def cached_read_records(path: Path, cache_dir: Path) -> list[dict[str, Any]]:
     except OSError:
         return []
     size, mtime = st.st_size, st.st_mtime
+    fingerprint = _content_fingerprint(path, size)
 
     cache_path = cache_dir / _cache_key(path)
     cached = _load(cache_path)
@@ -92,13 +114,14 @@ def cached_read_records(path: Path, cache_dir: Path) -> list[dict[str, Any]]:
         cached is not None
         and cached.get("size") == size
         and cached.get("mtime") == mtime
+        and cached.get("fingerprint") == fingerprint
     ):
         records = cached.get("records")
         if isinstance(records, list):
             return records
 
     records = _parse_records(path)
-    _store(cache_path, path, size, mtime, records)
+    _store(cache_path, path, size, mtime, fingerprint, records)
     return records
 
 
@@ -115,13 +138,20 @@ def _store(
     source: Path,
     size: int,
     mtime: float,
+    fingerprint: str,
     records: list[dict[str, Any]],
 ) -> None:
     """Atomic temp-file + rename write. Best-effort — a cache write must
     never break the scan it exists to speed up; any OSError is swallowed."""
     try:
         cache_path.parent.mkdir(parents=True, exist_ok=True)
-        payload = {"path": str(source), "size": size, "mtime": mtime, "records": records}
+        payload = {
+            "path": str(source),
+            "size": size,
+            "mtime": mtime,
+            "fingerprint": fingerprint,
+            "records": records,
+        }
         # Per-pid temp name so two processes racing the same cache entry (a
         # CLI run and a live `tj serve`) never collide mid-write — the loser
         # just overwrites the winner's file a moment later with the same


### PR DESCRIPTION
## Summary
- Adds a cheap head/tail content fingerprint alongside `(size, mtime)` so equal-length in-place rewrites that preserve mtime invalidate the parse cache.
- Extends unit coverage for the equal-size / same-mtime rewrite case.

Fixes #560

## Test plan
- [ ] `pytest tests/unit/test_transcript_cache.py -q`

Made with [Cursor](https://cursor.com)