### PR TITLE
Surface Summarize's and relearn's recoverable dollars on the Review inbox headline

### DIFF
--- a/tests/unit/test_cost_proposals.py
+++ b/tests/unit/test_cost_proposals.py
@@ -953,6 +953,88 @@ def test_rollup_with_no_token_estimates_reports_zero_coverage():
     assert "floor, not a total" not in rollup["estimate_basis"]
 
 
+# --- #326: relearn clusters fold into the SAME headline, and the excluded
+# (summarize) total is carried through rather than silently dropped -------- #
+
+def test_rollup_folds_relearn_monthly_usd_into_projected_only():
+    proposals = [
+        {"signature": "cost:downsize", "analyzer": "downsize", "title": "t1",
+         "estimated_recoverable_usd": 3.0},
+    ]
+    relearn_clusters = [
+        {"signature": "relearn:a", "estimated_monthly_usd": 5.0,
+         "estimated_monthly_tokens": 1000},
+        {"signature": "relearn:b", "estimated_monthly_usd": 2.5,
+         "estimated_monthly_tokens": 500},
+    ]
+    rollup = estimated_recoverable_rollup(proposals, relearn_clusters=relearn_clusters)
+    # The window-observed field is UNCHANGED by relearn — different time
+    # basis, never mixed in.
+    assert rollup["estimated_recoverable_usd"] == 3.0
+    # Relearn's own contribution is broken out...
+    assert rollup["relearn_monthly_usd"] == 7.5
+    assert rollup["relearn_monthly_tokens"] == 1500
+    assert rollup["relearn_cluster_count"] == 2
+    assert rollup["relearn_priced_cluster_count"] == 2
+    # ...and folded into the 30-day projected total alongside the cost
+    # proposals' own (unscaled here — the guardrails block projection with
+    # no active_days/n_sessions given, so cost proposals' window figure
+    # passes through as-is at scale 1.0).
+    assert rollup["projected_usd_30d"] == pytest.approx(3.0 + 7.5)
+    assert rollup["projected_tokens_30d"] == 1500
+
+
+def test_rollup_dedupes_relearn_clusters_by_signature():
+    relearn_clusters = [
+        {"signature": "relearn:a", "estimated_monthly_usd": 5.0},
+        {"signature": "relearn:a", "estimated_monthly_usd": 5.0},
+    ]
+    rollup = estimated_recoverable_rollup([], relearn_clusters=relearn_clusters)
+    assert rollup["relearn_monthly_usd"] == 5.0
+    assert rollup["relearn_cluster_count"] == 1
+
+
+def test_rollup_skips_relearn_clusters_with_no_dollar_estimate():
+    relearn_clusters = [
+        {"signature": "relearn:a", "estimated_monthly_usd": None,
+         "estimated_monthly_tokens": 400},
+    ]
+    rollup = estimated_recoverable_rollup([], relearn_clusters=relearn_clusters)
+    assert rollup["relearn_monthly_usd"] == 0.0
+    assert rollup["relearn_priced_cluster_count"] == 0
+    assert rollup["relearn_cluster_count"] == 1
+    # Tokens are still counted independently of the dollar estimate, same
+    # rule as the cost-proposal loop above.
+    assert rollup["relearn_monthly_tokens"] == 400
+    assert rollup["projected_tokens_30d"] == 400
+
+
+def test_rollup_excluded_is_carried_through_never_summed():
+    excluded = {"summarize": {"estimated_monthly_usd": 4135.35, "href": "#/optimize"}}
+    rollup = estimated_recoverable_rollup([], excluded=excluded)
+    assert rollup["excluded"] == excluded
+    assert rollup["estimated_recoverable_usd"] == 0.0
+    assert rollup["projected_usd_30d"] == 0.0
+
+
+def test_rollup_excluded_defaults_to_empty_dict_not_none():
+    rollup = estimated_recoverable_rollup([])
+    assert rollup["excluded"] == {}
+
+
+def test_rollup_empty_relearn_clusters_untouched_baseline():
+    # No relearn_clusters passed at all — the new fields exist but are inert,
+    # so an existing caller unaware of #326 keeps seeing the same totals.
+    proposals = [
+        {"signature": "cost:downsize", "analyzer": "downsize", "title": "t1",
+         "estimated_recoverable_usd": 3.0},
+    ]
+    rollup = estimated_recoverable_rollup(proposals)
+    assert rollup["relearn_monthly_usd"] == 0.0
+    assert rollup["relearn_cluster_count"] == 0
+    assert rollup["projected_usd_30d"] == 3.0
+
+
 # --- Review inbox monthly-basis fields (#273: single central projection) ---- #
 
 def test_downsize_monthly_uses_the_same_central_projection_as_everyone_else():

--- a/tests/unit/test_lens_ui_regression.py
+++ b/tests/unit/test_lens_ui_regression.py
@@ -2509,6 +2509,42 @@ def test_estimated_tile_hides_when_there_are_no_open_items(html):
     assert "openItems.length > 0 ? html`" in tile
 
 
+# --- #326: excluded waste (summarize) is stated + linked, never summed ----- #
+def test_inbox_stat_tiles_renders_the_excluded_cross_reference(html):
+    start = html.index("function ExcludedWasteNote")
+    end = html.index("function ReviewInboxView", start)
+    block = html[start:end]
+    # Rendered inside InboxStatTiles, not just defined standalone.
+    assert "<${ExcludedWasteNote} excluded=${excluded} />" in block
+    assert block.count("<${ExcludedWasteNote} excluded=${excluded} />") == 2
+    # Never folded into the blue tile's own dollar figure — only ever a
+    # separate stated line with a link out.
+    assert "not summed above" in block
+    assert "Review it" in block
+    assert "#/optimize/summarize" in block
+
+
+def test_review_inbox_view_fetches_and_threads_excluded_from_the_rollup(html):
+    view = html[html.index("function ReviewInboxView"):]
+    end = view.index("function ", len("function ReviewInboxView"))
+    view = view[:end]
+    assert "setCostExcluded((r.rollup && r.rollup.excluded) || {})" in view
+    assert "excluded=${costExcluded}" in view
+
+
+def test_estimated_tile_still_renders_with_only_excluded_waste_and_no_open_items(html):
+    # Summarize can be the ONLY recoverable figure in a given scan (no cost
+    # advisories, no recurring mistakes yet) — the tile must still surface it
+    # rather than disappearing the way the pre-#326 empty state did (issue
+    # #326: "the product's largest recoverable figure invisible from the
+    # headline a user reads").
+    start = html.index("function InboxStatTiles")
+    end = html.index("function ReviewInboxView", start)
+    tile = html[start:end]
+    assert "hasExcluded" in tile
+    assert "openItems.length === 0 && appliedCount === 0 && !hasExcluded" in tile
+
+
 # --- Review inbox copy: cost-led, and no hardcoded zero -------------------- #
 def test_review_inbox_intro_matches_the_founder_approved_mockup(html):
     # Inbox redesign: the page title and subtitle are the founder-approved

--- a/tokenjam/api/routes/relearn.py
+++ b/tokenjam/api/routes/relearn.py
@@ -455,7 +455,19 @@ def get_cost_proposals(request: Request) -> dict[str, Any]:
     ledger. Computed here, not client-side, so the headline reflects every
     viewer's state consistently (a browser's local "dismiss" never affects
     this figure — dismissing hides a card from one person's view, it doesn't
-    change what's actually still outstanding)."""
+    change what's actually still outstanding).
+
+    ``rollup`` also folds in the relearn detector's own OPEN clusters (#326:
+    ``rollup.relearn_monthly_usd``/``relearn_monthly_tokens``, added into
+    ``rollup.projected_usd_30d``/``projected_tokens_30d`` — never into the
+    window-observed ``estimated_recoverable_usd``, a different time basis —
+    filtered against the relearn applied-fixes ledger the same way the cost
+    proposals are filtered against the cost-applied one) and carries
+    ``rollup.excluded`` (currently ``{"summarize": {...}}`` when the analyzer
+    found something) — waste this headline deliberately does NOT sum in
+    because it has its own review surface, stated instead of silently
+    dropped. See ``cost_proposals.estimated_recoverable_rollup``'s docstring
+    for the full contract."""
     config = _config(request)
     block = relearn_store.read_cost_proposals(config=config)
     computing = cost_proposals_mod.is_computing_cost_proposals()
@@ -470,6 +482,20 @@ def get_cost_proposals(request: Request) -> dict[str, Any]:
         if rec.get("state") != "reverted"
     }
     open_proposals = [p for p in proposals if p.get("signature") not in applied_sigs]
+    # #326: fold the relearn detector's OWN open clusters into the SAME
+    # headline rollup — same "not yet applied" filter as the cost proposals
+    # above, just against the relearn ledger (`applied_fixes.json`) instead
+    # of the cost-applied one, since the two ledgers track different apply
+    # paths (see `_revert_linked_cost_record`'s docstring on why they're
+    # separate).
+    relearn_applied_sigs = {
+        rec.get("signature") for rec in relearn_apply.list_applied(config)
+        if rec.get("state") != "reverted"
+    }
+    open_relearn_clusters = [
+        c for c in relearn_proposals.list_proposals(config)
+        if c.get("signature") not in relearn_applied_sigs
+    ]
     # The window this batch of proposals was actually computed over (#273) —
     # stored alongside them at recompute time, never re-derived here, so the
     # rollup's projection ratio matches the data that produced these figures.
@@ -479,7 +505,12 @@ def get_cost_proposals(request: Request) -> dict[str, Any]:
             rollup_kwargs["window_days"] = block["cost_window_days"]
         rollup_kwargs["active_days"] = block.get("cost_active_days") or 0
         rollup_kwargs["n_sessions"] = block.get("cost_n_sessions") or 0
-    rollup = cost_proposals_mod.estimated_recoverable_rollup(open_proposals, **rollup_kwargs)
+    rollup = cost_proposals_mod.estimated_recoverable_rollup(
+        open_proposals,
+        relearn_clusters=open_relearn_clusters,
+        excluded=(block.get("cost_excluded") if block else None),
+        **rollup_kwargs,
+    )
     # Same plan-tier framing the cost-applied payload carries, so a dollar
     # figure rendered here never disagrees with its sibling surfaces.
     framing = _framing(request)

--- a/tokenjam/core/optimize/cost_proposals.py
+++ b/tokenjam/core/optimize/cost_proposals.py
@@ -1926,6 +1926,46 @@ def is_computing_cost_proposals() -> bool:
     return _COST_COMPUTING.is_set()
 
 
+#: The Review inbox's cross-reference for waste this rollup deliberately does
+#: NOT sum as a peer card (issue #326) — currently only ``summarize``, whose
+#: own three reasons for staying out of ``COST_ANALYZERS`` live on that
+#: constant's docstring. This dict is what ties those two together: the
+#: reasons stay valid, but the CONSEQUENCE (its dollars invisible from the
+#: Review inbox entirely) is fixed by stating the total and linking to its
+#: own surface, exactly like a "N proposals hidden, see X" footnote.
+EXCLUDED_HREF_SUMMARIZE = "#/optimize/summarize"
+
+
+def _excluded_summarize_block(
+    report: Any, *, ratio: float | None,
+) -> dict[str, Any] | None:
+    """The ``summarize`` finding's own recoverable total, on the SAME 30-day
+    basis every other proposal here is projected onto (issue #326's "keep
+    the time bases identical" requirement) — ``None`` when the analyzer
+    didn't run or found nothing, so an empty/absent finding never renders a
+    fabricated "$0 available" line."""
+    finding = (getattr(report, "findings", None) or {}).get("summarize")
+    usd = getattr(finding, "estimated_recoverable_usd", None) if finding is not None else None
+    tokens = getattr(finding, "estimated_recoverable_tokens", None) if finding is not None else None
+    if usd is None and tokens is None:
+        return None
+    scale = _effective_ratio("per_session", ratio)
+    return {
+        "estimated_recoverable_usd": usd,
+        "estimated_recoverable_tokens": tokens,
+        "estimated_monthly_usd": round(usd * scale, 6) if usd is not None else None,
+        "estimated_monthly_tokens": round(tokens * scale) if tokens is not None else None,
+        "estimate_basis": str(getattr(finding, "estimate_basis", "") or ""),
+        "href": EXCLUDED_HREF_SUMMARIZE,
+        "label": "Summarize",
+        "reason": (
+            "has its own review surface (curate -> diff -> apply) this "
+            "single-card rollup can't represent; not summed in, but not "
+            "hidden either"
+        ),
+    }
+
+
 def recompute_cost_proposals(
     db: Any,
     config: Any,
@@ -2010,6 +2050,12 @@ def recompute_cost_proposals(
                 report, config=config, pricing_mode=pricing_mode,
                 window_days=float(effective_window_days),
             )
+            active_days = int(getattr(report.window, "active_days", 0) or 0)
+            n_sessions = int(getattr(report.window, "sessions", 0) or 0)
+            ratio, _label = compute_projection_ratio(
+                float(effective_window_days), active_days, n_sessions,
+            )
+            excluded_summarize = _excluded_summarize_block(report, ratio=ratio)
         except Exception as exc:
             try:
                 relearn_store.write_cost_proposals_error(str(exc), config=config)
@@ -2021,8 +2067,11 @@ def recompute_cost_proposals(
             relearn_store.write_cost_proposals(
                 proposals, config=config,
                 window_days=effective_window_days,
-                active_days=int(getattr(report.window, "active_days", 0) or 0),
-                n_sessions=int(getattr(report.window, "sessions", 0) or 0),
+                active_days=active_days,
+                n_sessions=n_sessions,
+                excluded=(
+                    {"summarize": excluded_summarize} if excluded_summarize else {}
+                ),
             )
             relearn_store.clear_cost_proposals_error(config=config)
         except Exception:
@@ -2451,6 +2500,8 @@ def estimated_recoverable_rollup(
     window_days: int = DEFAULT_COST_WINDOW_DAYS,
     active_days: int = 0,
     n_sessions: int = 0,
+    relearn_clusters: list[Any] | None = None,
+    excluded: dict[str, Any] | None = None,
 ) -> dict[str, Any]:
     """Sum ``estimated_recoverable_usd`` across ``proposals``, deduplicated by
     ``signature`` (a proposal's stable identity — see the ``CostProposal``
@@ -2491,6 +2542,33 @@ def estimated_recoverable_rollup(
     rather than a fabricated ratio.
 
     Tagged ``estimated`` — this is a heuristic figure, never a measured one.
+
+    ``relearn_clusters`` (issue #326) folds the relearn detector's proposals
+    into the SAME headline, on the same 30-day basis — the only basis relearn
+    has (it scans unbounded history, so it has no fixed window to report an
+    ``estimated_recoverable_usd`` against; see ``RelearnCluster``'s own
+    docstring). Deduplicated by ``signature`` exactly like a cost proposal.
+    Each cluster's ``estimated_monthly_usd``/``estimated_monthly_tokens`` is
+    ALREADY a 30-day-pace figure, so it is added straight into
+    ``projected_usd_30d``/``projected_tokens_30d`` with no further scaling —
+    and deliberately NEVER into ``estimated_recoverable_usd``/
+    ``estimated_recoverable_tokens``, which would silently mix a monthly
+    figure into a window-observed sum (the two analyzers are not on the same
+    time basis, and the window fields' contract is unchanged, per above).
+    ``relearn_monthly_usd``/``relearn_monthly_tokens`` carry relearn's own
+    contribution separately so a caller can render "cost advisories: $X + N
+    recurring fixes: $Y" without re-deriving the split from the combined
+    total.
+
+    ``excluded`` (issue #326) is a passthrough for waste this rollup
+    deliberately does NOT sum in — currently ``summarize``, which has its own
+    review surface (see ``COST_ANALYZERS``'s docstring for why) and would
+    double-count the write budget if folded in as a peer card. Never summed
+    into any total here; carried on the result unchanged so the Review inbox
+    can render "$X more available in Summarize -> review it" instead of
+    silently omitting the product's largest recoverable figure. ``None``
+    becomes ``{}`` — "nothing known to be excluded", not "excluded total is
+    zero".
     """
     seen: dict[str, dict[str, Any]] = {}
     for p in proposals:
@@ -2538,6 +2616,34 @@ def estimated_recoverable_rollup(
             "title": row.get("title"), "usd": round(usd, 6),
         })
 
+    # Fold the relearn detector's OWN 30-day-basis figures into the projected
+    # total (never into the window-observed one — see the docstring). Deduped
+    # by signature the same way cost proposals are, independently of them
+    # (relearn and cost-proposal signatures live in different namespaces, so
+    # there is no cross-set collision to guard against).
+    relearn_seen: dict[str, dict[str, Any]] = {}
+    for c in relearn_clusters or []:
+        row = asdict(c) if is_dataclass(c) and not isinstance(c, type) else dict(c)
+        sig = str(row.get("signature") or "")
+        if not sig or sig in relearn_seen:
+            continue
+        relearn_seen[sig] = row
+    relearn_monthly_usd = 0.0
+    relearn_monthly_tokens = 0
+    relearn_priced_count = 0
+    for row in relearn_seen.values():
+        toks = row.get("estimated_monthly_tokens")
+        if toks is not None:
+            relearn_monthly_tokens += int(toks)
+        usd = row.get("estimated_monthly_usd")
+        if usd is None:
+            continue
+        usd = float(usd)
+        relearn_monthly_usd += usd
+        relearn_priced_count += 1
+    projected_usd += relearn_monthly_usd
+    projected_tokens += relearn_monthly_tokens
+
     proposal_count = len(contributing)
     # Denominator for BOTH coverage claims: every open, deduplicated proposal,
     # including the ones carrying neither estimate. A renderer that says "across
@@ -2584,6 +2690,14 @@ def estimated_recoverable_rollup(
             f"days, >= {MIN_ACTIVE_DAYS_FOR_PROJECTION} active days, and "
             f">= {MIN_SESSIONS_FOR_PROJECTION} sessions)."
         )
+    if relearn_priced_count:
+        disclosure += (
+            f" Recurring-mistake fixes add ${round(relearn_monthly_usd, 2)}/mo "
+            f"across {relearn_priced_count} of {len(relearn_seen)} open, "
+            f"deduplicated cluster(s) (already a 30-day-pace figure — the "
+            f"detector scans unbounded history, so it has no window to "
+            f"observe a figure over); included in projected_usd_30d only."
+        )
 
     return {
         "estimated_recoverable_usd": round(total_usd, 6),
@@ -2598,6 +2712,11 @@ def estimated_recoverable_rollup(
         "projection_label": label,
         "projected_usd_30d": round(projected_usd, 6),
         "projected_tokens_30d": projected_tokens,
+        "relearn_monthly_usd": round(relearn_monthly_usd, 6),
+        "relearn_monthly_tokens": relearn_monthly_tokens,
+        "relearn_cluster_count": len(relearn_seen),
+        "relearn_priced_cluster_count": relearn_priced_count,
+        "excluded": excluded or {},
         "disclosure": disclosure,
         "by_analyzer": sorted(by_analyzer.values(), key=lambda x: x["analyzer"]),
         "contributing": contributing,

--- a/tokenjam/core/optimize/relearn_store.py
+++ b/tokenjam/core/optimize/relearn_store.py
@@ -111,17 +111,21 @@ def read_cost_proposals(
     install). Shape: ``{"cost_computed_at": iso, "cost_proposals": [dict,
     ...], "cost_proposals_error": str | None, "cost_proposals_error_at": iso |
     None, "cost_window_days": int, "cost_active_days": int,
-    "cost_n_sessions": int}``. ``cost_proposals_error`` is the last recompute
-    failure's message (behavioral requirement #5) — present alongside a GOOD
-    ``cost_proposals`` list when a later recompute failed after an earlier one
-    had already succeeded, so a transient failure never hides the last good
-    result. The three ``cost_*`` count fields (#273) are the window's
-    active-day pace at the moment of the LAST successful recompute — the
-    inputs ``cost_proposals.estimated_recoverable_rollup`` needs to compute
-    its shared 30-day projection ratio centrally; ``0`` for a cache written
-    before they existed (a caller passes them straight to
-    ``compute_projection_ratio``, whose guardrails treat ``0`` as "not enough
-    data", never as a fabricated ratio)."""
+    "cost_n_sessions": int, "cost_excluded": dict}``. ``cost_proposals_error``
+    is the last recompute failure's message (behavioral requirement #5) —
+    present alongside a GOOD ``cost_proposals`` list when a later recompute
+    failed after an earlier one had already succeeded, so a transient failure
+    never hides the last good result. The three ``cost_*`` count fields
+    (#273) are the window's active-day pace at the moment of the LAST
+    successful recompute — the inputs ``cost_proposals.
+    estimated_recoverable_rollup`` needs to compute its shared 30-day
+    projection ratio centrally; ``0`` for a cache written before they existed
+    (a caller passes them straight to ``compute_projection_ratio``, whose
+    guardrails treat ``0`` as "not enough data", never as a fabricated
+    ratio). ``cost_excluded`` (#326) is the rollup's cross-reference for
+    waste deliberately NOT summed into it (currently ``summarize`` —  see
+    ``cost_proposals._excluded_summarize_block``); ``{}`` for a cache written
+    before it existed."""
     raw = read_cache(path, config=config)
     if raw is None:
         return None
@@ -137,6 +141,7 @@ def read_cost_proposals(
         "cost_window_days": raw.get("cost_window_days") or 0,
         "cost_active_days": raw.get("cost_active_days") or 0,
         "cost_n_sessions": raw.get("cost_n_sessions") or 0,
+        "cost_excluded": raw.get("cost_excluded") or {},
     }
 
 
@@ -179,7 +184,7 @@ def clear_cost_proposals_error(
 def write_cost_proposals(
     proposals: list[Any], path: Path | None = None, *, config: TjConfig | None = None,
     window_days: int | None = None, active_days: int | None = None,
-    n_sessions: int | None = None,
+    n_sessions: int | None = None, excluded: dict[str, Any] | None = None,
 ) -> dict[str, Any]:
     """Write the cost proposals into the SAME cache file the relearn finding
     lives in, under a separate ``cost_proposals`` key, preserving the relearn
@@ -193,7 +198,13 @@ def write_cost_proposals(
     time, since the window that produced these proposals may not be the
     window a later reader assumes. ``None`` (the default) leaves any
     previously-stored value untouched, so a caller that doesn't track these
-    yet (a legacy call site) doesn't silently zero out a real prior value."""
+    yet (a legacy call site) doesn't silently zero out a real prior value.
+
+    ``excluded`` (#326) is the rollup's cross-reference block (currently
+    ``{"summarize": {...}}`` when the analyzer found something, else ``{}``)
+    — always written when this call succeeds (unlike the three window
+    fields above, this one has no "leave untouched" case: a fresh recompute
+    always knows the current excluded state, even if it's "nothing")."""
     from dataclasses import is_dataclass
 
     p = path or default_cache_path(config)
@@ -216,6 +227,7 @@ def write_cost_proposals(
         payload["cost_active_days"] = active_days
     if n_sessions is not None:
         payload["cost_n_sessions"] = n_sessions
+    payload["cost_excluded"] = excluded or {}
     _atomic_write(p, payload)
     return payload
 

--- a/tokenjam/ui/index.html
+++ b/tokenjam/ui/index.html
@@ -8466,7 +8466,27 @@ function CostProposalCard({ prop, busy, focused, onMark, onDismiss, onChanged, s
 // shows per row), never a live re-measurement of what happened afterward. A
 // bounded verify redesign is a separate, later product decision — see
 // c0316aba before building one.
-function InboxStatTiles({ openItems, appliedEstimates, appliedCount, lastAppliedAt, suppressed }) {
+// #326: `excluded` (from GET /relearn/cost-proposals's rollup.excluded) is
+// waste this page's own totals deliberately do NOT sum in — currently only
+// `summarize`, which keeps its own curate/diff review surface rather than a
+// peer card here (see COST_ANALYZERS's docstring server-side). Left unstated
+// it reads as "the biggest recoverable figure the product computes doesn't
+// exist"; this renders it as an explicit line with a link to where it lives,
+// never folded into the blue tile's own number (a different review flow, not
+// a peer figure to add).
+function ExcludedWasteNote({ excluded }) {
+  const entries = Object.values(excluded || {}).filter(e => e && (e.estimated_monthly_usd != null || e.estimated_recoverable_usd != null));
+  if (entries.length === 0) return null;
+  return html`
+    <div class="dim" style="font-size:12px;margin-top:6px">
+      ${entries.map(e => html`
+        + ${e.estimated_monthly_usd != null ? fmtUsd(e.estimated_monthly_usd) : fmtUsd(e.estimated_recoverable_usd)}/mo more in ${e.label || 'Summarize'} (its own review surface, not summed above) ·
+        <a class="sz-link" href=${e.href || '#/optimize/summarize'}>Review it →</a>
+      `)}
+    </div>`;
+}
+
+function InboxStatTiles({ openItems, appliedEstimates, appliedCount, lastAppliedAt, suppressed, excluded }) {
   // monthlyUsdForDisplay excludes resend/TRIM's structural (not-a-savings-
   // claim) dollar figure from this tile the same way estMonthlyLine does for
   // the individual rows. appliedEstimates needs no equivalent call here — its
@@ -8486,9 +8506,11 @@ function InboxStatTiles({ openItems, appliedEstimates, appliedCount, lastApplied
     : appliedTokSum > 0 ? '~' + fmtTokens(appliedTokSum) + ' tok'
     : String(appliedCount);
 
-  if (openItems.length === 0 && appliedCount === 0) return null;
+  const hasExcluded = Object.keys(excluded || {}).length > 0;
+  if (openItems.length === 0 && appliedCount === 0 && !hasExcluded) return null;
   return html`
-    <div style="display:flex;gap:14px;flex-wrap:wrap;margin:10px 0 18px">
+    <div style="margin:10px 0 18px">
+    <div style="display:flex;gap:14px;flex-wrap:wrap">
       ${openItems.length > 0 ? html`
         <div class="opt-section" style="flex:1;min-width:260px;padding:12px 14px;border:1px solid var(--border);border-radius:8px;border-color:rgba(var(--accent-rgb,120,120,255),0.35)">
           <div class="dim" style="font-size:11px;text-transform:uppercase;letter-spacing:.03em">Estimated recoverable <span class="dim" style="font-weight:400">/ mo</span></div>
@@ -8496,6 +8518,14 @@ function InboxStatTiles({ openItems, appliedEstimates, appliedCount, lastApplied
             ${leadWithUsd ? fmtUsd(totalUsd) : '~' + fmtTokens(totalToks) + ' tok'}
           </div>
           <div class="dim" style="font-size:12px;margin-top:2px">across ${openItems.length} open item${openItems.length === 1 ? '' : 's'} · review before applying</div>
+          <${ExcludedWasteNote} excluded=${excluded} />
+        </div>
+      ` : hasExcluded ? html`
+        <div class="opt-section" style="flex:1;min-width:260px;padding:12px 14px;border:1px solid var(--border);border-radius:8px;border-color:rgba(var(--accent-rgb,120,120,255),0.35)">
+          <div class="dim" style="font-size:11px;text-transform:uppercase;letter-spacing:.03em">Estimated recoverable <span class="dim" style="font-weight:400">/ mo</span></div>
+          <div style="font-size:24px;font-weight:600;color:var(--accent);margin-top:4px">—</div>
+          <div class="dim" style="font-size:12px;margin-top:2px">no open cost advisory or recurring-mistake fix right now</div>
+          <${ExcludedWasteNote} excluded=${excluded} />
         </div>
       ` : null}
       <div class="opt-section" style="flex:1;min-width:260px;padding:12px 14px;border:1px solid var(--border);border-radius:8px">
@@ -8514,6 +8544,7 @@ function InboxStatTiles({ openItems, appliedEstimates, appliedCount, lastApplied
           ? html`most recent ${daysAgoLabel(lastAppliedAt) || 'unknown'}`
           : html`across ${appliedCount} applied fix${appliedCount === 1 ? '' : 'es'} · estimated when applied`}</div>
       </div>
+    </div>
     </div>`;
 }
 
@@ -8541,6 +8572,7 @@ function ReviewInboxView({ params }) {
   const [costDegraded, setCostDegraded] = useState(false); // a recompute failed even though a good result still renders
   const [costLastError, setCostLastError] = useState(null);
   const [costFraming, setCostFraming] = useState(null);    // plan-tier framing for the cost-advisory dollars
+  const [costExcluded, setCostExcluded] = useState({});    // #326: waste NOT summed into the headline (e.g. summarize)
   const [costApplied, setCostApplied] = useState([]);      // marked-applied cost proposals
   const [marking, setMarking] = useState(null);            // signature currently being marked applied
 
@@ -8574,6 +8606,7 @@ function ReviewInboxView({ params }) {
       setCostDegraded(!!r.degraded);
       setCostLastError(r.last_error || null);
       setCostFraming(r.framing || null);
+      setCostExcluded((r.rollup && r.rollup.excluded) || {});
     } catch (e) { /* the relearn list is load-bearing; degrade quietly */ }
     try {
       const r = await api('/relearn/cost-applied');
@@ -8746,7 +8779,7 @@ function ReviewInboxView({ params }) {
     </div>
     <div class="sz-note">Waste you're paying for more than once: mistakes your agents keep repeating, and cost fixes ready to apply.</div>
 
-    <${InboxStatTiles} openItems=${openItems} appliedEstimates=${appliedEstimates} appliedCount=${appliedOpenCount} lastAppliedAt=${lastAppliedAt} suppressed=${suppressed} />
+    <${InboxStatTiles} openItems=${openItems} appliedEstimates=${appliedEstimates} appliedCount=${appliedOpenCount} lastAppliedAt=${lastAppliedAt} suppressed=${suppressed} excluded=${costExcluded} />
 
     <div class="tab-bar" role="tablist">
       <button class="tab ${tab === 'mistakes' ? 'active' : ''}" role="tab" aria-selected=${tab === 'mistakes'} onClick=${() => setTab('mistakes')}>Recurring mistakes (${visible.length})</button>


### PR DESCRIPTION
The Review inbox's "Estimated recoverable / mo" headline only summed the cost-analyzer proposals' own rollup. Two categories of real recoverable value never reached it.

## Summary
- `summarize` deliberately has no peer card in the rollup (it owns its own curate/diff review surface), but the consequence of that exclusion was never addressed: its dollar total was invisible from the inbox entirely, discoverable only by opening a different tab.
- relearn's clusters carry a monthly-basis dollar figure, but the server-side rollup had no path to fold them in at all — it only ever received cost-proposal rows.

## What changed
- `estimated_recoverable_rollup` (`core/optimize/cost_proposals.py`) now accepts relearn's open clusters and folds their `estimated_monthly_usd`/`estimated_monthly_tokens` into the rollup's 30-day projected total, alongside the cost proposals' own projection. This stays out of the window-observed total (`estimated_recoverable_usd`) since relearn's figure is already a 30-day extrapolation and the two aren't on the same time basis.
- The same function now accepts (and simply carries through, never sums) an `excluded` block — currently summarize's own recoverable total, computed once during the existing background recompute that already builds a summarize finding for the write-budget calculation.
- `GET /relearn/cost-proposals` wires both of these in: it now passes the relearn store's open clusters into the rollup call, and threads the persisted `excluded` block through to the response.
- The Review inbox headline renders the excluded total as an explicit line ("+$X/mo more in Summarize -> Review it") linking to the existing Summarize surface, instead of silently dropping the figure. It renders even when there are no other open items, since summarize can legitimately be the only recoverable figure in a given scan.

## Tests / Verification
- Added unit coverage in `tests/unit/test_cost_proposals.py` for the rollup's new `relearn_clusters`/`excluded` parameters: folding, dedup-by-signature, skipping unpriced clusters, and that nothing is summed into the window-observed field.
- Added unit coverage in `tests/unit/test_lens_ui_regression.py` for the new UI component and its wiring.
- Full suite: `pytest tests/unit/ tests/synthetic/ tests/agents/ tests/integration/` — 3672 passed, 2 skipped.
- `ruff check` / `mypy` clean on every touched file.
- Live-verified against a real local telemetry database booted from this branch: hit `GET /api/v1/relearn/cost-proposals` directly to confirm the `rollup.excluded.summarize` block populates with real numbers, then drove the actual Review inbox page in a browser and confirmed the "+$X/mo more in Summarize" line renders with a working link to the Summarize page, with no console errors.

## What's NOT in this PR
- relearn's own monthly-basis extrapolation (`_corpus_window_days`/`_monthly_scale`) still isn't on the same guardrailed, capped, active-day-pace basis the cost-proposal ratio uses — this PR carries that figure through as-is rather than re-deriving it, since fixing relearn's own extrapolation is a separate, larger change.
- `resend`'s `cost_of_waste_usd` (a backward-looking observation, not a forward-looking saving) is deliberately left untouched and out of every total here.

🤖 shipped by [shiploop](https://github.com/anshss/shiploop)