### PR TITLE
fix(optimize): render <0.1× instead of 0.0× for tiny subscription multipliers

### DIFF
--- a/tests/unit/test_optimize_plan_multiplier.py
+++ b/tests/unit/test_optimize_plan_multiplier.py
@@ -1,0 +1,17 @@
+"""Unit tests for subscription-plan multiplier formatting in cmd_optimize."""
+from __future__ import annotations
+
+from tokenjam.cli.cmd_optimize import _format_plan_multiplier
+
+
+def test_format_plan_multiplier_below_threshold_uses_floor_label():
+    assert _format_plan_multiplier(0.0) == "<0.1×"
+    assert _format_plan_multiplier(0.049) == "<0.1×"
+    assert _format_plan_multiplier(0.099) == "<0.1×"
+
+
+def test_format_plan_multiplier_at_or_above_threshold_keeps_one_decimal():
+    assert _format_plan_multiplier(0.1) == "0.1×"
+    assert _format_plan_multiplier(0.12) == "0.1×"
+    assert _format_plan_multiplier(1.34) == "1.3×"
+    assert _format_plan_multiplier(21.2) == "21.2×"

--- a/tokenjam/cli/cmd_optimize.py
+++ b/tokenjam/cli/cmd_optimize.py
@@ -700,6 +700,13 @@ def _render_validation(result: Any) -> None:
     console.print(f"\n[dim]{_rich_escape(result.caveat)}[/dim]")
 
 
+def _format_plan_multiplier(multiplier: float) -> str:
+    """Render implied-API-value / plan-fee multiplier for subscription users."""
+    if multiplier < 0.1:
+        return "<0.1×"
+    return f"{multiplier:.1f}×"
+
+
 def _render_report(
     report: OptimizeReport,
     agent: str | None,
@@ -741,7 +748,7 @@ def _render_report(
             console.print(
                 f"[dim]Implied API value: "
                 f"[bold]{format_cost(w.total_cost_usd)}[/bold] — about "
-                f"{multiplier:.1f}× your plan cost.[/dim]\n"
+                f"{_format_plan_multiplier(multiplier)} your plan cost.[/dim]\n"
             )
         else:
             console.print(


### PR DESCRIPTION
## Summary

Subscription-plan users with very small implied API value relative to their plan fee saw a misleading `0.0×` multiplier because the header used one-decimal rounding. This adds a small formatter that renders `<0.1×` below the 0.1 threshold.

## Related issue

Closes #590

## Checklist

- [x] Tests pass (`pytest tests/unit/test_optimize_plan_multiplier.py`)
- [x] Lint clean (`ruff check tokenjam/cli/cmd_optimize.py tests/unit/test_optimize_plan_multiplier.py`)
- [x] Type check clean (`mypy tokenjam/cli/cmd_optimize.py`)
- [ ] CLAUDE.md updated (if architecture changed)
- [ ] Test spans use `tests/factories.py` (not raw `NormalizedSpan`)
- [x] Requested `@anilmurty` as reviewer (or @-mentioned him above)

cc @anilmurty