### PR TITLE
fix(policy): point recoverable meter at tj optimize

### DIFF
--- a/tests/unit/test_cmd_policy.py
+++ b/tests/unit/test_cmd_policy.py
@@ -299,6 +299,7 @@ def test_decisions_reads_persisted_from_db(runner):
     assert "unvalidated" in result.output
     # The savings meter is shown and is ESTIMATED / RECOVERABLE — never "saved".
     assert "Estimated recoverable" in result.output
+    assert "tj optimize" in result.output
 
 
 def test_decisions_savings_never_says_saved(runner):

--- a/tokenjam/cli/cmd_policy.py
+++ b/tokenjam/cli/cmd_policy.py
@@ -247,6 +247,9 @@ def _print_savings_summary(savings: dict) -> None:
         f"[dim]({savings.get('decisions', 0)} decisions, label={savings.get('label')})[/dim]"
     )
     console.print(f"[dim]{escape(savings.get('disclaimer', ''))}[/dim]")
+    console.print(
+        "[dim]Run [bold]tj optimize[/bold] for detail on recoverable savings.[/dim]"
+    )
 
 
 def _collect_rows(config: TjConfig) -> list[PolicyRow]:


### PR DESCRIPTION
## Summary

Add a one-line `tj optimize` pointer after the estimated-recoverable summary shown by `tj policy decisions`.

## Motivation

`tj policy decisions` prints an "Estimated recoverable" meter but never tells users where to act on that figure. `tj status` already has a matching teaser pattern (`_recoverable_teaser`) that points users at `tj optimize`; this brings the policy decisions meter in line with that UX.

Fixes #587

## Changes

- `tokenjam/cli/cmd_policy.py`: append a dim one-liner after the savings disclaimer in `_print_savings_summary()`.
- `tests/unit/test_cmd_policy.py`: assert the decisions output includes `tj optimize`.

## Tests

```bash
python3 -m pytest tests/unit/test_cmd_policy.py -q
# 24 passed
```

## Notes

- Text output only; JSON mode is unchanged.
- `_print_savings_summary()` is the single render path for the meter (empty-decisions and table views), so one addition covers all cases.