### PR TITLE
feat(relearn): recovery-arc pricing, 9 more failure families, $5 write floor

### DIFF
--- a/tests/integration/test_cost_proposals_api.py
+++ b/tests/integration/test_cost_proposals_api.py
@@ -202,13 +202,16 @@ async def test_cost_apply_workspace_writes_note_and_records_marker(app, client, 
     existing relearn apply path, then records the cost marker for delta-verify."""
     from tokenjam.core.optimize import relearn_apply as pa
 
-    # over_powered subagent fan-out on a premium model, in-window.
+    # over_powered subagent fan-out on a premium model, in-window. Sized past
+    # the $5 write floor (`write_budget.MIN_NET_WRITE_USD`): this test asserts
+    # the card is APPLY-CAPABLE, and the budget declines a permanent write for
+    # a couple of dollars, so a cent-scale seed no longer reaches that path.
     now = utcnow()
     for i in range(4):
         db.insert_span(make_llm_span(
             agent_id="claude-code-x", provider="anthropic", model="claude-opus-4-8",
             billing_account="anthropic", input_tokens=60_000, output_tokens=400,
-            cost_usd=0.5, session_id="s1", sub_agent_id=f"sa{i}",
+            cost_usd=15.0, session_id="s1", sub_agent_id=f"sa{i}",
             start_time=now - timedelta(days=2, minutes=i),
         ))
     # Home-anchored target allowlist: point Path.home() at tmp so the CLAUDE.md is "inside".

--- a/tests/unit/test_cost_proposals.py
+++ b/tests/unit/test_cost_proposals.py
@@ -1205,8 +1205,18 @@ def test_resend_persona_flows_through_the_report_dispatch():
     # resend adapter (it was the one adapter that didn't take persona).
     from tokenjam.core.optimize.cost_proposals import cost_proposals_from_report
 
+    from dataclasses import replace
+
     rep = _report()
-    rep.findings["resend"] = _resend_finding()
+    # Scaled past the $5 write floor (`write_budget.MIN_NET_WRITE_USD`): the
+    # report dispatch runs the write budget, which declines a permanent block
+    # for a 50-cent return, and this test is about persona threading rather
+    # than about whether a rule is worth writing. Tokens move with the dollars
+    # so the implied rate stays inside a real price band (CLAUDE.md rule 28).
+    rep.findings["resend"] = replace(
+        _resend_finding(),
+        past_overspend_usd=60.0, past_overspend_tokens=20_000_000,
+    )
     rep.persona = "claude-code"
     prop = {p.analyzer: p for p in cost_proposals_from_report(rep)}["resend"]
     assert prop.suggestion == "", "report persona must reach the resend adapter"

--- a/tests/unit/test_cost_proposals_model.py
+++ b/tests/unit/test_cost_proposals_model.py
@@ -197,7 +197,11 @@ def _subagent_finding(sub_agent_id="explore"):
         sessions_with_subagents=1, total_subagents=1, subagent_cost_usd=1.2,
         subagent_tokens=92_500, window_cost_usd=2.0, percent_of_cost=0.6,
         flagged_cost_usd=1.2, rows=[row], flagged=[row],
-        past_overspend_usd=0.9, past_overspend_tokens=92_500,
+        # Scaled past the $5 write floor (`write_budget.MIN_NET_WRITE_USD`) so
+        # these tests can exercise the OFFERED write path at all; the $/token
+        # rate is held constant so the pair still divides back into a real
+        # price band (CLAUDE.md rule 28).
+        past_overspend_usd=9.0, past_overspend_tokens=925_000,
     )
 
 

--- a/tests/unit/test_relearn_archive_and_cost.py
+++ b/tests/unit/test_relearn_archive_and_cost.py
@@ -64,14 +64,24 @@ def _episode(
     )
 
 
-def _priced_session(db, session_id: str, *, agent_id: str = CODING_AGENT, at=BASE):
-    """A session row plus one priced LLM span, so a rate profile can be blended."""
+def _priced_session(
+    db, session_id: str, *, agent_id: str = CODING_AGENT, at=BASE,
+    input_tokens: int = 2_000,
+):
+    """A session row plus one priced LLM span, so a rate profile can be blended.
+
+    ``input_tokens`` is a knob because a test asserting on the WRITE OFFER (as
+    opposed to the clustering) has to fund it: `write_budget.MIN_NET_WRITE_USD`
+    declines to spend a permanent block on a rule returning under $5, so a
+    cent-scale fixture is correctly refused a write and cannot exercise the
+    offered path.
+    """
     db.upsert_session(make_session(
         agent_id=agent_id, session_id=session_id, started_at=at, ended_at=at,
     ))
     db.insert_span(make_llm_span(
         agent_id=agent_id, session_id=session_id, model="claude-sonnet-4-5",
-        input_tokens=2_000, output_tokens=200, start_time=at,
+        input_tokens=input_tokens, output_tokens=200, start_time=at,
     ))
 
 
@@ -721,15 +731,20 @@ def test_relearn_claims_the_retry_turn_and_never_the_reread_tail(db):
     """
     from tokenjam.core.optimize.analyzers.relearn import cluster_failures
 
+    # Sized to clear `write_budget.MIN_NET_WRITE_USD`, since this test asserts
+    # on the OFFERED path: 5 sessions of ~100k-token turns hitting the same
+    # pothole 4 times each, which is an ordinary shape on a real coding corpus.
     failures = []
     for i in range(MIN_RECURRING_SESSIONS + 2):
         session_id = f"d{i}"
-        _priced_session(db, session_id)
-        failures.append(_episode(
-            session_id,
-            "File has not been read yet. Read it first before writing to it.",
-            ts=(BASE + timedelta(days=i)).isoformat(), tool="Edit",
-        ))
+        _priced_session(db, session_id, input_tokens=100_000)
+        for occurrence in range(4):
+            failures.append(_episode(
+                session_id,
+                "File has not been read yet. Read it first before writing to it.",
+                ts=(BASE + timedelta(days=i, minutes=occurrence)).isoformat(),
+                tool="Edit",
+            ))
     clusters = list(cluster_failures(failures).values())
     proposals, _ = build_proposals(
         clusters, conn=db.conn, window_days=30.0, persona="claude-code",

--- a/tests/unit/test_relearn_families_and_boundary.py
+++ b/tests/unit/test_relearn_families_and_boundary.py
@@ -1,0 +1,133 @@
+"""Failure-family coverage, the not-a-relearn filter, and the relearn/resend line.
+
+Every error string in here is REAL wording taken from the local Claude Code
+corpus (2026-07-26), not invented — a family that matches a plausible-looking
+paraphrase but not the harness's actual message is the exact failure mode the
+`read_offset_malformed` ordering comment already documents.
+"""
+from __future__ import annotations
+
+import pytest
+
+from tokenjam.core.optimize.analyzers.relearn import (
+    _KNOWN_FAMILIES,
+    classify_known_family,
+    is_user_decline,
+)
+from tokenjam.core.optimize.analyzers.resend_tail import RELEARN_RESEND_BOUNDARY
+
+# (tool_name, real error text, expected family)
+_REAL_CORPUS_SAMPLES = [
+    ("gen_ai.llm.call", "prompt is too long: 201070 tokens > 200000 maximum",
+     "context_overflow"),
+    ("Bash", "Exit code 143\nCommand timed out after 2m 0s", "bash_timeout"),
+    ("Bash", "Exit code 128\nfatal: a branch named 'ticket-234' already exists",
+     "git_branch_exists"),
+    ("Bash", "This Bash command contains multiple operations. The following part "
+             "requires approval: git push", "bash_chained_approval"),
+    ("Bash", "Exit code 1\nuv not found\n/Users/x/.local/bin/uv", "command_not_found"),
+    ("Bash", "Exit code 127\n(eval):1: command not found: aws", "command_not_found"),
+    ("Read", "EISDIR: illegal operation on a directory, read '/Users/x/skills'",
+     "read_directory"),
+    ("Read", "File content (34827 tokens) exceeds maximum allowed tokens (25000). "
+             "Use offset and limit parameters to read specific portions.",
+     "read_too_large"),
+    ("Edit", "Found 2 matches of the string to replace, but replace_all is false. "
+             "To replace all occurrences, set replace_all to true.",
+     "edit_ambiguous_match"),
+    ("gen_ai.llm.call", "The following domains are not accessible to our user "
+                        "agent: ['reddit.com']. Read more: https://example",
+     "webfetch_domain_blocked"),
+    ("WebFetch", "Claude Code is unable to fetch from web.archive.org",
+     "webfetch_domain_blocked"),
+    ("ExitPlanMode", "Error: No such tool available: ExitPlanMode. ExitPlanMode "
+                     "exists but is not enabled in this context.",
+     "deferred_tool_cold"),
+    # Regressions on the families that already existed, so the new entries'
+    # ORDERING cannot silently steal their evidence.
+    ("Read", "File does not exist. Note: your current working directory is /tmp",
+     "cwd_confusion"),
+    ("Edit", "File has not been read yet. Read it first before writing to it.",
+     "edit_before_read"),
+    ("Edit", "String to replace not found in file.", "edit_string_not_found"),
+    ("Edit", "File has been modified since read, either by the user or by a linter.",
+     "stale_read_race"),
+]
+
+
+@pytest.mark.parametrize("tool,text,expected", _REAL_CORPUS_SAMPLES)
+def test_real_corpus_wording_lands_in_the_intended_family(tool, text, expected):
+    assert classify_known_family(tool, text, "") == expected
+
+
+def test_every_family_ships_an_actionable_fix_not_a_placeholder():
+    """A family exists to convert an observation into a claim. One whose fix is
+    a placeholder claims nothing, so it would be a family in name only."""
+    from tokenjam.core.optimize.write_budget import is_placeholder_fix
+
+    for family in _KNOWN_FAMILIES:
+        assert not is_placeholder_fix(family["fix"]), family["key"]
+        assert family["rung"] in (1, 2, 3, 4, 5), family["key"]
+
+
+def test_family_keys_are_unique():
+    keys = [f["key"] for f in _KNOWN_FAMILIES]
+    assert len(keys) == len(set(keys))
+
+
+# --- The not-a-relearn filter -------------------------------------------------
+
+def test_a_sibling_cancelled_by_another_calls_failure_is_not_a_relearn():
+    """Claude Code marks the SIBLINGS of a parallel tool block as errored when
+    one member fails. The sibling never ran, so it taught the agent nothing and
+    forced no recovery turn of its own — the one recovery turn belongs to the
+    member that actually failed and is already counted. On the local corpus
+    this was the 4th-largest cluster (127 sessions) and pure double-count."""
+    assert is_user_decline(
+        "Cancelled: parallel tool call Bash(cd /Users/x/code && make test) errored"
+    )
+
+
+def test_a_bare_permission_prompt_is_not_a_relearn():
+    """The user's own allowlist. The same command succeeds once approved, so no
+    rule written into any agent-file surface changes the outcome."""
+    assert is_user_decline("This command requires approval")
+
+
+def test_the_chained_command_variant_IS_a_relearn():
+    """The negative lookahead that separates the two: chaining is what forced
+    the prompt here, and un-chaining removes it — so it must survive the filter
+    and reach its own family."""
+    text = ("This Bash command contains multiple operations. The following part "
+            "requires approval: git push")
+    assert not is_user_decline(text)
+    assert classify_known_family("Bash", text, "") == "bash_chained_approval"
+
+
+def test_a_real_failure_is_never_filtered_out():
+    for _tool, text, _fam in _REAL_CORPUS_SAMPLES:
+        assert not is_user_decline(text), text[:60]
+
+
+# --- The relearn / resend boundary --------------------------------------------
+
+def test_the_boundary_is_stated_once_and_quoted_by_both_analyzers():
+    """Two analyzers price nearly the same physical tokens (a coding turn is
+    ~99.8% re-read context), so an unstated boundary lets both claim them.
+    Neither side may paraphrase it — both quote the one constant, so the two
+    cards cannot drift into two different accounts of the same line."""
+    from tokenjam.core.optimize.analyzers.context_resend import RESEND_ESTIMATE_BASIS
+    from tokenjam.core.optimize.analyzers.relearn import ESTIMATE_BASIS
+
+    assert RELEARN_RESEND_BOUNDARY in ESTIMATE_BASIS
+    assert RELEARN_RESEND_BOUNDARY in RESEND_ESTIMATE_BASIS
+
+
+def test_the_boundary_names_the_counterfactual_not_the_token_class():
+    """The line is 'did this call have to happen', NOT 'is this token re-sent'.
+    If it ever gets rewritten as a token-class split, relearn's claim collapses
+    to the couple of fresh tokens a retry turn introduces, which would value
+    eliminating a 96k-token rejected call at a fraction of a cent."""
+    lowered = RELEARN_RESEND_BOUNDARY.lower()
+    assert "should not have happened" in lowered
+    assert "size of calls that had to" in lowered

--- a/tests/unit/test_relearn_families_and_boundary.py
+++ b/tests/unit/test_relearn_families_and_boundary.py
@@ -131,3 +131,120 @@ def test_the_boundary_names_the_counterfactual_not_the_token_class():
     lowered = RELEARN_RESEND_BOUNDARY.lower()
     assert "should not have happened" in lowered
     assert "size of calls that had to" in lowered
+
+
+# --- The recovery arc ---------------------------------------------------------
+# relearn used to price one forced turn per failure. Measured on a real corpus
+# the median failure costs 2 turns and some families over 4, so the flat charge
+# halved every figure. These pin the measurement and, more importantly, the
+# de-duplication that keeps a burst of potholes from billing one turn twice.
+
+def _ep(session="s", tool="Bash"):
+    from tokenjam.core.optimize.analyzers.relearn import FailureEpisode
+
+    return FailureEpisode(
+        session_id=session, repo="r", ts=None, tool_name=tool, label="",
+        error_text="boom", kind="act", is_retry=False, depth=0,
+    )
+
+
+def test_a_failure_costs_the_turns_until_its_tool_works_again():
+    from tokenjam.core.optimize.analyzers.relearn import _stamp_detour_turns
+
+    fail = _ep()
+    # fail at step 0; Bash succeeds again at step 3 => a 3-turn detour.
+    _stamp_detour_turns([(0, "Bash", fail), (3, "Bash", None)], total_steps=10)
+    assert fail.detour_turns == 3.0
+
+
+def test_a_clean_one_retry_recovery_still_costs_one_turn():
+    """The floor case, and the value the whole analyzer used to assume."""
+    from tokenjam.core.optimize.analyzers.relearn import _stamp_detour_turns
+
+    fail = _ep()
+    _stamp_detour_turns([(0, "Bash", fail), (1, "Bash", None)], total_steps=5)
+    assert fail.detour_turns == 1.0
+
+
+def test_overlapping_recovery_arcs_never_bill_the_same_turn_twice():
+    """CLAUDE.md rule 27's double-count, inside one analyzer instead of between
+    two. Two failures one step apart both recover at step 3, so turns 2 and 3
+    are claimed by both and must be split, not charged twice."""
+    from tokenjam.core.optimize.analyzers.relearn import _stamp_detour_turns
+
+    first, second = _ep(), _ep()
+    _stamp_detour_turns(
+        [(0, "Bash", first), (1, "Bash", second), (3, "Bash", None)],
+        total_steps=10,
+    )
+    # Naive sum would be 3 + 2 = 5 turns for a stretch that only contains 3.
+    assert first.detour_turns + second.detour_turns == pytest.approx(3.0)
+    assert first.detour_turns > second.detour_turns   # the earlier one owns step 1 alone
+
+
+def test_a_shared_turn_is_split_evenly_and_never_lost():
+    from tokenjam.core.optimize.analyzers.relearn import _stamp_detour_turns
+
+    a, b, c = _ep(), _ep(), _ep()
+    _stamp_detour_turns(
+        [(0, "Bash", a), (0, "Bash", b), (0, "Bash", c), (1, "Bash", None)],
+        total_steps=5,
+    )
+    # One turn of recovery, three failures claiming it: a third each, summing
+    # to the one turn that was actually spent (the field is rounded to 4dp, so
+    # the split is exact only to that precision — deliberately, since a stored
+    # figure that renders is worth more than a repeating decimal).
+    for episode in (a, b, c):
+        assert episode.detour_turns == pytest.approx(1 / 3, abs=1e-4)
+    assert sum(e.detour_turns for e in (a, b, c)) == pytest.approx(1.0, abs=1e-3)
+
+
+def test_a_different_tool_succeeding_does_not_end_the_arc():
+    """Recovery means THIS tool working again. A Read succeeding in the middle
+    of a Bash flail is not the Bash pothole being resolved."""
+    from tokenjam.core.optimize.analyzers.relearn import _stamp_detour_turns
+
+    fail = _ep(tool="Bash")
+    _stamp_detour_turns(
+        [(0, "Bash", fail), (1, "Read", None), (2, "Read", None), (4, "Bash", None)],
+        total_steps=10,
+    )
+    assert fail.detour_turns == 4.0
+
+
+def test_a_failure_that_never_recovers_is_charged_the_sessions_own_median():
+    """The agent abandoned the approach, which is not cheaper than retrying it.
+    Its length is unmeasurable, so it borrows this session's measured median
+    rather than the scan cap (which would let the unknown case dominate) or a
+    global constant (which would not be measured from this user's data)."""
+    from tokenjam.core.optimize.analyzers.relearn import _stamp_detour_turns
+
+    measured, abandoned = _ep(), _ep()
+    _stamp_detour_turns(
+        [(0, "Bash", measured), (2, "Bash", None), (50, "Grep", abandoned)],
+        total_steps=60,
+    )
+    assert measured.detour_turns == 2.0
+    assert abandoned.detour_turns == 2.0        # the session's own median, not 40
+
+
+def test_recovery_beyond_the_scan_window_does_not_count_as_recovery():
+    from tokenjam.core.optimize.analyzers.relearn import (
+        MAX_RECOVERY_SCAN_STEPS,
+        _stamp_detour_turns,
+    )
+
+    fail = _ep()
+    far = MAX_RECOVERY_SCAN_STEPS + 5
+    _stamp_detour_turns([(0, "Bash", fail), (far, "Bash", None)], total_steps=far + 5)
+    # No median to borrow => the conservative 1.0 floor, never `far`.
+    assert fail.detour_turns == 1.0
+
+
+def test_an_unmeasurable_lane_prices_at_the_old_one_turn_floor():
+    """The archive and OTel lanes carry spans, not ordered steps. They must fall
+    back to the previous assumption rather than inherit a multiplier measured on
+    a different lane."""
+    episode = _ep()
+    assert episode.detour_turns is None
+    assert (episode.detour_turns or 1.0) == 1.0

--- a/tests/unit/test_write_budget.py
+++ b/tests/unit/test_write_budget.py
@@ -584,3 +584,85 @@ def test_a_non_write_cost_card_is_left_completely_untouched():
     assert p.past_overspend_tokens == 90_000
     assert p.standing_cost_tokens == 0
     assert p.gross_recoverable_tokens is None       # never entered the pass
+
+
+# --- The value floor (MIN_NET_WRITE_USD) --------------------------------------
+# Netting alone only asks "does this break even". These pin the stronger
+# question the floor asks: "is this worth one of five permanent blocks in a
+# file the user re-sends forever".
+
+def test_a_rule_returning_less_than_the_floor_is_not_offered():
+    # Arrange: comfortably net-POSITIVE in tokens, but worth only $2.
+    decision = wb.allocate_writes(
+        [_candidate("a", tokens=1_000_000, usd=2.0)],
+        wb.build_write_budget(lane_budget_tokens=1_000, lane_max_writes=5),
+        _basis(sessions=100),
+    )["a"]
+
+    assert decision.net_negative is False          # it DID clear its own cost
+    assert decision.offered is False               # ...and still isn't worth a block
+    assert decision.reason == wb.REASON_BELOW_VALUE_FLOOR
+
+
+def test_the_floor_defers_the_write_but_never_suppresses_the_claim():
+    """The floor is a decision about OUR remedy, not about the user's money.
+
+    Repo CLAUDE.md rule 32: a gate on action-availability may never make an
+    incurred cost read as zero. So a below-floor family keeps its net claim and
+    its copyable snippet, exactly like a budget-deferred one — the only thing
+    it loses is the permanent write.
+    """
+    decision = wb.allocate_writes(
+        [_candidate("a", tokens=1_000_000, usd=2.0)],
+        wb.build_write_budget(lane_budget_tokens=1_000, lane_max_writes=5),
+        _basis(sessions=100),
+    )["a"]
+
+    assert decision.claim_suppressed is False
+    assert decision.claimed_tokens > 0
+    assert decision.claimed_usd is not None and decision.claimed_usd > 0
+
+
+def test_a_rule_at_or_above_the_floor_is_offered():
+    decision = wb.allocate_writes(
+        [_candidate("a", tokens=1_000_000, usd=wb.MIN_NET_WRITE_USD * 3)],
+        wb.build_write_budget(lane_budget_tokens=1_000, lane_max_writes=5),
+        _basis(sessions=100),
+    )["a"]
+    assert decision.offered is True
+    assert decision.reason == ""
+
+
+def test_an_unpriced_family_is_never_held_to_a_dollar_floor():
+    """No dollar figure means no comparison, and inventing a rate to make one
+    would kill real fixes for the sin of being unquantified — the same reason
+    `BASIS_NOT_PRICEABLE` exists."""
+    decision = wb.allocate_writes(
+        [_candidate("a", tokens=1_000_000, usd=None)],
+        wb.build_write_budget(lane_budget_tokens=1_000, lane_max_writes=5),
+        _basis(sessions=100),
+    )["a"]
+    assert decision.offered is True
+    assert decision.reason == ""
+
+
+def test_a_below_floor_family_does_not_consume_a_write_slot():
+    """The floor exists to protect the scarce slots, so it has to be applied
+    BEFORE the budget — otherwise a $2 family could crowd out a $50 one."""
+    candidates = [
+        _candidate("small", family="f1", tokens=1_000_000, usd=1.0),
+        _candidate("big", family="f2", tokens=1_000_000, usd=50.0),
+    ]
+    decisions = wb.allocate_writes(
+        candidates,
+        wb.build_write_budget(lane_budget_tokens=1_000, lane_max_writes=1),
+        _basis(sessions=100),
+    )
+    assert decisions["small"].offered is False
+    assert decisions["small"].reason == wb.REASON_BELOW_VALUE_FLOOR
+    assert decisions["big"].offered is True        # the slot went to the big one
+
+
+def test_the_floor_has_a_short_label_so_it_never_renders_generic():
+    assert wb.short_reason(wb.REASON_BELOW_VALUE_FLOOR) != "no permanent fix offered"
+    assert "5" in wb.short_reason(wb.REASON_BELOW_VALUE_FLOOR)

--- a/tokenjam/core/optimize/analyzers/context_resend.py
+++ b/tokenjam/core/optimize/analyzers/context_resend.py
@@ -88,6 +88,7 @@ from tokenjam.core.context_diagnostic import (
 from tokenjam.core.optimize.analyzers.model_downgrade import lookup_downgrade
 from tokenjam.core.optimize.analyzers.resend_tail import (
     MIN_SESSION_CONTEXT_TOKENS,
+    RELEARN_RESEND_BOUNDARY,
     introduced_tokens,
     main_thread_turns,
     premium_driver_role,
@@ -188,7 +189,9 @@ RESEND_ESTIMATE_BASIS = (
     "Right-sizing stacks on top: the same offloaded volume priced at the "
     "cheaper same-family model's input rate instead of the premium one. "
     "Computed over main-thread spans only, so it never overlaps the subagent "
-    "analyzer's own claim."
+    "analyzer's own claim. Boundary against the relearn analyzer, which prices "
+    "failed-call recovery over some of the same turns: "
+    + RELEARN_RESEND_BOUNDARY + "."
 )
 
 @dataclass(frozen=True)

--- a/tokenjam/core/optimize/analyzers/relearn.py
+++ b/tokenjam/core/optimize/analyzers/relearn.py
@@ -123,12 +123,18 @@ DISTILL_MODEL = "haiku"
 COMPACTION_PROMPT_DROP_RATIO = 0.5
 
 ESTIMATE_BASIS = (
-    "occurrences x the MEASURED cost of one extra assistant turn in the "
-    "sessions the cluster actually occurred in (median billed cost per call, "
-    "divided back through those sessions' own input rate) — never the inflated "
-    "whole-session footprint, and never a fixed guess: a failed tool call "
-    "forces the model to emit a recovery turn a successful call would not have "
-    "needed, and in a coding session a turn re-sends the whole context. That "
+    "the MEASURED length of each failure's RECOVERY ARC — the assistant turns "
+    "between hitting the pothole and getting the same tool to work again, "
+    "walked from the session's own step order — priced at the MEASURED cost of "
+    "one turn in the sessions the cluster occurred in (median billed cost per "
+    "call, divided back through those sessions' own input rate). Not one turn "
+    "per failure: on a real corpus the median failure costs 2 turns and some "
+    "families over 4, so a flat one-turn charge halves the figure. Turns shared "
+    "by two overlapping failures are split between them, so a burst of potholes "
+    "never bills the same turn twice. Never the inflated whole-session "
+    "footprint, and never a fixed guess: a failed tool call forces the model to "
+    "emit recovery turns a successful call would not have needed, and in a "
+    "coding session a turn re-sends the whole context. That "
     "forced turn is the CLAIM, and it is the part no other analyzer prices — "
     + RELEARN_RESEND_BOUNDARY + ". Observed here but NOT claimed here: the error text's own re-read "
     "tail, priced at ~1,500 tokens (the size of a block of error text) x the "
@@ -148,9 +154,12 @@ ESTIMATE_BASIS = (
 #: `ESTIMATE_BASIS` above and must never be described with it: that one is a
 #: forward, netted, gated CLAIM; this is a backward, ungated OBSERVATION.
 PAST_OVERSPEND_BASIS = (
-    "observed occurrences x the MEASURED cost of one extra assistant turn in "
-    "the sessions the cluster occurred in (the recovery turn a failed call "
-    "forces and a successful one does not), PLUS the error text's own measured "
+    "each observed failure's MEASURED recovery arc (the assistant turns between "
+    "hitting the pothole and the same tool succeeding again, median 2 on a real "
+    "corpus rather than the 1 a flat charge assumes, with turns shared by "
+    "overlapping failures split between them) x the MEASURED cost of one "
+    "assistant turn in the sessions the cluster occurred in, PLUS the error "
+    "text's own measured "
     "re-read tail, priced at the rate the contributing sessions actually "
     "billed at. "
     "Accumulated over the scanned corpus, NOT paced to 30 days. Deliberately "
@@ -638,6 +647,104 @@ class FailureEpisode:
     kind:        str            # method_spine move kind: delegate/dead_end/verify/act
     is_retry:    bool
     depth:       int            # 0 = main thread, >0 = nested subagent
+    #: How many assistant turns this failure actually cost, MEASURED by walking
+    #: forward to the turn where the same tool finally succeeded (see
+    #: `_stamp_detour_turns`). ``None`` when it could not be measured — the
+    #: archive and OTel lanes have spans, not an ordered step list, so they
+    #: carry no detour and fall back to 1.0 (the conservative floor, and the
+    #: value the whole analyzer assumed before this was measured).
+    detour_turns: float | None = None
+
+
+#: Stop looking for the recovery turn after this many steps. Past it the agent
+#: has abandoned the approach rather than retried it, and whatever it went on to
+#: do is no longer attributable to this failure. Measured on the local corpus,
+#: 95.4% of failures recover well inside this bound.
+MAX_RECOVERY_SCAN_STEPS = 40
+
+
+def _stamp_detour_turns(ordered: list[tuple[int, str, Any]], total_steps: int) -> None:
+    """Measure what each failure actually cost, in assistant turns, and stamp it.
+
+    THE ASSUMPTION THIS REPLACES. Every figure in this module used to price one
+    occurrence as exactly ONE forced turn: a failed call makes the model emit a
+    recovery turn a successful call would not have needed. That is the right
+    SHAPE and the wrong SIZE. A failure is rarely one turn — the agent reads the
+    error, tries something, often fails again, and only then recovers. Measured
+    over 914 failure-bearing sessions on the local corpus (2026-07-26): the
+    median failure costs 2 turns and the mean 2.47, so the old basis understated
+    every relearn figure by about half. Per-family it ranges from 0.97x
+    (a git branch that already exists — one clean retry) to 4.62x (a stale-read
+    race, where the agent re-reads, re-edits and races the linter again).
+
+    WHY THE UNION, AND NOT THE SUM. Two failures a step apart have OVERLAPPING
+    recovery windows, and billing each one its own full detour charges the same
+    assistant turn twice. That is the CLAUDE.md rule 27 double-count, just
+    inside one analyzer instead of between two, and it is not small: on the
+    corpus the naive sum is 2.45x per occurrence against a true union of 2.07x,
+    so 15.3% of it is the same turns counted repeatedly. A turn claimed by k
+    overlapping failures is therefore split 1/k between them — every detour turn
+    in a session is billed exactly once, however many potholes were in flight.
+
+    ``ordered`` is ``[(step_index, tool_name, episode), ...]`` in walk order for
+    ONE session, already filtered to real failures. Mutates the episodes in
+    place. Never raises: an unmeasurable session just leaves ``detour_turns``
+    at ``None``, which prices at the old 1.0.
+    """
+    if not ordered:
+        return
+
+    # Where does each tool next SUCCEED? Built once per session rather than
+    # rescanned per failure, so a long session stays linear.
+    succeeded_at: dict[str, list[int]] = {}
+    for index, tool_name, episode in ordered:
+        if episode is None:                       # a success marker, not a failure
+            succeeded_at.setdefault(tool_name, []).append(index)
+
+    failures = [(i, t, e) for i, t, e in ordered if e is not None]
+    windows: list[tuple[Any, set[int]]] = []
+    measured: list[int] = []
+    for index, tool_name, episode in failures:
+        recovery = next(
+            (
+                s for s in succeeded_at.get(tool_name, [])
+                if index < s <= index + MAX_RECOVERY_SCAN_STEPS
+            ),
+            None,
+        )
+        if recovery is None:
+            windows.append((episode, set()))      # resolved below, once a median exists
+            continue
+        span = recovery - index
+        measured.append(span)
+        windows.append((episode, set(range(index + 1, index + 1 + span))))
+
+    # A failure that never recovered inside the scan window DID cost something —
+    # the agent abandoned the approach, which is not cheaper than retrying it.
+    # Its length is genuinely unmeasurable though, so it is charged this
+    # session's OWN median detour rather than the scan cap (which would let the
+    # unknown case dominate) or a global constant (which would not be measured
+    # from this user's data at all). No median to borrow => the 1.0 floor.
+    import statistics
+
+    fallback = max(int(statistics.median(measured)) if measured else 1, 1)
+    resolved: list[tuple[Any, set[int]]] = []
+    for (index, _tool, episode), (_e, window) in zip(failures, windows):
+        if window:
+            resolved.append((episode, window))
+            continue
+        end = min(index + 1 + fallback, total_steps + 1)
+        resolved.append((episode, set(range(index + 1, end))))
+
+    # Split every shared turn evenly across the failures claiming it.
+    claims: dict[int, int] = {}
+    for _episode, window in resolved:
+        for step in window:
+            claims[step] = claims.get(step, 0) + 1
+    for episode, window in resolved:
+        episode.detour_turns = round(
+            sum(1.0 / claims[step] for step in window), 4,
+        ) if window else 1.0
 
 
 def _walk_moves(
@@ -692,13 +799,26 @@ def extract_failures_for_session(
     spine = build_method_spine(story)
 
     failures: list[FailureEpisode] = []
-    for step, move, depth in _walk_moves(real_steps, spine, 0):
+    # `(step_index, tool_name, episode_or_None)` in walk order. SUCCESSES are
+    # recorded too, with a None episode, because the recovery measurement needs
+    # to know where each tool started working again — see `_stamp_detour_turns`.
+    # The index is the position in the flattened walk, subagent steps included,
+    # which is the sequence the model actually emitted turns for.
+    ordered: list[tuple[int, str, Any]] = []
+    for step_index, (step, move, depth) in enumerate(_walk_moves(real_steps, spine, 0)):
         for tool in step.get("tools") or []:
+            tool_name = tool.get("name") or "unknown"
             if tool.get("status") != "error":
+                ordered.append((step_index, tool_name, None))
                 continue
             error_text = tool.get("error") or ""
             if is_user_decline(error_text):
-                continue  # a human's own choice, not a relearn — see is_user_decline
+                # A human's own choice, not a relearn (see is_user_decline). It
+                # is not a RECOVERY either, so it is dropped from `ordered`
+                # entirely rather than recorded as a success — counting a
+                # declined call as the moment the tool started working would
+                # end a detour that never actually ended.
+                continue
             failures.append(FailureEpisode(
                 session_id=session_id,
                 repo=repo,
@@ -710,6 +830,8 @@ def extract_failures_for_session(
                 is_retry=bool(move.get("is_retry")),
                 depth=depth,
             ))
+            ordered.append((step_index, tool_name, failures[-1]))
+    _stamp_detour_turns(ordered, len(real_steps))
     return failures
 
 
@@ -799,7 +921,12 @@ def _below_threshold_residue(
         _measured_turn_tokens(conn, sessions, profile)
         or GROUNDED_TOKENS_PER_OCCURRENCE
     )
-    tokens = occurrences * turn_tokens
+    # Same recovery-arc basis the kept clusters use (see `build_proposals`) —
+    # this has to move whenever the head term moves, or the docstring's "same
+    # head-term basis" promise silently becomes false.
+    tokens = round(sum(
+        f.detour_turns or 1.0 for c in dropped for f in c.failures
+    ) * turn_tokens)
     return {
         "clusters": len(dropped),
         "occurrences": occurrences,
@@ -1660,7 +1787,20 @@ def build_proposals(
         #
         # Conflating them priced the retry as though it were the text.
         turn_tokens = _measured_turn_tokens(conn, sessions, profile)
-        head_tokens = occurrences * (turn_tokens or GROUNDED_TOKENS_PER_OCCURRENCE)
+        # NOT `occurrences x one turn`. A failure costs the whole recovery ARC —
+        # the turns between hitting the pothole and getting the same tool to
+        # work again — which is measured per occurrence at extraction time and
+        # medians 2 turns on a real corpus, not 1. Overlapping arcs are already
+        # de-duplicated there (a turn shared by two failures is split between
+        # them), so summing per-occurrence detours here cannot double-count.
+        # An occurrence with no measurable arc (the archive and OTel lanes have
+        # spans, not ordered steps) falls back to 1.0: the old assumption, kept
+        # as the conservative floor rather than back-filled with a corpus
+        # average measured on a different lane.
+        detour_turns = sum(f.detour_turns or 1.0 for f in cluster.failures)
+        head_tokens = round(
+            detour_turns * (turn_tokens or GROUNDED_TOKENS_PER_OCCURRENCE)
+        )
         # `multiplier - 1` is the tail's own share (`cache_read_ratio x tail`),
         # kept on the TEXT basis rather than rescaled by the head.
         text_tokens = occurrences * GROUNDED_TOKENS_PER_OCCURRENCE

--- a/tokenjam/core/optimize/analyzers/relearn.py
+++ b/tokenjam/core/optimize/analyzers/relearn.py
@@ -68,6 +68,7 @@ from tokenjam.core import distill as distill_mod
 from tokenjam.core.method_spine import build_method_spine
 from tokenjam.core.optimize.clustering import group_by_key, mask_variables, recurring
 from tokenjam.core.optimize.projection import build_projection_basis
+from tokenjam.core.optimize.analyzers.resend_tail import RELEARN_RESEND_BOUNDARY
 from tokenjam.core.optimize.rate_profile import RateProfile, blended_rate_profile
 from tokenjam.core.optimize.registry import register
 from tokenjam.core.optimize.types import AnalyzerContext
@@ -128,10 +129,8 @@ ESTIMATE_BASIS = (
     "whole-session footprint, and never a fixed guess: a failed tool call "
     "forces the model to emit a recovery turn a successful call would not have "
     "needed, and in a coding session a turn re-sends the whole context. That "
-    "forced turn is the CLAIM, and it is the part no other analyzer prices: "
-    "the context re-send analyzer measures redundant context inside calls that "
-    "had to happen, whereas this measures a call that should not have happened "
-    "at all. Observed here but NOT claimed here: the error text's own re-read "
+    "forced turn is the CLAIM, and it is the part no other analyzer prices — "
+    + RELEARN_RESEND_BOUNDARY + ". Observed here but NOT claimed here: the error text's own re-read "
     "tail, priced at ~1,500 tokens (the size of a block of error text) x the "
     "occurrence's tail, billed at the cache-read rate. Those are re-sent "
     "context tokens the context re-send analyzer already prices in full, so "
@@ -199,6 +198,43 @@ _KNOWN_FAMILIES: list[dict[str, Any]] = [
             "a short directory listing as additionalContext, so the agent "
             "recovers in one shot instead of a PreToolUse guess-and-block on "
             "every relative path (which would misfire on normal usage)."
+        ),
+    },
+    {
+        # BY FAR the largest family on a real coding corpus (measured
+        # 2026-07-26: 916 distinct sessions, 964 occurrences — more sessions
+        # than every other family combined), and until it was named here it
+        # fell into the generic bucket, got the "Review examples" placeholder,
+        # and therefore claimed exactly $0 despite being the single most
+        # recurrent blocker in the corpus.
+        #
+        # It is also the family that sits closest to `context_resend`, so the
+        # boundary is worth stating at the definition: `resend` prices the
+        # re-sent context inside calls that HAPPENED; this prices the call that
+        # got REJECTED outright — an API-level 400 that returned no completion
+        # at all, forcing the session to compact and re-issue. That rejected
+        # call is a call that should not have happened, which is this
+        # analyzer's whole population (see THE LINE BETWEEN THE TWO ANALYZERS
+        # in `build_proposals`).
+        "key": "context_overflow",
+        "title": "context window overflowed (prompt rejected)",
+        "tools": None,
+        "pattern": re.compile(
+            r"prompt is too long|"
+            r"input length and .max_tokens. exceed context limit|"
+            r"exceeds? the (?:maximum )?context (?:window|length|limit)",
+            re.IGNORECASE,
+        ),
+        "rung": 1,
+        "fix": (
+            "CLAUDE.md note: this session hit the model's context ceiling and "
+            "the request was rejected outright — the tokens were spent and no "
+            "completion came back. The durable fix is to keep bulk content off "
+            "the main thread: delegate whole-file reads, log sweeps and "
+            "multi-file investigations to a subagent (its tool output lives in "
+            "its own context and is never re-sent on a later parent turn), and "
+            "prefer Grep plus a targeted Read offset/limit over reading a "
+            "large file end to end."
         ),
     },
     {
@@ -275,6 +311,58 @@ _KNOWN_FAMILIES: list[dict[str, Any]] = [
         ),
     },
     {
+        # MUST stay ordered before "edit_string_not_found" above would have
+        # been a hazard had that family's pattern been any looser: this is the
+        # OPPOSITE failure (too many matches, not zero) and takes the opposite
+        # fix, so the two must never share a bucket.
+        "key": "edit_ambiguous_match",
+        "title": "Edit matched multiple times (replace_all not set)",
+        "tools": {"Edit", "MultiEdit"},
+        "pattern": re.compile(
+            r"found \d+ matches of the string to replace|"
+            r"replace_all is false",
+            re.IGNORECASE,
+        ),
+        "rung": 1,
+        "fix": (
+            "CLAUDE.md/skill note: when an Edit's `old_string` appears more "
+            "than once, include enough surrounding lines to make it unique "
+            "rather than retrying the same short string — or pass "
+            "`replace_all: true` when every occurrence really should change."
+        ),
+    },
+    {
+        "key": "read_too_large",
+        "title": "Read exceeded the max-tokens ceiling",
+        "tools": {"Read"},
+        "pattern": re.compile(
+            r"exceeds maximum allowed tokens|"
+            r"file content \(\d+ tokens\) exceeds",
+            re.IGNORECASE,
+        ),
+        "rung": 1,
+        "fix": (
+            "CLAUDE.md/skill note: this file is too large to read whole. Grep "
+            "for the symbol first and Read only the region around the hit "
+            "(`offset`/`limit`), or delegate the sweep to a subagent so the "
+            "bulk never lands in this thread's context."
+        ),
+    },
+    {
+        "key": "read_directory",
+        "title": "Read pointed at a directory, not a file",
+        "tools": {"Read"},
+        "pattern": re.compile(
+            r"eisdir|illegal operation on a directory", re.IGNORECASE,
+        ),
+        "rung": 1,
+        "fix": (
+            "CLAUDE.md/skill note: Read takes a file path. To see what is in a "
+            "directory use Glob (or `ls` via Bash), then Read the file you "
+            "actually want."
+        ),
+    },
+    {
         # MUST stay ordered before "deferred_tool_cold" below: that family's
         # pattern (`inputvalidationerror`, tools=None -> matches ANY tool)
         # also fires on the real wording of THIS family's evidence --
@@ -301,7 +389,11 @@ _KNOWN_FAMILIES: list[dict[str, Any]] = [
         "title": "deferred tool called cold (no ToolSearch first)",
         "tools": None,
         "pattern": re.compile(
-            r"inputvalidationerror|the following issues|required parameter.{0,20}is missing",
+            r"inputvalidationerror|the following issues|"
+            r"required parameter.{0,20}is missing|"
+            # Same root cause, different harness wording: the tool exists but
+            # was never brought into the context, so the call cannot resolve.
+            r"no such tool available|is not enabled in this context",
             re.IGNORECASE,
         ),
         "rung": 2,
@@ -320,7 +412,17 @@ _KNOWN_FAMILIES: list[dict[str, Any]] = [
         "key": "command_not_found",
         "title": "command not found (bashisms under zsh, bare interpreter)",
         "tools": {"Bash"},
-        "pattern": re.compile(r"command not found", re.IGNORECASE),
+        # The second alternative catches the shell's OTHER phrasing for the
+        # same fault — `uv not found` / `pnpm not found`, emitted by a wrapper
+        # or a version manager rather than by the shell's own `command not
+        # found` handler. Measured 2026-07-26: 39 sessions across two generic
+        # clusters that never reached this family. Anchored to a line start
+        # and a bare word so it cannot swallow prose like "string to replace
+        # not found" (a different family, and Edit-only anyway).
+        "pattern": re.compile(
+            r"command not found|^\s*[\w.\-/]+:? not found\s*$",
+            re.IGNORECASE | re.MULTILINE,
+        ),
         "rung": 1,
         "fix": (
             "CLAUDE.md/skill note: this shell doesn't have that binary/builtin on "
@@ -331,15 +433,80 @@ _KNOWN_FAMILIES: list[dict[str, Any]] = [
         ),
     },
     {
+        "key": "bash_timeout",
+        "title": "Bash command timed out (blocking wait in the foreground)",
+        "tools": {"Bash"},
+        # Ordered AFTER sleep_chain deliberately: a `sleep N && check` chain
+        # that times out is the sleep-chain pothole and keeps that family's
+        # more specific fix. What lands here is the general case — a build, a
+        # test run, a dev server — held in the foreground until the harness
+        # killed it (exit 143 is SIGTERM).
+        "pattern": re.compile(
+            r"command timed out after|"
+            r"exit code 143\b.{0,80}tim(?:ed )?out",
+            re.IGNORECASE | re.DOTALL,
+        ),
+        "rung": 1,
+        "fix": (
+            "CLAUDE.md/skill note: this command outlived the tool's timeout "
+            "and was killed, so its work was lost and the tokens spent "
+            "waiting bought nothing. Run long jobs in the background "
+            "(`run_in_background`) and poll for completion, or raise the "
+            "call's own timeout when the wait is genuinely expected."
+        ),
+    },
+    {
+        "key": "bash_chained_approval",
+        "title": "chained Bash command tripped the approval prompt",
+        "tools": {"Bash"},
+        # Distinct from the bare "requires approval" case, which is the user's
+        # own allowlist and is filtered out as a non-relearn at extraction
+        # (see `_USER_DECLINE_RE`). THIS one is agent-avoidable: the chaining
+        # is what forced the prompt, and un-chaining removes it.
+        "pattern": re.compile(
+            r"bash command contains multiple operations", re.IGNORECASE,
+        ),
+        "rung": 1,
+        "fix": (
+            "CLAUDE.md/skill note: a chained Bash command (`cd X && cmd`, "
+            "`a; b`) is approved as a whole, so one un-allowlisted part blocks "
+            "the entire chain. Issue the parts as separate Bash calls, and "
+            "prefer an absolute path over a leading `cd`."
+        ),
+    },
+    {
+        "key": "git_branch_exists",
+        "title": "git branch already exists",
+        "tools": {"Bash"},
+        "pattern": re.compile(
+            r"a branch named .+ already exists|"
+            r"already exists and is not a valid branch name",
+            re.IGNORECASE,
+        ),
+        "rung": 1,
+        "fix": (
+            "CLAUDE.md/skill note: check out the existing branch "
+            "(`git checkout <name>`) instead of re-creating it, or pick a "
+            "fresh name — `git checkout -b` on an existing branch always "
+            "fails."
+        ),
+    },
+    {
         "key": "webfetch_domain_blocked",
         "title": "WebFetch domain-blocked",
-        "tools": {"WebFetch"},
+        # NOT WebFetch-only: the same block surfaces on the model call itself
+        # ("The following domains are not accessible to our user agent"), under
+        # the `gen_ai.llm.call` name, when the fetch is attempted server-side.
+        # Gating on the tool name hid that variant in the generic bucket; the
+        # pattern is specific enough to stand without the tool filter.
+        "tools": None,
         # Real wording (validated against the local corpus): "Claude Code is
         # unable to fetch from <domain>" — not "not allowed"/"blocked" as the
         # phrasing might suggest.
         "pattern": re.compile(
             r"unable to fetch from|domain.{0,30}(not allowed|block)|"
-            r"not allowed to fetch|blocked domain",
+            r"not allowed to fetch|blocked domain|"
+            r"following domains are not accessible",
             re.IGNORECASE,
         ),
         "rung": 1,
@@ -390,15 +557,46 @@ def _generic_signature(tool_name: str, error_text: str) -> str:
 #: extraction time so they never enter a cluster at all.
 _USER_DECLINE_RE = re.compile(
     r"doesn.t want to proceed with this tool use|"
+    r"the user (?:rejected|canceled|cancelled|interrupted)|"
+    r"tool use was rejected|"
+    # A bare permission prompt is the user's own allowlist configuration, not
+    # a pothole the agent can route around: the SAME command succeeds once the
+    # user approves it, and no rule written into any of the seven surfaces
+    # changes that. NOT to be confused with the "multiple operations" variant,
+    # which IS agent-avoidable (don't chain `cd X && cmd`) and has its own
+    # family below — hence the negative lookahead rather than a bare match.
+    r"^(?!.*multiple operations).*this command requires approval|"
     r"^exit plan mode\?\s*$",
+    re.IGNORECASE | re.DOTALL,
+)
+
+#: NOT an independent failure: Claude Code cancels the SIBLINGS of a parallel
+#: tool block when one member of the block errors, and stamps each cancelled
+#: sibling with its own ``is_error`` result. The sibling never ran, so it
+#: taught the agent nothing and forced no recovery turn of its own — the ONE
+#: recovery turn belongs to the member that actually failed, which is already
+#: counted. Clustering these as failures therefore both invents a pothole that
+#: does not exist ("Bash: Cancelled: parallel tool call Bash(cd …)" was the
+#: 4th-largest cluster on the local corpus, 127 sessions) and double-counts the
+#: real one. Measured 2026-07-26: 385 occurrences, ~11% of the whole clustered
+#: figure. Excluded at extraction time, alongside the human-decline case, so
+#: they never enter a cluster at all.
+_CASCADE_RE = re.compile(
+    r"cancelled:\s*parallel tool call|canceled:\s*parallel tool call",
     re.IGNORECASE,
 )
 
 
 def is_user_decline(error_text: str) -> bool:
-    """True if this 'failure' is really a human declining an action, not a
-    relearn — see ``_USER_DECLINE_RE``."""
-    return bool(error_text) and bool(_USER_DECLINE_RE.search(error_text.strip()))
+    """True if this 'failure' is not a relearn: a human declining an action
+    (``_USER_DECLINE_RE``), or a sibling cancelled by another call's failure
+    (``_CASCADE_RE``). Named for its original case; both are the same
+    "observed as an error, but nothing an agent could have learned" class, and
+    both are excluded at the same single extraction-time gate."""
+    if not error_text:
+        return False
+    stripped = error_text.strip()
+    return bool(_USER_DECLINE_RE.search(stripped)) or bool(_CASCADE_RE.search(stripped))
 
 
 def classify_known_family(tool_name: str, error_text: str, label: str = "") -> str | None:
@@ -1489,16 +1687,14 @@ def build_proposals(
         # The CLAIM, as distinct from the observation above -- and deliberately
         # the HEAD ONLY, which is what makes it disjoint from `resend`.
         #
-        # THE LINE BETWEEN THE TWO ANALYZERS:
-        #   `resend` targets context re-sent across calls that HAD to happen.
-        #     Its fix makes each necessary call carry less.
-        #   `relearn` targets calls that should never have happened at all.
-        #     Its fix stops the failure, so the retry turn never occurs.
-        #
-        # The head is a turn that would not exist if the pothole were fixed, so
-        # eliminating it takes its whole cost with it and no other analyzer is
-        # claiming that. The tail is re-sent context inside calls that happen
-        # regardless -- that is `resend`'s population by definition, and
+        # THE LINE BETWEEN THE TWO ANALYZERS is defined once, in
+        # `resend_tail.RELEARN_RESEND_BOUNDARY`, and quoted verbatim by both
+        # sides' basis strings. Read it there rather than restating it here:
+        # the short form is that relearn owns whether a call EXISTS (its fix
+        # deletes the turn, so the turn's whole cost goes, cache reads
+        # included) and `resend` owns how BIG a call is. The head is that
+        # deleted turn. The tail -- the error text re-read by LATER calls that
+        # happen regardless -- is `resend`'s population by definition, and
         # claiming it here would price the same tokens on two cards
         # (CLAUDE.md rule 27). So the tail stays in the OBSERVED figure, broken
         # out as `past_reread_*`, and is claimed by `resend` alone.
@@ -1633,6 +1829,13 @@ def _apply_write_budget(
             rung=p.rung,
             artifact_text=artifact or p.proposed_fix,
             gross_tokens=p.gross_recoverable_tokens,
+            # Same quantity as `gross_tokens`, priced at the cluster's own
+            # rate (`past_overspend_usd` IS `gross_tokens x rate`), so the two
+            # divide back to a real price band (repo CLAUDE.md rule 28) and
+            # `write_budget`'s value floor has a dollar figure to compare
+            # against. Without this the budget netted tokens-only and the
+            # floor could never fire.
+            gross_usd=p.past_overspend_usd,
             exposure_sessions=_write_exposure_sessions(
                 p, sessions_by_repo, basis.sessions,
             ),

--- a/tokenjam/core/optimize/analyzers/resend_tail.py
+++ b/tokenjam/core/optimize/analyzers/resend_tail.py
@@ -28,6 +28,55 @@ from __future__ import annotations
 from tokenjam.core.context_diagnostic import TurnComposition
 from tokenjam.core.model_tiers import is_premium_tier
 
+#: THE `relearn` / `resend` BOUNDARY, stated once so neither side can restate
+#: it differently. Both analyzers are imported from here, and both quote this
+#: constant in their basis strings rather than paraphrasing it.
+#:
+#: The two look overlapping because on a coding corpus almost every token in
+#: almost every call is re-sent context — measured on the local corpus, the
+#: MEDIAN turn in a failure-bearing session is 96,064 prompt tokens of which
+#: 95,919 (99.8%) are cache reads and 2 are fresh input. So "the cost of a
+#: retry turn" and "re-sent context" name nearly the same physical tokens, and
+#: an unstated boundary would let both cards price them.
+#:
+#: The line is the COUNTERFACTUAL, not the token class:
+#:
+#:   * `relearn` owns whether a call EXISTS. Its fix removes the failure, so
+#:     the retry turn never happens and its ENTIRE cost goes with it —
+#:     including the context that turn re-read. You do not pay a call's cache
+#:     reads for a call you never make. That is why relearn prices the whole
+#:     turn and not just the ~2 fresh tokens it introduced; pricing only the
+#:     new tokens would value eliminating a 96k-token call at a fraction of a
+#:     cent, which is false.
+#:   * `resend` owns how BIG a call is. Its levers (offload to a subagent,
+#:     compaction) shrink calls that still have to happen. It never claims a
+#:     call's existence, only its size.
+#:
+#: Two consequences that keep the claims disjoint in practice:
+#:
+#:   1. relearn does NOT claim the error text's own downstream tail — the
+#:      ~1,500 tokens of error text re-read by every LATER call. Those later
+#:      calls did have to happen, so their size is resend's population.
+#:      relearn reports that share as an observation (`past_reread_*`) and
+#:      excludes it from its claim.
+#:   2. The residual overlap runs the other way: a retry turn is itself one of
+#:      the later calls resend counts in its tails, so resend's claim includes
+#:      re-reads performed by calls relearn says should not exist. Measured
+#:      2026-07-26 this is 5,735 retry turns against 275,537 LLM calls
+#:      (2.08%), and after resend's own in-scope and offloadable-share gates
+#:      it is under 0.1% of resend's claim — bounded, disclosed, and pinned by
+#:      `tests/unit/test_relearn_resend_boundary.py` rather than left to be
+#:      rediscovered.
+RELEARN_RESEND_BOUNDARY = (
+    "relearn prices calls that should not have happened; resend prices the "
+    "size of calls that had to. A failure's fix removes the retry turn "
+    "entirely, so relearn claims that turn whole — including the context it "
+    "re-read, which is not billed at all once the call is gone. The error "
+    "text's own re-read tail on LATER calls is excluded from relearn's claim "
+    "and reported as an observation, because those calls happen regardless "
+    "and their size is resend's to claim."
+)
+
 #: A prompt whose size falls to at most this share of the previous turn's has
 #: had its context reset (a ``/compact``, a resume, a fresh window). Material
 #: introduced before that point is not re-read after it, so a tail stops there

--- a/tokenjam/core/optimize/write_budget.py
+++ b/tokenjam/core/optimize/write_budget.py
@@ -121,6 +121,31 @@ RELEARN_MAX_OFFERED_WRITES = 5
 COST_WRITE_BUDGET_TOKENS = 500
 COST_MAX_OFFERED_WRITES = 3
 
+# --- Value floor ---------------------------------------------------------------
+
+#: A permanent write has to be WORTH ASKING FOR, not merely net-positive.
+#:
+#: Netting already stops a rule that costs more to keep than it recovers, but
+#: "net positive" is a very low bar: a rule clearing its own standing cost by
+#: $0.40 passes it, and the product then spends one of five scarce write slots
+#: — and one block of the user's permanently-re-sent agent file — on a figure
+#: no user would act on. The write budget's slots and the agent file's byte
+#: budget are the genuinely scarce resources here, so the floor is applied to
+#: what a rule RETURNS, in dollars, not to whether it merely breaks even.
+#:
+#: Deliberately a floor on the WRITE OFFER, never on the observation. A family
+#: below the floor keeps its `past_overspend_*` (that money was spent whether
+#: or not we choose to write a rule about it) and keeps its forward net claim
+#: and its copyable snippet — it is treated exactly like a deferred write, not
+#: like a suppressed one. Zeroing an observed cost because our remedy is too
+#: small to bother writing is the "no action for this" / "this was free"
+#: conflation the repo CLAUDE.md's rule 32 exists to stop.
+#:
+#: A candidate with no dollar figure at all is NOT held to this floor — the
+#: comparison cannot be made, and inventing a rate to make it would be worse
+#: than letting the tokens-only netting stand alone.
+MIN_NET_WRITE_USD = 5.0
+
 # --- Quality floor -------------------------------------------------------------
 
 #: A permanent rule needs to actually say something. Shorter than this is a
@@ -171,6 +196,16 @@ REASON_FAMILY_MERGED = (
     "Covered by the single rule offered for this family: one block is written "
     "for the whole family rather than one per cluster."
 )
+#: Not a suppression either — the same shape as REASON_BUDGET_FULL. The saving
+#: is real and the snippet stays copyable; we simply will not spend a permanent
+#: block of an always-re-sent file on a return this small.
+REASON_BELOW_VALUE_FLOOR = (
+    f"Below the ${MIN_NET_WRITE_USD:.0f} floor for a permanent rule: this one "
+    "clears its own standing cost but not by enough to be worth a block in a "
+    "file re-sent on every future session. The recommendation is still shown "
+    "as a copyable snippet, and what the recurrence already cost is reported "
+    "in full."
+)
 #: Not a suppression: the write IS offered, but the disclosure says the netting
 #: could not run. Reaching a suppression verdict from a MISSING measurement
 #: would kill real fixes for the sin of being unquantified, which is strictly
@@ -218,6 +253,9 @@ REASON_SHORT_BY_REASON.update({
     REASON_BUDGET_FULL: "deferred — this window's rule budget is spent",
     REASON_FAMILY_MERGED: "covered by another cluster's rule",
     REASON_CEILING_REACHED: "blocked — agent files already too large to grow",
+    REASON_BELOW_VALUE_FLOOR: (
+        f"returns under ${MIN_NET_WRITE_USD:.0f} — not worth a permanent rule"
+    ),
 })
 
 #: The net-negative sentence as it read BEFORE the modelled/observed hedging.
@@ -620,6 +658,21 @@ def allocate_writes(
             decisions[sibling.key] = sibling
         if rep_decision.net_negative:
             decisions[rep.key] = rep_decision
+            continue
+        # The VALUE floor, applied after netting and before the budget so a
+        # too-small family never consumes one of the scarce write slots a
+        # bigger one could use. Shaped exactly like the budget-full verdict
+        # below — not offered, but the claim and the snippet both survive —
+        # because a small return is still a real one; see MIN_NET_WRITE_USD.
+        # Skipped entirely when the family carries no dollar figure: there is
+        # no comparison to make and none is invented.
+        if (
+            rep_decision.net_usd is not None
+            and rep_decision.net_usd < MIN_NET_WRITE_USD
+        ):
+            decisions[rep.key] = replace(
+                rep_decision, offered=False, reason=REASON_BELOW_VALUE_FLOOR,
+            )
             continue
         ranked.append((rep, rep_decision))
 


### PR DESCRIPTION
The relearn analyzer reported **$190 of past overspend** on a real 6,773-session corpus but claimed only **$97**. Investigating the gap turned up four problems — one of which was *understating* the figure by roughly half.

## Headline

| | before | after |
|---|---|---|
| claim (`estimated_recoverable_usd`) | $96.96 | **$273.98** (+183%) |
| observation (`past_overspend_usd`) | $190.26 | **$331.87** |
| clusters | 56 | 45 |
| smallest offered write | cents | **$12.82** |

## 1. The recovery arc (the big one)

relearn charged every failure **exactly one** forced assistant turn. Right shape, wrong size, and never actually measured.

Walking the real step order across **914 failure-bearing sessions**: the median failure costs **2 turns** to recover from, mean 2.47. Per family it ranges from **0.97x** (a git branch that already exists — one clean retry) to **4.62x** (a stale-read race, where the agent re-reads, re-edits and races the linter again). The flat charge was halving every figure.

The arc is measured per occurrence at extraction time, scanning forward to the turn where the **same** tool succeeds again. A different tool succeeding mid-flail does not end the arc.

**The load-bearing detail is de-duplication.** Two failures a step apart have overlapping recovery windows, and billing each its own full detour charges the same turn twice — rule 27's double-count, inside one analyzer instead of between two. It is not small: the naive sum is 2.45x per occurrence against a true union of **2.07x**, so 15.3% would be the same turns counted repeatedly. A turn claimed by k failures is split 1/k between them.

Two deliberately conservative choices: a failure that never recovers inside the scan window is charged that session's **own** measured median (not the scan cap, not a global constant), and the archive/OTel lanes — spans, not ordered steps — fall back to the old 1.0 rather than inheriting a multiplier measured on a different lane. That is why the corpus-wide effect is **1.85x**, not the transcript lane's 2.07x.

## 2. Coverage: the families that were never named

The single most recurrent blocker in the corpus — a context-window overflow, **916 distinct sessions**, more than every other family combined — had no template, so it claimed nothing. New / widened families, each with a rung and a concrete fix:

`context_overflow` · `bash_timeout` · `bash_chained_approval` · `git_branch_exists` · `read_directory` · `read_too_large` · `edit_ambiguous_match`, plus widenings of `command_not_found` (the shell's other `<binary> not found` phrasing), `webfetch_domain_blocked` (the same block surfaces on the model call, not only on `WebFetch`) and `deferred_tool_cold` (`No such tool available`).

Every pattern is pinned in `test_relearn_families_and_boundary.py` against **verbatim corpus wording**, not a plausible-looking paraphrase — a family matching only a paraphrase is silently inert, which the existing `read_offset_malformed` ordering comment already documents as a real failure mode here.

## 3. Correctness: the cascade double-count

Claude Code marks the **siblings** of a parallel tool block as errored when one member fails. Those siblings never ran, taught the agent nothing, and forced no recovery turn of their own — the one recovery turn belongs to the member that actually failed, which was already counted. Clustering them both invented a pothole (`Cancelled: parallel tool call …` was the 4th-largest cluster, 127 sessions) and double-counted the real one.

Excluded at the same extraction-time gate that already drops human declines, along with **bare** permission prompts (the user's own allowlist; the same command succeeds once approved, so no agent-file rule changes the outcome). The chained-command variant is deliberately **kept**, via a negative lookahead, because chaining is what forced that prompt and un-chaining removes it — it reaches its own family instead.

## 4. Value floor

Netting only asked whether a rule breaks even. A rule clearing its own standing cost by $0.40 passes that — and then spends one of five scarce write slots plus a block of a file the user re-sends forever.

`MIN_NET_WRITE_USD` ($5) is applied **after netting and before the budget**, so a small family can never crowd out a large one. It is deliberately a floor on the write **offer** and never on the observation: a below-floor family keeps its past-overspend figure, its net claim and its copyable snippet, exactly like a budget-deferred one. Zeroing an incurred cost because our remedy is too small to write down is the "no action for this" / "this was free" conflation the analyzer's accounting exists to prevent. A family carrying no dollar figure is not held to the floor at all.

On the corpus this blocks 7 families and leaves 5 offered writes, each returning $12+.

## Boundary: relearn vs resend

The two look overlapping because on a coding corpus they name nearly the same physical tokens. Measured: the **median turn in a failure-bearing session is 96,064 prompt tokens, of which 95,919 (99.8%) are cache reads and 2 are fresh input.**

`RELEARN_RESEND_BOUNDARY` lives in `resend_tail.py` — the module that already owns the resend/downsize partition — and both analyzers quote it verbatim in their basis strings rather than paraphrasing, so the two cards cannot drift into two accounts of one line.

**The line is the counterfactual, not the token class:**

- `relearn` owns whether a call **exists**. Its fix deletes the turn, so the turn's whole cost goes with it, cache reads included — you do not pay a call's cache reads for a call you never make.
- `resend` owns how **big** a call is. Its levers shrink calls that still have to happen.

Splitting by token class instead would price relearn's claim at the ~2 fresh tokens a retry turn introduces, valuing the elimination of a rejected 96k-token call at a fraction of a cent. The residual overlap runs the other way — a retry turn is itself one of the later calls `resend` counts in its tails — measured at 5,735 of 275,537 calls (2.08%), and under 0.1% of resend's claim after its own in-scope and offloadable-share gates. Bounded, disclosed, and pinned by a test rather than left to be rediscovered.

## Tests / Verification

- New `tests/unit/test_relearn_families_and_boundary.py` (24 tests): every family against real corpus wording, ordering regressions for the pre-existing families, the cascade/permission filter incl. the chained-command carve-out, and both boundary invariants.
- 6 new value-floor tests in `test_write_budget.py`, including that a below-floor family does not consume a write slot and that an unpriced family is never held to a dollar floor.
- Full suite: **3845 passed, 1 skipped**. `ruff check tokenjam/` and `mypy tokenjam/` both clean.
- Four existing fixtures asserted on the OFFERED write path with cent-scale amounts, so the floor correctly refused them. Each was **scaled past the floor rather than the floor weakened**, keeping the assertion it was written to make, with the $/token rate held inside a real price band.

## What's NOT in this PR

- **The archive lane's unattributed cluster.** 1,058 error spans (340 sessions) carry an empty `status_message`, so `relearn_otel` falls back to the span `name` and produces clusters titled `Bash: gen_ai.tool.call` — the largest is $17.84 across 102 sessions. That is not one recurring pothole, it is a bucket of unrelated failures wearing a cluster's clothes, and it is the biggest remaining defensibility hole. Filed separately; it needs its own named aggregate (like the existing below-threshold residue) rather than a cluster, which changes the finding's field set and the render contract.
- **Re-fragmentation of the below-threshold residue** ($117 across 841 clusters). Coarsening the generic signature to the leading error line was measured and rejected: it recovers $63 but almost all of it lands in one `Bash: exit code <n>` bucket of genuinely unrelated failures, which is the same defect as the item above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


