### PR TITLE
ci: guard good-first-issue/help-wanted labels against duplicate PRs

### DIFF
--- a/.github/scripts/contributor_label_guard.py
+++ b/.github/scripts/contributor_label_guard.py
@@ -1,0 +1,355 @@
+#!/usr/bin/env python3
+"""
+Prevent duplicate outside contributions on `good first issue` / `help wanted`
+issues.
+
+Background: agentic contribution tools (Cursor background agents and similar)
+poll GitHub for `is:open no:assignee label:"good first issue"` and pick up
+work from that feed. They do not read claim comments. The lever that
+actually keeps a second tool from picking up the same issue is the LABEL,
+not a comment — so this script removes the guarded labels the moment a PR
+that would close the issue is opened, and puts them back only if that PR is
+closed without being merged (i.e. the claim didn't pan out).
+
+Triggered by `.github/workflows/contributor-label-guard.yml` on
+`pull_request_target` (`opened` / `reopened` / `closed`). That event type is
+required — not `pull_request` — because label writes need a write-scoped
+`GITHUB_TOKEN`, which `pull_request` only grants for same-repo PRs. See the
+workflow file for the security constraints that come with running
+`pull_request_target` (no checkout of PR head, no execution of PR content);
+this script treats the PR title/body purely as untrusted text to pattern-match,
+never as code.
+
+Exact-restore mechanism (requirement: never re-add a label the issue never
+had): this script is STATELESS — it keeps no side file, DB row, or hidden
+issue comment. On restore, it reads the issue's own timeline
+(`GET /issues/{n}/timeline`) and, for each guarded label, finds that label's
+most recent `labeled`/`unlabeled` event. If the most recent event is an
+`unlabeled` event whose actor is this workflow's bot identity, and the label
+is not currently on the issue, that label is restored. This is exact because
+the timeline is already GitHub's own append-only ledger of every label
+mutation, ordered by time, without this script needing to write or maintain
+any bookkeeping of its own. A hidden HTML-comment marker on the issue was
+the other option considered (also stateless from this script's point of
+view, since GitHub stores the comment) but was passed over: it requires an
+extra write (posting/updating the marker comment) on every removal, and a
+second marker-parsing code path to keep in sync with the timeline reality if
+a human manually re-labels the issue in between. Reading the timeline needs
+no extra write and self-corrects if a human intervenes (their `labeled`
+event becomes the most recent event and this script no longer treats the
+label as ours to restore).
+
+Every network call is isolated in its own function and reports a normal
+(status_code, payload) pair rather than raising for HTTP error responses —
+callers decide what a given status means for their case, so a missing
+issue, a missing label, a closed issue, or an issue-number-that's-really-a-PR
+never fails the workflow run.
+"""
+from __future__ import annotations
+
+import json
+import os
+import re
+import sys
+import urllib.error
+import urllib.request
+from typing import Any, Sequence
+from urllib.parse import quote
+
+API_ROOT = "https://api.github.com"
+
+# The two labels the "outside contribution" feeds actually poll on. Order is
+# preserved in output (remove/restore lists) purely for stable, readable logs.
+DEFAULT_GUARD_LABELS: tuple[str, ...] = ("good first issue", "help wanted")
+
+# The actor GitHub records on timeline events performed by the default
+# `GITHUB_TOKEN` inside a workflow run. Overridable via the GUARD_ACTOR_LOGIN
+# env var (mainly for testing against a fork/org that renames its bot).
+DEFAULT_ACTOR_LOGIN = "github-actions[bot]"
+
+# GitHub's full closing-keyword set (case-insensitive), each optionally
+# followed by an owner/repo prefix and then '#<number>'. Keywords must be
+# immediately followed (allowing a colon/whitespace) by the reference — text
+# like "this fixes the typo" with no adjacent '#N' must NOT match, matching
+# GitHub's own closing-reference parsing.
+_CLOSING_KEYWORD_PATTERN = re.compile(
+    r"(?i)\b(?:close[sd]?|fix(?:e[sd])?|resolve[sd]?)\b\s*:?\s*"
+    r"(?:(?P<owner_repo>[\w.-]+/[\w.-]+))?#(?P<number>\d+)"
+)
+
+
+def parse_closing_issue_refs(text: str, repo: str) -> list[int]:
+    """Extract issue numbers closed by `text` (a PR title or body) that point
+    at `repo` ("owner/name").
+
+    Cross-repo references (`owner/repo#N`) are included only when the
+    `owner/repo` part matches `repo` (case-insensitive); a reference to a
+    different repo is ignored. Bare `#N` references always count (same
+    repo). Order of first appearance is preserved; duplicates are dropped.
+    """
+    if not text:
+        return []
+    numbers: list[int] = []
+    seen: set[int] = set()
+    for match in _CLOSING_KEYWORD_PATTERN.finditer(text):
+        owner_repo = match.group("owner_repo")
+        if owner_repo is not None and owner_repo.casefold() != repo.casefold():
+            continue
+        number = int(match.group("number"))
+        if number not in seen:
+            seen.add(number)
+            numbers.append(number)
+    return numbers
+
+
+def resolve_pr_closing_issues(title: str, body: str, repo: str) -> list[int]:
+    """Union of closing-keyword issue references in a PR's title and body,
+    in first-seen order (title scanned first), deduplicated."""
+    numbers: list[int] = []
+    seen: set[int] = set()
+    for text in (title or "", body or ""):
+        for number in parse_closing_issue_refs(text, repo):
+            if number not in seen:
+                seen.add(number)
+                numbers.append(number)
+    return numbers
+
+
+def labels_to_remove(
+    current_label_names: Sequence[str],
+    guard_labels: Sequence[str] = DEFAULT_GUARD_LABELS,
+) -> list[str]:
+    """Which of `guard_labels` are actually present on the issue right now.
+
+    A label that isn't present is left out — nothing to remove, so nothing
+    is ever attempted against the API for it (the no-op-safe "label not
+    present" case is handled here, before any network call)."""
+    current = set(current_label_names)
+    return [label for label in guard_labels if label in current]
+
+
+def labels_to_restore(
+    timeline_events: Sequence[dict[str, Any]],
+    current_label_names: Sequence[str],
+    guard_labels: Sequence[str] = DEFAULT_GUARD_LABELS,
+    actor_login: str = DEFAULT_ACTOR_LOGIN,
+) -> list[str]:
+    """Which of `guard_labels` this workflow should re-add to the issue.
+
+    For each guarded label, look at its most recent `labeled`/`unlabeled`
+    timeline event. The label is restored only if:
+      - it is not already on the issue (nothing to restore otherwise), and
+      - the most recent event for that label is an `unlabeled` event whose
+        actor matches `actor_login`.
+
+    A label whose most recent event is a `labeled` event (e.g. a human
+    manually re-added it while the PR was open) is left alone — this
+    workflow only ever restores what it, specifically, most recently took
+    off. `timeline_events` is expected in GitHub's timeline API shape
+    (`{"event": "labeled"|"unlabeled", "label": {"name": ...},
+    "actor": {"login": ...}, "created_at": ...}`); entries missing those
+    keys are ignored rather than raising.
+    """
+    current = set(current_label_names)
+    restore: list[str] = []
+    for label in guard_labels:
+        if label in current:
+            continue
+        relevant = [
+            event
+            for event in timeline_events
+            if event.get("event") in ("labeled", "unlabeled")
+            and isinstance(event.get("label"), dict)
+            and event["label"].get("name") == label
+        ]
+        if not relevant:
+            continue
+        relevant.sort(key=lambda event: event.get("created_at") or "")
+        last = relevant[-1]
+        actor = last.get("actor") or {}
+        last_login = str(actor.get("login", ""))
+        if last.get("event") == "unlabeled" and last_login.casefold() == actor_login.casefold():
+            restore.append(label)
+    return restore
+
+
+def _api_request(
+    method: str, path: str, token: str, body: dict[str, Any] | None = None
+) -> tuple[int, Any]:
+    """Perform one GitHub API call. Returns (status_code, parsed_json_or_None).
+
+    HTTP error responses (4xx/5xx) are returned as a normal result, not
+    raised — every caller in this script treats a particular status (404,
+    422, ...) as a legitimate, no-op-safe outcome rather than a crash.
+    Only network-level failures (DNS, timeout, TLS) propagate.
+    """
+    data = json.dumps(body).encode("utf-8") if body is not None else None
+    headers = {
+        "Authorization": f"Bearer {token}",
+        "Accept": "application/vnd.github+json",
+        "X-GitHub-Api-Version": "2022-11-28",
+        "User-Agent": "tokenjam-contributor-label-guard",
+    }
+    if data is not None:
+        headers["Content-Type"] = "application/json"
+    req = urllib.request.Request(f"{API_ROOT}{path}", data=data, method=method, headers=headers)
+    try:
+        with urllib.request.urlopen(req, timeout=30) as resp:
+            raw = resp.read()
+            payload = json.loads(raw) if raw else None
+            return resp.status, payload
+    except urllib.error.HTTPError as exc:
+        raw = exc.read()
+        try:
+            payload = json.loads(raw) if raw else None
+        except json.JSONDecodeError:
+            payload = None
+        return exc.code, payload
+
+
+def fetch_issue(repo: str, number: int, token: str) -> tuple[int, Any]:
+    return _api_request("GET", f"/repos/{repo}/issues/{number}", token)
+
+
+def fetch_issue_timeline(repo: str, number: int, token: str) -> list[dict[str, Any]]:
+    """All timeline events for an issue, paginated to completion."""
+    events: list[dict[str, Any]] = []
+    page = 1
+    while True:
+        status, payload = _api_request(
+            "GET", f"/repos/{repo}/issues/{number}/timeline?per_page=100&page={page}", token
+        )
+        if status != 200 or not payload:
+            break
+        events.extend(payload)
+        if len(payload) < 100:
+            break
+        page += 1
+    return events
+
+
+def remove_label(repo: str, number: int, label: str, token: str) -> int:
+    status, _ = _api_request(
+        "DELETE", f"/repos/{repo}/issues/{number}/labels/{quote(label, safe='')}", token
+    )
+    return status
+
+
+def add_labels(repo: str, number: int, labels: Sequence[str], token: str) -> int:
+    status, _ = _api_request(
+        "POST", f"/repos/{repo}/issues/{number}/labels", token, body={"labels": list(labels)}
+    )
+    return status
+
+
+def _is_pull_request(issue_payload: dict[str, Any]) -> bool:
+    """The issues API returns PRs too (they share the issue number-space);
+    a PR payload carries a `pull_request` key an issue payload never has."""
+    return "pull_request" in issue_payload
+
+
+def _handle_claim(repo: str, number: int, token: str) -> None:
+    status, issue = fetch_issue(repo, number, token)
+    if status == 404 or not isinstance(issue, dict):
+        print(f"no-op: issue #{number} not found (status {status})")
+        return
+    if _is_pull_request(issue):
+        print(f"no-op: #{number} is a pull request, not an issue")
+        return
+    if issue.get("state") != "open":
+        print(f"no-op: issue #{number} is already closed")
+        return
+    current = [lbl["name"] for lbl in issue.get("labels", [])]
+    to_remove = labels_to_remove(current)
+    if not to_remove:
+        print(f"no-op: issue #{number} has none of the guarded labels")
+        return
+    for label in to_remove:
+        result = remove_label(repo, number, label, token)
+        if result in (200, 204):
+            print(f"removed label '{label}' from issue #{number}")
+        else:
+            print(
+                f"warn: failed to remove label '{label}' from issue #{number} "
+                f"(status {result})",
+                file=sys.stderr,
+            )
+
+
+def _handle_release(repo: str, number: int, token: str, actor_login: str) -> None:
+    status, issue = fetch_issue(repo, number, token)
+    if status == 404 or not isinstance(issue, dict):
+        print(f"no-op: issue #{number} not found (status {status})")
+        return
+    if _is_pull_request(issue):
+        print(f"no-op: #{number} is a pull request, not an issue")
+        return
+    if issue.get("state") != "open":
+        print(f"no-op: issue #{number} is already closed — leaving labels as-is")
+        return
+    current = [lbl["name"] for lbl in issue.get("labels", [])]
+    events = fetch_issue_timeline(repo, number, token)
+    to_restore = labels_to_restore(events, current, actor_login=actor_login)
+    if not to_restore:
+        print(f"no-op: nothing to restore on issue #{number}")
+        return
+    result = add_labels(repo, number, to_restore, token)
+    if result in (200, 201):
+        print(f"restored labels {to_restore} on issue #{number}")
+    else:
+        print(
+            f"warn: failed to restore labels {to_restore} on issue #{number} "
+            f"(status {result})",
+            file=sys.stderr,
+        )
+
+
+def main() -> int:
+    token = os.environ.get("GITHUB_TOKEN")
+    repo = os.environ.get("GITHUB_REPOSITORY")
+    event_path = os.environ.get("GITHUB_EVENT_PATH")
+    actor_login = os.environ.get("GUARD_ACTOR_LOGIN", DEFAULT_ACTOR_LOGIN)
+    if not token or not repo or not event_path:
+        print(
+            "error: GITHUB_TOKEN, GITHUB_REPOSITORY, and GITHUB_EVENT_PATH must all be set",
+            file=sys.stderr,
+        )
+        return 1
+
+    try:
+        with open(event_path, encoding="utf-8") as fh:
+            event = json.load(fh)
+    except (OSError, json.JSONDecodeError) as exc:
+        print(f"error: could not read event payload at {event_path}: {exc}", file=sys.stderr)
+        return 1
+
+    action = event.get("action")
+    pr = event.get("pull_request") or {}
+    pr_number = pr.get("number")
+    title = pr.get("title") or ""
+    body = pr.get("body") or ""
+    merged = bool(pr.get("merged"))
+
+    if action not in ("opened", "reopened", "closed"):
+        print(f"no-op: unsupported action '{action}'")
+        return 0
+
+    issue_numbers = resolve_pr_closing_issues(title, body, repo)
+    if not issue_numbers:
+        print(f"no-op: PR #{pr_number} has no closing-keyword issue references")
+        return 0
+
+    if action in ("opened", "reopened"):
+        for number in issue_numbers:
+            _handle_claim(repo, number, token)
+    elif merged:
+        print(f"no-op: PR #{pr_number} merged — issue(s) {issue_numbers} close on merge")
+    else:
+        for number in issue_numbers:
+            _handle_release(repo, number, token, actor_login)
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.github/workflows/contributor-label-guard.yml
+++ b/.github/workflows/contributor-label-guard.yml
@@ -1,0 +1,54 @@
+name: contributor-label-guard
+
+# Prevents two outside-contribution tools (Cursor background agents and
+# similar) from picking up the same `good first issue` / `help wanted` issue
+# at once. They poll GitHub's search API on those labels, not on claim
+# comments — so the only lever that actually keeps an issue off their feed
+# is removing the labels the moment a PR that would close it is opened, and
+# restoring them only if that PR is later closed without merging.
+#
+# SECURITY — READ BEFORE EDITING THIS FILE:
+# This workflow MUST stay on `pull_request_target`, not `pull_request`. Fork
+# PRs under plain `pull_request` get a read-only GITHUB_TOKEN and this
+# workflow cannot write labels with one — that's exactly the case that
+# matters here (outside contributors are, definitionally, forking).
+# `pull_request_target` runs with the BASE repo's write-scoped token even
+# for a fork PR, which means this workflow executes in a privileged context.
+# DO NOT add `actions/checkout` of the PR head ref (no
+# `ref: ${{ github.event.pull_request.head.sha }}` / `.head.ref`), DO NOT
+# `pip install` / `npm install` / run anything sourced from the PR branch,
+# and DO NOT execute PR-authored scripts. The single checkout step below
+# pins explicitly to the BASE commit for this exact reason — leave it as is.
+# The PR title/body are read by `.github/scripts/contributor_label_guard.py`
+# purely as untrusted text to pattern-match against; they are never
+# evaluated, sourced, or shelled out to.
+on:
+  pull_request_target:
+    types: [opened, reopened, closed]
+
+permissions:
+  issues: write
+  pull-requests: read
+  contents: read
+
+jobs:
+  guard:
+    runs-on: ubuntu-latest
+    steps:
+      # Base repo only — see the security note above. Never point `ref` at
+      # the PR head.
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.base.sha }}
+          persist-credentials: false
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - name: Guard contributor labels
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_REPOSITORY: ${{ github.repository }}
+          GITHUB_EVENT_PATH: ${{ github.event_path }}
+        run: python .github/scripts/contributor_label_guard.py

--- a/tests/unit/test_contributor_label_guard.py
+++ b/tests/unit/test_contributor_label_guard.py
@@ -1,0 +1,245 @@
+"""
+Unit tests for `.github/scripts/contributor_label_guard.py` — the closing-
+keyword parser and the remove/restore decision logic behind the outside-
+contribution label guard. Pure logic only, no network calls.
+
+The module under test lives outside the `tokenjam` package (it's a workflow
+helper script, following the `archive_traffic.py` convention), so it's
+imported by path rather than as a normal package import.
+"""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+_SCRIPTS_DIR = Path(__file__).resolve().parents[2] / ".github" / "scripts"
+if str(_SCRIPTS_DIR) not in sys.path:
+    sys.path.insert(0, str(_SCRIPTS_DIR))
+
+import contributor_label_guard as guard  # noqa: E402
+
+REPO = "Metabuilder-Labs/tokenjam"
+
+
+# ---------------------------------------------------------------------------
+# parse_closing_issue_refs / resolve_pr_closing_issues
+# ---------------------------------------------------------------------------
+
+
+def test_parses_single_closing_keyword():
+    assert guard.parse_closing_issue_refs("Closes #560", REPO) == [560]
+
+
+def test_parses_multiple_distinct_closing_keywords():
+    text = "Fixes #1\nAlso resolves #2\nAnd closed #3"
+    assert guard.parse_closing_issue_refs(text, REPO) == [1, 2, 3]
+
+
+def test_parses_multiple_refs_in_one_body():
+    text = "This closes #10 and also fixes #20, plus resolves #30."
+    assert guard.parse_closing_issue_refs(text, REPO) == [10, 20, 30]
+
+
+def test_dedupes_repeated_refs():
+    text = "Closes #5. Also closes #5 again, and fixes #5."
+    assert guard.parse_closing_issue_refs(text, REPO) == [5]
+
+
+def test_all_closing_keyword_verb_forms():
+    for keyword in (
+        "close",
+        "closes",
+        "closed",
+        "fix",
+        "fixes",
+        "fixed",
+        "resolve",
+        "resolves",
+        "resolved",
+    ):
+        text = f"{keyword} #42"
+        assert guard.parse_closing_issue_refs(text, REPO) == [42], keyword
+
+
+def test_mixed_case_keyword_and_repo():
+    assert guard.parse_closing_issue_refs("FIXES #7", REPO) == [7]
+    assert (
+        guard.parse_closing_issue_refs(f"Closes {REPO.upper()}#9", REPO) == [9]
+    )
+
+
+def test_owner_repo_form_matching_this_repo_is_included():
+    text = f"Closes {REPO}#560"
+    assert guard.parse_closing_issue_refs(text, REPO) == [560]
+
+
+def test_owner_repo_form_for_a_different_repo_is_ignored():
+    text = "Closes some-other-org/other-repo#560"
+    assert guard.parse_closing_issue_refs(text, REPO) == []
+
+
+def test_owner_repo_and_bare_refs_together():
+    text = f"Closes {REPO}#1 and fixes other-org/other-repo#2 and resolves #3"
+    assert guard.parse_closing_issue_refs(text, REPO) == [1, 3]
+
+
+def test_no_reference_pr_body_returns_empty():
+    text = "This PR refactors the parser module for clarity, no issue attached."
+    assert guard.parse_closing_issue_refs(text, REPO) == []
+
+
+def test_empty_and_none_like_text_returns_empty():
+    assert guard.parse_closing_issue_refs("", REPO) == []
+
+
+def test_keyword_like_text_without_adjacent_reference_does_not_match():
+    # "fixes" appears but is not immediately followed by a '#N' reference —
+    # GitHub does not treat this as a closing reference and neither should we.
+    text = "This PR fixes the typo in the README. See #123 for background."
+    assert guard.parse_closing_issue_refs(text, REPO) == []
+
+
+def test_keyword_substring_inside_another_word_does_not_match():
+    # "enclosed" contains "close" but is not the keyword "close" itself.
+    text = "The enclosed #99 diagram explains the flow."
+    assert guard.parse_closing_issue_refs(text, REPO) == []
+
+
+def test_resolve_pr_closing_issues_unions_title_and_body():
+    title = "Fix #1: handle empty input"
+    body = "Also closes #2 while I'm in here."
+    assert guard.resolve_pr_closing_issues(title, body, REPO) == [1, 2]
+
+
+def test_resolve_pr_closing_issues_dedupes_across_title_and_body():
+    title = "Fixes #5"
+    body = "This closes #5 as well."
+    assert guard.resolve_pr_closing_issues(title, body, REPO) == [5]
+
+
+def test_resolve_pr_closing_issues_handles_missing_body():
+    assert guard.resolve_pr_closing_issues("Fixes #5", "", REPO) == [5]
+    assert guard.resolve_pr_closing_issues("No refs here", "", REPO) == []
+
+
+# ---------------------------------------------------------------------------
+# labels_to_remove
+# ---------------------------------------------------------------------------
+
+
+def test_labels_to_remove_returns_present_guarded_labels():
+    current = ["good first issue", "help wanted", "bug"]
+    assert guard.labels_to_remove(current) == ["good first issue", "help wanted"]
+
+
+def test_labels_to_remove_only_returns_labels_actually_present():
+    current = ["help wanted", "bug"]
+    assert guard.labels_to_remove(current) == ["help wanted"]
+
+
+def test_labels_to_remove_empty_when_no_guarded_labels_present():
+    assert guard.labels_to_remove(["bug", "documentation"]) == []
+
+
+def test_labels_to_remove_empty_current_labels():
+    assert guard.labels_to_remove([]) == []
+
+
+# ---------------------------------------------------------------------------
+# labels_to_restore — the exact-restore requirement
+# ---------------------------------------------------------------------------
+
+
+def _unlabeled_event(label: str, actor: str = guard.DEFAULT_ACTOR_LOGIN, at: str = "2026-07-25T00:00:00Z"):
+    return {
+        "event": "unlabeled",
+        "label": {"name": label},
+        "actor": {"login": actor},
+        "created_at": at,
+    }
+
+
+def _labeled_event(label: str, actor: str = "some-human", at: str = "2026-07-25T00:00:00Z"):
+    return {
+        "event": "labeled",
+        "label": {"name": label},
+        "actor": {"login": actor},
+        "created_at": at,
+    }
+
+
+def test_restores_only_the_label_the_workflow_removed():
+    # Workflow removed "good first issue" but "help wanted" was never on the
+    # issue in the first place — restore must not add it.
+    events = [_unlabeled_event("good first issue")]
+    current = []  # neither label present right now
+    assert guard.labels_to_restore(events, current) == ["good first issue"]
+
+
+def test_does_not_restore_a_label_still_present():
+    events = [_unlabeled_event("good first issue")]
+    current = ["good first issue"]  # somehow already back (e.g. human re-added)
+    assert guard.labels_to_restore(events, current) == []
+
+
+def test_does_not_restore_when_most_recent_event_is_a_human_relabel():
+    events = [
+        _unlabeled_event("good first issue", at="2026-07-25T00:00:00Z"),
+        _labeled_event("good first issue", actor="a-maintainer", at="2026-07-25T01:00:00Z"),
+    ]
+    # Label was re-added by a human after our removal, then somehow removed
+    # again from `current` externally — the most recent event is a human
+    # `labeled`, so this workflow must not claim credit / restore it.
+    assert guard.labels_to_restore(events, current_label_names=[]) == []
+
+
+def test_does_not_restore_when_unlabeled_by_a_different_actor():
+    events = [_unlabeled_event("good first issue", actor="a-maintainer")]
+    assert guard.labels_to_restore(events, current_label_names=[]) == []
+
+
+def test_restores_both_labels_when_both_were_removed():
+    events = [
+        _unlabeled_event("good first issue"),
+        _unlabeled_event("help wanted"),
+    ]
+    assert guard.labels_to_restore(events, current_label_names=[]) == [
+        "good first issue",
+        "help wanted",
+    ]
+
+
+def test_restore_ignores_malformed_events():
+    events = [
+        {"event": "unlabeled"},  # missing "label"
+        {"event": "unlabeled", "label": {}},  # missing "name"
+        {"event": "commented"},  # irrelevant event type
+        _unlabeled_event("good first issue"),
+    ]
+    assert guard.labels_to_restore(events, current_label_names=[]) == ["good first issue"]
+
+
+def test_restore_no_events_for_label_means_nothing_to_restore():
+    assert guard.labels_to_restore([], current_label_names=[]) == []
+
+
+def test_restore_actor_login_is_configurable():
+    events = [_unlabeled_event("good first issue", actor="custom-bot[bot]")]
+    assert (
+        guard.labels_to_restore(events, current_label_names=[], actor_login="custom-bot[bot]")
+        == ["good first issue"]
+    )
+    assert guard.labels_to_restore(events, current_label_names=[]) == []
+
+
+# ---------------------------------------------------------------------------
+# _is_pull_request
+# ---------------------------------------------------------------------------
+
+
+def test_is_pull_request_true_when_payload_has_pull_request_key():
+    assert guard._is_pull_request({"number": 1, "pull_request": {"url": "..."}}) is True
+
+
+def test_is_pull_request_false_for_plain_issue():
+    assert guard._is_pull_request({"number": 1}) is False


### PR DESCRIPTION
Agentic contribution tools (Cursor background agents and similar) poll GitHub's search API on `is:open no:assignee label:"good first issue"`. They don't read claim comments, only the label feed — so a claim comment doesn't stop a second tool from picking up the same issue.

## Summary
- On `pull_request_target` `opened`/`reopened`, if the PR's title/body references an issue with a closing keyword (`closes`, `fixes`, `resolves`, ...), remove `good first issue` and `help wanted` from that issue — taking it off the polling feeds immediately.
- On `pull_request_target` `closed` without merge, restore exactly the labels this workflow removed. On merge, leave them off (the issue closes anyway).
- Parsing + decision logic lives in `.github/scripts/contributor_label_guard.py` as plain, network-free functions (same convention as the existing `archive_traffic.py`); the workflow YAML just calls it.

## Real incident this addresses
15 issues were labeled `good first issue` + `help wanted` in one burst. Two different agentic tools opened PRs for the same issue (#560) within 50 minutes of each other — #572 and #573 — because neither tool's feed reflected the other's claim. One had to be closed, wasting both sides' work.

## Security
This has to run as `pull_request_target` (not `pull_request`) because fork PRs under `pull_request` get a read-only `GITHUB_TOKEN` and can't write labels — exactly the case that matters here. Since `pull_request_target` runs with base-repo write permissions even for a fork PR, the workflow:
- Checks out the **base** commit only (`ref: ${{ github.event.pull_request.base.sha }}`), never the PR head.
- Runs no PR-authored code — the script treats the PR title/body purely as untrusted text to regex-match, no `pip install`/execution of anything from the PR branch.
- Requests only `issues: write`, `pull-requests: read`, `contents: read`.
- A comment block at the top of the workflow file states these constraints explicitly so a future edit doesn't casually add a PR-head checkout.

## Exact-restore mechanism
The script is intentionally stateless — no side file, DB row, or hidden issue comment. On restore it reads the issue's own timeline (`GET /issues/{n}/timeline`) and, per guarded label, finds that label's most recent `labeled`/`unlabeled` event. A label is restored only if the most recent event is an `unlabeled` event whose actor is this workflow's bot identity and the label isn't currently on the issue. This is exact (never adds a label the issue never had) and self-corrects if a human manually re-labels in between — their `labeled` event becomes the most recent one and the workflow no longer treats the label as its own to restore. Reasoning for picking this over a hidden HTML-comment marker is documented in the module docstring.

## No-op safety
Every step is written to no-op rather than fail the run: label already absent (filtered out before any API call), issue number not found (404), issue number referring to a PR rather than an issue (`pull_request` key on the issues-API payload), issue already closed. `_api_request()` returns `(status, payload)` instead of raising on HTTP error responses so every caller decides what a given status means for its case.

## Tests / Verification
- `tests/unit/test_contributor_label_guard.py` (30 tests): all closing-keyword verb forms, multiple refs in one body, multiple distinct keywords, `owner/repo#N` matching this repo vs. a different repo, mixed case, no-reference PRs, keyword-adjacent-but-no-`#N` text ("this fixes the typo... #123" elsewhere) correctly not matching, keyword-substring-inside-another-word ("enclosed #99") not matching, and the restore-only-what-was-removed logic (including: label already present, most-recent event is a human re-label, different actor, malformed timeline entries).
- `ruff check .github/scripts/contributor_label_guard.py tests/unit/test_contributor_label_guard.py` — clean.
- `mypy .github/scripts/contributor_label_guard.py` — clean.
- `pytest tests/unit/` — 3023 passed, 2 skipped (full suite, unrelated to this change).
- Workflow YAML parsed with `yaml.safe_load` — valid.

## What's NOT in this PR
- Auto-assigning the contributor to the issue — GitHub only permits assigning users with write access or who've already commented on the issue, so it silently fails for the exact outside-contributor case this targets. Label removal has no such permission edge case.
- A "contribution bar" footer on issue bodies — a separate, deliberately deferred manual decision.
- Any change to existing issue labels or to CONTRIBUTING/AGENTS.md.

🤖 Generated with [Claude Code](https://claude.com/claude-code)