### PR TITLE
fix: format billion-scale tokens

### DIFF
--- a/tests/unit/test_formatting.py
+++ b/tests/unit/test_formatting.py
@@ -43,6 +43,15 @@ class TestFormatTokens:
     def test_millions_with_fraction(self):
         assert format_tokens(2_500_000) == "2.5M"
 
+    def test_just_below_billion_stays_millions(self):
+        assert format_tokens(999_999_999) == "1000.0M"
+
+    def test_billions(self):
+        assert format_tokens(1_000_000_000) == "1.0B"
+
+    def test_billions_with_fraction(self):
+        assert format_tokens(16_885_900_000) == "16.9B"
+
     def test_zero(self):
         assert format_tokens(0) == "0"
 

--- a/tokenjam/utils/humanize.py
+++ b/tokenjam/utils/humanize.py
@@ -11,8 +11,10 @@ from pathlib import Path
 
 
 def format_tokens(n: int) -> str:
-    """Human-size a token count: ``M`` at/above a million, ``k`` at/above a
-    thousand, otherwise the raw integer."""
+    """Human-size a token count: ``B`` at/above a billion, ``M`` at/above a
+    million, ``k`` at/above a thousand, otherwise the raw integer."""
+    if n >= 1_000_000_000:
+        return f"{n / 1_000_000_000:.1f}B"
     if n >= 1_000_000:
         return f"{n / 1_000_000:.1f}M"
     if n >= 1_000:


### PR DESCRIPTION
## Summary

Adds a billion-scale branch to Python `format_tokens()` so CLI text renders billion-token figures as `16.9B` instead of `16885.9M`. The dashboard formatter on current `main` already had the `B` branch, so this brings the shared CLI formatter into parity and pins the boundary behavior in unit tests.

## Related issue

Closes #610

## Checklist

- [ ] Tests pass (`pytest tests/unit/ tests/synthetic/ tests/agents/ tests/integration/`)
- [ ] Lint clean (`ruff check tokenjam/`)
- [ ] Type check clean (`mypy tokenjam/`)
- [ ] CLAUDE.md updated (if architecture changed)
- [x] Test spans use `tests/factories.py` (not raw `NormalizedSpan`) - N/A, no spans added
- [ ] Requested `@anilmurty` as reviewer (or @-mentioned him above)

## Validation

- `uv sync --extra dev`
- `uv run pytest tests/unit/test_formatting.py -q`
- `uv run pytest tests/unit/test_lens_ui_regression.py -q`
- `uv run pytest tests/unit/test_humanize.py tests/unit/test_formatting.py tests/unit/test_lens_ui_regression.py -q`
- `uv run ruff check tokenjam/utils/humanize.py tests/unit/test_formatting.py tests/unit/test_lens_ui_regression.py`
- `git diff --check`
