### PR TITLE
fix(config): honor TJ_CONFIG at every find_config_file() call site

### DIFF
--- a/tests/integration/test_api.py
+++ b/tests/integration/test_api.py
@@ -1118,7 +1118,7 @@ async def test_post_budget_zero_clears_limit(db):
     app = create_app(config=cfg, db=db, ingest_pipeline=pipeline)
     transport = httpx.ASGITransport(app=app)
 
-    with patch("tokenjam.api.routes.budget.find_config_file", return_value="/fake/tj.toml"), \
+    with patch("tokenjam.api.routes.budget.resolve_config_path", return_value="/fake/tj.toml"), \
          patch("tokenjam.api.routes.budget.write_config"):
         async with httpx.AsyncClient(transport=transport, base_url="http://test") as c:
             resp = await c.post("/api/v1/budget", json={"scope": "my-agent", "daily_usd": 0})
@@ -1165,7 +1165,7 @@ async def test_post_provider_budget_creates_new_ceiling(db):
     app = create_app(config=cfg, db=db, ingest_pipeline=pipeline)
     transport = httpx.ASGITransport(app=app)
 
-    with patch("tokenjam.api.routes.budget.find_config_file", return_value="/fake/tj.toml"), \
+    with patch("tokenjam.api.routes.budget.resolve_config_path", return_value="/fake/tj.toml"), \
          patch("tokenjam.api.routes.budget.write_config"):
         async with httpx.AsyncClient(transport=transport, base_url="http://test") as c:
             resp = await c.post(
@@ -1195,7 +1195,7 @@ async def test_post_provider_budget_zero_clears_ceiling_but_keeps_cycle(db):
     app = create_app(config=cfg, db=db, ingest_pipeline=pipeline)
     transport = httpx.ASGITransport(app=app)
 
-    with patch("tokenjam.api.routes.budget.find_config_file", return_value="/fake/tj.toml"), \
+    with patch("tokenjam.api.routes.budget.resolve_config_path", return_value="/fake/tj.toml"), \
          patch("tokenjam.api.routes.budget.write_config"):
         async with httpx.AsyncClient(transport=transport, base_url="http://test") as c:
             resp = await c.post("/api/v1/budget/provider", json={"provider": "anthropic", "usd": 0})
@@ -1204,6 +1204,86 @@ async def test_post_provider_budget_zero_clears_ceiling_but_keeps_cycle(db):
     pb = resp.json()["provider_budgets"]["anthropic"]
     assert pb["usd"] is None
     assert pb["cycle_start_day"] == 15  # untouched field survives
+
+
+async def test_post_budget_writes_to_tj_config_file_not_search_path(db, tmp_path, monkeypatch):
+    """POST /budget must write to the file `TJ_CONFIG` points at, not a
+    search-path config — the split-brain hazard `_warn_if_secrets_diverge`
+    already warns about, but for budget writes rather than ingest_secret."""
+    tj_config_file = tmp_path / "tj_config" / "custom.toml"
+    tj_config_file.parent.mkdir(parents=True)
+    tj_config_file.write_text("")
+    search_path_file = tmp_path / "search_path" / ".tj" / "config.toml"
+    search_path_file.parent.mkdir(parents=True)
+    search_path_file.write_text("")
+
+    monkeypatch.setenv("TJ_CONFIG", str(tj_config_file))
+    import tokenjam.core.config as cfg_mod
+    monkeypatch.setattr(cfg_mod, "SEARCH_PATHS", [
+        tmp_path / "tokenjam.toml",
+        search_path_file,
+        tmp_path / "global" / "config.toml",
+    ])
+
+    cfg = TjConfig(
+        version="1",
+        security=SecurityConfig(ingest_secret=INGEST_SECRET),
+        api=ApiConfig(auth=ApiAuthConfig(enabled=False)),
+        agents={"my-agent": AgentConfig(budget=BudgetConfig(daily_usd=5.0))},
+    )
+    pipeline = IngestPipeline(db=db, config=cfg)
+    app = create_app(config=cfg, db=db, ingest_pipeline=pipeline)
+    transport = httpx.ASGITransport(app=app)
+
+    with patch("tokenjam.api.routes.budget.write_config") as mock_write:
+        async with httpx.AsyncClient(transport=transport, base_url="http://test") as c:
+            resp = await c.post("/api/v1/budget", json={"scope": "my-agent", "daily_usd": 3.0})
+
+    assert resp.status_code == 200
+    assert mock_write.called
+    written_path = mock_write.call_args[0][1]
+    assert written_path == tj_config_file
+    assert written_path != search_path_file
+
+
+async def test_post_provider_budget_writes_to_tj_config_file_not_search_path(db, tmp_path, monkeypatch):
+    """POST /budget/provider — same split-brain hazard, second write site."""
+    tj_config_file = tmp_path / "tj_config" / "custom.toml"
+    tj_config_file.parent.mkdir(parents=True)
+    tj_config_file.write_text("")
+    search_path_file = tmp_path / "search_path" / ".tj" / "config.toml"
+    search_path_file.parent.mkdir(parents=True)
+    search_path_file.write_text("")
+
+    monkeypatch.setenv("TJ_CONFIG", str(tj_config_file))
+    import tokenjam.core.config as cfg_mod
+    monkeypatch.setattr(cfg_mod, "SEARCH_PATHS", [
+        tmp_path / "tokenjam.toml",
+        search_path_file,
+        tmp_path / "global" / "config.toml",
+    ])
+
+    cfg = TjConfig(
+        version="1",
+        security=SecurityConfig(ingest_secret=INGEST_SECRET),
+        api=ApiConfig(auth=ApiAuthConfig(enabled=False)),
+    )
+    pipeline = IngestPipeline(db=db, config=cfg)
+    app = create_app(config=cfg, db=db, ingest_pipeline=pipeline)
+    transport = httpx.ASGITransport(app=app)
+
+    with patch("tokenjam.api.routes.budget.write_config") as mock_write:
+        async with httpx.AsyncClient(transport=transport, base_url="http://test") as c:
+            resp = await c.post(
+                "/api/v1/budget/provider",
+                json={"provider": "anthropic", "usd": 250.0},
+            )
+
+    assert resp.status_code == 200
+    assert mock_write.called
+    written_path = mock_write.call_args[0][1]
+    assert written_path == tj_config_file
+    assert written_path != search_path_file
 
 
 async def test_post_provider_budget_rejects_invalid_cycle_start_day(db):
@@ -1216,7 +1296,7 @@ async def test_post_provider_budget_rejects_invalid_cycle_start_day(db):
     app = create_app(config=cfg, db=db, ingest_pipeline=pipeline)
     transport = httpx.ASGITransport(app=app)
 
-    with patch("tokenjam.api.routes.budget.find_config_file", return_value="/fake/tj.toml"), \
+    with patch("tokenjam.api.routes.budget.resolve_config_path", return_value="/fake/tj.toml"), \
          patch("tokenjam.api.routes.budget.write_config"):
         async with httpx.AsyncClient(transport=transport, base_url="http://test") as c:
             resp = await c.post(

--- a/tests/integration/test_cli.py
+++ b/tests/integration/test_cli.py
@@ -318,7 +318,7 @@ def test_doctor_exits_0_when_config_is_clean(runner, db, config, tmp_path):
     config.security.ingest_secret = "test-secret"
     # Disable drift so no "insufficient sessions" warning fires
     config.agents["test-agent"].drift.enabled = False
-    with patch("tokenjam.cli.cmd_doctor.find_config_file", return_value=config_file):
+    with patch("tokenjam.cli.cmd_doctor.resolve_config_path", return_value=config_file):
         result = _invoke(runner, db, config, ["doctor", "--json"])
     assert result.exit_code == 0
 
@@ -330,7 +330,7 @@ def test_doctor_exits_1_when_warnings_present(runner, db, config, tmp_path):
     config.agents["test-agent"].drift.enabled = False
     config_file = tmp_path / "tokenjam.toml"
     config_file.write_text('version = "1"\n')
-    with patch("tokenjam.cli.cmd_doctor.find_config_file", return_value=config_file):
+    with patch("tokenjam.cli.cmd_doctor.resolve_config_path", return_value=config_file):
         result = _invoke(runner, db, config, ["doctor", "--json"])
     assert result.exit_code == 1
     checks = json.loads(result.output)
@@ -340,7 +340,7 @@ def test_doctor_exits_1_when_warnings_present(runner, db, config, tmp_path):
 
 def test_doctor_exits_2_when_errors_present(runner, db, config):
     # No config file found => error
-    with patch("tokenjam.cli.cmd_doctor.find_config_file", return_value=None):
+    with patch("tokenjam.cli.cmd_doctor.resolve_config_path", return_value=None):
         result = _invoke(runner, db, config, ["doctor", "--json"])
     assert result.exit_code == 2
 
@@ -354,7 +354,7 @@ def test_doctor_sdk_only_setup_exits_0(runner, db, config, tmp_path):
     _clean_doctor_config(config, tmp_path)
     config_file = tmp_path / "tokenjam.toml"
     config_file.write_text('version = "1"\n')
-    with patch("tokenjam.cli.cmd_doctor.find_config_file", return_value=config_file):
+    with patch("tokenjam.cli.cmd_doctor.resolve_config_path", return_value=config_file):
         result = _invoke(runner, db, config, ["doctor", "--json"])
     assert result.exit_code == 0
     checks = json.loads(result.output)
@@ -377,7 +377,7 @@ def test_doctor_no_staleness_warning_with_fresh_spans(runner, db, config, tmp_pa
     db.insert_span(span)
     config_file = tmp_path / "tokenjam.toml"
     config_file.write_text('version = "1"\n')
-    with patch("tokenjam.cli.cmd_doctor.find_config_file", return_value=config_file):
+    with patch("tokenjam.cli.cmd_doctor.resolve_config_path", return_value=config_file):
         result = _invoke(runner, db, config, ["doctor", "--json"])
     assert result.exit_code == 0
     checks = json.loads(result.output)
@@ -394,7 +394,7 @@ def test_doctor_warns_on_stale_spans(runner, db, config, tmp_path):
     db.insert_span(span)
     config_file = tmp_path / "tokenjam.toml"
     config_file.write_text('version = "1"\n')
-    with patch("tokenjam.cli.cmd_doctor.find_config_file", return_value=config_file):
+    with patch("tokenjam.cli.cmd_doctor.resolve_config_path", return_value=config_file):
         result = _invoke(runner, db, config, ["doctor", "--json"])
     assert result.exit_code == 1
     checks = json.loads(result.output)
@@ -408,7 +408,7 @@ def test_doctor_no_staleness_warning_when_no_spans(runner, db, config, tmp_path)
     _clean_doctor_config(config, tmp_path)
     config_file = tmp_path / "tokenjam.toml"
     config_file.write_text('version = "1"\n')
-    with patch("tokenjam.cli.cmd_doctor.find_config_file", return_value=config_file):
+    with patch("tokenjam.cli.cmd_doctor.resolve_config_path", return_value=config_file):
         result = _invoke(runner, db, config, ["doctor", "--json"])
     assert result.exit_code == 0
     checks = json.loads(result.output)
@@ -423,7 +423,7 @@ def test_doctor_onboarding_signal_info_when_silent(runner, db, config, tmp_path)
     _clean_doctor_config(config, tmp_path)
     config_file = tmp_path / "tokenjam.toml"
     config_file.write_text('version = "1"\n')
-    with patch("tokenjam.cli.cmd_doctor.find_config_file", return_value=config_file):
+    with patch("tokenjam.cli.cmd_doctor.resolve_config_path", return_value=config_file):
         result = _invoke(runner, db, config, ["doctor", "--json"])
     assert result.exit_code == 0
     checks = json.loads(result.output)
@@ -438,7 +438,7 @@ def test_doctor_onboarding_signal_ok_with_spans(runner, db, config, tmp_path):
     db.insert_span(make_llm_span(agent_id="test-agent", start_time=utcnow()))
     config_file = tmp_path / "tokenjam.toml"
     config_file.write_text('version = "1"\n')
-    with patch("tokenjam.cli.cmd_doctor.find_config_file", return_value=config_file):
+    with patch("tokenjam.cli.cmd_doctor.resolve_config_path", return_value=config_file):
         result = _invoke(runner, db, config, ["doctor", "--json"])
     assert result.exit_code == 0
     checks = json.loads(result.output)
@@ -451,7 +451,7 @@ def test_doctor_warns_on_schema_without_capture(runner, db, config, tmp_path):
     config.capture.tool_outputs = False
     config_file = tmp_path / "tokenjam.toml"
     config_file.write_text('version = "1"\n')
-    with patch("tokenjam.cli.cmd_doctor.find_config_file", return_value=config_file):
+    with patch("tokenjam.cli.cmd_doctor.resolve_config_path", return_value=config_file):
         result = _invoke(runner, db, config, ["doctor", "--json"])
     checks = json.loads(result.output)
     schema_checks = [c for c in checks if c["name"] == "Schema vs capture"]
@@ -483,7 +483,7 @@ def test_doctor_warns_on_missing_schema_column(runner, config, tmp_path):
     config_file = tmp_path / "tokenjam.toml"
     config_file.write_text('version = "1"\n')
     try:
-        with patch("tokenjam.cli.cmd_doctor.find_config_file", return_value=config_file):
+        with patch("tokenjam.cli.cmd_doctor.resolve_config_path", return_value=config_file):
             result = _invoke(runner, backend, config, ["doctor", "--json"])
         assert result.exit_code == 1
         checks = json.loads(result.output)
@@ -501,7 +501,7 @@ def test_doctor_repair_heals_missing_schema_column(runner, config, tmp_path):
     config_file = tmp_path / "tokenjam.toml"
     config_file.write_text('version = "1"\n')
     try:
-        with patch("tokenjam.cli.cmd_doctor.find_config_file", return_value=config_file):
+        with patch("tokenjam.cli.cmd_doctor.resolve_config_path", return_value=config_file):
             repair = _invoke(runner, backend, config, ["doctor", "--repair"])
         assert "Schema reconciled" in repair.output
         cols = {
@@ -513,7 +513,7 @@ def test_doctor_repair_heals_missing_schema_column(runner, config, tmp_path):
         }
         assert {"request_params", "request_tools"} <= cols
         # A follow-up doctor run now reports the schema as healthy.
-        with patch("tokenjam.cli.cmd_doctor.find_config_file", return_value=config_file):
+        with patch("tokenjam.cli.cmd_doctor.resolve_config_path", return_value=config_file):
             again = _invoke(runner, backend, config, ["doctor", "--json"])
         checks = json.loads(again.output)
         integrity = [c for c in checks if c["name"] == "Schema integrity"]
@@ -538,7 +538,7 @@ def test_doctor_mcp_wiring_checks(runner, db, config, tmp_path):
     with patch("pathlib.Path.home", return_value=fake_home), \
          patch("pathlib.Path.cwd", return_value=fake_cwd), \
          patch("shutil.which", return_value=None), \
-         patch("tokenjam.cli.cmd_doctor.find_config_file", return_value=config_file):
+         patch("tokenjam.cli.cmd_doctor.resolve_config_path", return_value=config_file):
         result = _invoke(runner, db, config, ["doctor", "--json"])
         assert result.exit_code == 0
         checks = json.loads(result.output)
@@ -555,7 +555,7 @@ def test_doctor_mcp_wiring_checks(runner, db, config, tmp_path):
     with patch("pathlib.Path.home", return_value=fake_home), \
          patch("pathlib.Path.cwd", return_value=fake_cwd), \
          patch("shutil.which", side_effect=lambda cmd: "/bin/claude" if cmd == "claude" else None), \
-         patch("tokenjam.cli.cmd_doctor.find_config_file", return_value=config_file):
+         patch("tokenjam.cli.cmd_doctor.resolve_config_path", return_value=config_file):
         result = _invoke(runner, db, config, ["doctor", "--json"])
         checks = json.loads(result.output)
         mcp_checks = [c for c in checks if c["name"] == "MCP wiring"]
@@ -582,7 +582,7 @@ def test_doctor_mcp_wiring_checks(runner, db, config, tmp_path):
     with patch("pathlib.Path.home", return_value=fake_home), \
          patch("pathlib.Path.cwd", return_value=fake_cwd), \
          patch("shutil.which", return_value=None), \
-         patch("tokenjam.cli.cmd_doctor.find_config_file", return_value=config_file):
+         patch("tokenjam.cli.cmd_doctor.resolve_config_path", return_value=config_file):
         result = _invoke(runner, db, config, ["doctor", "--json"])
         assert result.exit_code == 1
         checks = json.loads(result.output)
@@ -608,7 +608,7 @@ def test_doctor_mcp_wiring_checks(runner, db, config, tmp_path):
     with patch("pathlib.Path.home", return_value=fake_home), \
          patch("pathlib.Path.cwd", return_value=fake_cwd), \
          patch("shutil.which", return_value=None), \
-         patch("tokenjam.cli.cmd_doctor.find_config_file", return_value=config_file):
+         patch("tokenjam.cli.cmd_doctor.resolve_config_path", return_value=config_file):
         result = _invoke(runner, db, config, ["doctor", "--json"])
         assert result.exit_code == 1
         checks = json.loads(result.output)
@@ -628,7 +628,7 @@ def test_doctor_mcp_wiring_checks(runner, db, config, tmp_path):
     with patch("pathlib.Path.home", return_value=fake_home), \
          patch("pathlib.Path.cwd", return_value=fake_cwd), \
          patch("shutil.which", return_value=None), \
-         patch("tokenjam.cli.cmd_doctor.find_config_file", return_value=config_file):
+         patch("tokenjam.cli.cmd_doctor.resolve_config_path", return_value=config_file):
         result = _invoke(runner, db, config, ["doctor", "--json"])
         assert result.exit_code == 1
         checks = json.loads(result.output)
@@ -660,7 +660,7 @@ def test_doctor_mcp_wiring_message_renders_bracket_literal(runner, db, config, t
     with patch("pathlib.Path.home", return_value=fake_home), \
          patch("pathlib.Path.cwd", return_value=fake_cwd), \
          patch("shutil.which", return_value=None), \
-         patch("tokenjam.cli.cmd_doctor.find_config_file", return_value=config_file):
+         patch("tokenjam.cli.cmd_doctor.resolve_config_path", return_value=config_file):
         result = _invoke(runner, db, config, ["doctor"])
 
     assert "[mcp_servers.tj]" in result.output
@@ -811,7 +811,7 @@ def test_onboard_claude_code_writes_settings(runner, tmp_path):
     fake_home.mkdir()
     settings_path = fake_home / ".claude" / "settings.json"
 
-    with patch("tokenjam.cli.cmd_onboard.find_config_file", return_value=None), \
+    with patch("tokenjam.cli.cmd_onboard.resolve_config_path", return_value=None), \
          patch("tokenjam.cli.cmd_onboard.Path.home", return_value=fake_home), \
          patch("tokenjam.cli.cmd_onboard.click.confirm", return_value=False):
         result = runner.invoke(cli, ["onboard", "--claude-code", "--no-daemon", "--budget", "5.0", "--plan", "max_20x", "--project", "aquanode"])
@@ -835,7 +835,7 @@ def test_onboard_claude_code_preserves_existing(runner, tmp_path):
         json.dumps({"theme": "dark", "env": {"MY_VAR": "preserved"}}) + "\n"
     )
 
-    with patch("tokenjam.cli.cmd_onboard.find_config_file", return_value=None), \
+    with patch("tokenjam.cli.cmd_onboard.resolve_config_path", return_value=None), \
          patch("tokenjam.cli.cmd_onboard.Path.home", return_value=fake_home), \
          patch("tokenjam.cli.cmd_onboard.click.confirm", return_value=False):
         runner.invoke(cli, ["onboard", "--claude-code", "--no-daemon", "--budget", "5.0", "--plan", "max_20x", "--project", "aquanode"])
@@ -854,7 +854,7 @@ def test_onboard_claude_code_creates_tj_config(runner, tmp_path):
     fake_home = tmp_path / "home"
     fake_home.mkdir()
 
-    with patch("tokenjam.cli.cmd_onboard.find_config_file", return_value=None), \
+    with patch("tokenjam.cli.cmd_onboard.resolve_config_path", return_value=None), \
          patch("tokenjam.cli.cmd_onboard.Path.home", return_value=fake_home), \
          patch("tokenjam.cli.cmd_onboard.click.confirm", return_value=False), \
          patch("tokenjam.core.config.write_config") as mock_write:
@@ -874,7 +874,7 @@ def test_onboard_claude_code_prompts_for_budget(runner, tmp_path):
     fake_home = tmp_path / "home"
     fake_home.mkdir()
 
-    with patch("tokenjam.cli.cmd_onboard.find_config_file", return_value=None), \
+    with patch("tokenjam.cli.cmd_onboard.resolve_config_path", return_value=None), \
          patch("tokenjam.cli.cmd_onboard.Path.home", return_value=fake_home), \
          patch("tokenjam.cli.cmd_onboard.click.confirm", return_value=False), \
          patch("tokenjam.core.config.write_config") as mock_write:
@@ -897,7 +897,7 @@ def test_onboard_claude_code_skips_budget_prompt_for_subscription_plan(runner, t
     fake_home = tmp_path / "home"
     fake_home.mkdir()
 
-    with patch("tokenjam.cli.cmd_onboard.find_config_file", return_value=None), \
+    with patch("tokenjam.cli.cmd_onboard.resolve_config_path", return_value=None), \
          patch("tokenjam.cli.cmd_onboard.Path.home", return_value=fake_home), \
          patch("tokenjam.cli.cmd_onboard.click.confirm", return_value=False), \
          patch("tokenjam.core.config.write_config") as mock_write:
@@ -920,7 +920,7 @@ def test_onboard_claude_code_project_flag_sets_config_project(runner, tmp_path):
     fake_home.mkdir()
 
     with runner.isolated_filesystem() as cwd, \
-         patch("tokenjam.cli.cmd_onboard.find_config_file", return_value=None), \
+         patch("tokenjam.cli.cmd_onboard.resolve_config_path", return_value=None), \
          patch("tokenjam.cli.cmd_onboard.Path.home", return_value=fake_home), \
          patch("tokenjam.cli.cmd_onboard.click.confirm", return_value=False):
         result = runner.invoke(cli, [
@@ -947,7 +947,7 @@ def test_onboard_claude_code_prompts_for_project_name(runner, tmp_path):
     fake_home.mkdir()
 
     with runner.isolated_filesystem() as cwd, \
-         patch("tokenjam.cli.cmd_onboard.find_config_file", return_value=None), \
+         patch("tokenjam.cli.cmd_onboard.resolve_config_path", return_value=None), \
          patch("tokenjam.cli.cmd_onboard.Path.home", return_value=fake_home), \
          patch("tokenjam.cli.cmd_onboard.click.confirm", return_value=False):
         # First prompt is the project name; budget is supplied via flag.
@@ -973,7 +973,7 @@ def test_onboard_claude_code_removes_existing_resource_attrs(runner, tmp_path):
     fake_home.mkdir()
 
     with runner.isolated_filesystem() as cwd, \
-         patch("tokenjam.cli.cmd_onboard.find_config_file", return_value=None), \
+         patch("tokenjam.cli.cmd_onboard.resolve_config_path", return_value=None), \
          patch("tokenjam.cli.cmd_onboard.Path.home", return_value=fake_home), \
          patch("tokenjam.cli.cmd_onboard.click.confirm", return_value=False):
         proj_settings = Path(cwd) / ".claude" / "settings.json"
@@ -1091,7 +1091,7 @@ def test_onboard_does_not_prompt_for_daemon(runner, tmp_path):
     """Regression: tj onboard should auto-install the daemon without
     prompting. The prompt was removed in v0.1.6 but reappeared.
     See v0.1.7 fix."""
-    with patch("tokenjam.cli.cmd_onboard.find_config_file", return_value=None), \
+    with patch("tokenjam.cli.cmd_onboard.resolve_config_path", return_value=None), \
          patch("tokenjam.cli.cmd_onboard._install_daemon", return_value="Daemon installed") as mock_daemon:
         result = runner.invoke(cli, ["onboard", "--budget", "5.0"], input="")
     assert result.exit_code == 0
@@ -1103,7 +1103,7 @@ def test_onboard_does_not_prompt_for_daemon(runner, tmp_path):
 
 def test_onboard_no_daemon_skips_install(runner, tmp_path):
     """--no-daemon flag should skip daemon installation entirely."""
-    with patch("tokenjam.cli.cmd_onboard.find_config_file", return_value=None), \
+    with patch("tokenjam.cli.cmd_onboard.resolve_config_path", return_value=None), \
          patch("tokenjam.cli.cmd_onboard._install_daemon") as mock_daemon:
         result = runner.invoke(cli, ["onboard", "--budget", "5.0", "--no-daemon"])
     assert result.exit_code == 0
@@ -1136,7 +1136,7 @@ def test_budget_set_global_writes_config(runner, db, config, tmp_path):
 
     with patch("tokenjam.cli.main.load_config", return_value=config), \
          patch("tokenjam.cli.main.open_db", return_value=db), \
-         patch("tokenjam.cli.cmd_budget.find_config_file", return_value=str(config_file)), \
+         patch("tokenjam.cli.cmd_budget.resolve_config_path", return_value=str(config_file)), \
          patch("tokenjam.cli.cmd_budget.write_config") as mock_write:
         result = runner.invoke(cli, ["budget", "--daily", "8.0"])
 
@@ -1153,7 +1153,7 @@ def test_budget_set_json_outputs_updated_values(runner, db, config, tmp_path):
 
     with patch("tokenjam.cli.main.load_config", return_value=config), \
          patch("tokenjam.cli.main.open_db", return_value=db), \
-         patch("tokenjam.cli.cmd_budget.find_config_file", return_value=str(config_file)), \
+         patch("tokenjam.cli.cmd_budget.resolve_config_path", return_value=str(config_file)), \
          patch("tokenjam.cli.cmd_budget.write_config"):
         result = runner.invoke(cli, ["budget", "--daily", "8.0", "--json"])
 
@@ -1176,7 +1176,7 @@ def test_budget_set_agent_writes_config(runner, db, config, tmp_path):
 
     with patch("tokenjam.cli.main.load_config", return_value=config), \
          patch("tokenjam.cli.main.open_db", return_value=db), \
-         patch("tokenjam.cli.cmd_budget.find_config_file", return_value=str(config_file)), \
+         patch("tokenjam.cli.cmd_budget.resolve_config_path", return_value=str(config_file)), \
          patch("tokenjam.cli.cmd_budget.write_config") as mock_write:
         result = runner.invoke(
             cli, ["budget", "--agent", "test-agent", "--daily", "3.0", "--session", "0.25"]
@@ -1187,6 +1187,38 @@ def test_budget_set_agent_writes_config(runner, db, config, tmp_path):
     saved_config = mock_write.call_args[0][0]
     assert saved_config.agents["test-agent"].budget.daily_usd == 3.0
     assert saved_config.agents["test-agent"].budget.session_usd == 0.25
+
+
+def test_budget_set_writes_to_tj_config_file_not_search_path(runner, db, config, tmp_path, monkeypatch):
+    """`tj budget --daily` must write to the file `TJ_CONFIG` points at, not a
+    search-path config — otherwise the write silently splits from the config
+    the process actually read (a stale search-path file gets the update,
+    while the live TJ_CONFIG file the daemon/SDK reads never changes)."""
+    tj_config_file = tmp_path / "tj_config" / "custom.toml"
+    tj_config_file.parent.mkdir(parents=True)
+    tj_config_file.write_text("")
+    search_path_file = tmp_path / "search_path" / ".tj" / "config.toml"
+    search_path_file.parent.mkdir(parents=True)
+    search_path_file.write_text("")
+
+    monkeypatch.setenv("TJ_CONFIG", str(tj_config_file))
+    import tokenjam.core.config as cfg_mod
+    monkeypatch.setattr(cfg_mod, "SEARCH_PATHS", [
+        tmp_path / "tokenjam.toml",
+        search_path_file,
+        tmp_path / "global" / "config.toml",
+    ])
+
+    with patch("tokenjam.cli.main.load_config", return_value=config), \
+         patch("tokenjam.cli.main.open_db", return_value=db), \
+         patch("tokenjam.cli.cmd_budget.write_config") as mock_write:
+        result = runner.invoke(cli, ["budget", "--daily", "8.0"])
+
+    assert result.exit_code == 0, result.output
+    assert mock_write.called
+    written_path = mock_write.call_args[0][1]
+    assert Path(written_path) == tj_config_file
+    assert Path(written_path) != search_path_file
 
 
 def test_optimize_empty_db_outputs_friendly_message(runner, db, config):
@@ -1654,7 +1686,7 @@ def test_budget_set_negative_daily_rejected(runner, db, config, tmp_path):
 
     with patch("tokenjam.cli.main.load_config", return_value=config), \
          patch("tokenjam.cli.main.open_db", return_value=db), \
-         patch("tokenjam.cli.cmd_budget.find_config_file", return_value=str(config_file)), \
+         patch("tokenjam.cli.cmd_budget.resolve_config_path", return_value=str(config_file)), \
          patch("tokenjam.cli.cmd_budget.write_config") as mock_write:
         result = runner.invoke(cli, ["budget", "--daily", "-5"])
 
@@ -1851,7 +1883,7 @@ def test_onboard_claude_code_installs_claude_wrapper(runner, tmp_path):
     fake_home.mkdir()
     zshrc = fake_home / ".zshrc"
 
-    with patch("tokenjam.cli.cmd_onboard.find_config_file", return_value=None), \
+    with patch("tokenjam.cli.cmd_onboard.resolve_config_path", return_value=None), \
          patch("tokenjam.cli.cmd_onboard.Path.home", return_value=fake_home), \
          patch("tokenjam.cli.cmd_onboard.click.confirm", return_value=False):
         result = runner.invoke(cli, [
@@ -1885,7 +1917,7 @@ def test_onboard_claude_code_wrapper_is_idempotent(runner, tmp_path):
     fake_home.mkdir()
     zshrc = fake_home / ".zshrc"
 
-    with patch("tokenjam.cli.cmd_onboard.find_config_file", return_value=None), \
+    with patch("tokenjam.cli.cmd_onboard.resolve_config_path", return_value=None), \
          patch("tokenjam.cli.cmd_onboard.Path.home", return_value=fake_home), \
          patch("tokenjam.cli.cmd_onboard.click.confirm", return_value=False):
         args = [
@@ -1910,7 +1942,7 @@ def test_onboard_claude_code_wrapper_writes_bashrc_when_present(runner, tmp_path
     bashrc = fake_home / ".bashrc"
     bashrc.write_text("# existing bashrc\n")
 
-    with patch("tokenjam.cli.cmd_onboard.find_config_file", return_value=None), \
+    with patch("tokenjam.cli.cmd_onboard.resolve_config_path", return_value=None), \
          patch("tokenjam.cli.cmd_onboard.Path.home", return_value=fake_home), \
          patch("tokenjam.cli.cmd_onboard.click.confirm", return_value=False):
         result = runner.invoke(cli, [
@@ -1951,7 +1983,7 @@ def test_onboard_claude_code_replaces_legacy_zshrc_otel_markers(runner, tmp_path
         'export OTEL_EXPORTER_OTLP_HEADERS="Authorization=Bearer stale-tj-token"\n'
     )
 
-    with patch("tokenjam.cli.cmd_onboard.find_config_file", return_value=None), \
+    with patch("tokenjam.cli.cmd_onboard.resolve_config_path", return_value=None), \
          patch("tokenjam.cli.cmd_onboard.Path.home", return_value=fake_home), \
          patch("tokenjam.cli.cmd_onboard.click.confirm", return_value=False):
         result = runner.invoke(cli, [

--- a/tests/unit/test_cmd_mcp_config_discovery.py
+++ b/tests/unit/test_cmd_mcp_config_discovery.py
@@ -1,0 +1,60 @@
+"""`tj mcp` config discovery honors TJ_CONFIG.
+
+Regression for the shape bug where several `find_config_file()` call sites
+across the codebase called it bare, ignoring `TJ_CONFIG`, even though the
+surrounding code already assumes a `TJ_CONFIG`-aware config. `cmd_mcp` boots
+the MCP server against whatever config it resolves here — a bare call would
+silently fall back to the global/search-path config even when the user (or
+an SDK-launched subprocess) set `TJ_CONFIG` to point elsewhere.
+"""
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+from click.testing import CliRunner
+
+from tokenjam.cli.cmd_mcp import cmd_mcp
+
+
+def test_cmd_mcp_resolves_config_via_tj_config(monkeypatch, tmp_path):
+    cfg_file = tmp_path / "custom.toml"
+    cfg_file.write_text(
+        'version = "1"\n\n[storage]\npath = "%s"\n' % (tmp_path / "db.duckdb")
+    )
+    monkeypatch.setenv("TJ_CONFIG", str(cfg_file))
+
+    mock_init = MagicMock()
+    mock_mcp = MagicMock()
+    with patch("tokenjam.mcp.server.init", mock_init), \
+         patch("tokenjam.mcp.server.mcp", mock_mcp), \
+         patch("tokenjam.cli.cmd_mcp._port_open", return_value=False), \
+         patch("tokenjam.cli.cmd_mcp._start_and_wait", return_value=False), \
+         patch("tokenjam.cli.cmd_mcp.duckdb.connect", return_value=MagicMock()):
+        result = CliRunner().invoke(cmd_mcp, [], obj={})
+
+    assert result.exit_code == 0, result.output
+    assert mock_init.called
+    _, kwargs = mock_init.call_args
+    assert kwargs["config"].storage.path == str(tmp_path / "db.duckdb")
+
+
+def test_cmd_mcp_falls_back_to_no_config_sentinel_without_tj_config(monkeypatch, tmp_path):
+    """No TJ_CONFIG and nothing on the search path → init() never called, so
+    the MCP tools return their built-in no-config sentinel."""
+    monkeypatch.delenv("TJ_CONFIG", raising=False)
+    monkeypatch.chdir(tmp_path)
+    import tokenjam.core.config as cfg_mod
+    monkeypatch.setattr(cfg_mod, "SEARCH_PATHS", [
+        tmp_path / "tokenjam.toml",
+        tmp_path / ".tj" / "config.toml",
+        tmp_path / ".config" / "tj" / "config.toml",
+    ])
+
+    mock_init = MagicMock()
+    mock_mcp = MagicMock()
+    with patch("tokenjam.mcp.server.init", mock_init), \
+         patch("tokenjam.mcp.server.mcp", mock_mcp):
+        result = CliRunner().invoke(cmd_mcp, [], obj={})
+
+    assert result.exit_code == 0, result.output
+    assert not mock_init.called

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -4,10 +4,10 @@ from pathlib import Path
 import pytest
 
 from tokenjam.core.config import (
-    find_config_file, load_config, _parse, _serialise, TjConfig, AgentConfig,
-    BudgetConfig, DefaultsConfig, SensitiveAction, SecurityConfig, CaptureConfig,
-    OptimizeConfig, StorageConfig, resolve_effective_budget, validate_budget_value,
-    validate_cycle_start_day,
+    find_config_file, load_config, resolve_config_path, _parse, _serialise,
+    TjConfig, AgentConfig, BudgetConfig, DefaultsConfig, SensitiveAction,
+    SecurityConfig, CaptureConfig, OptimizeConfig, StorageConfig,
+    resolve_effective_budget, validate_budget_value, validate_cycle_start_day,
 )
 
 
@@ -58,6 +58,57 @@ class TestFindConfigFile:
             tmp_path / ".config" / "tj" / "config.toml",
         ])
         assert find_config_file() is None
+
+
+class TestResolveConfigPath:
+    """resolve_config_path is the single source of truth every call site (CLI
+    writers, `tj doctor`, `tj mcp`, the MCP server) must go through so config
+    discovery honors TJ_CONFIG the same way load_config does -- a bare
+    find_config_file() call ignores TJ_CONFIG entirely."""
+
+    def test_honors_tj_config_env_var(self, tmp_path, monkeypatch):
+        cfg = tmp_path / "proj.toml"
+        cfg.write_bytes(b'version = "1"\n')
+        monkeypatch.setenv("TJ_CONFIG", str(cfg))
+        assert resolve_config_path() == cfg
+
+    def test_explicit_override_beats_tj_config_env_var(self, tmp_path, monkeypatch):
+        env_cfg = tmp_path / "env.toml"
+        env_cfg.write_bytes(b'version = "1"\n')
+        explicit_cfg = tmp_path / "explicit.toml"
+        explicit_cfg.write_bytes(b'version = "1"\n')
+        monkeypatch.setenv("TJ_CONFIG", str(env_cfg))
+        assert resolve_config_path(str(explicit_cfg)) == explicit_cfg
+
+    def test_falls_back_to_search_paths_when_tj_config_unset(self, tmp_path, monkeypatch):
+        monkeypatch.chdir(tmp_path)
+        monkeypatch.delenv("TJ_CONFIG", raising=False)
+        import tokenjam.core.config as cfg_mod
+        local_config = tmp_path / ".tj" / "config.toml"
+        local_config.parent.mkdir(parents=True)
+        local_config.write_bytes(b'version = "1"\n')
+        monkeypatch.setattr(cfg_mod, "SEARCH_PATHS", [
+            Path("tokenjam.toml"),
+            Path(".tj/config.toml"),
+            tmp_path / ".config" / "tj" / "config.toml",
+        ])
+        assert resolve_config_path() == Path(".tj/config.toml")
+
+    def test_raises_when_tj_config_points_at_missing_file(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("TJ_CONFIG", str(tmp_path / "nope.toml"))
+        with pytest.raises(FileNotFoundError, match="Config file not found"):
+            resolve_config_path()
+
+    def test_returns_none_when_nothing_discoverable(self, tmp_path, monkeypatch):
+        monkeypatch.chdir(tmp_path)
+        monkeypatch.delenv("TJ_CONFIG", raising=False)
+        import tokenjam.core.config as cfg_mod
+        monkeypatch.setattr(cfg_mod, "SEARCH_PATHS", [
+            Path("tokenjam.toml"),
+            Path(".tj/config.toml"),
+            tmp_path / ".config" / "tj" / "config.toml",
+        ])
+        assert resolve_config_path() is None
 
 
 class TestLoadConfig:

--- a/tests/unit/test_config_discovery_guard.py
+++ b/tests/unit/test_config_discovery_guard.py
@@ -1,0 +1,64 @@
+"""Guard against reintroducing bare `find_config_file()` call sites.
+
+A bare `find_config_file()` call silently ignores `TJ_CONFIG`, even when the
+surrounding code already assumes a `TJ_CONFIG`-aware config (loaded via
+`load_config`, which does honor it). That shape recurred at 8+ call sites
+across the CLI, the API, and the MCP server before this guard was added —
+each one independently "forgot" to pass the env override through. The fix:
+`resolve_config_path()` in `core/config.py` is now the single source of
+truth for "which config file is this process using"; everything except
+`core/config.py` itself (which defines both functions) and `cli/home.py`
+(whose bare `tj` landing screen must stay resilient to an invalid TJ_CONFIG —
+see the `_tj_config_env_path` docstring there) must go through it instead of
+calling `find_config_file` directly.
+"""
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+PACKAGE_ROOT = REPO_ROOT / "tokenjam"
+
+# Files allowed to call find_config_file() directly.
+#   - core/config.py: defines both find_config_file and resolve_config_path;
+#     resolve_config_path's own implementation calls find_config_file.
+#   - cli/home.py: the bare `tj` landing screen renders before any config is
+#     validated, so it needs a non-raising TJ_CONFIG check (see
+#     _tj_config_env_path) rather than resolve_config_path's fail-loud
+#     contract. Both of its bare calls are documented, safety-motivated
+#     exceptions, not oversights.
+_ALLOWED_RELATIVE_PATHS = {
+    Path("core/config.py"),
+    Path("cli/home.py"),
+}
+
+_CALL_PATTERN = re.compile(r"\bfind_config_file\s*\(")
+
+
+def _iter_source_files():
+    for path in PACKAGE_ROOT.rglob("*.py"):
+        yield path
+
+
+def test_no_bare_find_config_file_outside_allowlist():
+    offenders: list[str] = []
+    for path in _iter_source_files():
+        rel = path.relative_to(PACKAGE_ROOT)
+        if rel in _ALLOWED_RELATIVE_PATHS:
+            continue
+        text = path.read_text()
+        for lineno, line in enumerate(text.splitlines(), start=1):
+            stripped = line.strip()
+            if stripped.startswith("#"):
+                continue
+            if _CALL_PATTERN.search(line):
+                offenders.append(f"{rel}:{lineno}: {stripped}")
+
+    assert not offenders, (
+        "Found bare find_config_file() call(s) outside the allowlist — these "
+        "silently ignore TJ_CONFIG. Use resolve_config_path() instead (or, "
+        "for a call site that must stay resilient to an invalid TJ_CONFIG "
+        "like cli/home.py, add it to _ALLOWED_RELATIVE_PATHS with a comment "
+        "explaining why):\n" + "\n".join(offenders)
+    )

--- a/tests/unit/test_doctor_paths.py
+++ b/tests/unit/test_doctor_paths.py
@@ -13,13 +13,31 @@ def test_config_path_message_collapses_home(monkeypatch, tmp_path):
     cfg.parent.mkdir(parents=True)
     cfg.write_text('version = "1"\n')
     monkeypatch.setenv("HOME", str(home))
-    monkeypatch.setattr("tokenjam.cli.cmd_doctor.find_config_file", lambda: cfg)
+    monkeypatch.setattr("tokenjam.cli.cmd_doctor.resolve_config_path", lambda: cfg)
     monkeypatch.setattr("tokenjam.cli.cmd_doctor.load_config", lambda _p: None)
 
     check = _check_config()
     assert check["level"] == "ok"
     assert "~/.config/tj/config.toml" in check["message"]
     assert str(home) not in check["message"]
+
+
+def test_check_config_honors_tj_config(monkeypatch, tmp_path):
+    """`_check_config` must resolve the same file `load_config` reads —
+    otherwise doctor reports "No config file found" while every other check
+    (which reads `ctx.obj["config"]`, loaded via `load_config`/TJ_CONFIG) is
+    passing fine against a real, TJ_CONFIG-pointed config."""
+    cfg = tmp_path / "custom-location.toml"
+    cfg.write_text('version = "1"\n')
+    monkeypatch.setenv("TJ_CONFIG", str(cfg))
+    # No SEARCH_PATHS patching here — the point is that TJ_CONFIG alone,
+    # with nothing discoverable at the default search paths, is enough.
+    import tokenjam.core.config as cfg_mod
+    monkeypatch.setattr(cfg_mod, "SEARCH_PATHS", [])
+
+    check = _check_config()
+    assert check["level"] == "ok"
+    assert "custom-location.toml" in check["message"]
 
 
 def test_db_path_message_collapses_home(monkeypatch, tmp_path):

--- a/tests/unit/test_mcp_setup_project_tj_config.py
+++ b/tests/unit/test_mcp_setup_project_tj_config.py
@@ -1,0 +1,54 @@
+"""`setup_project` MCP tool resolves its config path via TJ_CONFIG.
+
+Regression for the shape bug where several `find_config_file()` call sites
+called it bare, ignoring `TJ_CONFIG`, even though the surrounding process was
+already `TJ_CONFIG`-aware. This tool passes its resolved config_path into
+`_tool_setup_project`, which uses it to decide where OTEL_RESOURCE_ATTRIBUTES
+gets written — a bare call would silently report the wrong (or no) config
+path when the MCP server process has TJ_CONFIG set.
+"""
+from __future__ import annotations
+
+from unittest.mock import patch
+
+from tokenjam.mcp import server as server_mod
+
+
+def test_setup_project_honors_tj_config(monkeypatch, tmp_path):
+    cfg_file = tmp_path / "custom.toml"
+    cfg_file.write_text('version = "1"\n')
+    monkeypatch.setenv("TJ_CONFIG", str(cfg_file))
+
+    captured = {}
+
+    def _fake_tool_setup_project(**kwargs):
+        captured.update(kwargs)
+        return {"ok": True}
+
+    with patch.object(server_mod, "_tool_setup_project", _fake_tool_setup_project):
+        result = server_mod.setup_project(agent_id="probe", project_path=str(tmp_path))
+
+    assert result == {"ok": True}
+    assert captured["config_path"] == str(cfg_file)
+
+
+def test_setup_project_no_config_when_nothing_discoverable(monkeypatch, tmp_path):
+    monkeypatch.delenv("TJ_CONFIG", raising=False)
+    monkeypatch.chdir(tmp_path)
+    import tokenjam.core.config as cfg_mod
+    monkeypatch.setattr(cfg_mod, "SEARCH_PATHS", [
+        tmp_path / "tokenjam.toml",
+        tmp_path / ".tj" / "config.toml",
+        tmp_path / ".config" / "tj" / "config.toml",
+    ])
+
+    captured = {}
+
+    def _fake_tool_setup_project(**kwargs):
+        captured.update(kwargs)
+        return {"ok": True}
+
+    with patch.object(server_mod, "_tool_setup_project", _fake_tool_setup_project):
+        server_mod.setup_project(agent_id="probe", project_path=str(tmp_path))
+
+    assert captured["config_path"] is None

--- a/tests/unit/test_onboard_capture_default.py
+++ b/tests/unit/test_onboard_capture_default.py
@@ -28,7 +28,7 @@ from tokenjam.core.config import load_config
 
 @pytest.fixture(autouse=True)
 def _no_existing_config(monkeypatch):
-    monkeypatch.setattr("tokenjam.cli.cmd_onboard.find_config_file", lambda: None)
+    monkeypatch.setattr("tokenjam.cli.cmd_onboard.resolve_config_path", lambda: None)
 
 
 def _run_plain(tmp_path):

--- a/tests/unit/test_onboard_hygiene.py
+++ b/tests/unit/test_onboard_hygiene.py
@@ -11,7 +11,7 @@ from tokenjam.cli.cmd_onboard import cmd_onboard
 
 @pytest.fixture(autouse=True)
 def _no_existing_config(monkeypatch):
-    monkeypatch.setattr("tokenjam.cli.cmd_onboard.find_config_file", lambda: None)
+    monkeypatch.setattr("tokenjam.cli.cmd_onboard.resolve_config_path", lambda: None)
 
 
 def _run(tmp_path):

--- a/tests/unit/test_onboard_plan.py
+++ b/tests/unit/test_onboard_plan.py
@@ -12,7 +12,7 @@ from tokenjam.cli.cmd_onboard import cmd_onboard
 @pytest.fixture(autouse=True)
 def _no_existing_config(monkeypatch):
     # Force the fresh-config path regardless of any ~/.config/tj on the machine.
-    monkeypatch.setattr("tokenjam.cli.cmd_onboard.find_config_file", lambda: None)
+    monkeypatch.setattr("tokenjam.cli.cmd_onboard.resolve_config_path", lambda: None)
 
 
 def _onboard(tmp_path, *args):

--- a/tests/unit/test_onboard_stack_detection.py
+++ b/tests/unit/test_onboard_stack_detection.py
@@ -17,7 +17,7 @@ from tokenjam.cli.cmd_onboard import cmd_onboard
 
 @pytest.fixture(autouse=True)
 def _no_existing_config(monkeypatch):
-    monkeypatch.setattr("tokenjam.cli.cmd_onboard.find_config_file", lambda: None)
+    monkeypatch.setattr("tokenjam.cli.cmd_onboard.resolve_config_path", lambda: None)
 
 
 def _run(tmp_path, manifest_name=None, manifest_text=None):

--- a/tests/unit/test_onboard_tool_inputs_default.py
+++ b/tests/unit/test_onboard_tool_inputs_default.py
@@ -38,7 +38,7 @@ from tokenjam.core.config import load_config
 
 @pytest.fixture(autouse=True)
 def _no_existing_config(monkeypatch):
-    monkeypatch.setattr("tokenjam.cli.cmd_onboard.find_config_file", lambda: None)
+    monkeypatch.setattr("tokenjam.cli.cmd_onboard.resolve_config_path", lambda: None)
 
 
 def _run_plain(tmp_path):

--- a/tests/unit/test_onboard_verify_cli.py
+++ b/tests/unit/test_onboard_verify_cli.py
@@ -97,7 +97,7 @@ def test_verify_only_sdk_loads_config_and_polls(monkeypatch, tmp_path):
     cfg.parent.mkdir(parents=True)
     cfg.write_text('version = "1"\n')
     calls = []
-    monkeypatch.setattr(cmd_onboard, "find_config_file", lambda: cfg)
+    monkeypatch.setattr(cmd_onboard, "resolve_config_path", lambda: cfg)
     monkeypatch.setattr(cmd_onboard, "load_config", lambda _p: _config(), raising=False)
     monkeypatch.setattr(
         cmd_onboard, "_run_onboard_verification",
@@ -127,7 +127,7 @@ def test_verify_only_claude_code_reads_global_config(monkeypatch, tmp_path):
 
 
 def test_verify_only_errors_cleanly_when_no_config(monkeypatch, capsys):
-    monkeypatch.setattr(cmd_onboard, "find_config_file", lambda: None)
+    monkeypatch.setattr(cmd_onboard, "resolve_config_path", lambda: None)
     called = []
     monkeypatch.setattr(
         cmd_onboard, "_run_onboard_verification",

--- a/tokenjam/api/routes/budget.py
+++ b/tokenjam/api/routes/budget.py
@@ -35,7 +35,7 @@ from tokenjam.core.config import (
     AgentConfig,
     BudgetConfig,
     ProviderBudget,
-    find_config_file,
+    resolve_config_path,
     resolve_effective_budget,
     validate_budget_value,
     validate_cycle_start_day,
@@ -110,7 +110,7 @@ class BudgetUpdate(BaseModel):
 @router.post("/budget")
 async def post_budget(request: Request, body: BudgetUpdate):
     config = request.app.state.config
-    config_path_str = find_config_file()
+    config_path_str = resolve_config_path()
     if config_path_str is None:
         return JSONResponse(status_code=400, content={"error": "No config file found"})
 
@@ -145,7 +145,7 @@ async def post_provider_budget(request: Request, body: ProviderBudgetUpdate):
     that Optimize's Budget projection analyzer reads. Distinct from
     `POST /budget` above, which edits the per-agent alert caps."""
     config = request.app.state.config
-    config_path_str = find_config_file()
+    config_path_str = resolve_config_path()
     if config_path_str is None:
         return JSONResponse(status_code=400, content={"error": "No config file found"})
 

--- a/tokenjam/cli/cmd_budget.py
+++ b/tokenjam/cli/cmd_budget.py
@@ -9,7 +9,7 @@ import click
 from tokenjam.cli.json_option import json_option, resolve_output_json
 from tokenjam.core.config import (
     AgentConfig,
-    find_config_file,
+    resolve_config_path,
     resolve_effective_budget,
     validate_budget_value,
     write_config,
@@ -50,8 +50,10 @@ def cmd_budget(
         _show_budgets(config, ctx.obj.get("db"), output_json)
         return
 
-    # Write mode — find config file on disk
-    config_path_str = find_config_file()
+    # Write mode — find config file on disk, honoring TJ_CONFIG so writes land
+    # in the same file `config` (ctx.obj["config"], loaded above) was read
+    # from — otherwise the budget update silently splits from the live config.
+    config_path_str = resolve_config_path()
     if config_path_str is None:
         raise click.ClickException(
             "No config file found. Run 'tj onboard' to create one."

--- a/tokenjam/cli/cmd_doctor.py
+++ b/tokenjam/cli/cmd_doctor.py
@@ -7,7 +7,7 @@ import duckdb
 from rich.markup import escape
 
 from tokenjam.cli.json_option import json_option, resolve_output_json
-from tokenjam.core.config import find_config_file, load_config
+from tokenjam.core.config import load_config, resolve_config_path
 from tokenjam.utils.formatting import console, display_path
 
 
@@ -105,7 +105,7 @@ def cmd_doctor(ctx: click.Context, output_json_flag: bool, repair: bool) -> None
 
 def _check_config() -> dict:
     try:
-        path = find_config_file()
+        path = resolve_config_path()
         if path is None:
             return {"name": "Config file", "level": "error",
                     "message": "No config file found. Run `tj onboard` to create one."}

--- a/tokenjam/cli/cmd_mcp.py
+++ b/tokenjam/cli/cmd_mcp.py
@@ -17,7 +17,7 @@ from pathlib import Path
 import click
 import duckdb
 
-from tokenjam.core.config import find_config_file, load_config
+from tokenjam.core.config import load_config, resolve_config_path
 
 
 def _port_open(host: str, port: int) -> bool:
@@ -69,7 +69,7 @@ def cmd_mcp(ctx: click.Context) -> None:
     """
     from tokenjam.mcp.server import mcp, init
 
-    config_path = find_config_file()
+    config_path = resolve_config_path()
     if config_path is not None:
         config = load_config(str(config_path))
         host = config.api.host

--- a/tokenjam/cli/cmd_onboard.py
+++ b/tokenjam/cli/cmd_onboard.py
@@ -14,7 +14,7 @@ from rich.markup import escape
 
 from tokenjam.cli.banner import print_welcome_banner
 from tokenjam.cli.onboard_detect import SdkMatch, detect_stack, install_hint
-from tokenjam.core.config import find_config_file
+from tokenjam.core.config import resolve_config_path
 from tokenjam.core.ingest_adapters.codex import ingest_codex
 from tokenjam.otel.semconv import SUBSCRIPTION_PLAN_TIERS
 from tokenjam.utils.formatting import console, display_path
@@ -506,7 +506,15 @@ def cmd_onboard(ctx: click.Context, claude_code: bool, codex: bool, budget: floa
             return
         # choice == "sdk" → fall through to the generic SDK/API path below.
 
-    existing = find_config_file()
+    # Honor TJ_CONFIG for the EXISTING-config check only (not the write
+    # target below, which always writes a new `.tj/config.toml` by design —
+    # see the comment at that assignment). This is deliberately asymmetric:
+    # a bare search-path find_config_file() here would miss a TJ_CONFIG-
+    # pointed config and go on to double-write `.tj/config.toml` alongside
+    # it, leaving the user with two configs and the wrong one still active
+    # (TJ_CONFIG always wins at read time). Honoring TJ_CONFIG here instead
+    # makes onboard correctly report "Config already exists" and no-op.
+    existing = resolve_config_path()
     if existing and not force:
         # --reconfigure is only meaningful with --claude-code / --codex.
         # The bare onboard path writes a generic config and doesn't manage
@@ -819,9 +827,10 @@ def _run_verify_only(ctx: click.Context, *, claude_code: bool, codex: bool) -> N
 
     The persona (and which config to read) follows the same flag the user
     onboarded with: ``--claude-code`` / ``--codex`` read the global config;
-    bare reads the nearest project/SDK config via ``find_config_file``. Errors
-    out cleanly when no config exists yet — that's an "run `tj onboard` first"
-    situation, not a verification failure.
+    bare reads the nearest project/SDK config via ``resolve_config_path``
+    (honoring ``TJ_CONFIG`` like every other read path). Errors out cleanly
+    when no config exists yet — that's an "run `tj onboard` first" situation,
+    not a verification failure.
     """
     from tokenjam.core.config import load_config
 
@@ -830,7 +839,7 @@ def _run_verify_only(ctx: click.Context, *, claude_code: bool, codex: bool) -> N
         persona = "claude_code" if claude_code else "codex"
         config_path: Path | None = global_path if global_path.exists() else None
     else:
-        found = find_config_file()
+        found = resolve_config_path()
         config_path = Path(found) if found else None
         persona = "sdk"
 

--- a/tokenjam/cli/home.py
+++ b/tokenjam/cli/home.py
@@ -19,6 +19,24 @@ from tokenjam.core.config import StorageConfig, find_config_file
 from tokenjam.utils.formatting import console
 
 
+def _tj_config_env_path() -> Path | None:
+    """A valid ``TJ_CONFIG`` path, if the env var is set and points at a real
+    file — ``None`` otherwise (including when it's set but broken).
+
+    Shared by ``_is_set_up`` and ``_db_has_data``: both need to honor
+    ``TJ_CONFIG`` (like every other config-reading path in this codebase, via
+    ``resolve_config_path``) but must NOT raise on a bad value. The bare ``tj``
+    landing screen renders before ``main.py``'s group callback validates
+    config (it returns early, skipping ``load_config``), so this is the one
+    context where ``resolve_config_path``'s fail-loud contract would crash a
+    screen that's supposed to always render something actionable.
+    """
+    tj_config = os.environ.get("TJ_CONFIG")
+    if tj_config and Path(tj_config).expanduser().is_file():
+        return Path(tj_config).expanduser()
+    return None
+
+
 def _db_has_data() -> bool:
     """Cheaply detect a populated on-disk DB WITHOUT opening it.
 
@@ -28,10 +46,11 @@ def _db_has_data() -> bool:
     lock — so we treat the presence of a non-empty DB file as the signal.
 
     Resolves the DB path from an existing config's ``[storage] path`` when one
-    is discoverable, else from the default (``~/.tj/telemetry.duckdb``).
+    is discoverable (honoring ``TJ_CONFIG`` first, then search-path discovery),
+    else from the default (``~/.tj/telemetry.duckdb``).
     """
     db_path = StorageConfig.path
-    cfg_file = find_config_file()
+    cfg_file = _tj_config_env_path() or find_config_file()
     if cfg_file is not None:
         # Cheap TOML parse (no DB open) to honor a custom storage path.
         try:

--- a/tokenjam/core/config.py
+++ b/tokenjam/core/config.py
@@ -527,25 +527,50 @@ def find_config_file(override: str | None = None) -> Path | None:
     return None
 
 
+def resolve_config_path(override: str | None = None) -> Path | None:
+    """
+    The single source of truth for "which config file is this process using".
+
+    Precedence: an explicit ``override`` wins, then the ``TJ_CONFIG``
+    environment variable, then ``find_config_file``'s ``SEARCH_PATHS`` walk.
+    ``load_config`` resolves through here, so any call site that independently
+    needs the config path — to write back to the file config was read from
+    (budget updates), to report it (``tj doctor``), or to hand it to a
+    subprocess (``tj mcp``, the MCP server) — must call this too, never bare
+    ``find_config_file()``. A bare call ignores ``TJ_CONFIG`` and silently
+    splits reads (TJ_CONFIG-aware, via ``load_config``) from writes/reports
+    (search-path only) across two different files.
+
+    Like ``find_config_file``, raises ``FileNotFoundError`` when an explicit
+    override or ``TJ_CONFIG`` points at a path that doesn't exist — this
+    matches ``load_config``'s fail-loud contract. Callers that must stay
+    resilient to a bad ``TJ_CONFIG`` (e.g. the bare ``tj`` landing screen,
+    which renders before any config is validated) should not use this
+    function directly; see ``cli/home.py``.
+    """
+    if override is None:
+        override = os.environ.get("TJ_CONFIG") or None
+    return find_config_file(override)
+
+
 def load_config(path: str | None = None) -> TjConfig:
     """
     Load config from file, merge with defaults, return TjConfig.
 
     When no explicit ``path`` is given, honor the ``TJ_CONFIG`` environment
-    variable before falling back to the search-path discovery order. This keeps
-    SDK-bootstrapped processes (``ensure_initialised`` and the SDK integrations,
-    which call ``load_config()`` with no argument) consistent with the CLI — the
-    CLI already resolves ``TJ_CONFIG`` via Click's ``envvar`` and passes the
-    path in, so without this the SDK silently wrote spans to the global DB even
+    variable before falling back to the search-path discovery order (via
+    ``resolve_config_path``). This keeps SDK-bootstrapped processes
+    (``ensure_initialised`` and the SDK integrations, which call
+    ``load_config()`` with no argument) consistent with the CLI — the CLI
+    already resolves ``TJ_CONFIG`` via Click's ``envvar`` and passes the path
+    in, so without this the SDK silently wrote spans to the global DB even
     when ``TJ_CONFIG`` pointed elsewhere (#196). An explicit ``path`` argument
     still wins over the env var.
 
     IMPORTANT: tomllib requires binary mode "rb" -- not text mode "r".
     Using "r" raises TypeError at runtime.
     """
-    if path is None:
-        path = os.environ.get("TJ_CONFIG") or None
-    config_path = find_config_file(path)
+    config_path = resolve_config_path(path)
     if config_path is None:
         return TjConfig(version="1")
 

--- a/tokenjam/core/pricing.py
+++ b/tokenjam/core/pricing.py
@@ -386,10 +386,10 @@ def _config_pricing_section() -> dict | None:
     None; config problems surface through the normal config-load path
     elsewhere.
     """
-    from tokenjam.core.config import find_config_file
+    from tokenjam.core.config import resolve_config_path
 
     try:
-        path = find_config_file(os.environ.get("TJ_CONFIG"))
+        path = resolve_config_path()
     except (FileNotFoundError, OSError):
         return None
     if path is None:

--- a/tokenjam/mcp/server.py
+++ b/tokenjam/mcp/server.py
@@ -1240,8 +1240,8 @@ def setup_project(agent_id: str | None = None, project_path: str | None = None) 
     for this repo. Infers agent_id from the git remote if not provided.
     """
     try:
-        from tokenjam.core.config import find_config_file
-        cp = find_config_file()
+        from tokenjam.core.config import resolve_config_path
+        cp = resolve_config_path()
         return _tool_setup_project(
             config=_config,
             config_path=str(cp) if cp else None,


### PR DESCRIPTION
## Summary

`find_config_file()` was called bare across the CLI, API, and MCP server, silently ignoring the `TJ_CONFIG` env var and falling back to `SEARCH_PATHS` discovery — even at call sites that already held a `TJ_CONFIG`-aware config object from `load_config()`. This caused split-brain behavior: e.g. a budget update could write to a different file than the one config was actually read from, or `tj doctor` could report "No config file found" while other checks used a config that loaded fine.

- Adds `resolve_config_path()` as the single source of truth for "which config file is this process using" (explicit override, then `TJ_CONFIG`, then `SEARCH_PATHS`).
- Migrates every call site that needs write/report/subprocess-handoff behavior onto it: `cmd_budget.py`, `api/routes/budget.py` (both endpoints), `cmd_doctor.py`, `cmd_mcp.py`, `mcp/server.py`'s `setup_project`, and `pricing.py`'s config-section lookup (previously a partial, non-shared `TJ_CONFIG` check).
- `cli/home.py`'s bare `tj` landing screen keeps its two direct `find_config_file()` calls as a deliberate, documented exception — it renders before config is validated, so it needs a non-raising `TJ_CONFIG` check rather than `resolve_config_path()`'s fail-loud contract on a bad override.
- `cmd_onboard.py`'s write paths are intentionally asymmetric: the existing-config check now honors `TJ_CONFIG` (so onboard correctly reports "Config already exists" instead of double-writing `.tj/config.toml` alongside a `TJ_CONFIG`-pointed config), but the actual write target stays a fixed search-path location by design — onboard creates new configs, it doesn't update wherever `TJ_CONFIG` happens to point.
- Adds a regression guard (`test_config_discovery_guard.py`) that greps the package for bare `find_config_file()` calls outside the two documented exceptions, so a new call site can't reintroduce this silently.

## Test plan

- [x] `pytest tests/unit/ tests/synthetic/ tests/agents/ tests/integration/` — 4362 passed, 5 skipped
- [x] `ruff check tokenjam/` — all checks passed
- [x] `mypy tokenjam/` — no issues in 229 source files
- [x] Verified `origin/main` was already current with this branch (no merge needed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)