### PR TITLE
fix: stop hardcoding absolute dates in transcript-sync test fixtures

### DIFF
--- a/tests/unit/test_quickstart.py
+++ b/tests/unit/test_quickstart.py
@@ -8,6 +8,7 @@ a transient in-memory backend and must never call `open_db`).
 from __future__ import annotations
 
 import json
+from datetime import date, datetime, timedelta, timezone
 from pathlib import Path
 
 from click.testing import CliRunner
@@ -17,6 +18,33 @@ from tokenjam.core.session_timeline import (
     compute_session_timeline,
     timeline_to_dict,
 )
+
+_NOW = datetime.now(timezone.utc)
+
+
+def _date(month: int, day: int) -> str:
+    """A `YYYY-MM-DD` fixture date anchored to test-execution time, not a
+    hardcoded absolute literal.
+
+    Every fixture below represents "recent" Claude Code history filtered
+    through `--since 90d` (computed from real wall-clock `now()` inside the
+    CLI). A fixed literal is a time bomb: once wall time passes
+    `literal + 90d`, every assertion here starts failing with no code change
+    involved -- the same class of bug fixed in
+    `test_onboard_backfill_scope.py` and `test_transcript_sync.py`. The
+    `(month, day)` pair only encodes the ORIGINAL relative spacing between
+    fixture dates (e.g. `_date(6, 10)` is always ~20 days older than
+    `_date(6, 30)`, `_date(6, 28)` ~2 days older); the actual calendar date
+    floats with "now" so the gap to the `--since` cutoff never closes.
+    """
+    offset_days = (date(2026, 6, 30) - date(2026, month, day)).days
+    return (_NOW - timedelta(days=offset_days)).strftime("%Y-%m-%d")
+
+
+def _ts(month: int, day: int, time_of_day: str) -> str:
+    """Full `...Z` timestamp for `_date(month, day)` at a given time-of-day
+    (e.g. `"10:05:00.000"`)."""
+    return f"{_date(month, day)}T{time_of_day}Z"
 
 
 def _make_session_file(root: Path, session_id: str, cwd: str,
@@ -54,11 +82,11 @@ def _fixture_root(tmp_path: Path) -> Path:
     root = tmp_path / "projects"
     # Two sessions across two projects, recent timestamps.
     _make_session_file(root, "sess-a", "/Users/me/projA", [
-        _assistant("a1", "sess-a", "/Users/me/projA", "2026-06-20T10:00:00.000Z"),
-        _assistant("a2", "sess-a", "/Users/me/projA", "2026-06-20T10:05:00.000Z"),
+        _assistant("a1", "sess-a", "/Users/me/projA", _ts(6, 20, "10:00:00.000")),
+        _assistant("a2", "sess-a", "/Users/me/projA", _ts(6, 20, "10:05:00.000")),
     ])
     _make_session_file(root, "sess-b", "/Users/me/projB", [
-        _assistant("b1", "sess-b", "/Users/me/projB", "2026-06-21T11:00:00.000Z",
+        _assistant("b1", "sess-b", "/Users/me/projB", _ts(6, 21, "11:00:00.000"),
                    cache_read=50000),
     ])
     return root
@@ -214,7 +242,7 @@ def _heavy_reread_fixture_root(tmp_path: Path) -> Path:
     root = tmp_path / "projects"
     _make_session_file(root, "sess-heavy", "/Users/me/projHeavy", [
         _assistant("h1", "sess-heavy", "/Users/me/projHeavy",
-                   "2026-06-20T10:00:00.000Z",
+                   _ts(6, 20, "10:00:00.000"),
                    input_tokens=500, output_tokens=200, cache_read=300_000),
     ])
     return root
@@ -352,8 +380,8 @@ def _large_fixture_root(tmp_path: Path, n_sessions: int) -> Path:
         sid = f"sess-{i:05d}"
         cwd = f"/Users/me/proj{i % 5}"
         path = _make_session_file(root, sid, cwd, [
-            _assistant(f"{sid}-a", sid, cwd, "2026-06-20T10:00:00.000Z"),
-            _assistant(f"{sid}-b", sid, cwd, "2026-06-20T10:05:00.000Z"),
+            _assistant(f"{sid}-a", sid, cwd, _ts(6, 20, "10:00:00.000")),
+            _assistant(f"{sid}-b", sid, cwd, _ts(6, 20, "10:05:00.000")),
         ])
         # Newer index => newer mtime, so the cap keeps the highest indices.
         os.utime(path, (base_ts + i, base_ts + i))
@@ -509,12 +537,12 @@ def test_quickstart_preview_shows_most_recent_substantial_crossing_session(
     root = tmp_path / "projects"
     # Older, more turns, but NOT more recent -> must lose to the recent one.
     _session_with_crossing(
-        root, "sess-old", "/Users/me/projA", "2026-06-10",
+        root, "sess-old", "/Users/me/projA", _date(6, 10),
         n_turns=10, crossing_turn=2,
     )
     # Recent AND substantial (5 >= PREVIEW_MIN_TURNS=3) -> wins on recency.
     recent_path = _session_with_crossing(
-        root, "sess-recent", "/Users/me/projB", "2026-06-25",
+        root, "sess-recent", "/Users/me/projB", _date(6, 25),
         n_turns=5, crossing_turn=3,
     )
 
@@ -561,12 +589,12 @@ def test_quickstart_preview_stops_walking_after_first_substantial_candidate(
     # Most-recent session is ALREADY substantial + crossing -> must win
     # without inspecting any of the five older sessions below it.
     _session_with_crossing(
-        root, "sess-newest", "/Users/me/projZ", "2026-06-28",
+        root, "sess-newest", "/Users/me/projZ", _date(6, 28),
         n_turns=5, crossing_turn=2,
     )
     for i in range(5):
         _session_with_crossing(
-            root, f"sess-old-{i}", f"/Users/me/proj{i}", f"2026-06-{10 + i:02d}",
+            root, f"sess-old-{i}", f"/Users/me/proj{i}", _date(6, 10 + i),
             n_turns=5, crossing_turn=2,
         )
 
@@ -595,11 +623,11 @@ def test_quickstart_preview_falls_back_to_largest_when_none_substantial(
     monkeypatch.setattr(q, "PREVIEW_MIN_TURNS", 50)  # neither session qualifies
     root = tmp_path / "projects"
     _session_with_crossing(
-        root, "sess-recent", "/Users/me/projB", "2026-06-25",
+        root, "sess-recent", "/Users/me/projB", _date(6, 25),
         n_turns=5, crossing_turn=3,
     )
     _session_with_crossing(
-        root, "sess-old", "/Users/me/projA", "2026-06-10",
+        root, "sess-old", "/Users/me/projA", _date(6, 10),
         n_turns=8, crossing_turn=5,
     )
 
@@ -616,7 +644,7 @@ def test_quickstart_preview_omitted_when_no_session_crosses_threshold(tmp_path):
     # Healthy sessions: tiny cache reads relative to input/output, never near
     # the 70% nudge threshold.
     _make_session_file(root, "sess-a", "/Users/me/projA", [
-        _assistant("a1", "sess-a", "/Users/me/projA", "2026-06-20T10:00:00.000Z",
+        _assistant("a1", "sess-a", "/Users/me/projA", _ts(6, 20, "10:00:00.000"),
                    input_tokens=1000, output_tokens=200, cache_read=10),
     ])
 
@@ -645,7 +673,7 @@ def test_quickstart_session_story_teaser_appears_for_qualifying_session(
     monkeypatch.setattr(q, "PREVIEW_MIN_TURNS", 3)
     root = tmp_path / "projects"
     _session_with_crossing(
-        root, "sess-recent", "/Users/me/projB", "2026-06-25",
+        root, "sess-recent", "/Users/me/projB", _date(6, 25),
         n_turns=5, crossing_turn=3,
     )
 
@@ -664,7 +692,7 @@ def test_quickstart_session_story_teaser_omitted_when_no_preview_candidate(tmp_p
     Session Story teaser either (nothing to reuse the selection from)."""
     root = tmp_path / "projects"
     _make_session_file(root, "sess-a", "/Users/me/projA", [
-        _assistant("a1", "sess-a", "/Users/me/projA", "2026-06-20T10:00:00.000Z",
+        _assistant("a1", "sess-a", "/Users/me/projA", _ts(6, 20, "10:00:00.000"),
                    input_tokens=1000, output_tokens=200, cache_read=10),
     ])
 

--- a/tests/unit/test_transcript_sync.py
+++ b/tests/unit/test_transcript_sync.py
@@ -56,8 +56,19 @@ def _write_transcript(root: Path, project: str, filename: str,
     return path
 
 
+# The default "recent" timestamp is a time bomb if pinned to an absolute
+# literal: `run_catch_up`'s lookback window is computed from wall-clock
+# now(), so a fixed literal eventually falls outside any lookback window and
+# every test relying on the default starts failing with no code change
+# involved (see the `test_onboard_backfill_scope.py` fix for the same class
+# of bug). Anchor it relative to test-execution time instead.
+_DEFAULT_RECENT_TS = (
+    datetime.now(tz=timezone.utc) - timedelta(hours=2)
+).strftime("%Y-%m-%dT%H:%M:%S.000Z")
+
+
 def _write_session(root: Path, session_id: str, project: str = "-tmp-proj",
-                   ts: str = "2026-07-25T10:00:00.000Z",
+                   ts: str = _DEFAULT_RECENT_TS,
                    filename: str | None = None) -> Path:
     return _write_transcript(
         root, project, filename or session_id,


### PR DESCRIPTION
## Summary

CI on `main` was permanently red: `test_catch_up_ingests_the_missing_session_and_is_idempotent` in
`tests/unit/test_transcript_sync.py` failed deterministically with `assert first.sessions_new == 1`
-> `assert 0 == 1`.

Root cause: the file's `_write_session()` test helper defaulted its timestamp to a hardcoded absolute
literal (`2026-07-25T10:00:00.000Z`). The failing test runs `run_catch_up(..., lookback=timedelta(days=1))`,
which filters sessions whose content timestamp falls before `now() - 1 day`. Once real wall-clock time
passed 24 hours after that literal, the fixture session fell outside the lookback window and 0 sessions
were (correctly) ingested — a pure test-fixture time bomb, no production bug.

Production code (`tokenjam/core/backfill.py`) is unchanged.

## Fix

- `tests/unit/test_transcript_sync.py`: `_write_session()`'s default `ts` is now computed relative to
  test-execution time (`datetime.now(timezone.utc) - timedelta(hours=2)`), formatted in the same
  `...Z` shape the parser expects, instead of a fixed literal. Tests that deliberately assert
  window-exclusion behavior still pass an explicit `ts` and are unaffected.

## Sweep for the same bug class

Grepped the rest of `tests/` for hardcoded absolute date literals used as "recent" fixture timestamps
that could expire the same way (a prior commit already fixed one instance of this exact class in
`test_onboard_backfill_scope.py`).

**Fixed one more live instance:**
- `tests/unit/test_quickstart.py`: every fixture session timestamp was a hardcoded June 2026 literal,
  and all 30 tests in the file invoke `quickstart` with `--since 90d` — a real wall-clock-relative
  window. Once time passed `literal + 90 days`, these fixtures would start falling outside the window
  the same way. Added `_date()` / `_ts()` helpers that compute each fixture date relative to
  test-execution time while preserving the original relative ordering/spacing between fixtures (which
  several tests depend on for "most recent session wins" assertions).

**Deliberately left alone** (verified these are not wall-clock-dependent):
- `tests/unit/test_backfill.py` — its `--since` window tests monkeypatch `now()`/`utcnow()` to a fixed
  value, so they're immune to real time passing.
- `tests/unit/test_relearn.py`, `tests/unit/test_relearn_archive_and_cost.py` — the relearn analyzer
  scans unbounded on-disk history and derives its window from the data's own timestamp span, never
  from wall-clock `now()`; the literal timestamps there are inert for windowing purposes.
- `tests/unit/test_cmd_session_story.py` — its literal transcript timestamp is cosmetic display
  content, not used in any window/since filter (session selection uses `now()`-relative synthetic DB
  rows instead).
- `tests/unit/test_drift.py`, `tests/unit/test_cmd_policy.py` — literal timestamps are only
  round-tripped/rendered/asserted directly, never compared against a real `now()`.
- `tests/unit/test_export_route_generators.py` — the `until="2026-06-22"` value is opaque test data
  embedded verbatim into rendered output text, never compared to wall-clock time.
- Many other files (`test_ingest_otlp.py`, `test_ingest_langfuse.py`, `test_ingest_helicone.py`,
  `test_logs_converter.py`, `test_backfill_codex.py`, `test_optimize_clustering.py`,
  `test_optimize_reuse.py`, `test_mcp_server.py`, `test_sessionmap.py`, `test_transcript.py`,
  `test_method_capture.py`, `test_reuse_skeleton.py`, `test_contributor_label_guard.py`,
  `test_cost_proposals.py`, `integration/test_cli.py`'s since-flag parsing test) — their literal
  timestamps are compared only against other literals in the same test, never against a real, unmocked
  `now()`.

## Test plan

- [x] `pytest tests/unit/test_transcript_sync.py::test_catch_up_ingests_the_missing_session_and_is_idempotent -v` — passes
- [x] `pytest tests/unit/test_transcript_sync.py -v` — 14 passed
- [x] `pytest tests/unit/test_quickstart.py -v` — 30 passed
- [x] Full suite per CI (`pytest tests/unit/ tests/synthetic/ tests/agents/ tests/integration/`) — 3814 passed, 2 skipped
