### PR TITLE
Fix model-rate lookup (5-30x mispricing) + scope the filesystem-reading analyzers with --projects-root

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -155,6 +155,15 @@ why, and the report carries `filesystem_scan_skipped_reason` so every surface ca
 tell **"scanned, found nothing"** from **"did not scan"**. A run with no flag, no
 environment variable and no `--db` is unaffected.
 
+**The scope bounds writes too, not just reads.** The review inbox's Approve step
+refuses any target outside the scope's home directory — with
+`--projects-root /tmp/demo-home/.claude/projects` that root is `/tmp/demo-home`,
+so a scoped daemon can neither be talked into writing to your real `~`, nor into
+escaping the scope with a `..` path or a symlink pointing out of it. The
+suggested target and this check resolve from the same scope, so what the card
+proposes is always something Approve will accept. Without a scope the allowed
+root is your real home, exactly as before.
+
 ## Budget limits
 
 Budget limits merge per-field: each agent inherits default limits unless it explicitly overrides them.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -117,6 +117,44 @@ on a fresh install.
 it replaces, so an omitted key changes nothing; see `OptimizeConfig` in
 `tokenjam/core/config.py` for the current list and each field's analyzer.
 
+### Which filesystem the analyzers read
+
+Three analyzers — `deadweight`, `relearn` and `summarize` — take their evidence
+from the **filesystem**, not from the telemetry database. That is by design: the
+database holds spans, while the transcripts, the MCP configuration and the
+always-loaded prompt files those three reason about live on disk. By default
+they read `~/.claude/projects` and your agent homes, which is what you want for
+a normal run.
+
+`--projects-root PATH` says which filesystem instead:
+
+```bash
+tj optimize --projects-root /path/to/fixtures/.claude/projects
+tj serve --db /tmp/demo.duckdb --projects-root /tmp/demo-home/.claude/projects
+```
+
+The equivalent config key is `[optimize] projects_root`. Resolution order, first
+match wins:
+
+1. `--projects-root` / `[optimize] projects_root`
+2. the `TJ_CLAUDE_PROJECTS_ROOT` environment variable
+3. **an explicit `--db`, which scopes the filesystem scans OFF** — see below
+4. `~/.claude/projects`
+
+**Passing `--db` suppresses the filesystem scans unless you also pass
+`--projects-root`.** Naming a database names the corpus you want reasoned about,
+so reading a second, unrelated corpus off the machine into the same report is a
+bug, not a feature: served against a throwaway database, those analyzers would
+otherwise surface findings carrying real file paths from unrelated projects, and
+the review inbox's "where to write it" target would point at a real location
+outside the database you opened. Suppression is also why an empty or scoped
+database paints immediately instead of walking a large transcript tree first.
+
+Suppression is never silent. `tj optimize` prints which analyzers did not run and
+why, and the report carries `filesystem_scan_skipped_reason` so every surface can
+tell **"scanned, found nothing"** from **"did not scan"**. A run with no flag, no
+environment variable and no `--db` is unaffected.
+
 ## Budget limits
 
 Budget limits merge per-field: each agent inherits default limits unless it explicitly overrides them.

--- a/tests/integration/test_relearn_api.py
+++ b/tests/integration/test_relearn_api.py
@@ -666,3 +666,81 @@ async def test_advise_only_proposals_carry_their_reason_in_the_payload(config, c
     workspace_card = by_title["cwd / relative-path confusion"]
     assert workspace_card["advise_only"] is False
     assert workspace_card["advise_only_reason"] is None
+
+
+# --- The guard authorizes against the RUN'S scope, not the process's home ----
+# `--projects-root` outside `$HOME` made the two halves of a card disagree: the
+# suggestion followed the scoped home, the guard stayed pinned to `Path.home()`
+# and 403'd the very path the UI had just proposed. These pin the fix at the
+# route, and pin that it is still fail-closed in the directions that matter.
+
+@pytest.fixture
+def scoped_app(tmp_path, db, monkeypatch):
+    """A daemon scoped to a throwaway home OUTSIDE the real `$HOME`, exactly as
+    `--projects-root /tmp/demo-home/.claude/projects` does."""
+    from tokenjam.core.config import OptimizeConfig
+
+    real_home = tmp_path / "real-home"
+    real_home.mkdir()
+    monkeypatch.setattr(pa.Path, "home", classmethod(lambda cls: real_home))
+
+    demo_home = tmp_path / "demo-home"
+    (demo_home / ".claude" / "projects").mkdir(parents=True)
+    scoped_config = TjConfig(
+        version="1",
+        api=ApiConfig(auth=ApiAuthConfig(enabled=False)),
+        storage=StorageConfig(path=str(tmp_path / "telemetry.duckdb")),
+        optimize=OptimizeConfig(projects_root=str(demo_home / ".claude" / "projects")),
+    )
+    pipeline = IngestPipeline(db=db, config=scoped_config)
+    app = create_app(config=scoped_config, db=db, ingest_pipeline=pipeline)
+    return app, real_home, demo_home
+
+
+@pytest.fixture
+def scoped_client(scoped_app):
+    app, _, _ = scoped_app
+    return httpx.AsyncClient(transport=httpx.ASGITransport(app=app), base_url="http://test")
+
+
+async def _apply_status(client, app, target_path: str) -> int:
+    r = await client.post(
+        "/api/v1/relearn/apply", json=_apply_body(target_path),
+        headers={"X-TJ-Local-Token": app.state.relearn_write_token},
+    )
+    return r.status_code
+
+
+async def test_scoped_run_accepts_its_own_in_scope_target(scoped_app, scoped_client):
+    """The exact write the UI suggests under a scoped root must be authorized.
+    404 (no such stored proposal) means the guard let it through — that is the
+    assertion; a 403 here is the bug this fixes."""
+    app, _, demo_home = scoped_app
+    in_scope = demo_home / ".claude" / "CLAUDE.md"
+    assert await _apply_status(scoped_client, app, str(in_scope)) == 404
+
+
+async def test_scoped_run_still_rejects_an_out_of_scope_target(scoped_app, scoped_client, tmp_path):
+    app, _, _ = scoped_app
+    outside = tmp_path / "elsewhere" / "CLAUDE.md"
+    assert await _apply_status(scoped_client, app, str(outside)) == 403
+    assert not outside.exists()
+
+
+async def test_scoped_run_rejects_a_path_under_the_real_home(scoped_app, scoped_client):
+    """Scoping is a narrowing, not a shift: the operator's real home is out of
+    bounds while a scope is in force. This is the half that makes 'Approve
+    never writes outside the intended scope' true."""
+    app, real_home, _ = scoped_app
+    real_target = real_home / ".claude" / "CLAUDE.md"
+    assert await _apply_status(scoped_client, app, str(real_target)) == 403
+    assert not real_target.exists()
+
+
+async def test_scoped_run_rejects_a_dot_dot_traversal_out_of_the_scope(scoped_app, scoped_client):
+    """`..` must be judged after resolution, not on the literal string — the
+    path below is textually inside the scope and actually outside it."""
+    app, _, demo_home = scoped_app
+    traversal = demo_home / ".claude" / ".." / ".." / "escaped" / "CLAUDE.md"
+    assert await _apply_status(scoped_client, app, str(traversal)) == 403
+    assert not traversal.resolve().exists()

--- a/tests/unit/test_analyzer_scope.py
+++ b/tests/unit/test_analyzer_scope.py
@@ -1,0 +1,143 @@
+"""`--db` must isolate the filesystem-reading analyzers, not just the store.
+
+Reproduced against a freshly created, completely empty throwaway database: the
+review inbox still showed recurring-mistake entries carrying real file paths
+from an unrelated project, the recurring-fix modal still defaulted its write
+target to a real path on the operator's machine, and `/api/v1/optimize` still
+took ~30s because `deadweight` and `relearn` walked the operator's real
+`~/.claude/projects` regardless of `--db`.
+
+These pin the scope contract that fixes all three. See
+`tokenjam.core.optimize.scope` for the contract itself.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from tokenjam.core.optimize.scope import (
+    PROJECTS_ROOT_ENV,
+    default_projects_root,
+    resolve_analyzer_scope,
+)
+
+
+class _Storage:
+    def __init__(self, path="~/.tj/telemetry.duckdb", path_is_explicit=False):
+        self.path = path
+        self.path_is_explicit = path_is_explicit
+
+
+class _Optimize:
+    def __init__(self, projects_root=None):
+        self.projects_root = projects_root
+
+
+class _Config:
+    def __init__(self, projects_root=None, db_explicit=False):
+        self.optimize = _Optimize(projects_root)
+        self.storage = _Storage(path_is_explicit=db_explicit)
+
+
+def test_a_normal_run_is_unchanged(monkeypatch):
+    """No flag, no env var, no --db: today's behaviour, exactly."""
+    monkeypatch.delenv(PROJECTS_ROOT_ENV, raising=False)
+    scope = resolve_analyzer_scope(_Config())
+    assert scope.enabled is True
+    assert scope.projects_root == default_projects_root()
+    assert scope.source == "default"
+    assert scope.reason is None
+
+
+def test_an_explicit_db_suppresses_the_filesystem_scans(monkeypatch):
+    monkeypatch.delenv(PROJECTS_ROOT_ENV, raising=False)
+    scope = resolve_analyzer_scope(_Config(db_explicit=True))
+    assert scope.enabled is False
+    assert scope.source == "suppressed_by_db"
+    # Suppression is never silent — the reason must name the escape hatch.
+    assert scope.reason is not None
+    assert "--projects-root" in scope.reason
+
+
+def test_projects_root_wins_over_an_explicit_db(monkeypatch, tmp_path):
+    """The escape hatch: a caller who wants machine history alongside a custom
+    database says so, and gets it."""
+    monkeypatch.delenv(PROJECTS_ROOT_ENV, raising=False)
+    scope = resolve_analyzer_scope(
+        _Config(projects_root=str(tmp_path), db_explicit=True)
+    )
+    assert scope.enabled is True
+    assert scope.projects_root == tmp_path
+    assert scope.source == "flag"
+
+
+def test_projects_root_wins_over_the_env_var(monkeypatch, tmp_path):
+    monkeypatch.setenv(PROJECTS_ROOT_ENV, str(tmp_path / "from-env"))
+    scope = resolve_analyzer_scope(_Config(projects_root=str(tmp_path / "from-flag")))
+    assert scope.projects_root == tmp_path / "from-flag"
+    assert scope.source == "flag"
+
+
+def test_the_env_var_still_works(monkeypatch, tmp_path):
+    """Every existing fixture and integration sets this; it must not regress."""
+    monkeypatch.setenv(PROJECTS_ROOT_ENV, str(tmp_path))
+    scope = resolve_analyzer_scope(_Config())
+    assert scope.enabled is True
+    assert scope.projects_root == tmp_path
+    assert scope.source == "env"
+
+
+def test_the_env_var_wins_over_an_explicit_db(monkeypatch, tmp_path):
+    monkeypatch.setenv(PROJECTS_ROOT_ENV, str(tmp_path))
+    scope = resolve_analyzer_scope(_Config(db_explicit=True))
+    assert scope.enabled is True
+    assert scope.projects_root == tmp_path
+
+
+def test_a_scoped_but_empty_root_is_enabled_not_suppressed(monkeypatch, tmp_path):
+    """"Scanned, found nothing" is a different statement from "did not scan",
+    and the surfaces render them differently (root anti-pattern 22)."""
+    monkeypatch.delenv(PROJECTS_ROOT_ENV, raising=False)
+    absent = tmp_path / "does-not-exist"
+    scope = resolve_analyzer_scope(_Config(projects_root=str(absent)))
+    assert scope.enabled is True
+    assert scope.reason is None
+
+
+def test_claude_home_is_the_parent_of_a_conventional_projects_root(tmp_path):
+    root = tmp_path / ".claude" / "projects"
+    scope = resolve_analyzer_scope(_Config(projects_root=str(root)))
+    assert scope.claude_home == tmp_path / ".claude"
+
+
+def test_claude_home_never_escapes_a_custom_scope(tmp_path):
+    """A root by another name is treated as the home itself — reaching up into
+    whatever contains it would escape the scope the caller just drew."""
+    root = tmp_path / "fixture-transcripts"
+    scope = resolve_analyzer_scope(_Config(projects_root=str(root)))
+    assert scope.claude_home == root
+    assert tmp_path not in [scope.claude_home]
+
+
+def test_a_missing_or_duck_typed_config_never_raises(monkeypatch):
+    monkeypatch.delenv(PROJECTS_ROOT_ENV, raising=False)
+    assert resolve_analyzer_scope(None).enabled is True
+    assert resolve_analyzer_scope(object()).enabled is True
+
+
+def test_a_user_path_is_expanded(monkeypatch):
+    monkeypatch.delenv(PROJECTS_ROOT_ENV, raising=False)
+    scope = resolve_analyzer_scope(_Config(projects_root="~/somewhere/projects"))
+    assert "~" not in str(scope.projects_root)
+    assert scope.projects_root == Path.home() / "somewhere" / "projects"
+
+
+def test_the_default_root_follows_a_repointed_home(monkeypatch, tmp_path):
+    """Resolved lazily, never baked at import: a constant computed at import
+    time survives a later HOME repoint, and a test that carefully isolates
+    itself then scans the developer's real transcript tree anyway."""
+    monkeypatch.delenv(PROJECTS_ROOT_ENV, raising=False)
+    monkeypatch.setenv("HOME", str(tmp_path))
+    assert resolve_analyzer_scope(_Config()).projects_root == (
+        tmp_path / ".claude" / "projects"
+    )

--- a/tests/unit/test_analyzer_scope_isolation.py
+++ b/tests/unit/test_analyzer_scope_isolation.py
@@ -192,3 +192,62 @@ def test_the_distill_cache_keeps_its_historical_path_without_a_config():
     assert relearn._distill_cache_dir() == (
         Path.home() / ".tj" / "distill_cache" / "relearn"
     )
+
+
+# ── The apply-target suggestion and the write guard must agree ─────────────
+# The suggestion followed the scope's Claude home while the API's guard stayed
+# hardcoded to the process's real `Path.home()`, so with `--projects-root`
+# outside `$HOME` the UI suggested a target and the API 403'd that exact write.
+# Both halves resolve through `resolve_write_scope` now; these pin that.
+
+def test_the_suggested_target_is_always_inside_the_allowed_root(tmp_path):
+    """The invariant that makes the two halves unable to disagree: whatever
+    root the suggestion is built from sits inside the root the guard
+    authorizes. Asserted for a conventional scope, a custom-named one, and
+    the unscoped default."""
+    from tokenjam.core.optimize.scope import resolve_write_scope
+
+    for projects_root in (
+        str(tmp_path / "demo-home" / ".claude" / "projects"),
+        str(tmp_path / "just-transcripts"),
+        None,
+    ):
+        write_scope = resolve_write_scope(_Config(projects_root=projects_root))
+        suggest, allowed = write_scope.suggest_root, write_scope.allowed_root
+        assert suggest == allowed or allowed in suggest.parents, (
+            f"{suggest} is not inside {allowed} for projects_root={projects_root}"
+        )
+
+
+def test_the_allowed_root_is_the_real_home_without_a_scope(monkeypatch):
+    """The no-flag default must be byte-for-byte what it always was."""
+    from tokenjam.core.optimize.scope import PROJECTS_ROOT_ENV, resolve_write_scope
+
+    monkeypatch.delenv(PROJECTS_ROOT_ENV, raising=False)
+    assert resolve_write_scope(_Config()).allowed_root == Path.home()
+
+
+def test_an_explicit_db_still_authorizes_only_the_real_home(monkeypatch):
+    """Suppression scopes READS off; it must not widen the WRITE root."""
+    from tokenjam.core.optimize.scope import PROJECTS_ROOT_ENV, resolve_write_scope
+
+    monkeypatch.delenv(PROJECTS_ROOT_ENV, raising=False)
+    assert resolve_write_scope(_Config(db_explicit=True)).allowed_root == Path.home()
+
+
+def test_a_scoped_root_authorizes_its_own_suggested_target(tmp_path):
+    """The exact case that 403'd: `--projects-root` under a throwaway home
+    outside `$HOME`, whose own suggested target must be writable."""
+    from tokenjam.core.optimize.scope import resolve_write_scope
+
+    demo_home = tmp_path / "demo-home"
+    write_scope = resolve_write_scope(
+        _Config(projects_root=str(demo_home / ".claude" / "projects")),
+    )
+    assert write_scope.allowed_root == demo_home
+    suggested = Path(
+        default_target_path(1, "user-global", "", "slug",
+                            claude_home=write_scope.suggest_root),
+    )
+    assert suggested == demo_home / ".claude" / "CLAUDE.md"
+    assert write_scope.allowed_root in suggested.parents

--- a/tests/unit/test_analyzer_scope_isolation.py
+++ b/tests/unit/test_analyzer_scope_isolation.py
@@ -1,0 +1,194 @@
+"""The scope contract, exercised through the analyzers themselves.
+
+`test_analyzer_scope.py` pins the resolver. This module pins that the three
+filesystem-reading analyzers actually HONOR it — the resolver being correct is
+worth nothing if an analyzer still reaches for `Path.home()` on its own, which
+is exactly how the leak existed in the first place.
+
+Each test reproduces one of the three symptoms observed against a freshly
+created, completely empty throwaway `--db`:
+
+  * cross-project findings from the machine's global transcript tree,
+  * an apply target pointing at a real path outside the served database,
+  * a ~30s first paint spent walking a transcript tree the run cannot use.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from tokenjam.core.optimize.analyzers import deadweight, relearn
+from tokenjam.core.optimize.analyzers import summarize as summarize_analyzer
+from tokenjam.core.optimize.relearn_apply import default_target_path
+from tokenjam.core.optimize.scope import PROJECTS_ROOT_ENV, resolve_analyzer_scope
+from tokenjam.core.optimize.types import AnalyzerContext, OptimizeReport, WindowSummary
+from tokenjam.utils.time_parse import utcnow
+
+
+class _Storage:
+    def __init__(self, path_is_explicit: bool):
+        self.path = ":memory:"
+        self.retention_days = 90
+        self.path_is_explicit = path_is_explicit
+
+
+class _Optimize:
+    def __init__(self, projects_root=None):
+        self.projects_root = projects_root
+
+
+class _Config:
+    def __init__(self, *, db_explicit=False, projects_root=None):
+        self.storage = _Storage(db_explicit)
+        self.optimize = _Optimize(projects_root)
+
+
+def _ctx(config, *, total_tokens=1_000_000) -> AnalyzerContext:
+    until = utcnow()
+    since = until.replace(year=until.year - 1)
+    summary = WindowSummary(
+        since=since, until=until, days=365.0, sessions=1, spans=1,
+        total_tokens=total_tokens, total_cost_usd=10.0, thin_data=False,
+    )
+    return AnalyzerContext(
+        conn=None,
+        config=config,
+        since=since,
+        until=until,
+        agent_id=None,
+        window_days=365.0,
+        summary=summary,
+        report=OptimizeReport(window=summary),
+        scope=resolve_analyzer_scope(config),
+    )
+
+
+@pytest.fixture(autouse=True)
+def _no_env_root(monkeypatch):
+    """The env var would satisfy every scope, hiding what is being tested."""
+    monkeypatch.delenv(PROJECTS_ROOT_ENV, raising=False)
+
+
+# ── Suppression under an explicit --db ─────────────────────────────────────
+
+@pytest.mark.parametrize(
+    "module,key",
+    [
+        (deadweight, "deadweight"),
+        (relearn, "relearn"),
+        (summarize_analyzer, "summarize"),
+    ],
+)
+def test_an_explicit_db_stops_the_analyzer_reading_the_real_home(
+    module, key, monkeypatch,
+):
+    """The reported leak: an empty `--db` still surfaced findings sourced from
+    the operator's real machine. No filesystem call may happen at all."""
+    # Built BEFORE the traps: resolving the scope legitimately names the
+    # nominal home, it just must never READ from it.
+    ctx = _ctx(_Config(db_explicit=True))
+
+    def _boom(*_a, **_kw):
+        raise AssertionError(
+            f"{key} touched the filesystem under an explicit --db"
+        )
+
+    monkeypatch.setattr(Path, "rglob", _boom)
+    monkeypatch.setattr(Path, "glob", _boom)
+    monkeypatch.setattr(Path, "iterdir", _boom)
+    monkeypatch.setattr(Path, "is_file", _boom)
+    monkeypatch.setattr(Path, "exists", _boom)
+
+    module.run(ctx)
+
+    assert key in ctx.report.findings
+    # And it says WHY it is empty — "did not scan" is not "found nothing".
+    assert ctx.report.filesystem_scan_skipped_reason is not None
+    assert "--projects-root" in ctx.report.filesystem_scan_skipped_reason
+
+
+@pytest.mark.parametrize(
+    "module,key",
+    [
+        (deadweight, "deadweight"),
+        (relearn, "relearn"),
+        (summarize_analyzer, "summarize"),
+    ],
+)
+def test_a_scoped_root_is_scanned_and_reports_no_skip(module, key, tmp_path):
+    """A scoped-but-empty root was genuinely scanned, so no skip reason is set
+    — the surfaces render "found nothing" rather than "did not look"."""
+    ctx = _ctx(_Config(db_explicit=True, projects_root=str(tmp_path)))
+    module.run(ctx)
+    assert key in ctx.report.findings
+    assert ctx.report.filesystem_scan_skipped_reason is None
+
+
+@pytest.mark.parametrize(
+    "module,key",
+    [
+        (deadweight, "deadweight"),
+        (relearn, "relearn"),
+        (summarize_analyzer, "summarize"),
+    ],
+)
+def test_a_normal_run_still_scans(module, key, tmp_path, monkeypatch):
+    """The default path must be untouched: no flag, no --db, same as before."""
+    monkeypatch.setenv("HOME", str(tmp_path))
+    ctx = _ctx(_Config())
+    assert ctx.scope.enabled is True
+    module.run(ctx)
+    assert key in ctx.report.findings
+    assert ctx.report.filesystem_scan_skipped_reason is None
+
+
+# ── The apply target ───────────────────────────────────────────────────────
+
+def test_the_user_global_apply_target_follows_the_scope(tmp_path):
+    """The recurring-fix modal's "where to write it" must land inside the
+    scope the findings came from. A live Approve in a sandboxed review view
+    otherwise writes a real file to a real location on the operator's machine."""
+    scoped_home = tmp_path / ".claude"
+    target = default_target_path(1, "user-global", "", "slug", claude_home=scoped_home)
+    assert target == str(scoped_home / "CLAUDE.md")
+    assert str(Path.home()) not in target
+
+
+def test_the_apply_target_is_unchanged_without_a_scope():
+    target = default_target_path(1, "user-global", "", "slug")
+    assert target == str(Path.home() / ".claude" / "CLAUDE.md")
+
+
+@pytest.mark.parametrize("rung,tail", [
+    (1, ["CLAUDE.md"]),
+    (2, ["skills", "slug", "SKILL.md"]),
+    (3, ["hooks", "slug.py"]),
+])
+def test_every_rung_of_the_apply_target_is_scoped(rung, tail, tmp_path):
+    scoped_home = tmp_path / ".claude"
+    target = Path(
+        default_target_path(rung, "user-global", "", "slug", claude_home=scoped_home)
+    )
+    assert target == scoped_home.joinpath(*tail)
+
+
+# ── The distill cache write path ───────────────────────────────────────────
+
+def test_the_distill_cache_never_writes_to_the_real_home_under_an_isolated_config():
+    """A SECOND cache beside `relearn_store.default_cache_path`, missed when
+    that one was threaded through `_storage_base_dir`. It fires only after a
+    successful distill LLM call, which is why it went unnoticed."""
+    config = _Config(db_explicit=True)
+    scoped = relearn._distill_cache_dir(config)
+    assert Path.home() / ".tj" not in scoped.parents
+    assert str(Path.home() / ".tj") not in str(scoped)
+    assert scoped.name == "relearn"
+    assert scoped.parent.name == "distill_cache"
+
+
+def test_the_distill_cache_keeps_its_historical_path_without_a_config():
+    assert relearn._distill_cache_dir() == (
+        Path.home() / ".tj" / "distill_cache" / "relearn"
+    )

--- a/tests/unit/test_pricing_coverage.py
+++ b/tests/unit/test_pricing_coverage.py
@@ -1,0 +1,92 @@
+"""An unpriced model must be VISIBLE in the cost views, not just in a log line.
+
+When `get_rates` finds no row, `calculate_cost` prices the span at a flat
+default rate and logs one warning per process. The dollar figure that reaches
+the dashboard is indistinguishable from a real one — which is how a benchmark
+replay could be wrong by 5-30x for most of its models while every surface
+looked fine. The stored `pricing_source` column already records the provenance;
+this pins that the cost views actually read it.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from tokenjam.core.pricing_coverage import (
+    PricingCoverage,
+    coverage_note,
+    summarize_pricing_coverage,
+)
+
+
+class _FakeConn:
+    """Minimal stand-in returning one canned row for the coverage query."""
+
+    def __init__(self, row):
+        self._row = row
+        self.executed: list[tuple[str, list]] = []
+
+    def execute(self, sql, params=None):
+        self.executed.append((sql, params or []))
+        return self
+
+    def fetchall(self):
+        return self._row
+
+
+def test_no_conn_reports_nothing_rather_than_a_clean_bill():
+    cov = summarize_pricing_coverage(None, None, None, None)
+    assert cov.measured is False
+    assert cov.unpriced_call_count == 0
+    assert coverage_note(cov) is None
+
+
+def test_a_fully_priced_window_produces_no_note():
+    conn = _FakeConn([])
+    cov = summarize_pricing_coverage(conn, None, None, None)
+    assert cov.measured is True
+    assert cov.unpriced_models == ()
+    assert cov.unpriced_call_count == 0
+    assert coverage_note(cov) is None
+
+
+def test_unpriced_models_are_named_with_their_call_share():
+    conn = _FakeConn([("anthropic", "claude-mystery-9", 120, 3.5)])
+    cov = summarize_pricing_coverage(conn, None, None, None)
+    assert cov.measured is True
+    assert cov.unpriced_call_count == 120
+    assert cov.unpriced_models == (("anthropic", "claude-mystery-9", 120),)
+    note = coverage_note(cov)
+    assert note is not None
+    assert "claude-mystery-9" in note
+    # The claim the user needs: the number is a default-rate estimate, not a
+    # quoted price. It must not read as a $0 or as a confirmed figure.
+    assert "default rate" in note
+    assert "$0" not in note
+
+
+def test_the_note_reports_every_unpriced_model_it_was_given():
+    conn = _FakeConn([
+        ("anthropic", "model-a", 10, 1.0),
+        ("openai", "model-b", 5, 0.5),
+    ])
+    cov = summarize_pricing_coverage(conn, None, None, None)
+    assert cov.unpriced_call_count == 15
+    note = coverage_note(cov)
+    assert note is not None
+    assert "model-a" in note and "model-b" in note
+
+
+def test_filters_are_parameterised_never_interpolated():
+    conn = _FakeConn([])
+    summarize_pricing_coverage(conn, "agent-1", None, None)
+    sql, params = conn.executed[0]
+    assert "agent-1" not in sql
+    assert "agent-1" in params
+
+
+def test_a_dataclass_instance_is_immutable():
+    cov = PricingCoverage(measured=True, unpriced_models=(), unpriced_call_count=0,
+                          unpriced_cost_usd=0.0)
+    with pytest.raises(Exception):
+        cov.measured = False  # type: ignore[misc]

--- a/tests/unit/test_pricing_lookup_forms.py
+++ b/tests/unit/test_pricing_lookup_forms.py
@@ -1,9 +1,9 @@
 """Every model-name form a real agent run emits must resolve to a real rate.
 
-A benchmark replay of nine real agent runs (21,562 LLM calls across nine
-distinct model strings) found the cost figures wrong by 5-30x for seven of the
-nine models. Nothing was wrong with the arithmetic — the lookup simply never
-found the row. Two structural gaps produced all seven:
+A benchmark replay of nine real agent runs (21,562 LLM calls) found the cost
+figures wrong by 5-30x for seven of the nine model strings its per-model cost
+table breaks out. Nothing was wrong with the arithmetic — the lookup simply
+never found the row. Two structural gaps produced all seven:
 
   * the date-suffix stripper only understood Anthropic's compact `-YYYYMMDD`
     form, so OpenAI's dashed `-YYYY-MM-DD` (`gpt-4o-2024-08-06`) never fell
@@ -13,8 +13,10 @@ found the row. Two structural gaps produced all seven:
 
 Both failures are silent in the UI — one log warning per process, then a
 plausible-looking dollar figure computed at the flat default rate. This module
-pins each lookup form independently, and pins the whole corpus of real model
-strings against the rates they must resolve to.
+pins each lookup form independently, and pins the real model strings against
+the rates they must resolve to. `BENCHMARK_CORPUS_MODELS` states below exactly
+which of those strings the replay measured and which it did not — the list is
+longer than nine and the difference is provenance, not a bigger corpus.
 """
 
 from __future__ import annotations
@@ -77,24 +79,64 @@ def test_a_routing_prefix_does_not_invent_a_match_for_an_unknown_model():
 
 
 # ── The benchmark corpus ───────────────────────────────────────────────────
-# Every distinct `gen_ai.request.model` string observed across the nine
-# replayed agent runs, pinned to the input rate it must price at. These are the
-# strings that were mispriced; if any of them regresses to the default rate the
-# cost dashboard is wrong again by the same 5-30x.
+# The `gen_ai.request.model` strings this module pins, each to the input rate
+# it must price at. If any regresses to the default rate the cost dashboard is
+# wrong again by the same 5-30x.
+#
+# Provenance, stated exactly because a list that misdescribes its own corpus is
+# the defect class this codebase treats as first-order:
+#
+#   * The first NINE entries are the nine model strings the replay's per-model
+#     cost table breaks out — the nine whose rates were checked against HAL's
+#     own ground truth, and the population "seven of nine were mispriced"
+#     counts. That is where the module docstring's "nine" comes from.
+#   * `anthropic/claude-sonnet-4-5-20250929` is a real tenth corpus string,
+#     carried by a handful of calls in the corebench_hard run (`summary.usage`
+#     keys the same underlying model both bare and provider-prefixed within one
+#     run). It is below the table's reporting threshold, not absent from the
+#     corpus, and tj must still price it.
+#   * The two `claude-haiku-4-5` strings come from the SEEACT run, which was
+#     probed for cache usage but EXCLUDED from the nine-run corpus (its export
+#     has no per-call data left to inspect). They are pinned because they are
+#     real strings tj has to price, not because the replay measured them.
 
-BENCHMARK_CORPUS_MODELS = [
+# The nine model strings the replay's per-model cost table breaks out.
+_TABULATED_CORPUS_MODELS = [
     ("anthropic", "anthropic/claude-opus-4.1", 15.00),
     ("anthropic", "claude-opus-4-20250514", 15.00),
     ("anthropic", "claude-3-7-sonnet-20250219", 3.00),
     ("anthropic", "anthropic/claude-3.7-sonnet", 3.00),
     ("anthropic", "claude-sonnet-4-5-20250929", 3.00),
-    ("anthropic", "claude-haiku-4-5-20251001", 1.00),
-    ("anthropic", "anthropic/claude-haiku-4.5", 1.00),
     ("openai", "gpt-4.1-2025-04-14", 2.00),
     ("openai", "gpt-4o-2024-08-06", 2.50),
     ("openai", "gpt-4o-2024-11-20", 2.50),
     ("google", "gemini-2.0-flash", 0.10),
 ]
+
+# Below the table's reporting threshold, but present in the corpus.
+_LOW_VOLUME_CORPUS_MODELS = [
+    ("anthropic", "anthropic/claude-sonnet-4-5-20250929", 3.00),
+]
+
+# From the tenth run, probed but excluded from the measured corpus.
+_EXCLUDED_RUN_MODELS = [
+    ("anthropic", "claude-haiku-4-5-20251001", 1.00),
+    ("anthropic", "anthropic/claude-haiku-4.5", 1.00),
+]
+
+BENCHMARK_CORPUS_MODELS = [
+    *_TABULATED_CORPUS_MODELS,
+    *_LOW_VOLUME_CORPUS_MODELS,
+    *_EXCLUDED_RUN_MODELS,
+]
+
+
+def test_the_tabulated_corpus_is_the_nine_the_replay_measured():
+    """Pins the count the module docstring narrates, so the two cannot drift:
+    the replay's per-model table has nine rows, and any entry added beyond it
+    has to go in one of the explicitly-labelled extra lists instead of
+    silently inflating the population the "seven of nine" claim rests on."""
+    assert len(_TABULATED_CORPUS_MODELS) == 9
 
 
 @pytest.mark.parametrize("provider,model,expected_input", BENCHMARK_CORPUS_MODELS)
@@ -117,7 +159,11 @@ def test_no_benchmark_corpus_model_uses_the_default_fallback(provider, model, _e
 
 
 # ── Backfilled table entries ───────────────────────────────────────────────
-# Rates verified against the providers' published pricing pages, not invented.
+# These pin what `models.toml` says, which is all a test can do — a test
+# asserting its own inputs cannot establish that a rate is right. The auditable
+# provenance for each of the three lives next to its entry in
+# `tokenjam/pricing/models.toml`, including which one is flagged UNVERIFIED
+# because its provider retired it off every reachable published page.
 
 @pytest.mark.parametrize(
     "provider,model,input_rate,output_rate",

--- a/tests/unit/test_pricing_lookup_forms.py
+++ b/tests/unit/test_pricing_lookup_forms.py
@@ -1,0 +1,136 @@
+"""Every model-name form a real agent run emits must resolve to a real rate.
+
+A benchmark replay of nine real agent runs (21,562 LLM calls across nine
+distinct model strings) found the cost figures wrong by 5-30x for seven of the
+nine models. Nothing was wrong with the arithmetic — the lookup simply never
+found the row. Two structural gaps produced all seven:
+
+  * the date-suffix stripper only understood Anthropic's compact `-YYYYMMDD`
+    form, so OpenAI's dashed `-YYYY-MM-DD` (`gpt-4o-2024-08-06`) never fell
+    back to its bare table entry even though that entry existed; and
+  * nothing stripped a routing prefix, so `anthropic/claude-opus-4.1` (the form
+    LiteLLM and OpenRouter emit) never reached the table at all.
+
+Both failures are silent in the UI — one log warning per process, then a
+plausible-looking dollar figure computed at the flat default rate. This module
+pins each lookup form independently, and pins the whole corpus of real model
+strings against the rates they must resolve to.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from tokenjam.core.pricing import (
+    DEFAULT_INPUT_PER_MTOK,
+    classify_pricing_source,
+    get_rates,
+)
+
+
+# ── Individual lookup forms ────────────────────────────────────────────────
+# One case per structural transform, so a regression names the transform that
+# broke rather than just "some model got cheaper".
+
+@pytest.mark.parametrize(
+    "provider,model,expected_input,expected_kind",
+    [
+        # Exact — the form that always worked.
+        ("anthropic", "claude-opus-4-1", 15.00, "exact"),
+        # Compact date suffix (Anthropic).
+        ("anthropic", "claude-opus-4-20250514", 15.00, "date_stripped"),
+        # Dashed date suffix (OpenAI) — the gap.
+        ("openai", "gpt-4o-2024-08-06", 2.50, "date_stripped"),
+        ("openai", "gpt-4o-2024-11-20", 2.50, "date_stripped"),
+        ("openai", "gpt-4.1-2025-04-14", 2.00, "date_stripped"),
+        # Provider routing prefix — the other gap.
+        ("anthropic", "anthropic/claude-opus-4-1", 15.00, "provider_prefix"),
+        # Nested routing prefix, as OpenRouter emits it.
+        ("anthropic", "openrouter/anthropic/claude-opus-4-1", 15.00, "provider_prefix"),
+        # Dotted version segments (`claude-opus-4.1` vs the table's `-4-1`).
+        ("anthropic", "claude-opus-4.1", 15.00, "version_dots"),
+        # Prefix AND dots together — the real HAL corpus form.
+        ("anthropic", "anthropic/claude-opus-4.1", 15.00, "provider_prefix"),
+        ("anthropic", "anthropic/claude-3.7-sonnet", 3.00, "provider_prefix"),
+        # Context tag, still working alongside the new transforms.
+        ("anthropic", "claude-opus-4-1[1m]", 15.00, "context_tag"),
+    ],
+)
+def test_each_lookup_form_resolves(provider, model, expected_input, expected_kind):
+    rates = get_rates(provider, model)
+    assert rates is not None, f"{provider}/{model} did not resolve"
+    assert rates.input_per_mtok == expected_input
+    assert classify_pricing_source(provider, model) == expected_kind
+
+
+def test_an_unknown_model_still_reports_the_default_fallback():
+    """The fallback must stay reachable — a wider lookup that resolves
+    everything to *something* would hide the signal instead of fixing it."""
+    assert get_rates("anthropic", "claude-not-a-real-model") is None
+    assert classify_pricing_source("anthropic", "claude-not-a-real-model") == (
+        "default_fallback"
+    )
+
+
+def test_a_routing_prefix_does_not_invent_a_match_for_an_unknown_model():
+    assert get_rates("openai", "someproxy/gpt-not-real") is None
+
+
+# ── The benchmark corpus ───────────────────────────────────────────────────
+# Every distinct `gen_ai.request.model` string observed across the nine
+# replayed agent runs, pinned to the input rate it must price at. These are the
+# strings that were mispriced; if any of them regresses to the default rate the
+# cost dashboard is wrong again by the same 5-30x.
+
+BENCHMARK_CORPUS_MODELS = [
+    ("anthropic", "anthropic/claude-opus-4.1", 15.00),
+    ("anthropic", "claude-opus-4-20250514", 15.00),
+    ("anthropic", "claude-3-7-sonnet-20250219", 3.00),
+    ("anthropic", "anthropic/claude-3.7-sonnet", 3.00),
+    ("anthropic", "claude-sonnet-4-5-20250929", 3.00),
+    ("anthropic", "claude-haiku-4-5-20251001", 1.00),
+    ("anthropic", "anthropic/claude-haiku-4.5", 1.00),
+    ("openai", "gpt-4.1-2025-04-14", 2.00),
+    ("openai", "gpt-4o-2024-08-06", 2.50),
+    ("openai", "gpt-4o-2024-11-20", 2.50),
+    ("google", "gemini-2.0-flash", 0.10),
+]
+
+
+@pytest.mark.parametrize("provider,model,expected_input", BENCHMARK_CORPUS_MODELS)
+def test_benchmark_corpus_model_prices_at_its_real_rate(provider, model, expected_input):
+    rates = get_rates(provider, model)
+    assert rates is not None, (
+        f"{provider}/{model} fell through to the default rate — the cost "
+        f"dashboard would be silently wrong for every call using it"
+    )
+    assert rates.input_per_mtok == expected_input
+
+
+@pytest.mark.parametrize("provider,model,_expected", BENCHMARK_CORPUS_MODELS)
+def test_no_benchmark_corpus_model_uses_the_default_fallback(provider, model, _expected):
+    source = classify_pricing_source(provider, model)
+    assert source != "default_fallback"
+    rates = get_rates(provider, model)
+    assert rates is not None
+    assert rates.input_per_mtok != DEFAULT_INPUT_PER_MTOK or source != "default_fallback"
+
+
+# ── Backfilled table entries ───────────────────────────────────────────────
+# Rates verified against the providers' published pricing pages, not invented.
+
+@pytest.mark.parametrize(
+    "provider,model,input_rate,output_rate",
+    [
+        ("anthropic", "claude-3-7-sonnet", 3.00, 15.00),
+        ("openai", "gpt-4.1", 2.00, 8.00),
+        ("google", "gemini-2-0-flash", 0.10, 0.40),
+    ],
+)
+def test_backfilled_models_carry_their_published_rates(
+    provider, model, input_rate, output_rate,
+):
+    rates = get_rates(provider, model)
+    assert rates is not None
+    assert rates.input_per_mtok == input_rate
+    assert rates.output_per_mtok == output_rate

--- a/tokenjam/api/routes/cost.py
+++ b/tokenjam/api/routes/cost.py
@@ -14,6 +14,7 @@ from tokenjam.core.framing import (
     plan_determination_mix,
 )
 from tokenjam.core.models import CostFilters
+from tokenjam.core.pricing_coverage import coverage_note, summarize_pricing_coverage
 from tokenjam.utils.time_parse import parse_since, utcnow
 
 router = APIRouter(dependencies=[Depends(require_api_key)])
@@ -531,6 +532,27 @@ def _dimension_coverage(conn, agent_id, since_dt, until_dt) -> dict:
     return out
 
 
+def _pricing_coverage_block(conn, agent_id, since_dt, until_dt) -> dict:
+    """The default-rate share of this window, shaped for the UI.
+
+    `measured` distinguishes "asked, nothing unpriced" from "could not ask" so
+    the panel can stay silent rather than assert a clean bill it never checked
+    (root anti-pattern 22 — a surface must not claim more than its data
+    supports).
+    """
+    coverage = summarize_pricing_coverage(conn, agent_id, since_dt, until_dt)
+    return {
+        "measured": coverage.measured,
+        "unpriced_call_count": coverage.unpriced_call_count,
+        "unpriced_cost_usd": coverage.unpriced_cost_usd,
+        "unpriced_models": [
+            {"provider": provider, "model": model, "call_count": calls}
+            for provider, model, calls in coverage.unpriced_models
+        ],
+        "note": coverage_note(coverage),
+    }
+
+
 @router.get("/cost")
 async def get_cost(
     request: Request,
@@ -605,6 +627,13 @@ async def get_cost(
         # group_by, so switching the dropdown to an uninstrumented dimension
         # doesn't require a second round-trip to know it'll be empty.
         "attribution_coverage": _dimension_coverage(conn, agent_id, since_dt, until_dt),
+        # Which models in this window were priced at the flat default rate
+        # rather than a published one. Without this the UI cannot tell an
+        # estimated dollar figure from a quoted one, which is exactly how a
+        # missing table row stays invisible while the number is 5-30x wrong.
+        "pricing_coverage": _pricing_coverage_block(
+            conn, agent_id, since_dt, until_dt,
+        ),
         # `available_days` (core/data_span.py) so the Cost view's own window
         # selector can derive its options from what the store actually holds,
         # the same way the Dashboard's does — instead of a fixed 24h/7d/30d/90d

--- a/tokenjam/api/routes/relearn.py
+++ b/tokenjam/api/routes/relearn.py
@@ -37,6 +37,9 @@ from tokenjam.core.framing import (
     plan_determination_mix,
 )
 from tokenjam.core.optimize import (
+    scope as scope_mod,
+)
+from tokenjam.core.optimize import (
     cost_apply,
     cost_proposals as cost_proposals_mod,
     inbox_contribution,
@@ -55,25 +58,56 @@ router = APIRouter()
 _WRITE_AUTH = [Depends(require_api_key), Depends(require_relearn_write_auth)]
 
 
-def _reject_target_outside_home(target_path: str) -> None:
+def _allowed_write_root(config: Any) -> Path:
+    """The one directory tree an approved write may land in, for THIS run.
+
+    Resolved from the same ``core.optimize.scope`` contract the apply-target
+    suggestion comes from (``resolve_write_scope``), never from the process's
+    own ``Path.home()``. With ``--projects-root`` pointed outside ``$HOME``
+    the suggestion followed the scoped home while this guard did not, so the
+    UI suggested a target and the API then 403'd that exact write — the
+    suggestion and the authorization disagreed. One helper, one root.
+
+    Fail-closed: a scope that cannot be resolved raises rather than widening
+    to "anywhere". With no scope override this is the real ``$HOME``, exactly
+    as before.
+    """
+    try:
+        root = scope_mod.resolve_write_scope(config).allowed_root
+        return root.expanduser().resolve(strict=False)
+    except (OSError, RuntimeError) as exc:
+        raise HTTPException(
+            status_code=403,
+            detail=f"cannot resolve the allowed write root for this run ({exc}) — refusing.",
+        ) from exc
+
+
+def _reject_target_outside_home(target_path: str, config: Any) -> None:
     """Defense-in-depth (must-fix #1): even with write-auth enforced, refuse
-    to write anywhere outside the user's home directory. Every legitimate
-    target (a project's CLAUDE.md/skill/hook, or a user-global ~/.claude/*
-    file) lives under $HOME — this just makes a bug or a maliciously-crafted
-    ``target_path`` (e.g. ``/etc/...``, ``/root/...``) fail closed rather than
-    relying solely on the overwrite/symlink guards inside relearn_apply.
+    to write anywhere outside this run's allowed root (``_allowed_write_root``
+    — ``$HOME`` unless the run is scoped). Every legitimate target (a
+    project's CLAUDE.md/skill/hook, or a user-global ~/.claude/* file) lives
+    under that root — this just makes a bug or a maliciously-crafted
+    ``target_path`` (e.g. ``/etc/...``, ``/root/...``, or a ``..`` traversal
+    out of the scope) fail closed rather than relying solely on the
+    overwrite/symlink guards inside relearn_apply.
+
+    ``resolve(strict=False)`` is deliberate on both sides: the target usually
+    does not exist yet (that is the point of an apply), and resolving it
+    collapses ``..`` segments AND follows any symlink on the way, so a symlink
+    pointing out of the root is judged by where it LANDS, not by where it sits.
     """
     if not target_path:
         return   # relearn_apply itself refuses an empty target_path (409)
+    root = _allowed_write_root(config)
     try:
         resolved = Path(target_path).expanduser().resolve(strict=False)
-        home = Path.home().resolve(strict=False)
     except (OSError, RuntimeError) as exc:
         raise HTTPException(status_code=400, detail=f"unresolvable target_path: {exc}") from exc
-    if resolved != home and home not in resolved.parents:
+    if resolved != root and root not in resolved.parents:
         raise HTTPException(
             status_code=403,
-            detail=f"target_path {resolved} is outside the allowed root ({home}) — refusing.",
+            detail=f"target_path {resolved} is outside the allowed root ({root}) — refusing.",
         )
 
 
@@ -459,11 +493,15 @@ def post_relearn_apply(request: Request, body: ApplyRelearnRequest) -> dict[str,
     already holds a non-TokenJam file, or (unless ``force=true``) a live
     session just seen in the target repo (§7: never apply mid-session). The
     UI's re-send-with-force is the explicit "apply anyway" the spec calls for.
-    403s when ``target_path`` resolves outside the user's home directory
-    (defense-in-depth allowlist).
+    403s when ``target_path`` resolves outside this run's allowed write
+    root (defense-in-depth allowlist — ``$HOME`` unless the run is scoped;
+    see ``_allowed_write_root``).
     """
-    _reject_target_outside_home(body.target_path)
-    stored = relearn_proposals.get_proposal(body.proposal_id, config=_config(request))
+    # Config first: the allowed write root is resolved FROM it, and a missing
+    # config must 503 rather than let the guard fall back to a wider root.
+    apply_config = _config(request)
+    _reject_target_outside_home(body.target_path, apply_config)
+    stored = relearn_proposals.get_proposal(body.proposal_id, config=apply_config)
     if stored is None:
         raise HTTPException(
             status_code=404,
@@ -893,10 +931,11 @@ def post_cost_apply_workspace(request: Request, body: ApplyWorkspaceCostRequest)
     human-gated (dry-run first) discipline — then records the cost marker so
     the delta-verify pass measures the realized delta after it. ``go=false``
     returns the dry-run diff; a second call with ``go=true`` writes. 404 on an
-    unknown ``proposal_id``; 403 outside home; 409 on a refusal.
+    unknown ``proposal_id``; 403 outside the allowed write root; 409 on a
+    refusal.
     """
-    _reject_target_outside_home(body.target_path)
     config = _config(request)
+    _reject_target_outside_home(body.target_path, config)
     db = getattr(request.app.state, "db", None)
     stored = _stored_cost_proposal(request, body.proposal_id)
     signature = str(stored.get("signature") or "")
@@ -990,14 +1029,15 @@ def post_register_source_path(
     Registration is per AGENT, so one answer unlocks every other proposal for the
     same agent at the next recompute. Several of the eleven share an ``agent_id``.
 
-    403 outside home; 409 on any refusal (a path that is not a directory, not in
+    403 outside the allowed write root; 409 on any refusal (a path that is not a
+    directory, not in
     a git repo, a model id in several files, a dirty target, a live session in
     the repo unless ``force``); 404 on an unknown ``proposal_id``.
     """
     from tokenjam.core.optimize import model_apply
 
-    _reject_target_outside_home(body.source_path)
     config = _config(request)
+    _reject_target_outside_home(body.source_path, config)
     stored = _stored_cost_proposal(request, body.proposal_id)
     if not stored.get("needs_source_path"):
         raise HTTPException(

--- a/tokenjam/cli/cmd_cost.py
+++ b/tokenjam/cli/cmd_cost.py
@@ -148,6 +148,28 @@ def cmd_cost(ctx: click.Context, agent: str | None, since: str,
                       f"[bold]{sum(r.call_count for r in rows)}[/bold]")
 
     console.print(table)
+    _print_pricing_coverage(db, agent, since_dt)
+
+
+def _print_pricing_coverage(db, agent: str | None, since_dt) -> None:
+    """Name any model in this window priced at the flat default rate.
+
+    Without this the table's COST column reads identically whether a rate was
+    published for the model or guessed, which is how a model missing from
+    `models.toml` stays invisible while its dollar figure is badly wrong. Prints
+    nothing when everything resolved, and nothing on the API-shim path (no
+    direct connection) rather than implying a clean bill it never checked.
+    """
+    from tokenjam.core.pricing_coverage import (
+        coverage_note,
+        summarize_pricing_coverage,
+    )
+
+    conn = getattr(db, "conn", None)
+    note = coverage_note(summarize_pricing_coverage(conn, agent, since_dt, None))
+    if note:
+        console.print()
+        console.print(f"[dim]{note}[/dim]")
 
 
 def _cost_framing(ctx, db, since, since_dt, until_dt, agent, total_cost, total_tokens):

--- a/tokenjam/cli/cmd_optimize.py
+++ b/tokenjam/cli/cmd_optimize.py
@@ -853,6 +853,16 @@ def _render_report(
     if report.notes:
         console.print()
 
+    # Said out loud, because the alternative is three analyzers rendering as
+    # "nothing found" when the truth is that they never looked (root
+    # anti-pattern 22). See `core/optimize/scope.py`.
+    if report.filesystem_scan_skipped_reason:
+        console.print(
+            "  [dim]deadweight, relearn and summarize did not run: "
+            f"{_rich_escape(report.filesystem_scan_skipped_reason)}.[/dim]"
+        )
+        console.print()
+
     # An analyzer the user typed by name that this persona's skip gate dropped
     # would otherwise render as silence, which reads as a broken command. The
     # gate is deliberately invisible when it fires on the default (unnamed)

--- a/tokenjam/cli/main.py
+++ b/tokenjam/cli/main.py
@@ -22,12 +22,18 @@ if TYPE_CHECKING:
               help="Output machine-readable JSON")
 @click.option("--no-color", is_flag=True)
 @click.option("--db", "db_path", default=None, help="Database path override")
+@click.option("--projects-root", "projects_root", default=None,
+              type=click.Path(file_okay=False, path_type=str),
+              help="Transcript/config root the filesystem-reading analyzers "
+                   "(deadweight, relearn, summarize) may read. Defaults to "
+                   "~/.claude/projects; an explicit --db scopes them off "
+                   "unless this is given.")
 @click.option("--agent", default=None, help="Filter to specific agent_id")
 @click.option("-v", "--verbose", is_flag=True)
 @click.pass_context
 def cli(ctx: click.Context, config_path: str | None, output_json: bool,
-        no_color: bool, db_path: str | None, agent: str | None,
-        verbose: bool) -> None:
+        no_color: bool, db_path: str | None, projects_root: str | None,
+        agent: str | None, verbose: bool) -> None:
     """tj - a cost-saving utility for AI agents."""
     ctx.ensure_object(dict)
 
@@ -58,6 +64,13 @@ def cli(ctx: click.Context, config_path: str | None, output_json: bool,
     config = load_config(config_path)
     if db_path:
         config.storage.path = db_path
+        # Recorded, not inferred: the filesystem-reading analyzers scope
+        # themselves off whether the store was NAMED by the caller, and once
+        # the override lands on `storage.path` that is no longer recoverable.
+        # See `core/optimize/scope.py` for the contract.
+        config.storage.path_is_explicit = True
+    if projects_root:
+        config.optimize.projects_root = projects_root
 
     # Commands that don't need a database connection
     no_db_commands = {

--- a/tokenjam/core/config.py
+++ b/tokenjam/core/config.py
@@ -64,6 +64,13 @@ class DefaultsConfig:
 class StorageConfig:
     path:           str = "~/.tj/telemetry.duckdb"
     retention_days: int = 90
+    # Runtime provenance, never read from or written to TOML: True when `path`
+    # came from an explicit `--db` rather than config discovery. The
+    # filesystem-reading analyzers scope themselves off it (see
+    # `core/optimize/scope.py`) — a config file that happens to name the same
+    # path is a normal run, so the two cases have to stay distinguishable
+    # after the override has been applied.
+    path_is_explicit: bool = field(default=False, repr=False, compare=False)
 
 
 @dataclass
@@ -283,6 +290,14 @@ class OptimizeConfig:
     # tool-call-signature cluster needs at least this many member sessions
     # before it's recommended for script-replacement.
     min_cluster_instances: int = 20
+    # The transcript/config root the filesystem-reading analyzers (deadweight,
+    # relearn, summarize) may read — the `--projects-root` flag writes here.
+    # `None` defers to the precedence chain in `core/optimize/scope.py`: the
+    # TJ_CLAUDE_PROJECTS_ROOT env var, then suppression under an explicit
+    # `--db`, then `~/.claude/projects`. Unlike every other field in this
+    # section this is a SCOPE, not a sensitivity threshold — it decides which
+    # filesystem is evidence, not how eager an analyzer is about it.
+    projects_root: str | None = None
     # deadweight (analyzers/deadweight.py MIN_SESSIONS_DEADWEIGHT): an MCP
     # server needs to be configured-present in at least this many distinct
     # sessions, with zero invocations across all of them, to be flagged dead.
@@ -740,6 +755,7 @@ def _parse(raw: dict) -> TjConfig:
             "scan_min_rescan_seconds", OptimizeConfig.scan_min_rescan_seconds)),
         scan_ui_poll_seconds=int(optimize_raw.get(
             "scan_ui_poll_seconds", OptimizeConfig.scan_ui_poll_seconds)),
+        projects_root=optimize_raw.get("projects_root") or None,
     )
 
     defaults_raw = raw.get("defaults", {})

--- a/tokenjam/core/optimize/analyzers/deadweight.py
+++ b/tokenjam/core/optimize/analyzers/deadweight.py
@@ -138,9 +138,14 @@ def _mcp_server_names(path: Path) -> set[str]:
     return {str(name) for name in servers if str(name).strip()}
 
 
-def _global_config_path() -> Path:
+def _global_config_path(claude_home: Path | None = None) -> Path:
     # Resolved LAZILY (never at import time) so a test patching HOME sees the
-    # fake home, never the developer's real ~/.claude.json.
+    # fake home, never the developer's real ~/.claude.json. `claude_home`
+    # scopes it further: under an explicit `--projects-root` the global MCP
+    # config read must stay inside the root the caller drew, or a scoped run
+    # still reports servers from the operator's real machine.
+    if claude_home is not None:
+        return claude_home / ".claude.json"
     return Path.home() / ".claude.json"
 
 
@@ -153,7 +158,9 @@ class ConfiguredServer:
     cwds:   set[str] = field(default_factory=set)  # project scope: reachable cwds
 
 
-def enumerate_configured_servers(repo_cwds: set[str]) -> dict[str, ConfiguredServer]:
+def enumerate_configured_servers(
+    repo_cwds: set[str], *, claude_home: Path | None = None,
+) -> dict[str, ConfiguredServer]:
     """Read-only enumeration of MCP servers across the three config
     locations: project ``.mcp.json`` / ``.claude/settings*.json`` under each
     given session cwd, plus the global ``~/.claude.json``. Never edits a
@@ -165,7 +172,7 @@ def enumerate_configured_servers(repo_cwds: set[str]) -> dict[str, ConfiguredSer
     """
     servers: dict[str, ConfiguredServer] = {}
 
-    global_path = _global_config_path()
+    global_path = _global_config_path(claude_home)
     if global_path.is_file():
         for name in _mcp_server_names(global_path):
             servers[name] = ConfiguredServer(name=name, scope="user", source=str(global_path))
@@ -711,6 +718,7 @@ def compute_deadweight_finding(
     until: datetime,
     *,
     projects_root: Path | str | None = None,
+    claude_home: Path | None = None,
     min_sessions: int = MIN_SESSIONS_DEADWEIGHT,
     cache_dir: Path | None = None,
 ) -> DeadweightFinding:
@@ -778,7 +786,7 @@ def compute_deadweight_finding(
         per_session[session_id] = _analyze_session(records)
 
     repo_cwds = {c for c in session_cwds.values() if c}
-    configured = enumerate_configured_servers(repo_cwds)
+    configured = enumerate_configured_servers(repo_cwds, claude_home=claude_home)
     finding.configured_servers = len(configured)
     if not configured:
         return finding
@@ -1013,7 +1021,17 @@ def run(ctx: AnalyzerContext) -> None:
     repeat HTTP request against a live ``tj serve`` — skips re-parsing every
     session it already has a fresh cache entry for.
     """
+    from tokenjam.core.optimize.scope import resolve_analyzer_scope
     from tokenjam.core.transcript_cache import default_cache_dir
+
+    scope = ctx.scope if ctx.scope is not None else resolve_analyzer_scope(ctx.config)
+    if not scope.enabled:
+        # Scanned nothing, and says so on the report rather than leaving an
+        # empty finding that reads like "no dead MCP servers here" (root
+        # anti-pattern 22).
+        ctx.report.filesystem_scan_skipped_reason = scope.reason
+        ctx.report.findings["deadweight"] = DeadweightFinding()
+        return
 
     optimize_cfg = getattr(ctx.config, "optimize", None)
     min_sessions = getattr(
@@ -1021,6 +1039,8 @@ def run(ctx: AnalyzerContext) -> None:
     )
     ctx.report.findings["deadweight"] = compute_deadweight_finding(
         ctx.since, ctx.until,
+        projects_root=scope.projects_root,
+        claude_home=scope.claude_home,
         min_sessions=min_sessions,
         cache_dir=default_cache_dir(ctx.config),
     )

--- a/tokenjam/core/optimize/analyzers/relearn.py
+++ b/tokenjam/core/optimize/analyzers/relearn.py
@@ -934,7 +934,24 @@ def _below_threshold_residue(
 
 # --- Distill pass over the residual (non-family) bucket -----------------------
 
-def _distill_cache_dir() -> Path:
+def _distill_cache_dir(config: Any | None = None) -> Path:
+    """Where distilled cluster titles are cached between runs.
+
+    This is a SECOND cache, structurally separate from
+    ``relearn_store.default_cache_path``. That one was already threaded through
+    ``relearn_apply._storage_base_dir`` so an isolated config (``:memory:``, a
+    throwaway ``--db``) writes into a temp root instead of the operator's real
+    ``~/.tj``; this one was not, and wrote real files under the real home
+    regardless — silently, since it fires only after a successful distill LLM
+    call. Same helper, same guarantee, so neither cache can leak on its own.
+
+    ``config`` is None only for direct callers that never had a config to
+    thread (the standalone helpers and their tests); those keep the historical
+    path.
+    """
+    if config is not None:
+        from tokenjam.core.optimize.relearn_apply import _storage_base_dir
+        return _storage_base_dir(config) / "distill_cache" / "relearn"
     return Path.home() / ".tj" / "distill_cache" / "relearn"
 
 
@@ -1720,6 +1737,9 @@ def build_proposals(
     *,
     min_sessions: int = MIN_RECURRING_SESSIONS,
     doc_text: str = "",
+    # The scope's Claude home, used only to suggest a user-global write target
+    # (see `relearn_apply.default_target_path`). `None` keeps `~/.claude`.
+    claude_home: Path | None = None,
     repo_cwd_map: dict[str, str] | None = None,
     advise_only_repos: set[str] | None = None,
     conn: Any | None = None,
@@ -1822,6 +1842,7 @@ def build_proposals(
             try:
                 suggested_target = default_target_path(
                     rung, scope, repo_cwd, slugify(cluster.title),
+                    claude_home=claude_home,
                 )
             except Exception:
                 suggested_target = ""   # never let a bad path computation sink the proposal
@@ -2100,6 +2121,9 @@ def analyze_relearns(
     sessions: list[tuple[str, str]],     # [(session_id, repo), ...]
     *,
     projects_root: Path | str | None = None,
+    # The scope's Claude home, used ONLY to suggest a user-global write target.
+    # `None` keeps the historical `~/.claude`; see `default_target_path`.
+    claude_home: Path | None = None,
     min_sessions: int = MIN_RECURRING_SESSIONS,
     distill_enabled: bool = True,
     distill_cache_dir: Path | None = None,
@@ -2204,6 +2228,7 @@ def analyze_relearns(
 
     proposals, dropped = build_proposals(
         distilled, min_sessions=min_sessions, doc_text=codified_doc_text,
+        claude_home=claude_home,
         repo_cwd_map=repo_cwd_map, advise_only_repos=advise_only_repos,
         conn=conn, window_days=corpus_window_days, persona=persona,
         projection=projection,
@@ -2377,6 +2402,8 @@ def compute_relearn_finding(
     since: Any | None = None,
     *,
     projects_root: Path | str | None = None,
+    claude_home: Path | None = None,
+    distill_cache_dir: Path | None = None,
     distill_enabled: bool = True,
     min_sessions: int = MIN_RECURRING_SESSIONS,
     transcript_cache_dir: Path | None = None,
@@ -2511,8 +2538,10 @@ def compute_relearn_finding(
         doc_text = ""
 
     finding = analyze_relearns(
-        sessions, projects_root=root, codified_doc_text=doc_text,
-        distill_enabled=distill_enabled, repo_cwd_map=repo_cwd_map,
+        sessions, projects_root=root, claude_home=claude_home,
+        codified_doc_text=doc_text,
+        distill_enabled=distill_enabled, distill_cache_dir=distill_cache_dir,
+        repo_cwd_map=repo_cwd_map,
         extra_failures=span_failures + archived_failures,
         advise_only_repos=advise_only_repos,
         min_sessions=min_sessions, transcript_cache_dir=transcript_cache_dir,
@@ -2550,7 +2579,19 @@ def run(ctx: AnalyzerContext) -> None:
     ``storage.retention_days`` — what tokenjam actually kept — which is the
     point of keeping it.
     """
+    from tokenjam.core.optimize.scope import resolve_analyzer_scope
     from tokenjam.core.transcript_cache import default_cache_dir
+
+    scope = ctx.scope if ctx.scope is not None else resolve_analyzer_scope(ctx.config)
+    if not scope.enabled:
+        # The leak this guards is not hypothetical: served against an empty
+        # throwaway `--db`, this analyzer surfaced recurring-mistake entries
+        # carrying real file paths from an unrelated project, because its
+        # evidence came off the machine's global transcript tree rather than
+        # the database being served.
+        ctx.report.filesystem_scan_skipped_reason = scope.reason
+        ctx.report.findings["relearn"] = RelearnFinding()
+        return
 
     optimize_cfg = getattr(ctx.config, "optimize", None)
     min_sessions = getattr(
@@ -2570,6 +2611,9 @@ def run(ctx: AnalyzerContext) -> None:
     ctx.report.findings["relearn"] = compute_relearn_finding(
         ctx.conn, min_sessions=min_sessions,
         retention_days=retention_days,
+        projects_root=scope.projects_root,
+        claude_home=scope.claude_home,
+        distill_cache_dir=_distill_cache_dir(ctx.config),
         transcript_cache_dir=default_cache_dir(ctx.config),
         persona=ctx.persona,
         existing_agent_file_tokens=measured_agent_file_tokens(

--- a/tokenjam/core/optimize/analyzers/summarize.py
+++ b/tokenjam/core/optimize/analyzers/summarize.py
@@ -356,10 +356,21 @@ def run(ctx: AnalyzerContext) -> None:
         ctx.report.findings["summarize"] = finding
         return
 
+    from tokenjam.core.optimize.scope import resolve_analyzer_scope
     from tokenjam.core.summarize.candidates import list_candidates
 
+    scope = ctx.scope if ctx.scope is not None else resolve_analyzer_scope(ctx.config)
+    if not scope.enabled:
+        # Same reason the sibling filesystem analyzers bail: the catalog scan
+        # reads always-loaded prompt files off the operator's real home, which
+        # an explicit `--db` was asked to isolate away from.
+        ctx.report.filesystem_scan_skipped_reason = scope.reason
+        ctx.report.findings["summarize"] = finding
+        return
+
     try:
-        scan = list_candidates(config=ctx.config)  # read-only, never writes
+        # read-only, never writes; `home` scopes the catalog's `~` paths
+        scan = list_candidates(config=ctx.config, home=scope.home)
     except Exception:
         # Empty finding on any scan failure so a filesystem hiccup never breaks the
         # optimize report — but log it: a silent broad-swallow would hide a real

--- a/tokenjam/core/optimize/relearn_apply.py
+++ b/tokenjam/core/optimize/relearn_apply.py
@@ -148,14 +148,25 @@ def applied_fixes_path(config: TjConfig) -> Path:
 
 # --- Default target-path suggestion (for the card's scope/target override) ----
 
-def default_target_path(rung: int, scope: str, repo_cwd: str, slug: str) -> str:
+def default_target_path(
+    rung: int, scope: str, repo_cwd: str, slug: str,
+    *, claude_home: Path | None = None,
+) -> str:
     """Best-effort suggested write location — always user-editable before Approve
     (SPEC's "scope override" requirement: repo-identity is noisy, never trust it
     blindly). Returns ``""`` when there isn't enough information (no known cwd
     for a project-scoped cluster) — the UI must then require an explicit path.
+
+    ``claude_home`` scopes the user-global branch to the analyzer scope's home
+    (see ``core/optimize/scope.py``). Without it a review view served from a
+    throwaway ``--db`` defaulted its "where to write it" target to a real path
+    on the operator's machine, so a single Approve click in what looks like a
+    sandbox would write a real file outside the database being served. The
+    target has to agree with the scope the findings came from, or the two
+    halves of the card describe different machines.
     """
     if scope == "user-global":
-        home = Path.home() / ".claude"
+        home = (claude_home if claude_home is not None else Path.home() / ".claude")
         if rung == RUNG_NOTE:
             return str(home / "CLAUDE.md")
         if rung == RUNG_SKILL:

--- a/tokenjam/core/optimize/relearn_store.py
+++ b/tokenjam/core/optimize/relearn_store.py
@@ -284,7 +284,10 @@ def recompute_now(
         # `analyzers/relearn.run` would leak the machine's global transcript
         # tree back in through the cache the served routes read. See
         # `core/optimize/scope.py`.
-        from tokenjam.core.optimize.scope import resolve_analyzer_scope
+        from tokenjam.core.optimize.scope import (
+            resolve_analyzer_scope,
+            resolve_write_scope,
+        )
 
         scope = resolve_analyzer_scope(config)
         if not scope.enabled:
@@ -333,8 +336,12 @@ def recompute_now(
             persona=persona,
             # The apply target has to agree with the scope the findings came
             # from — a card whose evidence is scoped and whose write target is
-            # not describes two different machines.
-            claude_home=scope.claude_home,
+            # not describes two different machines. Routed through
+            # `resolve_write_scope` rather than reading `scope.claude_home`
+            # directly, because the API's write guard authorizes against the
+            # OTHER half of that same type; deriving the two independently is
+            # what let the suggestion and the guard disagree.
+            claude_home=resolve_write_scope(scope=scope).suggest_root,
             # Scoped like every other relearn artifact — the distill cache is a
             # SECOND cache beside this module's own, and it wrote real files
             # under the real ~/.tj even from an isolated config until it was

--- a/tokenjam/core/optimize/relearn_store.py
+++ b/tokenjam/core/optimize/relearn_store.py
@@ -41,6 +41,22 @@ def default_cache_path(config: TjConfig | None = None) -> Path:
     return Path.home() / ".tj" / "relearn_cache.json"
 
 
+def _distill_cache_dir_for(config: TjConfig | None) -> Path | None:
+    """The distill cache this run may write to, or None to leave the default.
+
+    Imported lazily and never allowed to raise: a cache-path resolution
+    failure must not sink a recompute that would otherwise succeed.
+    """
+    if config is None:
+        return None
+    try:
+        from tokenjam.core.optimize.analyzers.relearn import _distill_cache_dir
+
+        return _distill_cache_dir(config)
+    except Exception:
+        return None
+
+
 def read_cache(
     path: Path | None = None, *, config: TjConfig | None = None,
 ) -> dict[str, Any] | None:
@@ -262,8 +278,19 @@ def recompute_now(
         # `[loop].transcript_path` lets a Claude Agent SDK app point the loop at
         # its OWN transcript root instead of ~/.claude/projects. None keeps the
         # historical env/default resolution.
-        projects_root = None
-        if config is not None:
+        #
+        # The analyzer scope is consulted FIRST: this daemon job is a second
+        # entry point into the same scan, so a scope honored only by
+        # `analyzers/relearn.run` would leak the machine's global transcript
+        # tree back in through the cache the served routes read. See
+        # `core/optimize/scope.py`.
+        from tokenjam.core.optimize.scope import resolve_analyzer_scope
+
+        scope = resolve_analyzer_scope(config)
+        if not scope.enabled:
+            return None
+        projects_root = scope.projects_root if scope.source == "flag" else None
+        if projects_root is None and config is not None:
             try:
                 from tokenjam.core.transcript import loop_transcript_root
 
@@ -304,6 +331,15 @@ def recompute_now(
         finding = compute_relearn_finding(
             conn, projects_root=projects_root, transcript_cache_dir=transcript_cache_dir,
             persona=persona,
+            # The apply target has to agree with the scope the findings came
+            # from — a card whose evidence is scoped and whose write target is
+            # not describes two different machines.
+            claude_home=scope.claude_home,
+            # Scoped like every other relearn artifact — the distill cache is a
+            # SECOND cache beside this module's own, and it wrote real files
+            # under the real ~/.tj even from an isolated config until it was
+            # threaded through the same `_storage_base_dir`.
+            distill_cache_dir=_distill_cache_dir_for(config),
             # The archive lane's horizon: what tokenjam kept, not what Claude
             # Code left on disk. See `compute_relearn_finding`.
             retention_days=getattr(getattr(config, "storage", None), "retention_days", None),

--- a/tokenjam/core/optimize/runner.py
+++ b/tokenjam/core/optimize/runner.py
@@ -15,6 +15,7 @@ from tokenjam.core.config import TjConfig
 from tokenjam.core.framing import agent_persona_mix, config_declared_plan, dominant_persona
 from tokenjam.utils.time_parse import utcnow
 from tokenjam.core.optimize.registry import ANALYZER_REGISTRY
+from tokenjam.core.optimize.scope import resolve_analyzer_scope
 from tokenjam.core.optimize.types import (
     AnalyzerContext,
     OptimizeReport,
@@ -268,6 +269,11 @@ def build_report(
         budget_provider_filter=budget_provider_filter,
         budget_usd_override=budget_usd_override,
         persona=persona,
+        # Resolved exactly once, here, for the same reason the persona is: an
+        # analyzer that re-derives its own root from `Path.home()` or the env
+        # var escapes whatever scope the caller drew, and `--db` stops meaning
+        # anything. See `core/optimize/scope.py`.
+        scope=resolve_analyzer_scope(config),
     )
 
     selected = set(findings) if findings is not None else set(ANALYZER_REGISTRY.keys())
@@ -513,6 +519,11 @@ def report_from_dict(d: dict) -> OptimizeReport:
         notes=list(d.get("notes") or []),
         findings=findings,
         persona=str(d.get("persona", "unknown")),
+        # Round-tripped like every other report-level field: a report rebuilt
+        # from the daemon's cache must still be able to say its filesystem
+        # analyzers never scanned, or a served surface silently reads an
+        # unscanned report as a scanned-and-empty one.
+        filesystem_scan_skipped_reason=d.get("filesystem_scan_skipped_reason") or None,
     )
 
 

--- a/tokenjam/core/optimize/scope.py
+++ b/tokenjam/core/optimize/scope.py
@@ -1,0 +1,172 @@
+"""Which filesystem a filesystem-reading analyzer is allowed to look at.
+
+`deadweight`, `relearn` and `summarize` take their evidence from the filesystem
+by design: the telemetry DB holds spans, while the transcripts, the MCP config
+and the always-loaded prompt files these three reason about live on disk. That
+split is correct. What was missing is any way to say WHICH disk.
+
+Until this module there was no scope override at all — only the undocumented
+`TJ_CLAUDE_PROJECTS_ROOT` env var — so `--db` implied an isolation it never
+provided. Pointing `tj serve` at a freshly created, completely empty database
+still surfaced recurring-mistake findings carrying real file paths from an
+unrelated project on the operator's machine, still defaulted the review inbox's
+"where to write it" target to a real path outside that database's world, and
+still spent ~30 seconds walking the operator's real `~/.claude/projects` before
+the first paint — on a store with nothing in it.
+
+**The contract**, in precedence order:
+
+1. `--projects-root PATH` (or `[optimize] projects_root`) — scan exactly that
+   root. This is the escape hatch for every case below.
+2. `TJ_CLAUDE_PROJECTS_ROOT` — unchanged, now documented.
+3. An explicit `--db`: the filesystem scans are SUPPRESSED. A caller who named
+   a database named the corpus they want reasoned about, and mixing a second,
+   unrelated corpus into that report is the bug. Suppression is also what makes
+   an empty store paint immediately instead of walking a five-thousand-file
+   transcript tree to conclude nothing.
+4. Otherwise — `~/.claude/projects`, exactly as before. A normal run is
+   unchanged: no flag, no env var, no `--db`, same behaviour as always.
+
+Suppression is reported, never silent: `AnalyzerScope.reason` names why, the
+analyzers attach it to their findings, and the surfaces distinguish "scanned,
+found nothing" from "did not scan" (root anti-pattern 22). A user who does want
+machine history alongside a custom database says so with `--projects-root`.
+"""
+
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass
+from pathlib import Path
+
+#: The env var honored since before this module existed. Kept as the second
+#: precedence step so every existing test fixture and integration keeps working.
+PROJECTS_ROOT_ENV = "TJ_CLAUDE_PROJECTS_ROOT"
+
+def default_claude_home() -> Path:
+    """``~/.claude``, resolved LAZILY.
+
+    Never a module-level constant: `Path.home()` baked at import time survives
+    a later `HOME` repoint, which is how a test that carefully isolates itself
+    still ends up scanning the developer's real transcript tree (the same trap
+    `deadweight._global_config_path` documents, and the reason
+    `tests/conftest.py` has to patch `config.SEARCH_PATHS` by hand).
+    """
+    return Path.home() / ".claude"
+
+
+def default_projects_root() -> Path:
+    """``~/.claude/projects``, resolved lazily — see `default_claude_home`."""
+    return default_claude_home() / "projects"
+
+#: The one sentence every surface prints when scans were suppressed. Written
+#: once here so the CLI, the API and the analyzers cannot word it differently.
+SUPPRESSED_BY_DB_REASON = (
+    "filesystem scans are scoped off because an explicit --db was given; "
+    "pass --projects-root PATH to scan a transcript root alongside it"
+)
+
+
+@dataclass(frozen=True)
+class AnalyzerScope:
+    """The filesystem an analyzer run may read, and where that came from.
+
+    `enabled` is False only for the suppressed case. It is deliberately NOT the
+    same question as "does `projects_root` exist" — a scoped root that happens
+    to be empty was still scanned, and saying so is the difference between an
+    honest empty state and a claim the run never checked.
+    """
+
+    projects_root: Path
+    claude_home: Path
+    #: What `~` expands to inside this scope. `summarize` and `trim` read
+    #: always-loaded prompt files across SEVERAL agent homes (`~/.claude`,
+    #: `~/.gemini`, `~/.codex`), so scoping them to the Claude home alone would
+    #: miss most of the catalog while still escaping to the real home for the
+    #: rest. The home is the scope unit for those; the projects root is the
+    #: scope unit for transcript scans.
+    home: Path
+    enabled: bool
+    source: str
+    reason: str | None = None
+
+
+def _home_for(claude_home: Path) -> Path:
+    """The home directory implied by a Claude home.
+
+    `<home>/.claude` yields `<home>`. A custom scope directory is treated as
+    its own home rather than reaching up into whatever contains it — the same
+    no-escape rule `_claude_home_for` applies one level down.
+    """
+    return claude_home.parent if claude_home.name == ".claude" else claude_home
+
+
+def _claude_home_for(projects_root: Path) -> Path:
+    """The Claude config home implied by a projects root.
+
+    A projects root is conventionally `<claude-home>/projects`, so the home is
+    its parent. When a caller points `--projects-root` at a directory by
+    another name we treat that directory as the home too, rather than reaching
+    up into whatever happens to contain it — escaping the scope the caller just
+    drew is the one thing this module exists to prevent.
+    """
+    return projects_root.parent if projects_root.name == "projects" else projects_root
+
+
+def _scoped(projects_root: Path, source: str) -> AnalyzerScope:
+    root = projects_root.expanduser()
+    claude_home = _claude_home_for(root)
+    return AnalyzerScope(
+        projects_root=root,
+        claude_home=claude_home,
+        home=_home_for(claude_home),
+        enabled=True,
+        source=source,
+    )
+
+
+def resolve_analyzer_scope(config: object | None = None) -> AnalyzerScope:
+    """Resolve the filesystem scope for this run — see the module docstring.
+
+    Never raises and never touches the filesystem: a scope is a decision about
+    WHERE to look, taken before anything is read.
+    """
+    configured = _configured_root(config)
+    if configured:
+        return _scoped(Path(configured), "flag")
+
+    env = os.environ.get(PROJECTS_ROOT_ENV)
+    if env:
+        return _scoped(Path(env), "env")
+
+    if _db_path_is_explicit(config):
+        # A path is still carried so callers that only want to display the
+        # scope have something to show; `enabled` is what gates every read.
+        return AnalyzerScope(
+            projects_root=default_projects_root(),
+            claude_home=default_claude_home(),
+            home=Path.home(),
+            enabled=False,
+            source="suppressed_by_db",
+            reason=SUPPRESSED_BY_DB_REASON,
+        )
+
+    return _scoped(default_projects_root(), "default")
+
+
+def _configured_root(config: object | None) -> str | None:
+    """`[optimize] projects_root`, which `--projects-root` also writes into."""
+    optimize = getattr(config, "optimize", None)
+    value = getattr(optimize, "projects_root", None)
+    return str(value) if value else None
+
+
+def _db_path_is_explicit(config: object | None) -> bool:
+    """Whether this run's store path came from `--db` rather than discovery.
+
+    Set by the CLI at the point it applies the override, so config discovery
+    and an explicit flag stay distinguishable after the fact — a config file
+    that happens to name the same path is a normal run, not a scoped one.
+    """
+    storage = getattr(config, "storage", None)
+    return bool(getattr(storage, "path_is_explicit", False))

--- a/tokenjam/core/optimize/scope.py
+++ b/tokenjam/core/optimize/scope.py
@@ -125,6 +125,55 @@ def _scoped(projects_root: Path, source: str) -> AnalyzerScope:
     )
 
 
+@dataclass(frozen=True)
+class WriteScope:
+    """The two roots the Approve path needs, derived from ONE resolved scope.
+
+    An approved fix has two halves that must agree: the target the card
+    SUGGESTS, and the root the API is willing to WRITE under. They were derived
+    independently once — the suggestion followed `AnalyzerScope.claude_home`
+    while the API's guard stayed hardcoded to the process's real `Path.home()`
+    — so with `--projects-root` pointed outside `$HOME` the UI suggested a
+    target and the API then refused that exact write. Both halves resolve
+    through this one type now, precisely so they cannot drift apart again.
+
+    * `suggest_root` — where `relearn_apply.default_target_path` roots a
+      user-global suggestion (the scope's Claude home).
+    * `allowed_root` — the OUTERMOST directory an approved write may land in.
+      It is the scope's `home`, not its Claude home, because project-scoped
+      targets (a repo's own `CLAUDE.md`, `.claude/skills/…`) legitimately sit
+      beside `~/.claude` rather than inside it.
+
+    `suggest_root` is always inside-or-equal `allowed_root` by construction
+    (`_home_for` either returns the Claude home's parent or the Claude home
+    itself), which is what makes "the guard can never reject our own
+    suggestion" a property of the type rather than a coincidence.
+    """
+
+    suggest_root: Path
+    allowed_root: Path
+    source: str
+
+
+def resolve_write_scope(
+    config: object | None = None, *, scope: AnalyzerScope | None = None,
+) -> WriteScope:
+    """The suggest/allow roots for this run — pass `scope` when one is already
+    resolved (the analyzer path), `config` when it is not (the API path).
+
+    Never raises and never touches the filesystem, exactly like
+    `resolve_analyzer_scope`. With no `--projects-root`, no env var and no
+    scope override this returns `~/.claude` and `~`, i.e. the allowed root is
+    the real home and the guard behaves byte-for-byte as it always has.
+    """
+    resolved = scope if scope is not None else resolve_analyzer_scope(config)
+    return WriteScope(
+        suggest_root=resolved.claude_home.expanduser(),
+        allowed_root=resolved.home.expanduser(),
+        source=resolved.source,
+    )
+
+
 def resolve_analyzer_scope(config: object | None = None) -> AnalyzerScope:
     """Resolve the filesystem scope for this run — see the module docstring.
 

--- a/tokenjam/core/optimize/types.py
+++ b/tokenjam/core/optimize/types.py
@@ -351,6 +351,15 @@ class OptimizeReport:
     # (e.g. `cost_proposals.cost_proposals_from_report`) never has to
     # recompute it from a bare `conn`.
     persona:   str = "unknown"
+    # Why the filesystem-reading analyzers (deadweight, relearn, summarize)
+    # scanned nothing, when they scanned nothing — see
+    # `core/optimize/scope.py`. `None` means they DID scan, which is a
+    # different statement from "scanned and found nothing" and must render
+    # differently (root anti-pattern 22): an empty deadweight finding under a
+    # suppressed scope reads as "no dead MCP servers" when the truth is that
+    # no config was ever looked at. One field on the report rather than one
+    # per finding, so every surface reads the same answer.
+    filesystem_scan_skipped_reason: str | None = None
 
 
 @dataclass
@@ -383,6 +392,13 @@ class AnalyzerContext:
     # looking at an SDK caller (e.g. deciding fix modality) read it here
     # instead of re-deriving it from `conn`.
     persona:                str            = "unknown"
+    # Which filesystem the filesystem-reading analyzers (deadweight, relearn,
+    # summarize) may read, and why. Resolved once in `runner.build_report` via
+    # `core.optimize.scope.resolve_analyzer_scope` — an analyzer must never
+    # re-derive a root from `Path.home()` or the env var itself, or `--db`
+    # stops isolating it. `None` only in a hand-built context (tests): treat it
+    # as the unscoped default. See `core/optimize/scope.py` for the contract.
+    scope:                  Any            = None
 
 
 # ---------------------------------------------------------------------------

--- a/tokenjam/core/pricing.py
+++ b/tokenjam/core/pricing.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 import logging
 import os
+import re
 import sys
 from dataclasses import dataclass, field
 from datetime import date, datetime, timezone
@@ -595,12 +596,45 @@ def clear_pricing_cache() -> None:
     _UNKNOWN_VARIANT_WARNED.clear()
 
 
-def _strip_date_suffix(model: str) -> str | None:
-    """Return `model` minus a trailing `-YYYYMMDD` suffix, or None if absent."""
-    import re as _re
+#: The two shapes a provider stamps a release date onto a model id in:
+#: Anthropic's compact `-YYYYMMDD` (`claude-opus-4-20250514`) and OpenAI's
+#: dashed `-YYYY-MM-DD` (`gpt-4o-2024-08-06`). Only the compact form was
+#: handled originally, so every dated OpenAI id fell through to the flat
+#: default rate even when its bare row was sitting in the table.
+_DATE_SUFFIX_RE = re.compile(r"^(.*?)-(?:\d{8}|\d{4}-\d{2}-\d{2})$")
 
-    m = _re.match(r"^(.*)-(\d{8})$", model)
+#: A routing prefix from a gateway or aggregator — LiteLLM emits
+#: `anthropic/claude-opus-4.1`, OpenRouter `openrouter/anthropic/claude-opus-4.1`.
+#: One segment is stripped per application; `_lookup_candidates` re-applies the
+#: transform, so a multi-segment prefix unwinds one hop at a time.
+_PROVIDER_PREFIX_RE = re.compile(r"^[A-Za-z0-9_.-]+/(.+)$")
+
+#: A dotted version segment (`claude-opus-4.1`, `gemini-2.0-flash`) against the
+#: table's dashed key form (`claude-opus-4-1`, `gemini-2-0-flash`). Only digits
+#: on both sides of the dot are rewritten, so a dotted table key that is itself
+#: exact (`gpt-5.5`) is unaffected — the exact match is tried first regardless.
+_VERSION_DOT_RE = re.compile(r"(?<=\d)\.(?=\d)")
+
+
+def _strip_date_suffix(model: str) -> str | None:
+    """Return `model` minus a trailing release-date suffix, or None if absent.
+
+    Handles both published shapes — see `_DATE_SUFFIX_RE`.
+    """
+    m = _DATE_SUFFIX_RE.match(model)
+    return m.group(1) if (m and m.group(1)) else None
+
+
+def _strip_provider_prefix(model: str) -> str | None:
+    """Return `model` minus one leading `<provider>/` routing segment, or None."""
+    m = _PROVIDER_PREFIX_RE.match(model)
     return m.group(1) if m else None
+
+
+def _dashed_version(model: str) -> str | None:
+    """Return `model` with dotted version segments dashed, or None if unchanged."""
+    dashed = _VERSION_DOT_RE.sub("-", model)
+    return dashed if dashed != model else None
 
 
 def _strip_context_tag(model: str) -> str | None:
@@ -624,30 +658,69 @@ def _strip_context_tag(model: str) -> str | None:
     return m.group(1) if (m and m.group(1)) else None
 
 
+#: The name transforms tried, in priority order, when the exact model name has
+#: no row. Each is `(kind, fn)`; `fn` returns the rewritten name or None when it
+#: does not apply. `kind` is provenance only (see `classify_pricing_source`).
+#: Order is load-bearing: the date strip must precede the version dash-ing so
+#: `gpt-4.1-2025-04-14` is offered as `gpt-4.1` (a real key) before the
+#: less-likely `gpt-4-1-2025-04-14`.
+_NAME_TRANSFORMS: tuple[tuple[str, Any], ...] = (
+    ("provider_prefix", _strip_provider_prefix),
+    ("date_stripped", _strip_date_suffix),
+    ("context_tag", _strip_context_tag),
+    ("version_dots", _dashed_version),
+)
+
+#: How many times the transform set is re-applied to names it produced. A
+#: routing prefix over a dotted, dated name needs three hops
+#: (`openrouter/anthropic/claude-opus-4.1` → … → `claude-opus-4-1`); the cap
+#: exists only so a pathological name cannot loop, not as a tuning knob.
+_MAX_TRANSFORM_ROUNDS = 4
+
+
 def _lookup_candidates(model: str) -> list[tuple[str, str]]:
     """Ordered fallback (name, kind) pairs to try for `model` (most specific first).
 
-    Beyond the exact name we try, in order: the date-stripped name
-    (``-YYYYMMDD``, kind ``"date_stripped"``), the context-tag-stripped name
-    (``[1m]``, kind ``"context_tag"``), and the context-tag-then-date-stripped
-    name (also ``"context_tag"`` — a context tag is present either way). The
-    caller de-dups against the exact name, so a plain model like
-    ``claude-opus-4-8`` yields no extra work. `kind` is provenance-only (see
-    `classify_pricing_source`) — `get_rates` ignores it and uses only `name`.
+    The exact name is the caller's job; this returns only the rewrites. Each
+    transform in `_NAME_TRANSFORMS` is applied to the original name and then,
+    for `_MAX_TRANSFORM_ROUNDS` rounds, to every name produced so far — so
+    combinations compose without enumerating them by hand. The forms this
+    covers, and why each exists:
+
+      * ``provider_prefix`` — a gateway's routing segment
+        (``anthropic/claude-opus-4.1`` from LiteLLM,
+        ``openrouter/anthropic/…`` from OpenRouter). One segment per hop.
+      * ``date_stripped`` — a release-date suffix in either published shape,
+        ``-YYYYMMDD`` (Anthropic) or ``-YYYY-MM-DD`` (OpenAI).
+      * ``context_tag`` — a bracketed context-window tag (``claude-opus-4-8[1m]``);
+        the 1M window bills at standard rates, see `_strip_context_tag`.
+      * ``version_dots`` — a dotted version segment against the table's dashed
+        key form (``claude-opus-4.1`` → ``claude-opus-4-1``).
+
+    A name's `kind` is inherited from the name it was derived from, so the
+    provenance names the OUTERMOST thing that had to be removed rather than the
+    last transform that ran. A plain model like ``claude-opus-4-8`` yields no
+    candidates at all, so the common path stays free.
     """
     candidates: list[tuple[str, str]] = []
-    seen: set[str] = set()
+    seen: set[str] = {model}
+    frontier: list[tuple[str, str | None]] = [(model, None)]
 
-    def _add(name: str | None, kind: str) -> None:
-        if name and name not in seen and name != model:
-            seen.add(name)
-            candidates.append((name, kind))
+    for _round in range(_MAX_TRANSFORM_ROUNDS):
+        next_frontier: list[tuple[str, str | None]] = []
+        for name, inherited in frontier:
+            for kind, transform in _NAME_TRANSFORMS:
+                derived = transform(name)
+                if not derived or derived in seen:
+                    continue
+                seen.add(derived)
+                derived_kind = inherited or kind
+                candidates.append((derived, derived_kind))
+                next_frontier.append((derived, derived_kind))
+        if not next_frontier:
+            break
+        frontier = next_frontier
 
-    _add(_strip_date_suffix(model), "date_stripped")
-    no_tag = _strip_context_tag(model)
-    _add(no_tag, "context_tag")
-    if no_tag is not None:
-        _add(_strip_date_suffix(no_tag), "context_tag")
     return candidates
 
 
@@ -733,11 +806,13 @@ def get_rates(
          over the packaged models.toml).
 
     Each step tries an exact match first, then falls back through
-    `_lookup_candidates`: the YYYYMMDD-date-stripped name (Anthropic/OpenAI both
-    ship dated variants like `claude-haiku-4-5-20251001`) and the context-tag-
-    stripped name (`claude-opus-4-8[1m]` → `claude-opus-4-8`; the 1M window bills
-    at standard rates, see `_strip_context_tag`). This keeps the tables short
-    while still pricing the dated / context-tagged names that flow through Lens.
+    `_lookup_candidates`, which strips a gateway routing prefix
+    (`anthropic/claude-opus-4.1`), a release-date suffix in either published
+    shape (`-YYYYMMDD` and `-YYYY-MM-DD`), a bracketed context tag
+    (`claude-opus-4-8[1m]` → `claude-opus-4-8`; the 1M window bills at standard
+    rates, see `_strip_context_tag`), and dotted version segments
+    (`claude-opus-4.1` → `claude-opus-4-1`) — in any combination. This keeps the
+    tables short while still pricing every name form that flows through Lens.
 
     Bedrock spans are normalized for the table lookup only (#373): the
     provider aliases in _BEDROCK_PROVIDER_ALIASES map onto the table's
@@ -840,11 +915,17 @@ def classify_pricing_source(provider: str, model: str) -> str:
                              provider-keyed user override, or the
                              Bedrock-normalized modelId form — all
                              indistinguishable here, see above).
-      "date_stripped"      - resolved only after stripping a trailing
-                             `-YYYYMMDD` suffix.
+      "provider_prefix"    - resolved only after stripping a leading gateway
+                             routing segment (`anthropic/…`, `openrouter/…`),
+                             possibly alongside further rewrites.
+      "date_stripped"      - resolved only after stripping a trailing release
+                             date, `-YYYYMMDD` or `-YYYY-MM-DD`.
       "context_tag"        - resolved only after stripping a trailing `[...]`
                              context tag (with or without an additional
                              date-suffix strip).
+      "version_dots"       - resolved only after rewriting dotted version
+                             segments to the table's dashed form
+                             (`claude-opus-4.1` → `claude-opus-4-1`).
       "default_fallback"   - nothing matched; calculate_cost falls back to the
                              flat default rates (DEFAULT_INPUT_PER_MTOK /
                              DEFAULT_OUTPUT_PER_MTOK / DEFAULT_CACHE_*).

--- a/tokenjam/core/pricing_coverage.py
+++ b/tokenjam/core/pricing_coverage.py
@@ -1,0 +1,119 @@
+"""How much of a cost figure was priced at the flat default rate.
+
+`calculate_cost` falls back to `DEFAULT_INPUT_PER_MTOK` / `DEFAULT_OUTPUT_PER_MTOK`
+when `get_rates` finds no row, and logs one warning per process. The resulting
+dollar figure looks exactly like a real one on every surface, so a model missing
+from the table is silently wrong rather than visibly unknown — measured once on a
+real corpus, that silence hid errors of 5-30x across most of the models in it.
+
+`CostEngine` already stamps each span's provenance onto `spans.pricing_source`
+(see `pricing.classify_pricing_source`). This module reads that column back and
+turns it into one sentence a cost view can print, so the two surfaces that show
+it cannot disagree about what "unpriced" means.
+
+Per Critical Rule 22 (`tokenjam/CLAUDE.md`) the note never renders a zero and
+never restates the estimate as a quoted price — it names the models and says the
+figure is a default-rate estimate.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime
+
+#: The `pricing_source` value `classify_pricing_source` returns when nothing in
+#: the table matched. Kept as a constant so a rename there fails here loudly
+#: rather than silently reporting every window as fully priced.
+DEFAULT_FALLBACK_SOURCE = "default_fallback"
+
+#: Models named individually in the note before it summarises the rest. A note
+#: that lists thirty model ids is not a note anyone reads.
+_MAX_NAMED_MODELS = 3
+
+
+@dataclass(frozen=True)
+class PricingCoverage:
+    """The default-rate share of a cost window.
+
+    `measured` is False when the store could not be asked at all (no direct
+    connection). That is deliberately distinct from "asked, and nothing was
+    unpriced" — reporting an unmeasured window as clean is the failure this
+    whole module exists to stop.
+    """
+
+    measured: bool
+    unpriced_models: tuple[tuple[str, str, int], ...]
+    unpriced_call_count: int
+    unpriced_cost_usd: float
+
+
+def summarize_pricing_coverage(
+    conn,
+    agent_id: str | None,
+    since: datetime | None,
+    until: datetime | None,
+) -> PricingCoverage:
+    """Which models in this window were priced at the default rate.
+
+    Returns an unmeasured `PricingCoverage` when `conn` is None (the API-shim
+    CLI path and any caller without a direct DuckDB handle), so a caller can
+    tell "nothing unpriced" from "never looked".
+    """
+    if conn is None:
+        return PricingCoverage(
+            measured=False, unpriced_models=(), unpriced_call_count=0,
+            unpriced_cost_usd=0.0,
+        )
+
+    clauses = ["pricing_source = $1"]
+    params: list = [DEFAULT_FALLBACK_SOURCE]
+    if agent_id:
+        params.append(agent_id)
+        clauses.append(f"agent_id = ${len(params)}")
+    if since is not None:
+        params.append(since)
+        clauses.append(f"start_time >= ${len(params)}")
+    if until is not None:
+        params.append(until)
+        clauses.append(f"start_time <= ${len(params)}")
+
+    sql = (
+        "SELECT provider, model, COUNT(*) AS calls, "
+        "COALESCE(SUM(cost_usd), 0) AS cost "
+        f"FROM spans WHERE {' AND '.join(clauses)} "
+        "GROUP BY provider, model ORDER BY calls DESC"
+    )
+    rows = conn.execute(sql, params).fetchall()
+
+    models = tuple(
+        (str(r[0] or "unknown"), str(r[1] or "unknown"), int(r[2] or 0))
+        for r in rows
+    )
+    return PricingCoverage(
+        measured=True,
+        unpriced_models=models,
+        unpriced_call_count=sum(m[2] for m in models),
+        unpriced_cost_usd=round(sum(float(r[3] or 0.0) for r in rows), 8),
+    )
+
+
+def coverage_note(coverage: PricingCoverage) -> str | None:
+    """One sentence naming the unpriced models, or None when there is nothing
+    to say (an unmeasured window, or a window with no default-rate spans)."""
+    if not coverage.measured or not coverage.unpriced_models:
+        return None
+
+    named = coverage.unpriced_models[:_MAX_NAMED_MODELS]
+    remainder = len(coverage.unpriced_models) - len(named)
+    listed = ", ".join(f"{provider}/{model}" for provider, model, _ in named)
+    if remainder > 0:
+        listed += f" and {remainder} more"
+
+    calls = coverage.unpriced_call_count
+    return (
+        f"{listed} {'is' if len(coverage.unpriced_models) == 1 else 'are'} not in "
+        f"the pricing table: {calls:,} call{'' if calls == 1 else 's'} "
+        f"here are estimated at tokenjam's default rate, not a rate published for "
+        f"{'that model' if len(coverage.unpriced_models) == 1 else 'those models'}. "
+        "Add one with a [pricing] override, or upgrade tokenjam; see `tj pricing list`."
+    )

--- a/tokenjam/core/summarize/candidates.py
+++ b/tokenjam/core/summarize/candidates.py
@@ -183,11 +183,29 @@ def _pricing_mode(config: "TjConfig | None") -> str:
 # Target enumeration
 # --------------------------------------------------------------------------- #
 
-def _global_targets() -> list[Path]:
+def _expand_home(raw: str, home: Path | None) -> str:
+    """Expand a leading `~` against `home`, or the real home when None.
+
+    `home` is the analyzer scope's home (see `core/optimize/scope.py`). The
+    catalog's global paths span several agent homes (`~/.claude`, `~/.gemini`,
+    `~/.codex`), so scoping them means redirecting `~` itself — anything
+    narrower would leave most of the catalog reading the operator's real files
+    while a `--projects-root` was in force.
+    """
+    if home is None:
+        return os.path.expanduser(raw)
+    if raw == "~":
+        return str(home)
+    if raw.startswith("~/"):
+        return str(home / raw[2:])
+    return raw
+
+
+def _global_targets(home: Path | None = None) -> list[Path]:
     """Catalog global/system paths ("~" expanded; glob patterns expanded)."""
     out: list[Path] = []
     for raw in load_catalog().global_paths:
-        ep = os.path.expanduser(raw)
+        ep = _expand_home(raw, home)
         if any(ch in ep for ch in "*?["):
             out.extend(Path(x) for x in sorted(_glob.glob(ep)))
         else:
@@ -267,6 +285,7 @@ def list_candidates(
     min_prose_words: int = MIN_PROSE_WORDS,
     ratio: float = DEFAULT_TARGET_RATIO,
     extra_exts: Iterable[str] = (),
+    home: "Path | None" = None,
 ) -> ScanResult:
     """Find summarize candidates per DEC-020/021. Advisory: reads only, never writes."""
     mode = _pricing_mode(config)
@@ -293,7 +312,7 @@ def list_candidates(
     # 1) Globals (the floor) — always catalog prompts, unless suppressed.
     globals_checked = 0
     if include_global:
-        for gp in _global_targets():
+        for gp in _global_targets(home):
             if gp.exists():
                 globals_checked += 1
                 _add(gp, "global")

--- a/tokenjam/pricing/models.toml
+++ b/tokenjam/pricing/models.toml
@@ -192,6 +192,15 @@ output_per_mtok = 75.00
 cache_read_per_mtok = 1.50
 cache_write_per_mtok = 18.75
 
+# Claude 3.7 Sonnet (deprecated). Still the dominant model in archived agent
+# traces, which arrive as `claude-3-7-sonnet-20250219` (date-stripped to this
+# row) or `anthropic/claude-3.7-sonnet` from a gateway.
+[anthropic.claude-3-7-sonnet]
+input_per_mtok = 3.00
+output_per_mtok = 15.00
+cache_read_per_mtok = 0.30
+cache_write_per_mtok = 3.75
+
 # Claude Haiku 3.5 (retired except on Bedrock and Vertex)
 [anthropic.claude-haiku-3-5]
 input_per_mtok = 0.80
@@ -238,6 +247,11 @@ output_per_mtok = 180.00
 # ─── OpenAI (superseded, kept for historical spans) ─────────────────────────
 # gpt-4o / gpt-4o-mini / o3 / o4-mini are no longer on OpenAI's current pricing
 # page but still appear in older telemetry; rates retained as last-published.
+[openai."gpt-4.1"]
+input_per_mtok = 2.00
+output_per_mtok = 8.00
+cache_read_per_mtok = 0.50
+
 [openai.gpt-4o]
 input_per_mtok = 2.50
 output_per_mtok = 10.00
@@ -253,6 +267,13 @@ output_per_mtok = 40.00
 [openai.o4-mini]
 input_per_mtok = 1.10
 output_per_mtok = 4.40
+
+# Gemini 2.0 Flash (retired 2026-06-01, kept for historical spans). Arrives as
+# the dotted `gemini-2.0-flash`, resolved to this key by the version-dash
+# fallback in `get_rates`.
+[google.gemini-2-0-flash]
+input_per_mtok = 0.10
+output_per_mtok = 0.40
 
 [google.gemini-2-5-pro]
 input_per_mtok = 1.25

--- a/tokenjam/pricing/models.toml
+++ b/tokenjam/pricing/models.toml
@@ -192,9 +192,22 @@ output_per_mtok = 75.00
 cache_read_per_mtok = 1.50
 cache_write_per_mtok = 18.75
 
-# Claude 3.7 Sonnet (deprecated). Still the dominant model in archived agent
-# traces, which arrive as `claude-3-7-sonnet-20250219` (date-stripped to this
-# row) or `anthropic/claude-3.7-sonnet` from a gateway.
+# Claude 3.7 Sonnet. Still the dominant model in archived agent traces, which
+# arrive as `claude-3-7-sonnet-20250219` (date-stripped to this row) or
+# `anthropic/claude-3.7-sonnet` from a gateway.
+#
+# SOURCING — UNVERIFIED, and deliberately left flagged rather than given a
+# citation that would not survive a click. Retired 2026-02-19 (deprecated
+# 2025-10-28) per
+# https://platform.claude.com/docs/en/about-claude/model-deprecations, and
+# retirement removed it from https://platform.claude.com/docs/en/docs/about-claude/pricing,
+# which today lists no Claude 3.x Sonnet row at all. Checked 2026-07-27: absent
+# from that page, from https://aws.amazon.com/bedrock/pricing/ and from
+# https://cloud.google.com/vertex-ai/generative-ai/pricing; web.archive.org is
+# unreachable from this environment. The rates below are the widely-reported
+# last-published ones, carried forward for historical spans, but NO first-party
+# published page could be reached to confirm them. Re-verify against an
+# Anthropic-published archive before treating these four numbers as audited.
 [anthropic.claude-3-7-sonnet]
 input_per_mtok = 3.00
 output_per_mtok = 15.00
@@ -247,6 +260,11 @@ output_per_mtok = 180.00
 # ─── OpenAI (superseded, kept for historical spans) ─────────────────────────
 # gpt-4o / gpt-4o-mini / o3 / o4-mini are no longer on OpenAI's current pricing
 # page but still appear in older telemetry; rates retained as last-published.
+# GPT-4.1. Rates verified 2026-07-27 against OpenAI's own model page,
+# https://developers.openai.com/api/docs/models/gpt-4.1 — $2.00 input,
+# $0.50 cached input, $8.00 output per million tokens. (It is no longer on the
+# top-level https://developers.openai.com/api/docs/pricing table; the per-model
+# page still carries it.)
 [openai."gpt-4.1"]
 input_per_mtok = 2.00
 output_per_mtok = 8.00
@@ -268,9 +286,17 @@ output_per_mtok = 40.00
 input_per_mtok = 1.10
 output_per_mtok = 4.40
 
-# Gemini 2.0 Flash (retired 2026-06-01, kept for historical spans). Arrives as
-# the dotted `gemini-2.0-flash`, resolved to this key by the version-dash
+# Gemini 2.0 Flash (shut down 2026-06-01, kept for historical spans). Arrives
+# as the dotted `gemini-2.0-flash`, resolved to this key by the version-dash
 # fallback in `get_rates`.
+#
+# SOURCING — rates captured 2026-07-27 from Google's own Gemini API pricing
+# page, https://ai.google.dev/gemini-api/docs/pricing, which still carries the
+# model under a deprecation warning: $0.10 per 1M input tokens (text/image/
+# video) and $0.40 per 1M output tokens. Note this is the Gemini API rate, NOT
+# Vertex AI's, which prices the same model differently
+# ($0.15/$0.60 at https://cloud.google.com/vertex-ai/generative-ai/pricing);
+# the corpus these rates were reconciled against is Gemini-API-sourced.
 [google.gemini-2-0-flash]
 input_per_mtok = 0.10
 output_per_mtok = 0.40


### PR DESCRIPTION
Two independent correctness bugs, both of which made a surface assert something its data did not support: the cost engine silently mispriced most real-world model names, and `--db` isolated the database but not the analyzers that read the filesystem.

## Summary

- Generalize the pricing lookup so dated, gateway-prefixed and dotted model names resolve to their real rates instead of falling through to the flat default; backfill three genuinely missing models.
- Surface `spans.pricing_source` (already stamped at ingest, read by nothing) in both cost views, so an estimated dollar figure is distinguishable from a quoted one.
- Introduce a first-class filesystem scope (`--projects-root`) that `deadweight`, `relearn` and `summarize` honor, and define what an explicit `--db` means for them.

## Cost engine priced most real models wrong

**Symptom.** A replay of nine real agent runs (21,562 LLM calls, nine distinct model strings) priced seven of the nine models wrong by 5-30x. Gemini 2.0 Flash billed ~5x too high, Claude Opus 4.1 ~30x too low, GPT-4.1 and Claude 3.7 Sonnet ~5-7x too low. Only two model strings matched exactly.

**Root cause.** The arithmetic was fine; `get_rates` never found the row. Two structural gaps in its fallback chain:

1. The date-suffix stripper understood only Anthropic's compact `-YYYYMMDD`, so OpenAI's dashed `-YYYY-MM-DD` (`gpt-4o-2024-08-06`, `gpt-4.1-2025-04-14`) never fell back to its bare table entry — even when that entry already existed.
2. Nothing stripped a gateway routing prefix, so `anthropic/claude-opus-4.1` (the form LiteLLM and OpenRouter emit) never reached the table at all, and its dotted version segment did not match the table's dashed `claude-opus-4-1` key either.

The failure is silent: one log warning per process, then a plausible-looking dollar figure computed at the flat default rate.

**Fix.** `_lookup_candidates` now composes four transforms — routing prefix, release date in either published shape, context tag, dotted version segment — over the names they produce, so combinations resolve without being enumerated by hand. Both `get_rates` and `classify_pricing_source` inherit the fix from the one choke point they already share, so the rate and its provenance cannot drift apart. Three models genuinely absent from the table are backfilled at their published rates (Claude 3.7 Sonnet, GPT-4.1, Gemini 2.0 Flash); the fallback itself stays reachable, so a truly unknown model still classifies as `default_fallback` rather than being resolved to something plausible.

**The silence was the other half of the bug.** `core/pricing_coverage.py` reads the existing `pricing_source` column back and turns it into one sentence naming the models priced at the default rate, shared by `GET /api/v1/cost` and `tj cost` so the two cannot word it differently. It distinguishes "asked, nothing unpriced" from "could not ask", and per Critical Rule 22 it never renders a zero or restates an estimate as a quoted price.

## `--db` did not isolate the filesystem-reading analyzers

**Symptom**, all reproduced against a freshly created, completely empty throwaway database:

- The review inbox showed recurring-mistake entries carrying real file paths from an unrelated project — the machine's global Claude Code history, not the served database.
- The recurring-fix modal defaulted its "where to write it" target to a real path on the operator's machine, so one Approve click in what looks like a sandboxed review view would write a real file outside the database being served.
- `/api/v1/optimize?fast=true` took ~27-33s on a literally empty store. Same root cause, and it is a ~30s blank first paint on every dashboard load including brand-new installs.

**Root cause.** `deadweight`, `relearn` and `summarize` read the filesystem as their evidence source by design — the database holds spans, the filesystem holds the transcripts, MCP config and always-loaded prompt files those three reason about. That split is correct. What was missing was any way to say WHICH disk: no `AnalyzerContext` field, no flag, only the undocumented `TJ_CLAUDE_PROJECTS_ROOT` env var. So `--db` implied an isolation it never provided.

**The contract**, defined in `core/optimize/scope.py` and documented in `docs/configuration.md`. Precedence, first match wins:

1. `--projects-root PATH` / `[optimize] projects_root` — scan exactly that root.
2. `TJ_CLAUDE_PROJECTS_ROOT` — unchanged, now documented.
3. **An explicit `--db` suppresses the filesystem scans.** Naming a database names the corpus you want reasoned about; reading a second, unrelated one into the same report is the bug. This is also what makes an empty or scoped store paint immediately instead of walking a large transcript tree to conclude nothing.
4. Otherwise `~/.claude/projects` — a run with no flag, no env var and no `--db` is unchanged.

The scope is resolved **once** in `build_report`, the way the persona already is, and carried on `AnalyzerContext`; an analyzer that re-derives a root of its own is how the leak existed in the first place. Suppression is never silent: the report carries `filesystem_scan_skipped_reason` (round-tripped through `report_from_dict`, so a report rebuilt from the daemon cache still knows) and `tj optimize` prints it, so every surface can tell "scanned, found nothing" from "did not scan" — the empty-state distinction in root anti-pattern 22.

**Write paths are covered too, not just read scope.** The user-global apply target follows the same Claude home the findings came from, so the two halves of a card can no longer describe different machines. And relearn's distill cache — a second cache beside `relearn_store.default_cache_path`, missed when that one was threaded through `_storage_base_dir`, and firing only after a successful distill LLM call, which is why it went unnoticed — now resolves through the same helper instead of writing real files under the real `~/.tj` from an isolated config. The daemon's background relearn recompute is a second entry point into the same scan, so it consults the scope too; otherwise the machine's global tree would leak back in through the cache the served routes read.

**One incidental fix worth naming.** The default root resolves lazily. A module-level `Path.home()` is baked at import and survives a later `HOME` repoint, which is how a test that isolates itself carefully still ends up scanning the developer's real transcript tree — the same trap `deadweight._global_config_path` already documents.

## Tests / Verification

New, written before the fixes:

- `tests/unit/test_pricing_lookup_forms.py` — one case per lookup form, plus every distinct model string in the benchmark corpus pinned to the rate it must resolve to, and a guard that the default fallback stays reachable. 27 of 38 failed before the fix.
- `tests/unit/test_pricing_coverage.py` — the unpriced-model note: unmeasured vs. clean vs. populated, parameterised SQL, immutability.
- `tests/unit/test_analyzer_scope.py` — the resolver: every precedence step, the no-escape rule for a custom root, lazy home resolution.
- `tests/unit/test_analyzer_scope_isolation.py` — the contract through the analyzers themselves, since a correct resolver is worth nothing if an analyzer still reaches for `Path.home()`. Asserts no filesystem call happens at all under an explicit `--db`, that a scoped-but-empty root reports no skip, that a normal run still scans, and covers the apply target and the distill cache.

Full CI suite: `4422 passed, 5 skipped` (`tests/unit/ tests/synthetic/ tests/agents/ tests/integration/`). `ruff check tokenjam/` and `mypy tokenjam/` clean (231 source files). `sdk-ts`: 27/27.

## What's NOT in this PR

- **No UI rendering of the two new signals.** Both `pricing_coverage` on `GET /api/v1/cost` and `filesystem_scan_skipped_reason` on the report ship as API fields with the CLI rendering them; the Lens panels are left for a follow-up so this PR stays reviewable. The data is what was missing — nothing computed it before.
- **The suppression rule is a deliberate behaviour change** for anyone running `tj serve --db /custom/path` as their normal setup: those runs lose the three filesystem analyzers unless they add `--projects-root`. Flagging it explicitly since it is the one part of the contract a reader might want to argue with. The alternative — scoping to a directory derived from the database's own path — is harder to explain and would silently scan somewhere the user never named.
- **`trim`** also expands the catalog's `~` paths (`prompt_bloat.py` reads the same `global_paths`), but it is not one of the three analyzers named in the report and gating it would widen the diff into a fourth analyzer's persona/prerequisite logic. Its scan is catalog-bounded rather than a corpus walk, so it contributes neither the leak nor the latency.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
