### PR TITLE
Add tj upgrade: upgrade the package and restart the daemon

### DIFF
--- a/docs/installation.md
+++ b/docs/installation.md
@@ -108,17 +108,24 @@ See [`docs/optimize/trim.md`](optimize/trim.md) for performance numbers, capture
 ## Upgrading
 
 ```bash
-pipx upgrade tokenjam          # if you installed via pipx (recommended)
-pip install --upgrade tokenjam # if you're in a pip + venv setup
+tj upgrade
 ```
 
-After upgrading:
+`tj upgrade` detects how `tj` is installed (pipx / `uv tool` / pip+venv), runs the matching upgrade command, and — only once that succeeds — restarts the `tj serve` daemon (`launchctl kickstart` if launchd supervises it, otherwise `tj stop` + relaunch) so it actually reflects the new version, instead of quietly continuing to serve the old one from process memory. It then polls `/api/v1/version` to confirm the restart landed before printing success.
 
-1. Restart the daemon to pick up the new code: `tj stop && tj serve &`
-2. DB migrations apply automatically on the next `tj` invocation; no manual step required
-3. Verify with `tj --version`
+If you installed via an ephemeral runner (`uvx`/`npx tokenjam`) or a read-only system Python, `tj upgrade` refuses to attempt an in-place upgrade and tells you what to run instead — install persistently first (`uv tool install tokenjam` or `pipx install tokenjam`).
 
-PyPI's CDN occasionally lags ~1–2 min after a release. If `pipx upgrade` reports "already at the latest version" but the reported `tj --version` is older than what's on the [releases page](https://github.com/Metabuilder-Labs/tokenjam/releases), wait a minute and retry.
+Manual equivalent, if you'd rather do it yourself:
+
+```bash
+pipx upgrade tokenjam          # if you installed via pipx (recommended)
+pip install --upgrade tokenjam # if you're in a pip + venv setup
+tj stop && tj serve &          # restart the daemon to pick up the new code
+```
+
+DB migrations apply automatically on the next `tj` invocation either way; no manual step required.
+
+PyPI's CDN occasionally lags ~1–2 min after a release. If the upgrade reports "already at the latest version" but the reported `tj --version` is older than what's on the [releases page](https://github.com/Metabuilder-Labs/tokenjam/releases), wait a minute and retry.
 
 ## TypeScript SDK
 

--- a/tests/unit/test_cmd_upgrade.py
+++ b/tests/unit/test_cmd_upgrade.py
@@ -1,0 +1,318 @@
+"""Unit tests for `tj upgrade` (cmd_upgrade.py).
+
+Covers: install-manager detection per install layout, the ephemeral/
+unmanaged refusal, the daemon-not-restarted-on-failed-install guard, the
+launchd-vs-stop/serve restart branch, the no-daemon-running case, and the
+post-restart version verification (success + failing-loudly-on-timeout).
+
+Everything here mocks subprocess/launchctl/HTTP -- nothing in this file may
+upgrade a real package, shell out to launchctl for real, or touch a real
+daemon.
+"""
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+from click.testing import CliRunner
+
+from tokenjam.cli import cmd_upgrade as upgrade_mod
+from tokenjam.core.server_state import ServerState
+
+
+# -- detect_upgrade_plan(): install-manager detection per layout
+
+
+class TestDetectUpgradePlan:
+    def test_pipx_install_produces_pipx_upgrade_plan(self):
+        with patch.object(upgrade_mod, "_is_ephemeral_runner", return_value=False), \
+             patch.object(upgrade_mod, "_installed_via_pipx", return_value=True), \
+             patch.object(upgrade_mod, "_installed_via_uv_tool", return_value=False):
+            plan = upgrade_mod.detect_upgrade_plan()
+        assert plan is not None
+        assert plan.manager == "pipx"
+        assert plan.argv == ["pipx", "upgrade", "tokenjam"]
+
+    def test_uv_tool_install_produces_uv_tool_upgrade_plan(self):
+        with patch.object(upgrade_mod, "_is_ephemeral_runner", return_value=False), \
+             patch.object(upgrade_mod, "_installed_via_pipx", return_value=False), \
+             patch.object(upgrade_mod, "_installed_via_uv_tool", return_value=True):
+            plan = upgrade_mod.detect_upgrade_plan()
+        assert plan is not None
+        assert plan.manager == "uv-tool"
+        assert plan.argv == ["uv", "tool", "upgrade", "tokenjam"]
+
+    def test_plain_writable_pip_install_produces_pip_upgrade_plan(self):
+        with patch.object(upgrade_mod, "_is_ephemeral_runner", return_value=False), \
+             patch.object(upgrade_mod, "_installed_via_pipx", return_value=False), \
+             patch.object(upgrade_mod, "_installed_via_uv_tool", return_value=False), \
+             patch.object(upgrade_mod, "_pip_target_writable", return_value=True):
+            plan = upgrade_mod.detect_upgrade_plan()
+        assert plan is not None
+        assert plan.manager == "pip"
+        assert plan.argv[-3:] == ["install", "--upgrade", "tokenjam"]
+
+    def test_ephemeral_runner_refuses_to_upgrade(self):
+        with patch.object(upgrade_mod, "_is_ephemeral_runner", return_value=True):
+            plan = upgrade_mod.detect_upgrade_plan()
+        assert plan is None
+
+    def test_unwritable_pip_target_refuses_to_upgrade(self):
+        """A system/read-only Python: never attempted, so it can't be left
+        half-upgraded."""
+        with patch.object(upgrade_mod, "_is_ephemeral_runner", return_value=False), \
+             patch.object(upgrade_mod, "_installed_via_pipx", return_value=False), \
+             patch.object(upgrade_mod, "_installed_via_uv_tool", return_value=False), \
+             patch.object(upgrade_mod, "_pip_target_writable", return_value=False):
+            plan = upgrade_mod.detect_upgrade_plan()
+        assert plan is None
+
+
+class TestCmdUpgradeRefusesEphemeralInstall(object):
+    def test_cli_exits_nonzero_and_never_touches_daemon(self):
+        restart_mock = MagicMock()
+        with patch.object(upgrade_mod, "detect_upgrade_plan", return_value=None), \
+             patch.object(upgrade_mod, "restart_daemon", restart_mock):
+            result = CliRunner().invoke(upgrade_mod.cmd_upgrade, [], obj={})
+        assert result.exit_code != 0
+        assert "ephemeral" in result.output.lower() or "unmanaged" in result.output.lower()
+        restart_mock.assert_not_called()
+
+
+# -- daemon NOT restarted when install fails
+
+
+class TestDaemonNotRestartedOnFailedInstall:
+    def test_run_package_upgrade_reports_failure_on_nonzero_exit(self):
+        plan = upgrade_mod.UpgradePlan(
+            manager="pipx", argv=["pipx", "upgrade", "tokenjam"], display="pipx upgrade tokenjam",
+        )
+        fake = MagicMock(returncode=1, stdout="", stderr="not installed")
+        with patch.object(upgrade_mod.subprocess, "run", return_value=fake):
+            success, detail = upgrade_mod.run_package_upgrade(plan)
+        assert success is False
+        assert "not installed" in detail
+
+    def test_cli_exits_nonzero_and_skips_restart_when_install_fails(self):
+        plan = upgrade_mod.UpgradePlan(
+            manager="pipx", argv=["pipx", "upgrade", "tokenjam"], display="pipx upgrade tokenjam",
+        )
+        restart_mock = MagicMock()
+        with patch.object(upgrade_mod, "detect_upgrade_plan", return_value=plan), \
+             patch.object(upgrade_mod, "run_package_upgrade", return_value=(False, "boom")), \
+             patch.object(upgrade_mod, "restart_daemon", restart_mock):
+            result = CliRunner().invoke(upgrade_mod.cmd_upgrade, [], obj={})
+        assert result.exit_code != 0
+        assert "Upgrade failed" in result.output
+        restart_mock.assert_not_called()
+
+
+# -- restart_daemon(): launchd path vs stop/serve fallback vs no-daemon-running
+
+
+class TestRestartDaemon:
+    def test_no_daemon_running_is_a_noop_not_a_failure(self):
+        method, success, detail = upgrade_mod.restart_daemon(None)
+        assert method == "none"
+        assert success is True
+
+    def test_no_daemon_running_when_pid_dead(self):
+        state = ServerState(pid=99999, port=7391, config_path=None)
+        with patch.object(upgrade_mod, "is_pid_alive", return_value=False):
+            method, success, detail = upgrade_mod.restart_daemon(state)
+        assert method == "none"
+        assert success is True
+
+    def test_no_daemon_running_when_pid_alive_but_not_a_serve_process(self):
+        state = ServerState(pid=123, port=7391, config_path=None)
+        with patch.object(upgrade_mod, "is_pid_alive", return_value=True), \
+             patch.object(upgrade_mod, "is_serve_process", return_value=False):
+            method, success, detail = upgrade_mod.restart_daemon(state)
+        assert method == "none"
+        assert success is True
+
+    def test_uses_launchd_kickstart_when_launchd_supervises_it(self):
+        state = ServerState(pid=123, port=7391, config_path=None)
+        run_mock = MagicMock(return_value=MagicMock(returncode=0, stdout="", stderr=""))
+        with patch.object(upgrade_mod, "is_pid_alive", return_value=True), \
+             patch.object(upgrade_mod, "is_serve_process", return_value=True), \
+             patch.object(upgrade_mod, "_launchd_loaded", return_value=True), \
+             patch.object(upgrade_mod.subprocess, "run", run_mock), \
+             patch.object(upgrade_mod.os, "getuid", return_value=501, create=True):
+            method, success, detail = upgrade_mod.restart_daemon(state)
+        assert method == "launchd"
+        assert success is True
+        called_argv = run_mock.call_args.args[0]
+        assert called_argv[:2] == ["launchctl", "kickstart"]
+        assert "-k" in called_argv
+        assert any("com.tokenjam.serve" in arg for arg in called_argv)
+
+    def test_launchd_kickstart_failure_is_reported_not_swallowed(self):
+        state = ServerState(pid=123, port=7391, config_path=None)
+        run_mock = MagicMock(return_value=MagicMock(returncode=1, stdout="", stderr="no such target"))
+        with patch.object(upgrade_mod, "is_pid_alive", return_value=True), \
+             patch.object(upgrade_mod, "is_serve_process", return_value=True), \
+             patch.object(upgrade_mod, "_launchd_loaded", return_value=True), \
+             patch.object(upgrade_mod.subprocess, "run", run_mock), \
+             patch.object(upgrade_mod.os, "getuid", return_value=501, create=True):
+            method, success, detail = upgrade_mod.restart_daemon(state)
+        assert method == "launchd"
+        assert success is False
+        assert "no such target" in detail
+
+    def test_falls_back_to_stop_serve_when_launchd_not_loaded(self):
+        state = ServerState(pid=123, port=7391, config_path=None)
+        fallback_mock = MagicMock(return_value=(True, "restarted via tj serve"))
+        with patch.object(upgrade_mod, "is_pid_alive", return_value=True), \
+             patch.object(upgrade_mod, "is_serve_process", return_value=True), \
+             patch.object(upgrade_mod, "_launchd_loaded", return_value=False), \
+             patch.object(upgrade_mod, "_restart_via_stop_serve", fallback_mock):
+            method, success, detail = upgrade_mod.restart_daemon(state)
+        assert method == "stop-serve"
+        assert success is True
+        fallback_mock.assert_called_once()
+
+    def test_stop_serve_fallback_stops_then_relaunches_via_resolved_binary(self, tmp_path, monkeypatch):
+        monkeypatch.setattr(upgrade_mod.Path, "home", lambda: tmp_path)
+        stop_mock = MagicMock(return_value=(True, ["PID 123"]))
+        popen_mock = MagicMock()
+        with patch.object(upgrade_mod, "stop_tj_serve", stop_mock), \
+             patch("tokenjam.cli.cmd_onboard._resolve_tj_binary", return_value="/usr/local/bin/tj"), \
+             patch.object(upgrade_mod.subprocess, "Popen", popen_mock):
+            success, detail = upgrade_mod._restart_via_stop_serve()
+        assert success is True
+        stop_mock.assert_called_once_with(quiet=True)
+        popen_args = popen_mock.call_args.args[0]
+        assert popen_args == ["/usr/local/bin/tj", "serve"]
+        assert popen_mock.call_args.kwargs.get("start_new_session") is True
+
+
+# -- post-restart version verification
+
+
+class TestPollDaemonVersion:
+    def test_verifies_once_new_version_appears(self):
+        fetch_mock = MagicMock(side_effect=["0.6.0", "0.6.0", "0.6.1"])
+        sleep_mock = MagicMock()
+        monotonic_mock = MagicMock(side_effect=[0.0, 0.1, 0.2, 0.3])
+        verified, seen = upgrade_mod.poll_daemon_version(
+            7391, "0.6.1", timeout_s=5.0, interval_s=0.1,
+            sleep=sleep_mock, monotonic=monotonic_mock, fetch=fetch_mock,
+        )
+        assert verified is True
+        assert seen == "0.6.1"
+        assert sleep_mock.call_count == 2
+
+    def test_fails_loudly_when_daemon_never_reports_new_version(self):
+        """Regression guard: must never claim success for a daemon still
+        stuck on the old version."""
+        fetch_mock = MagicMock(return_value="0.6.0")
+        monotonic_mock = MagicMock(side_effect=[0.0, 10.0])
+        verified, seen = upgrade_mod.poll_daemon_version(
+            7391, "0.6.1", timeout_s=1.0, interval_s=0.1,
+            sleep=MagicMock(), monotonic=monotonic_mock, fetch=fetch_mock,
+        )
+        assert verified is False
+        assert seen == "0.6.0"
+
+    def test_fetch_daemon_version_returns_none_on_connection_failure(self):
+        import urllib.error
+
+        with patch.object(
+            upgrade_mod.urllib.request, "urlopen",
+            side_effect=urllib.error.URLError("connection refused"),
+        ):
+            assert upgrade_mod.fetch_daemon_version(7391) is None
+
+
+# -- full CLI success + failure paths
+
+
+class TestCmdUpgradeEndToEnd:
+    def test_success_path_reports_verified_version(self):
+        plan = upgrade_mod.UpgradePlan(
+            manager="uv-tool", argv=["uv", "tool", "upgrade", "tokenjam"],
+            display="uv tool upgrade tokenjam",
+        )
+        state = ServerState(pid=123, port=7391, config_path=None)
+        with patch.object(upgrade_mod, "detect_upgrade_plan", return_value=plan), \
+             patch.object(upgrade_mod, "run_package_upgrade", return_value=(True, "ok")), \
+             patch.object(upgrade_mod, "detect_new_version", return_value="0.6.1"), \
+             patch.object(upgrade_mod, "read_server_state", return_value=state), \
+             patch.object(upgrade_mod, "restart_daemon", return_value=("launchd", True, "restarted")), \
+             patch.object(upgrade_mod, "poll_daemon_version", return_value=(True, "0.6.1")):
+            result = CliRunner().invoke(upgrade_mod.cmd_upgrade, [], obj={})
+        assert result.exit_code == 0, result.output
+        assert "verified running 0.6.1" in result.output
+
+    def test_no_daemon_running_exits_zero(self):
+        plan = upgrade_mod.UpgradePlan(
+            manager="pipx", argv=["pipx", "upgrade", "tokenjam"], display="pipx upgrade tokenjam",
+        )
+        with patch.object(upgrade_mod, "detect_upgrade_plan", return_value=plan), \
+             patch.object(upgrade_mod, "run_package_upgrade", return_value=(True, "ok")), \
+             patch.object(upgrade_mod, "detect_new_version", return_value="0.6.1"), \
+             patch.object(upgrade_mod, "read_server_state", return_value=None), \
+             patch.object(upgrade_mod, "restart_daemon", return_value=("none", True, "no daemon running")):
+            result = CliRunner().invoke(upgrade_mod.cmd_upgrade, [], obj={})
+        assert result.exit_code == 0, result.output
+        assert "not running" in result.output.lower()
+
+    def test_restart_failure_exits_nonzero(self):
+        plan = upgrade_mod.UpgradePlan(
+            manager="pipx", argv=["pipx", "upgrade", "tokenjam"], display="pipx upgrade tokenjam",
+        )
+        state = ServerState(pid=123, port=7391, config_path=None)
+        with patch.object(upgrade_mod, "detect_upgrade_plan", return_value=plan), \
+             patch.object(upgrade_mod, "run_package_upgrade", return_value=(True, "ok")), \
+             patch.object(upgrade_mod, "detect_new_version", return_value="0.6.1"), \
+             patch.object(upgrade_mod, "read_server_state", return_value=state), \
+             patch.object(upgrade_mod, "restart_daemon", return_value=("launchd", False, "kickstart failed")):
+            result = CliRunner().invoke(upgrade_mod.cmd_upgrade, [], obj={})
+        assert result.exit_code != 0
+        assert "Daemon restart failed" in result.output
+
+    def test_verification_timeout_exits_nonzero_and_does_not_claim_success(self):
+        plan = upgrade_mod.UpgradePlan(
+            manager="pipx", argv=["pipx", "upgrade", "tokenjam"], display="pipx upgrade tokenjam",
+        )
+        state = ServerState(pid=123, port=7391, config_path=None)
+        with patch.object(upgrade_mod, "detect_upgrade_plan", return_value=plan), \
+             patch.object(upgrade_mod, "run_package_upgrade", return_value=(True, "ok")), \
+             patch.object(upgrade_mod, "detect_new_version", return_value="0.6.1"), \
+             patch.object(upgrade_mod, "read_server_state", return_value=state), \
+             patch.object(upgrade_mod, "restart_daemon", return_value=("stop-serve", True, "restarted")), \
+             patch.object(upgrade_mod, "poll_daemon_version", return_value=(False, "0.6.0")):
+            result = CliRunner().invoke(upgrade_mod.cmd_upgrade, [], obj={})
+        assert result.exit_code != 0
+        assert "still reports 0.6.0" in result.output
+        assert "verified running" not in result.output
+
+
+# -- _pip_target_writable()
+
+
+class TestPipTargetWritable:
+    def test_true_when_purelib_dir_is_writable(self, tmp_path):
+        purelib = tmp_path / "site-packages"
+        purelib.mkdir()
+        with patch("sysconfig.get_paths", return_value={"purelib": str(purelib)}):
+            assert upgrade_mod._pip_target_writable() is True
+
+    def test_false_when_purelib_dir_is_unwritable(self, tmp_path):
+        purelib = tmp_path / "site-packages"
+        purelib.mkdir()
+        purelib.chmod(0o555)
+        try:
+            with patch("sysconfig.get_paths", return_value={"purelib": str(purelib)}):
+                assert upgrade_mod._pip_target_writable() is False
+        finally:
+            purelib.chmod(0o755)
+
+    def test_false_when_sysconfig_raises(self):
+        with patch("sysconfig.get_paths", side_effect=Exception("boom")):
+            assert upgrade_mod._pip_target_writable() is False
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])

--- a/tokenjam/cli/cmd_upgrade.py
+++ b/tokenjam/cli/cmd_upgrade.py
@@ -1,0 +1,368 @@
+"""`tj upgrade`: upgrade the installed tokenjam package AND restart the
+`tj serve` daemon so it actually reflects the new version.
+
+Why this exists: `tokenjam/__init__.py` resolves `__version__` once at
+import time. `tj serve` is a long-lived process (often supervised by
+launchd/systemd), so a package upgrade done outside `tj` (`pipx upgrade
+tokenjam`, `uv tool upgrade tokenjam`, ...) leaves the RUNNING daemon
+serving the OLD version out of process memory until something restarts it.
+Before this command, nothing did that automatically -- the only guidance was
+a manual `tj stop && tj serve &` in the CLI epilog and docs/installation.md.
+
+Three phases, each gated on the previous succeeding:
+1. Detect how THIS running `tj` is installed and upgrade it in place.
+   Ephemeral/unmanaged installs (uvx/npx/pipx-run cache, or a read-only
+   Python) are refused up front -- never half-upgraded.
+2. Only on a SUCCESSFUL install, restart the daemon: `launchctl kickstart`
+   when launchd supervises it, otherwise reuse `stop_tj_serve()` +
+   relaunch `tj serve` in the background. No daemon running is a no-op,
+   not a failure.
+3. Poll `/api/v1/version` on the daemon's own port until it reports the
+   newly installed version, or fail loudly on timeout -- never claim
+   success without observing it.
+"""
+from __future__ import annotations
+
+import importlib
+import importlib.metadata
+import json
+import os
+import subprocess
+import sys
+import time
+import urllib.error
+import urllib.request
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Callable
+
+import click
+
+from tokenjam import __version__
+from tokenjam.cli.cmd_stop import stop_tj_serve
+from tokenjam.cli.cmd_uninstall import (
+    _installed_via_pipx,
+    _installed_via_uv_tool,
+    _is_ephemeral_runner,
+)
+from tokenjam.core.server_state import (
+    ServerState,
+    is_pid_alive,
+    is_serve_process,
+    read_server_state,
+)
+from tokenjam.utils.formatting import console
+
+_LAUNCHD_LABEL = "com.tokenjam.serve"
+
+# How long to poll the daemon's /api/v1/version for the new version to show
+# up after a restart. Generous enough to cover a cold uvicorn boot (imports,
+# scheduler start, DB open) without hanging the CLI on a genuine failure.
+_VERSION_POLL_TIMEOUT_S = 15.0
+_VERSION_POLL_INTERVAL_S = 0.5
+_VERSION_HTTP_TIMEOUT_S = 2.0
+
+
+@dataclass(frozen=True)
+class UpgradePlan:
+    """How to upgrade the persistent install THIS `tj` process is running
+    from. `argv` is always safe to run non-interactively -- unmanaged/
+    ephemeral installs never produce a plan (see `detect_upgrade_plan`)."""
+
+    manager: str  # "pipx" | "uv-tool" | "pip"
+    argv: list[str]
+    display: str
+
+
+def _pip_target_writable() -> bool:
+    """Best-effort check that this interpreter's site-packages dir is
+    writable, so a system-managed/read-only Python is refused UP FRONT
+    rather than attempted and left in a half-upgraded state on failure.
+
+    Walks up to the nearest existing ancestor directory since the exact
+    package dir may not exist yet, but its writability is what determines
+    whether `pip install --upgrade` can actually write there.
+    """
+    try:
+        import sysconfig
+
+        purelib = sysconfig.get_paths().get("purelib")
+    except Exception:
+        return False
+    if not purelib:
+        return False
+    target = Path(purelib)
+    while not target.exists():
+        parent = target.parent
+        if parent == target:
+            return False
+        target = parent
+    return os.access(target, os.W_OK)
+
+
+def detect_upgrade_plan() -> UpgradePlan | None:
+    """Return the upgrade plan for how THIS running `tj` is installed, or
+    None when it must NOT be auto-upgraded in place (ephemeral uvx/npx/
+    pipx-run runner, or an unwritable pip target).
+
+    Derived from `sys.executable` / the resolved install path -- the same
+    detection `tj uninstall` already uses (`cmd_uninstall._installed_via_*`)
+    -- rather than probing the whole machine, since upgrade targets THIS
+    process's own install, not every install that happens to exist.
+    """
+    if _is_ephemeral_runner():
+        return None
+    if _installed_via_pipx():
+        return UpgradePlan(
+            manager="pipx",
+            argv=["pipx", "upgrade", "tokenjam"],
+            display="pipx upgrade tokenjam",
+        )
+    if _installed_via_uv_tool():
+        return UpgradePlan(
+            manager="uv-tool",
+            argv=["uv", "tool", "upgrade", "tokenjam"],
+            display="uv tool upgrade tokenjam",
+        )
+    if not _pip_target_writable():
+        return None
+    return UpgradePlan(
+        manager="pip",
+        argv=[sys.executable, "-m", "pip", "install", "--upgrade", "tokenjam"],
+        display="pip install --upgrade tokenjam",
+    )
+
+
+def _print_refusal() -> None:
+    console.print(
+        "[yellow]tj is running from an ephemeral or unmanaged install "
+        "(uvx / npx / pipx run, or a read-only Python) -- there is no "
+        "persistent install here to upgrade in place.[/yellow]"
+    )
+    console.print("  Install tokenjam persistently first, then re-run `tj upgrade`:")
+    console.print("    [bold]uv tool install tokenjam[/bold]  (or)")
+    console.print("    [bold]pipx install tokenjam[/bold]")
+
+
+def run_package_upgrade(plan: UpgradePlan) -> tuple[bool, str]:
+    """Run the upgrade command. Never raises -- a subprocess failure to even
+    launch (missing binary, etc.) is reported the same way as a non-zero
+    exit."""
+    console.print(f"Running: [bold]{plan.display}[/bold]")
+    try:
+        result = subprocess.run(
+            plan.argv, capture_output=True, text=True, timeout=300,
+        )
+    except (OSError, subprocess.TimeoutExpired) as exc:
+        return False, str(exc)
+    if result.returncode != 0:
+        detail = result.stderr.strip() or result.stdout.strip() or f"exit {result.returncode}"
+        return False, detail
+    return True, (result.stdout.strip() or result.stderr.strip())
+
+
+def detect_new_version() -> str | None:
+    """Best-effort re-read of the installed `tokenjam` version straight from
+    disk, after a package upgrade completed in this same process. Distinct
+    from the process-level `tokenjam.__version__`, which was resolved once
+    at import time and stays pinned to the OLD version for the lifetime of
+    this process.
+    """
+    importlib.invalidate_caches()
+    try:
+        return importlib.metadata.version("tokenjam")
+    except importlib.metadata.PackageNotFoundError:
+        return None
+
+
+def _launchd_loaded() -> bool:
+    try:
+        result = subprocess.run(
+            ["launchctl", "list", _LAUNCHD_LABEL],
+            capture_output=True, text=True,
+        )
+    except OSError:
+        return False
+    return result.returncode == 0
+
+
+def _restart_via_launchd() -> tuple[bool, str]:
+    """`launchctl kickstart -k` restarts an already-loaded job in place --
+    verified live to actually pick up the new binary/version, unlike
+    `unload`/`load`, which can race a Disabled flag left over from `tj stop`
+    (see cmd_stop.py's `_launchd_label_loaded` note)."""
+    uid = os.getuid()
+    target = f"gui/{uid}/{_LAUNCHD_LABEL}"
+    try:
+        result = subprocess.run(
+            ["launchctl", "kickstart", "-k", target],
+            capture_output=True, text=True,
+        )
+    except OSError as exc:
+        return False, str(exc)
+    if result.returncode != 0:
+        detail = result.stderr.strip() or result.stdout.strip() or f"exit {result.returncode}"
+        return False, detail
+    return True, f"restarted via `launchctl kickstart -k {target}`"
+
+
+def _restart_via_stop_serve() -> tuple[bool, str]:
+    """Fallback for installs not supervised by launchd: reuse `stop_tj_serve`
+    (cmd_stop.py) to stop the current daemon, then relaunch `tj serve` as a
+    detached background process -- deliberately NOT re-implementing either
+    command's own logic."""
+    from tokenjam.cli.cmd_onboard import _resolve_tj_binary
+
+    stop_tj_serve(quiet=True)
+
+    tj_bin = _resolve_tj_binary()
+    log_dir = Path.home() / ".local" / "share" / "tj"
+    try:
+        log_dir.mkdir(parents=True, exist_ok=True)
+        out_f = open(log_dir / "serve-restart.out", "ab")
+        err_f = open(log_dir / "serve-restart.err", "ab")
+    except OSError as exc:
+        return False, str(exc)
+    try:
+        subprocess.Popen(
+            [tj_bin, "serve"],
+            stdout=out_f, stderr=err_f, stdin=subprocess.DEVNULL,
+            start_new_session=True,
+        )
+    except OSError as exc:
+        return False, str(exc)
+    finally:
+        out_f.close()
+        err_f.close()
+    return True, f"restarted via `{tj_bin} serve` in the background"
+
+
+def restart_daemon(state: ServerState | None) -> tuple[str, bool, str]:
+    """Restart the daemon described by `state` (the server.state read BEFORE
+    the upgrade ran). Returns (method, success, detail):
+    - method="none": no daemon was running -- nothing to restart, not a
+      failure.
+    - method="launchd": restarted via `launchctl kickstart`.
+    - method="stop-serve": restarted via the stop + relaunch fallback.
+    """
+    daemon_running = (
+        state is not None
+        and is_pid_alive(state.pid)
+        and is_serve_process(state.pid)
+    )
+    if not daemon_running:
+        return "none", True, "no daemon running -- nothing to restart"
+
+    if _launchd_loaded():
+        success, detail = _restart_via_launchd()
+        return "launchd", success, detail
+
+    success, detail = _restart_via_stop_serve()
+    return "stop-serve", success, detail
+
+
+def fetch_daemon_version(port: int) -> str | None:
+    try:
+        with urllib.request.urlopen(
+            f"http://127.0.0.1:{port}/api/v1/version", timeout=_VERSION_HTTP_TIMEOUT_S,
+        ) as resp:
+            data = json.loads(resp.read().decode())
+    except (urllib.error.URLError, OSError, ValueError):
+        return None
+    return data.get("version")
+
+
+def poll_daemon_version(
+    port: int,
+    expected_version: str,
+    *,
+    timeout_s: float = _VERSION_POLL_TIMEOUT_S,
+    interval_s: float = _VERSION_POLL_INTERVAL_S,
+    sleep: Callable[[float], None] = time.sleep,
+    monotonic: Callable[[], float] = time.monotonic,
+    fetch: Callable[[int], str | None] | None = None,
+) -> tuple[bool, str | None]:
+    """Poll until the daemon reports `expected_version` or `timeout_s`
+    elapses. Returns (verified, last_seen_version). `sleep`/`monotonic`/
+    `fetch` are injectable so tests never wait real time or hit a real
+    daemon."""
+    fetch = fetch or fetch_daemon_version
+    start = monotonic()
+    seen: str | None = None
+    while True:
+        seen = fetch(port)
+        if seen == expected_version:
+            return True, seen
+        if monotonic() - start >= timeout_s:
+            return False, seen
+        sleep(interval_s)
+
+
+@click.command("upgrade")
+@click.pass_context
+def cmd_upgrade(ctx: click.Context) -> None:
+    """Upgrade the tokenjam package and restart the daemon so the dashboard
+    actually reflects the new version."""
+    old_version = __version__
+
+    plan = detect_upgrade_plan()
+    if plan is None:
+        _print_refusal()
+        raise SystemExit(1)
+
+    console.print(f"Current version: [bold]{old_version}[/bold]")
+
+    success, detail = run_package_upgrade(plan)
+    if not success:
+        console.print(f"[red]Upgrade failed:[/red] {detail}")
+        console.print("[dim]Daemon left untouched.[/dim]")
+        raise SystemExit(1)
+
+    new_version = detect_new_version()
+    console.print(
+        f"[green]Package upgraded.[/green] {old_version} -> {new_version or 'unknown'}"
+    )
+
+    # Read BEFORE restarting -- the daemon's port doesn't change across a
+    # restart, and this is the one snapshot that's guaranteed to describe
+    # the daemon we're about to restart (a stop-serve restart rewrites the
+    # state file's pid, so reading again afterward would race the new
+    # process's own lifespan write).
+    state = read_server_state()
+    method, restarted, restart_detail = restart_daemon(state)
+
+    if method == "none":
+        console.print("[dim]tj serve is not running -- nothing to restart.[/dim]")
+        return
+
+    if not restarted:
+        console.print(f"[red]Daemon restart failed ({method}):[/red] {restart_detail}")
+        raise SystemExit(1)
+
+    console.print(f"[dim]{restart_detail}[/dim]")
+
+    if new_version is None:
+        console.print(
+            "[yellow]Could not determine the newly installed version -- "
+            "skipping restart verification. Check `tj --version` "
+            "manually.[/yellow]"
+        )
+        raise SystemExit(1)
+
+    if state is None or state.port is None:
+        console.print(
+            "[yellow]Could not determine the daemon's port -- skipping "
+            "restart verification. Check `tj --version` manually.[/yellow]"
+        )
+        raise SystemExit(1)
+
+    verified, seen = poll_daemon_version(state.port, new_version)
+    if not verified:
+        console.print(
+            f"[red]Daemon still reports {seen or 'no version'} after "
+            f"restart (expected {new_version}).[/red] Try "
+            "`tj stop && tj serve &` manually."
+        )
+        raise SystemExit(1)
+
+    console.print(f"[green]Daemon verified running {new_version}.[/green]")

--- a/tokenjam/cli/main.py
+++ b/tokenjam/cli/main.py
@@ -12,9 +12,8 @@ if TYPE_CHECKING:
 
 @click.group(
     invoke_without_command=True,
-    epilog="Upgrade with: pipx upgrade tokenjam "
-           "(then `tj stop && tj serve &` to reload the daemon). "
-           "Verify with `tj --version`.",
+    epilog="Upgrade with: tj upgrade (installs the new package AND "
+           "restarts the daemon). Verify with `tj --version`.",
 )
 @click.version_option(package_name="tokenjam")
 @click.option("--config", "config_path", default=None, envvar="TJ_CONFIG",
@@ -64,7 +63,7 @@ def cli(ctx: click.Context, config_path: str | None, output_json: bool,
     no_db_commands = {
         "stop", "uninstall", "onboard", "mcp", "demo", "policy",
         "proxy", "summarize", "pricing", "otel-resource-attrs", "session-end",
-        "statusline",
+        "statusline", "upgrade",
         # `ping` emits a test span through the SDK (which resolves its own
         # HTTP-vs-direct path); it must not take the CLI's DuckDB lock (#80).
         "ping",
@@ -123,6 +122,7 @@ from tokenjam.cli.cmd_tools import cmd_tools  # noqa: E402
 from tokenjam.cli.cmd_export import cmd_export  # noqa: E402
 from tokenjam.cli.cmd_serve import cmd_serve  # noqa: E402
 from tokenjam.cli.cmd_stop import cmd_stop  # noqa: E402
+from tokenjam.cli.cmd_upgrade import cmd_upgrade  # noqa: E402
 from tokenjam.cli.cmd_uninstall import cmd_uninstall  # noqa: E402
 from tokenjam.cli.cmd_reset import cmd_reset  # noqa: E402
 from tokenjam.cli.cmd_doctor import cmd_doctor  # noqa: E402
@@ -156,6 +156,7 @@ cli.add_command(cmd_tools, name="tools")
 cli.add_command(cmd_export, name="export")
 cli.add_command(cmd_serve, name="serve")
 cli.add_command(cmd_stop, name="stop")
+cli.add_command(cmd_upgrade, name="upgrade")
 cli.add_command(cmd_uninstall, name="uninstall")
 cli.add_command(cmd_reset, name="reset")
 cli.add_command(cmd_doctor, name="doctor")


### PR DESCRIPTION
`tokenjam/__init__.py` resolves `__version__` once at import time, and `tj serve` is a long-lived daemon (often supervised by launchd). Upgrading the package outside `tj` (`pipx upgrade tokenjam`, etc.) previously left the running daemon serving the OLD version out of process memory indefinitely — verified live: the package on disk was 0.6.1 while the daemon's own `/api/v1/version` endpoint still reported 0.6.0. There was no `tj upgrade` subcommand at all; the only guidance was a manual `tj stop && tj serve &` in the CLI epilog and docs/installation.md.

## Summary
- New `tj upgrade` subcommand: detects how the running `tj` is installed (pipx / `uv tool` / pip+venv), runs the matching upgrade command, and only on a successful install restarts the daemon and verifies it actually picked up the new version.
- Ephemeral/unmanaged installs (uvx/npx/pipx-run cache, or an unwritable pip target) are refused up front with actionable guidance — never half-upgraded.
- Daemon restart prefers `launchctl kickstart -k` when launchd supervises the daemon (verified live to work); otherwise falls back to the existing `stop_tj_serve()` + relaunching `tj serve` in the background, reusing `cmd_stop.py`/`cmd_onboard.py` rather than duplicating their logic.
- After restart, polls `/api/v1/version` on the daemon's own port with a bounded timeout and reports old → new version; fails loudly (non-zero exit) if the daemon still reports the old version once the timeout elapses — it never claims success without observing the new version.
- Updated the CLI epilog and `docs/installation.md` to point at `tj upgrade` (manual pipx/pip + `tj stop && tj serve &` steps kept as a documented fallback).

## Tests / Verification
- `tests/unit/test_cmd_upgrade.py` (25 tests): install-manager detection per layout (pipx / uv-tool / pip / ephemeral-refusal / unwritable-refusal), daemon NOT restarted when the install fails, launchd-kickstart vs stop/serve fallback branch, no-daemon-running no-op, and post-restart version verification (success + failing loudly on timeout). All subprocess/launchctl/HTTP calls are mocked — nothing here upgrades a real package, shells out to launchctl for real, or touches a real daemon.
- Full suite: `pytest tests/unit/ tests/synthetic/ tests/agents/ tests/integration/` — 3841 passed, 1 skipped.
- `ruff check tokenjam/` and `mypy tokenjam/` (223 files) both clean.

## What's NOT in this PR
- systemd (Linux) daemon restart uses the existing stop/serve fallback rather than a `systemctl restart`-equivalent fast path — only the launchd fast path was explicitly verified live on this machine; the systemd case still gets a correct (if slightly slower) restart via the shared fallback.

🤖 Generated with [Claude Code](https://claude.com/claude-code)