### PR TITLE
[feature] Detect streamed calls that closed without a usage payload (stream-usage analyzer)

### DIFF
--- a/tests/unit/test_persona_analyzer_gate.py
+++ b/tests/unit/test_persona_analyzer_gate.py
@@ -47,6 +47,7 @@ NO_LEVER = set(PERSONA_DISABLED_ANALYZERS["claude-code"])
 # is a product decision and must be made here deliberately.
 assert NO_LEVER == {
     "cache", "cache-recommend", "placement", "trim", "verbosity", "script", "reuse",
+    "stream-usage",
 }
 
 # `placement` is the odd one out: it is not an ANALYZER_REGISTRY name at all

--- a/tests/unit/test_stream_usage_analyzer.py
+++ b/tests/unit/test_stream_usage_analyzer.py
@@ -1,0 +1,379 @@
+"""The `stream-usage` analyzer: report the blind spot, never bank it as savings.
+
+The load-bearing constraint here is accounting, not detection. What this
+analyzer measures is spend that ALREADY HAPPENED and was never recorded —
+capturing it makes the spend figure correct, it does not make it smaller. A
+figure derived that way must never reach the recoverable-waste total, whose
+whole meaning is "money that could have been avoided". The tests below pin
+that separation structurally (no `past_overspend_*` field, absent from
+`COST_ANALYZERS`, invisible to the rollup) rather than by inspecting copy,
+because copy is what drifted the last three times this class of bug shipped.
+"""
+from __future__ import annotations
+
+from datetime import timedelta
+
+import pytest
+
+from tokenjam.core.config import StorageConfig, TjConfig
+from tokenjam.core.db import InMemoryBackend
+from tokenjam.core.optimize import build_report
+from tokenjam.core.optimize.analyzers.stream_usage import StreamUsageFinding
+from tokenjam.core.optimize.cost_proposals import (
+    COST_ANALYZERS,
+    cost_proposals_from_report,
+    past_overspend_rollup,
+)
+from tokenjam.core.pricing import get_rates
+from tokenjam.otel.semconv import TjAttributes
+from tokenjam.utils.time_parse import utcnow
+from tests.factories import make_llm_span, make_session
+
+WINDOW_DAYS = 30
+
+
+@pytest.fixture
+def db():
+    backend = InMemoryBackend()
+    yield backend
+    backend.close()
+
+
+@pytest.fixture
+def cfg(tmp_path):
+    return TjConfig(version="1", storage=StorageConfig(path=str(tmp_path / "t.duckdb")))
+
+
+def _stream_attrs(*, usage_reported: bool, content_chunks: int = 4) -> dict:
+    return {
+        TjAttributes.STREAMING: True,
+        TjAttributes.STREAM_USAGE_REPORTED: usage_reported,
+        TjAttributes.STREAM_CONTENT_CHUNKS: content_chunks,
+    }
+
+
+def _seed_stream(db, *, agent_id, provider, model, usage_reported,
+                 input_tokens=0, output_tokens=0, cache_tokens=0,
+                 cache_write_tokens=0, content_chunks=4, session_suffix="0",
+                 days_ago=1):
+    """One streamed call, complete or truncated, plus its session."""
+    started = utcnow() - timedelta(days=days_ago)
+    session_id = f"{agent_id}-{session_suffix}"
+    db.upsert_session(make_session(
+        agent_id=agent_id, session_id=session_id,
+        plan_tier="api", started_at=started,
+    ))
+    db.insert_span(make_llm_span(
+        agent_id=agent_id, provider=provider, model=model,
+        billing_account=provider,
+        input_tokens=input_tokens, output_tokens=output_tokens,
+        cache_tokens=cache_tokens, cache_write_tokens=cache_write_tokens,
+        session_id=session_id, start_time=started,
+        extra_attributes=_stream_attrs(
+            usage_reported=usage_reported, content_chunks=content_chunks,
+        ),
+    ))
+
+
+def _seed_openai_app(db, *, truncated=2, complete=4):
+    """An SDK app streaming from an OpenAI-compatible API.
+
+    The complete calls are the peer baseline; the truncated ones are the gap.
+    """
+    for i in range(complete):
+        _seed_stream(
+            db, agent_id="chat-service", provider="openai", model="gpt-4o-mini",
+            usage_reported=True, input_tokens=1000, output_tokens=300,
+            session_suffix=f"c{i}", days_ago=i + 1,
+        )
+    for i in range(truncated):
+        _seed_stream(
+            db, agent_id="chat-service", provider="openai", model="gpt-4o-mini",
+            usage_reported=False, session_suffix=f"t{i}", days_ago=i + 1,
+        )
+
+
+def _seed_anthropic_app(db, *, truncated=1, complete=3):
+    for i in range(complete):
+        _seed_stream(
+            db, agent_id="support-bot", provider="anthropic",
+            model="claude-haiku-4-5", usage_reported=True,
+            input_tokens=800, output_tokens=200, cache_tokens=500,
+            cache_write_tokens=100, session_suffix=f"ac{i}", days_ago=i + 1,
+        )
+    for i in range(truncated):
+        _seed_stream(
+            db, agent_id="support-bot", provider="anthropic",
+            model="claude-haiku-4-5", usage_reported=False,
+            session_suffix=f"at{i}", days_ago=i + 1,
+        )
+
+
+def _finding(db, cfg) -> StreamUsageFinding:
+    report = build_report(
+        db, cfg, since=utcnow() - timedelta(days=WINDOW_DAYS),
+        findings=["stream-usage"],
+    )
+    return report.findings["stream-usage"]
+
+
+# ---------------------------------------------------------------------------
+# Detection + the fix each provider actually needs
+# ---------------------------------------------------------------------------
+
+def test_openai_compatible_stream_without_usage_is_flagged_with_its_own_fix(db, cfg):
+    _seed_openai_app(db, truncated=2, complete=4)
+
+    finding = _finding(db, cfg)
+
+    assert finding.streams_observed == 6
+    assert finding.streams_missing_usage == 2
+    assert len(finding.call_sites) == 1
+    site = finding.call_sites[0]
+    assert (site.provider, site.model, site.agent_id) == (
+        "openai", "gpt-4o-mini", "chat-service",
+    )
+    assert site.affected_calls == 2
+    assert site.complete_calls == 4
+    # The remediation must be the OpenAI-compatible one: the API emits no usage
+    # payload at all without the opt-in, so naming only "drain the stream"
+    # would be advice that cannot work.
+    assert 'stream_options={"include_usage": True}' in site.remediation_snippet
+    assert "get_final_message" not in site.remediation_snippet
+
+
+def test_anthropic_stream_without_usage_gets_the_anthropic_fix(db, cfg):
+    _seed_anthropic_app(db, truncated=1, complete=3)
+
+    site = _finding(db, cfg).call_sites[0]
+
+    assert site.provider == "anthropic"
+    assert site.affected_calls == 1
+    # Anthropic has no include_usage flag — offering one would be wrong.
+    assert "stream_options" not in site.remediation_snippet
+    assert "get_final_message" in site.remediation_snippet
+    assert "messages.stream" in site.remediation_snippet
+
+
+def test_both_providers_are_reported_as_separate_call_sites(db, cfg):
+    _seed_openai_app(db)
+    _seed_anthropic_app(db)
+
+    finding = _finding(db, cfg)
+
+    providers = {s.provider for s in finding.call_sites}
+    assert providers == {"openai", "anthropic"}
+    assert all(s.remediation_snippet for s in finding.call_sites)
+
+
+def test_a_stream_that_produced_no_content_is_not_counted_as_a_gap(db, cfg):
+    """An empty stream under-counted nothing; flagging it is noise."""
+    _seed_openai_app(db, truncated=0, complete=4)
+    _seed_stream(
+        db, agent_id="chat-service", provider="openai", model="gpt-4o-mini",
+        usage_reported=False, content_chunks=0, session_suffix="empty",
+    )
+
+    finding = _finding(db, cfg)
+
+    assert finding.streams_missing_usage == 0
+    assert finding.call_sites == []
+
+
+def test_no_streams_observed_explains_itself_rather_than_claiming_zero(db, cfg):
+    db.upsert_session(make_session(
+        agent_id="chat-service", session_id="s0", plan_tier="api",
+        started_at=utcnow() - timedelta(days=1),
+    ))
+
+    finding = _finding(db, cfg)
+
+    assert finding.streams_observed == 0
+    assert finding.undercounted_usd is None
+    assert "No streamed calls were observed" in finding.hint
+
+
+# ---------------------------------------------------------------------------
+# The estimate and its derivation
+# ---------------------------------------------------------------------------
+
+def test_the_estimate_states_its_derivation_and_names_the_peer_baseline(db, cfg):
+    _seed_openai_app(db, truncated=2, complete=4)
+
+    finding = _finding(db, cfg)
+    site = finding.call_sites[0]
+
+    # Peer medians are the observed complete calls, not a constant.
+    assert site.peer_input_tokens == 1000
+    assert site.peer_output_tokens == 300
+    assert site.undercounted_tokens == 2 * 1300
+    assert site.undercounted_usd is not None and site.undercounted_usd > 0
+    assert "median" in site.derivation.lower()
+    assert "Estimated, not observed" in site.derivation
+    assert finding.estimate_basis
+    assert finding.estimate_confidence == "heuristic"
+
+
+def test_cache_token_types_both_enter_the_peer_baseline(db, cfg):
+    """Cache-read and cache-write bill at different rates and both count."""
+    _seed_anthropic_app(db, truncated=1, complete=3)
+
+    site = _finding(db, cfg).call_sites[0]
+
+    assert site.peer_cache_tokens == 500
+    assert site.peer_cache_write_tokens == 100
+    assert site.undercounted_tokens == 800 + 200 + 500 + 100
+
+
+def test_implied_per_token_rate_equals_the_blend_the_basis_advertises(db, cfg):
+    """Critical Rule 28: divide the dollar field by the token field and the
+    implied rate must be the blend the basis string describes.
+
+    The price-band check alone is necessary but not sufficient — a 2x basis
+    mismatch (dollars multiplied per call, tokens left one-time) sits happily
+    inside a band that spans cache-read to output rates. Asserting the EXACT
+    blend is what makes a drift between the two fields impossible to miss."""
+    _seed_anthropic_app(db, truncated=2, complete=3)
+
+    finding = _finding(db, cfg)
+    rates = get_rates("anthropic", "claude-haiku-4-5")
+    implied_per_mtok = (
+        finding.undercounted_usd / finding.undercounted_tokens * 1_000_000
+    )
+
+    # The blend the derivation claims: the peer-median mix of the four token
+    # types, each at its own rate. Call count cancels out — which is the point:
+    # it must cancel out of BOTH fields or not at all.
+    site = finding.call_sites[0]
+    expected_usd_per_call = (
+        site.peer_input_tokens * rates.input_per_mtok
+        + site.peer_output_tokens * rates.output_per_mtok
+        + site.peer_cache_tokens * rates.cache_read_per_mtok
+        + site.peer_cache_write_tokens * rates.cache_write_per_mtok
+    ) / 1_000_000
+    expected_tokens_per_call = (
+        site.peer_input_tokens + site.peer_output_tokens
+        + site.peer_cache_tokens + site.peer_cache_write_tokens
+    )
+    expected_per_mtok = expected_usd_per_call / expected_tokens_per_call * 1_000_000
+    assert implied_per_mtok == pytest.approx(expected_per_mtok, rel=1e-6)
+
+    # ...and it is still a rate somebody actually charges.
+    floor = min(rates.cache_read_per_mtok, rates.input_per_mtok)
+    ceiling = max(rates.output_per_mtok, rates.cache_write_per_mtok)
+    assert floor <= implied_per_mtok <= ceiling
+
+
+def test_a_call_site_with_no_completed_peer_degrades_on_BOTH_fields(db, cfg):
+    """Symmetric degrade: a call site contributes to both sums or to neither.
+    A zero on one side and a number on the other corrupts the implied rate."""
+    _seed_stream(
+        db, agent_id="chat-service", provider="openai", model="gpt-4o-mini",
+        usage_reported=False, session_suffix="lonely",
+    )
+
+    finding = _finding(db, cfg)
+    site = finding.call_sites[0]
+
+    assert site.affected_calls == 1
+    assert site.undercounted_tokens is None
+    assert site.undercounted_usd is None
+    assert finding.undercounted_usd is None
+    assert finding.undercounted_tokens is None
+    assert "no per-call baseline" in site.derivation
+
+
+def test_an_unpriced_call_site_does_not_silently_shrink_the_total(db, cfg):
+    """The priced part is still published; the unpriced part is disclosed in
+    words rather than folded in as zero."""
+    _seed_openai_app(db, truncated=2, complete=4)
+    _seed_stream(
+        db, agent_id="other-service", provider="anthropic",
+        model="claude-haiku-4-5", usage_reported=False, session_suffix="solo",
+    )
+
+    finding = _finding(db, cfg)
+
+    priced = [s for s in finding.call_sites if s.undercounted_usd is not None]
+    assert len(priced) == 1
+    assert finding.undercounted_usd == priced[0].undercounted_usd
+    assert "had no completed stream to size against" in finding.estimate_basis
+
+
+# ---------------------------------------------------------------------------
+# The accounting separation — the reason this analyzer is unusual
+# ---------------------------------------------------------------------------
+
+def test_the_finding_carries_no_canonical_recoverable_dollar_field(db, cfg):
+    """`past_overspend_*` is THE avoidable-spend field the rollup sums. This
+    quantity is not avoidable spend, so it must not wear that name — the
+    rollup is generic over analyzers and would pick it up by field presence."""
+    _seed_openai_app(db)
+
+    finding = _finding(db, cfg)
+
+    for banned in (
+        "past_overspend_usd", "past_overspend_tokens", "past_overspend_basis",
+        "estimated_recoverable_usd", "estimated_monthly_usd",
+        "gross_recoverable_usd",
+    ):
+        assert not hasattr(finding, banned), banned
+        assert all(not hasattr(s, banned) for s in finding.call_sites), banned
+
+
+def test_stream_usage_is_absent_from_the_second_selection_surface():
+    """`COST_ANALYZERS` is an independent selector feeding the Review inbox.
+    Absence from it is what keeps this finding off the money surfaces."""
+    assert "stream-usage" not in COST_ANALYZERS
+
+
+def test_the_undercount_never_reaches_the_recoverable_waste_rollup(db, cfg):
+    """End to end: build the report, adapt it, roll it up. The gap figure is
+    real and non-zero, and none of it appears in the recoverable total."""
+    _seed_openai_app(db, truncated=3, complete=4)
+
+    report = build_report(db, cfg, since=utcnow() - timedelta(days=WINDOW_DAYS))
+    finding = report.findings["stream-usage"]
+    proposals = cost_proposals_from_report(report, cfg, window_days=WINDOW_DAYS)
+    rollup = past_overspend_rollup(proposals, window_days=WINDOW_DAYS)
+
+    # The gap is real...
+    assert finding.undercounted_usd is not None and finding.undercounted_usd > 0
+    # ...and no proposal was minted from it, so the rollup cannot see it.
+    assert all("stream-usage" not in (p.signature or "") for p in proposals)
+    assert all(
+        getattr(p, "analyzer", None) != "stream-usage" for p in proposals
+    )
+    assert rollup["past_overspend_usd"] != pytest.approx(finding.undercounted_usd)
+    total = sum(p.past_overspend_usd or 0.0 for p in proposals)
+    assert rollup["past_overspend_usd"] == pytest.approx(total)
+
+
+def test_the_accounting_note_travels_with_the_figure(db, cfg):
+    """It is a dataclass default so a renderer cannot drop it."""
+    _seed_openai_app(db)
+
+    finding = _finding(db, cfg)
+
+    assert "not recoverable waste" in finding.accounting_note
+    assert "does not make it smaller" in finding.accounting_note
+
+
+def test_the_finding_round_trips_through_the_daemon_path(db, cfg):
+    """Every consumer deserialises through report_from_dict; a finding absent
+    from that table comes back empty and the card silently renders nothing."""
+    from tokenjam.core.optimize import report_to_dict
+    from tokenjam.core.optimize.runner import report_from_dict
+
+    _seed_openai_app(db)
+    report = build_report(db, cfg, since=utcnow() - timedelta(days=WINDOW_DAYS))
+
+    restored = report_from_dict(report_to_dict(report))
+
+    original = report.findings["stream-usage"]
+    came_back = restored.findings["stream-usage"]
+    assert isinstance(came_back, StreamUsageFinding)
+    assert came_back.undercounted_usd == original.undercounted_usd
+    assert came_back.call_sites[0].remediation_snippet == (
+        original.call_sites[0].remediation_snippet
+    )

--- a/tests/unit/test_stream_usage_analyzer.py
+++ b/tests/unit/test_stream_usage_analyzer.py
@@ -321,6 +321,22 @@ def test_the_finding_carries_no_canonical_recoverable_dollar_field(db, cfg):
         assert all(not hasattr(s, banned) for s in finding.call_sites), banned
 
 
+def test_the_serialized_finding_cannot_mint_an_overview_waste_tile(db, cfg):
+    """The Overview's recoverable-waste band is registry-driven off the
+    PRESENCE of `past_overspend_usd` in the serialized finding dict — it reads
+    the payload, not the dataclass — so the key must be absent there too."""
+    from tokenjam.core.optimize import report_to_dict
+
+    _seed_openai_app(db)
+    report = build_report(db, cfg, since=utcnow() - timedelta(days=WINDOW_DAYS))
+
+    payload = report_to_dict(report)["findings"]["stream-usage"]
+
+    assert "past_overspend_usd" not in payload
+    assert payload["undercounted_usd"] is not None  # the figure IS published
+    assert payload["accounting_note"]
+
+
 def test_stream_usage_is_absent_from_the_second_selection_surface():
     """`COST_ANALYZERS` is an independent selector feeding the Review inbox.
     Absence from it is what keeps this finding off the money surfaces."""

--- a/tests/unit/test_stream_usage_capture.py
+++ b/tests/unit/test_stream_usage_capture.py
@@ -1,0 +1,325 @@
+"""Recording the streaming usage gap at observation time.
+
+A streamed response reports its token usage only in a final payload, and two
+ordinary things stop that payload arriving: an OpenAI-compatible caller that
+never sent ``stream_options={"include_usage": true}``, and a client that
+disconnects before the stream finishes. Either way the call is recorded with no
+token counts, which is indistinguishable from a free call.
+
+These tests pin the three places that notice — the OpenAI provider patch, the
+Anthropic provider patch, and the proxy's SSE tap — because the analyzer that
+reports the gap can only ever be as good as what these stamp.
+"""
+from __future__ import annotations
+
+import json
+from types import SimpleNamespace
+
+import pytest
+
+from tokenjam.otel.semconv import TjAttributes
+
+
+class _FakeSpan:
+    """Records attributes so a wrapper can be tested without a TracerProvider."""
+
+    def __init__(self) -> None:
+        self.attributes: dict = {}
+        self.ended = False
+
+    def set_attribute(self, key, value):
+        self.attributes[key] = value
+
+    def set_status(self, _status):
+        pass
+
+    def end(self):
+        self.ended = True
+
+
+def _openai_chunk(content=None, usage=None):
+    delta = SimpleNamespace(content=content, tool_calls=None)
+    choices = [SimpleNamespace(delta=delta)] if content is not None else []
+    return SimpleNamespace(choices=choices, usage=usage)
+
+
+def _anthropic_text_event(text):
+    return SimpleNamespace(delta=SimpleNamespace(text=text, partial_json=None))
+
+
+# ---------------------------------------------------------------------------
+# OpenAI-compatible provider patch
+# ---------------------------------------------------------------------------
+
+def test_openai_stream_without_include_usage_is_marked_as_missing_usage():
+    # Arrange: a stream that produced content and never emitted a usage chunk,
+    # which is exactly what an OpenAI-compatible API returns when the request
+    # omitted stream_options={"include_usage": True}.
+    from tokenjam.sdk.integrations.openai import _StreamWrapper
+
+    span = _FakeSpan()
+    chunks = [_openai_chunk(content="Hel"), _openai_chunk(content="lo")]
+
+    # Act
+    list(_StreamWrapper(iter(chunks), span))
+
+    # Assert
+    assert span.attributes[TjAttributes.STREAMING] is True
+    assert span.attributes[TjAttributes.STREAM_USAGE_REPORTED] is False
+    assert span.attributes[TjAttributes.STREAM_CONTENT_CHUNKS] == 2
+    assert span.ended
+
+
+def test_openai_stream_with_trailing_usage_chunk_is_marked_complete():
+    from tokenjam.sdk.integrations.openai import _StreamWrapper
+
+    span = _FakeSpan()
+    usage = SimpleNamespace(prompt_tokens=120, completion_tokens=40)
+    chunks = [_openai_chunk(content="Hi"), _openai_chunk(usage=usage)]
+
+    list(_StreamWrapper(iter(chunks), span))
+
+    assert span.attributes[TjAttributes.STREAM_USAGE_REPORTED] is True
+    assert span.attributes[TjAttributes.STREAM_CONTENT_CHUNKS] == 1
+
+
+def test_openai_stream_abandoned_midway_still_records_the_gap():
+    """A client disconnect abandons the iterator; the span must still say so."""
+    from tokenjam.sdk.integrations.openai import _StreamWrapper
+
+    span = _FakeSpan()
+    usage = SimpleNamespace(prompt_tokens=120, completion_tokens=40)
+    chunks = [_openai_chunk(content="Hi"), _openai_chunk(content="there"),
+              _openai_chunk(usage=usage)]
+
+    iterator = iter(_StreamWrapper(iter(chunks), span))
+    next(iterator)
+    # The consumer goes away before the usage chunk arrives.
+    iterator.close()
+
+    assert span.attributes[TjAttributes.STREAM_USAGE_REPORTED] is False
+    assert span.attributes[TjAttributes.STREAM_CONTENT_CHUNKS] == 1
+
+
+# ---------------------------------------------------------------------------
+# Anthropic provider patch
+# ---------------------------------------------------------------------------
+
+class _FakeAnthropicStream:
+    """Anthropic's stream raises from get_final_message when not drained."""
+
+    def __init__(self, events, final_usage=None, drained_required=True):
+        self._events = list(events)
+        self._final_usage = final_usage
+        self._drained_required = drained_required
+        self._consumed = 0
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *_exc):
+        return False
+
+    def __iter__(self):
+        for event in self._events:
+            self._consumed += 1
+            yield event
+
+    def get_final_message(self):
+        if self._drained_required and self._consumed < len(self._events):
+            raise RuntimeError("stream was not consumed to completion")
+        return SimpleNamespace(usage=self._final_usage)
+
+
+def test_anthropic_stream_interrupted_before_message_delta_is_marked_missing():
+    # Arrange: two text deltas consumed, then the caller stops. Anthropic
+    # reports output tokens only in the trailing message_delta, so nothing is
+    # available — and get_final_message() raises rather than returning it.
+    from tokenjam.sdk.integrations.anthropic import _StreamWrapper
+
+    span = _FakeSpan()
+    stream = _FakeAnthropicStream(
+        [_anthropic_text_event("Hel"), _anthropic_text_event("lo"),
+         _anthropic_text_event("!")],
+        final_usage=SimpleNamespace(input_tokens=90, output_tokens=12),
+    )
+
+    # Act
+    with _StreamWrapper(stream, span) as wrapped:
+        iterator = iter(wrapped)
+        next(iterator)
+        next(iterator)
+
+    # Assert
+    assert span.attributes[TjAttributes.STREAMING] is True
+    assert span.attributes[TjAttributes.STREAM_USAGE_REPORTED] is False
+    assert span.attributes[TjAttributes.STREAM_CONTENT_CHUNKS] == 2
+    assert span.ended
+
+
+def test_anthropic_stream_drained_to_completion_is_marked_complete():
+    from tokenjam.sdk.integrations.anthropic import _StreamWrapper
+
+    span = _FakeSpan()
+    stream = _FakeAnthropicStream(
+        [_anthropic_text_event("Hi")],
+        final_usage=SimpleNamespace(input_tokens=90, output_tokens=12),
+    )
+
+    with _StreamWrapper(stream, span) as wrapped:
+        list(wrapped)
+
+    assert span.attributes[TjAttributes.STREAM_USAGE_REPORTED] is True
+    assert span.attributes[TjAttributes.STREAM_CONTENT_CHUNKS] == 1
+
+
+def test_anthropic_get_final_message_raise_never_escapes_the_wrapper():
+    """The raise is the ANSWER (stream not drained), never an error to leak."""
+    from tokenjam.sdk.integrations.anthropic import _StreamWrapper
+
+    span = _FakeSpan()
+
+    class _Exploding(_FakeAnthropicStream):
+        def get_final_message(self):
+            raise RuntimeError("boom")
+
+    stream = _Exploding([_anthropic_text_event("Hi")])
+    with _StreamWrapper(stream, span) as wrapped:
+        list(wrapped)
+
+    assert span.attributes[TjAttributes.STREAM_USAGE_REPORTED] is False
+
+
+# ---------------------------------------------------------------------------
+# Proxy SSE tap
+# ---------------------------------------------------------------------------
+
+def _sse(*events: dict) -> bytes:
+    return b"".join(
+        b"data: " + json.dumps(e).encode() + b"\n\n" for e in events
+    )
+
+
+def test_scanner_flags_openai_stream_that_never_emitted_usage():
+    from tokenjam.proxy.stream_usage import SseUsageScanner
+
+    scanner = SseUsageScanner("openai", model="gpt-4o-mini", opt_in=False)
+    scanner.feed(_sse(
+        {"choices": [{"delta": {"content": "Hel"}}], "usage": None},
+        {"choices": [{"delta": {"content": "lo"}}], "usage": None},
+    ))
+    scanner.feed(b"data: [DONE]\n\n")
+
+    result = scanner.result()
+    assert result.usage_missing is True
+    assert result.content_chunks == 2
+    assert result.usage_opt_in is False
+
+
+def test_scanner_accepts_openai_trailing_usage_chunk():
+    from tokenjam.proxy.stream_usage import SseUsageScanner
+
+    scanner = SseUsageScanner("openai", model="gpt-4o-mini", opt_in=True)
+    scanner.feed(_sse(
+        {"choices": [{"delta": {"content": "Hi"}}], "usage": None},
+        {"choices": [], "usage": {"prompt_tokens": 10, "completion_tokens": 3,
+                                  "total_tokens": 13}},
+    ))
+
+    assert scanner.result().usage_missing is False
+
+
+def test_scanner_ignores_anthropic_message_start_placeholder_usage():
+    """message_start carries a placeholder output_tokens for an ungenerated
+    response — treating it as the real total marks every interrupted stream
+    complete, which is the exact failure this analyzer exists to catch."""
+    from tokenjam.proxy.stream_usage import SseUsageScanner
+
+    scanner = SseUsageScanner("anthropic", model="claude-haiku-4-5")
+    scanner.feed(_sse(
+        {"type": "message_start",
+         "message": {"usage": {"input_tokens": 90, "output_tokens": 1}},
+         "usage": {"input_tokens": 90, "output_tokens": 1}},
+        {"type": "content_block_delta", "delta": {"type": "text_delta", "text": "Hi"}},
+    ))
+
+    result = scanner.result()
+    assert result.usage_missing is True
+    assert result.usage_opt_in is None  # Anthropic has no include_usage flag
+
+
+def test_scanner_accepts_anthropic_message_delta_usage():
+    from tokenjam.proxy.stream_usage import SseUsageScanner
+
+    scanner = SseUsageScanner("anthropic", model="claude-haiku-4-5")
+    scanner.feed(_sse(
+        {"type": "content_block_delta", "delta": {"type": "text_delta", "text": "Hi"}},
+        {"type": "message_delta", "delta": {"stop_reason": "end_turn"},
+         "usage": {"output_tokens": 12}},
+    ))
+
+    assert scanner.result().usage_missing is False
+
+
+def test_scanner_survives_a_usage_payload_split_across_chunk_boundaries():
+    """A provider chunk boundary can fall mid-JSON; a per-chunk parse would
+    miss the usage payload and report a healthy stream as broken."""
+    from tokenjam.proxy.stream_usage import SseUsageScanner
+
+    raw = _sse(
+        {"choices": [{"delta": {"content": "Hi"}}], "usage": None},
+        {"choices": [], "usage": {"prompt_tokens": 10, "completion_tokens": 3}},
+    )
+    scanner = SseUsageScanner("openai", model="gpt-4o-mini", opt_in=True)
+    for i in range(0, len(raw), 7):
+        scanner.feed(raw[i:i + 7])
+
+    assert scanner.result().usage_missing is False
+
+
+def test_scanner_never_raises_on_malformed_bytes():
+    from tokenjam.proxy.stream_usage import SseUsageScanner
+
+    scanner = SseUsageScanner("openai")
+    scanner.feed(b"data: {not json at all\n\n")
+    scanner.feed(b"\xff\xfe garbage \n")
+
+    assert scanner.result().usage_missing is False  # nothing observed, no claim
+
+
+@pytest.mark.asyncio
+async def test_tap_records_on_client_disconnect_midstream():
+    """The disconnect case is the one that under-counts, so it is the one the
+    tap must report — the generator's `finally` is what makes that true."""
+    from tokenjam.proxy.stream_usage import SseUsageScanner, tap_stream
+
+    recorded = []
+
+    async def _source():
+        yield _sse({"choices": [{"delta": {"content": "Hi"}}], "usage": None})
+        yield _sse({"choices": [], "usage": {"completion_tokens": 3}})
+
+    scanner = SseUsageScanner("openai", model="gpt-4o-mini", opt_in=False)
+    relay = tap_stream(_source(), scanner, recorded.append)
+    assert await relay.__anext__()  # first chunk relayed
+    await relay.aclose()            # client goes away
+
+    assert len(recorded) == 1
+    assert recorded[0].usage_missing is True
+
+
+@pytest.mark.asyncio
+async def test_tap_relays_bytes_unmodified():
+    """Pass-through is sacred: observing must not alter a single byte."""
+    from tokenjam.proxy.stream_usage import SseUsageScanner, tap_stream
+
+    payload = [b"data: {\"choices\":[]}\n\n", b"data: [DONE]\n\n"]
+
+    async def _source():
+        for chunk in payload:
+            yield chunk
+
+    scanner = SseUsageScanner("openai")
+    relayed = [chunk async for chunk in tap_stream(_source(), scanner, None)]
+
+    assert relayed == payload

--- a/tokenjam/cli/cmd_optimize.py
+++ b/tokenjam/cli/cmd_optimize.py
@@ -2802,11 +2802,13 @@ def _render_stream_usage(
         )
 
     for site in finding.call_sites[:5]:
-        label = f"{site.provider}/{site.model or 'unknown model'}"
-        if site.agent_id:
-            label += f" [dim]({site.agent_id})[/dim]"
+        # Escape the analyzer-supplied values, never the markup around them:
+        # a model id or agent name can contain brackets Rich would eat as a
+        # style tag, but escaping the whole line prints the tags literally.
+        label = _rich_escape(f"{site.provider}/{site.model or 'unknown model'}")
+        agent = f" [dim]({_rich_escape(site.agent_id)})[/dim]" if site.agent_id else ""
         console.print(
-            f"       [bold]{_rich_escape(label)}[/bold]  "
+            f"       [bold]{label}[/bold]{agent}  "
             f"{site.affected_calls} call"
             f"{'s' if site.affected_calls != 1 else ''} across "
             f"{site.sessions} session{'s' if site.sessions != 1 else ''}"

--- a/tokenjam/cli/cmd_optimize.py
+++ b/tokenjam/cli/cmd_optimize.py
@@ -489,6 +489,7 @@ _MINOR_FINDING_LABELS = {
     "deadweight":      "Deadweight",
     "placement":       "Batch placement",
     "summarize":       "Summarize",
+    "stream-usage":    "Streaming usage gap",
 }
 
 
@@ -2760,6 +2761,72 @@ def _render_resend_fix(finding, persona: str) -> None:
             )
 
 
+def _render_stream_usage(
+    finding, *, pricing_mode: str = "api", marker: str = "",
+) -> None:
+    """
+    Render the streaming usage gap — streamed calls whose token counts the
+    provider never reported, so their spend is missing from every total.
+
+    This is the one finding on this screen that is NOT a saving. The figure it
+    carries is spend that already happened and was never recorded, so the copy
+    below never says "recoverable" and the accounting note is printed verbatim
+    rather than summarised: a data-quality number sitting among savings
+    numbers is read as a saving unless it says otherwise every time.
+    """
+    console.print(_finding_header(marker, "Streaming usage gap:"))
+    if not finding.call_sites:
+        console.print(f"     [dim]{_rich_escape(finding.hint)}[/dim]" if finding.hint
+                      else "     [dim]Every observed stream reported its token "
+                           "usage — no measurement gap in this window.[/dim]")
+        return
+
+    console.print(
+        f"     • [bold]{finding.streams_missing_usage}[/bold] of "
+        f"[bold]{finding.streams_observed}[/bold] streamed calls closed without a "
+        f"usage payload [dim](content was produced; no token counts were "
+        f"reported)[/dim]"
+    )
+    if pricing_mode == "api" and finding.undercounted_usd is not None:
+        console.print(
+            f"     [dim]unrecorded spend[/dim] ~"
+            f"{format_tokens(finding.undercounted_tokens)} tokens / "
+            f"{format_cost(finding.undercounted_usd)} "
+            f"[dim](estimated — see basis below)[/dim]"
+        )
+    elif finding.undercounted_tokens is not None:
+        console.print(
+            f"     [dim]unrecorded spend[/dim] ~"
+            f"{format_tokens(finding.undercounted_tokens)} tokens "
+            f"[dim](no dollar figure on this pricing mode)[/dim]"
+        )
+
+    for site in finding.call_sites[:5]:
+        label = f"{site.provider}/{site.model or 'unknown model'}"
+        if site.agent_id:
+            label += f" [dim]({site.agent_id})[/dim]"
+        console.print(
+            f"       [bold]{_rich_escape(label)}[/bold]  "
+            f"{site.affected_calls} call"
+            f"{'s' if site.affected_calls != 1 else ''} across "
+            f"{site.sessions} session{'s' if site.sessions != 1 else ''}"
+        )
+        console.print(f"          [dim]{_rich_escape(site.derivation)}[/dim]")
+        console.print(f"          [yellow]→[/yellow] {_rich_escape(site.remediation)}")
+        console.print(
+            site.remediation_snippet, markup=False, highlight=False, soft_wrap=True,
+        )
+    if len(finding.call_sites) > 5:
+        console.print(
+            f"       [dim]… and {len(finding.call_sites) - 5} more call site(s). "
+            f"Full detail with [bold]tj optimize stream-usage --json[/bold].[/dim]"
+        )
+
+    if finding.estimate_basis:
+        console.print(f"     [dim]{_rich_escape(finding.estimate_basis)}[/dim]")
+    console.print(f"     [dim]{_rich_escape(finding.accounting_note)}[/dim]")
+
+
 # Dispatch table — analyzer registration name → renderer.
 _FINDING_RENDERERS = {
     "cache":       _render_cache_efficacy,
@@ -2774,4 +2841,5 @@ _FINDING_RENDERERS = {
     "deadweight":   _render_deadweight,
     "placement":    _render_placement,
     "summarize":    _render_summarize,
+    "stream-usage": _render_stream_usage,
 }

--- a/tokenjam/core/optimize/analyzers/stream_usage.py
+++ b/tokenjam/core/optimize/analyzers/stream_usage.py
@@ -1,0 +1,362 @@
+"""Streaming calls that closed without reporting usage — a DATA-QUALITY finding.
+
+A streamed response reports its token usage only in a final payload. On
+Anthropic that is the trailing ``message_delta``; on OpenAI-compatible APIs it
+is an extra trailing chunk emitted **only** when the request carried
+``stream_options={"include_usage": true}``. Two ordinary things stop that
+payload arriving: the caller never opted in, or the client disconnected before
+the stream finished. Either way the call lands with no token counts, which
+looks exactly like a call that cost nothing — so the spend total reads LOW and
+nothing on any surface says so.
+
+**This finding is not recoverable waste and must never be treated as any.** The
+money was already spent and the provider already billed it; the fix makes the
+figure CORRECT, it does not make it smaller. That is why this analyzer is
+absent from ``cost_proposals.COST_ANALYZERS`` and why its finding carries no
+``past_overspend_*`` field: those are the two mechanisms that would pull a
+figure into the recoverable-waste rollup, and neither can reach it. See
+Critical Rule 27 / 30 in ``tokenjam/CLAUDE.md`` for why mixing a
+differently-derived figure into that total is a first-order bug.
+
+**Persona.** This is an SDK-persona failure mode. An interactive coding agent
+is not proxying end-user streaming chat and its harness drains its own streams,
+so ``stream-usage`` is gated off for the ``claude-code`` persona in
+``runner.PERSONA_DISABLED_ANALYZERS`` — it has no request-side lever there
+either (the harness builds the request, per the Claude Code actionable
+ceiling).
+
+The signature is recorded at observation time, not inferred here: every path
+that watches a stream — the SDK provider patches and the proxy's SSE tap —
+stamps ``TjAttributes.STREAMING`` / ``STREAM_USAGE_REPORTED`` /
+``STREAM_CONTENT_CHUNKS`` on the span. This module only reads them.
+"""
+from __future__ import annotations
+
+import json
+import logging
+from dataclasses import dataclass, field
+from statistics import median
+from typing import Any
+
+from tokenjam.core.cost import calculate_cost
+from tokenjam.core.optimize.registry import register
+from tokenjam.core.optimize.types import AnalyzerContext
+from tokenjam.otel.semconv import TjAttributes
+
+logger = logging.getLogger(__name__)
+
+# The one sentence that keeps this figure out of the savings story wherever it
+# is rendered. Carried on the finding as a dataclass default (the same device
+# `MODEL_DOWNGRADE_CAVEAT` uses) so it cannot be dropped by a renderer that
+# forgets it.
+DATA_QUALITY_NOTE = (
+    "This is a measurement gap, not recoverable waste. The money was already "
+    "spent and the provider already billed it; capturing the usage payload "
+    "makes the spend figure correct, it does not make it smaller. It is "
+    "excluded from the recoverable-waste total for that reason."
+)
+
+# Providers whose streaming API needs an explicit request-side opt-in before a
+# usage payload is emitted at all. Anthropic always reports usage on a stream
+# that runs to completion, so its remediation is only about draining.
+_OPENAI_COMPATIBLE_REMEDIATION = """\
+stream = client.chat.completions.create(
+    model=model,
+    messages=messages,
+    stream=True,
+    # Without this the API emits NO usage payload for a streamed response.
+    stream_options={"include_usage": True},
+)
+usage = None
+for chunk in stream:
+    # The usage chunk is the LAST one and carries an empty `choices` list, so
+    # it only arrives if the iterator is drained. Consume the stream here,
+    # server-side, rather than handing it to a client that may disconnect.
+    if chunk.usage:
+        usage = chunk.usage
+"""
+
+_ANTHROPIC_REMEDIATION = """\
+with client.messages.stream(model=model, messages=messages) as stream:
+    for event in stream:
+        ...  # forward to your caller
+    # Only reachable once the stream has been drained; a caller that
+    # disconnects mid-response never gets here, so consume the stream
+    # server-side and forward from what you have already accumulated.
+    usage = stream.get_final_message().usage
+"""
+
+
+@dataclass
+class StreamUsageCallSite:
+    """One (agent, provider, model) whose streams lost their usage payload."""
+    provider:             str
+    model:                str | None
+    agent_id:             str | None
+    affected_calls:       int
+    complete_calls:       int
+    sessions:             int
+    # Per-call peer medians the estimate is built from. None when this call
+    # site has no completed stream to learn from — in which case both estimate
+    # fields below are None too, never zero (Critical Rule 28's symmetric
+    # degrade: a call site contributes to both sums or to neither).
+    peer_input_tokens:    int | None = None
+    peer_output_tokens:   int | None = None
+    peer_cache_tokens:    int | None = None
+    peer_cache_write_tokens: int | None = None
+    undercounted_tokens:  int | None = None
+    undercounted_usd:     float | None = None
+    derivation:           str = ""
+    remediation:          str = ""
+    remediation_snippet:  str = ""
+
+
+@dataclass
+class StreamUsageFinding:
+    """Streamed calls whose token counts were never reported."""
+    streams_observed:      int = 0
+    streams_missing_usage: int = 0
+    call_sites:            list[StreamUsageCallSite] = field(default_factory=list)
+    # Deliberately NOT named `past_overspend_*`. That name is the canonical
+    # avoidable-spend field every cost analyzer publishes and the rollup sums;
+    # this quantity is spend that WAS incurred and never recorded, a different
+    # question over a different population. Reusing the name would put it in
+    # the recoverable total by construction.
+    undercounted_usd:      float | None = None
+    undercounted_tokens:   int | None = None
+    estimate_basis:        str = ""
+    estimate_confidence:   str = "heuristic"
+    accounting_note:       str = DATA_QUALITY_NOTE
+    hint:                  str = ""
+
+
+def _remediation_for(provider: str) -> tuple[str, str]:
+    """(one-line instruction, copyable snippet) for a provider's stream API."""
+    if provider == "anthropic":
+        return (
+            "Consume the stream to completion server-side and read "
+            "`get_final_message().usage` — Anthropic reports output tokens only "
+            "in the trailing `message_delta`, so an abandoned stream reports "
+            "none at all.",
+            _ANTHROPIC_REMEDIATION,
+        )
+    return (
+        "Send `stream_options={\"include_usage\": True}` on the request AND "
+        "drain the stream server-side — an OpenAI-compatible API emits no usage "
+        "payload without the flag, and emits it only in the final chunk.",
+        _OPENAI_COMPATIBLE_REMEDIATION,
+    )
+
+
+def _parse_attributes(raw: Any) -> dict | None:
+    if isinstance(raw, dict):
+        return raw
+    if isinstance(raw, str):
+        try:
+            parsed = json.loads(raw)
+        except (ValueError, TypeError):
+            return None
+        return parsed if isinstance(parsed, dict) else None
+    return None
+
+
+def _median_int(values: list[int]) -> int | None:
+    return int(round(median(values))) if values else None
+
+
+@dataclass
+class _Bucket:
+    """Mutable accumulator for one call site while scanning rows."""
+    affected: int = 0
+    sessions: set = field(default_factory=set)
+    peer_input: list = field(default_factory=list)
+    peer_output: list = field(default_factory=list)
+    peer_cache: list = field(default_factory=list)
+    peer_cache_write: list = field(default_factory=list)
+
+    @property
+    def complete(self) -> int:
+        return len(self.peer_output)
+
+
+def _select_streaming_spans(ctx: AnalyzerContext) -> list[tuple]:
+    """Spans in the window that a stream observer stamped.
+
+    Filtered in SQL on the streaming marker so this never scans the whole span
+    table; the JSON path is quoted because the attribute keys contain dots.
+    """
+    clauses = [
+        "start_time >= $1", "start_time < $2",
+        f"json_extract_string(attributes, '$.\"{TjAttributes.STREAMING}\"') "
+        f"IS NOT NULL",
+    ]
+    params: list[Any] = [ctx.since, ctx.until]
+    if ctx.agent_id:
+        clauses.append(f"agent_id = ${len(params) + 1}")
+        params.append(ctx.agent_id)
+    where = " AND ".join(clauses)
+    return ctx.conn.execute(
+        f"SELECT provider, model, agent_id, session_id, attributes, "
+        f"COALESCE(input_tokens, 0), COALESCE(output_tokens, 0), "
+        f"COALESCE(cache_tokens, 0), COALESCE(cache_write_tokens, 0) "
+        f"FROM spans WHERE {where}",
+        params,
+    ).fetchall()
+
+
+def _bucket_rows(rows: list[tuple]) -> tuple[dict, int, int]:
+    """Fold spans into per-call-site buckets. Returns (buckets, seen, missing)."""
+    buckets: dict[tuple, _Bucket] = {}
+    seen = 0
+    missing = 0
+    for (provider, model, agent_id, session_id, attrs_raw,
+         input_tokens, output_tokens, cache_tokens, cache_write_tokens) in rows:
+        attrs = _parse_attributes(attrs_raw)
+        if attrs is None or not attrs.get(TjAttributes.STREAMING):
+            continue
+        seen += 1
+        key = (str(provider or "unknown"), model, agent_id)
+        bucket = buckets.setdefault(key, _Bucket())
+        if attrs.get(TjAttributes.STREAM_USAGE_REPORTED):
+            # A completed stream is the peer baseline the missing ones are
+            # estimated against, so it is recorded rather than skipped.
+            bucket.peer_input.append(int(input_tokens))
+            bucket.peer_output.append(int(output_tokens))
+            bucket.peer_cache.append(int(cache_tokens))
+            bucket.peer_cache_write.append(int(cache_write_tokens))
+            continue
+        # No usage payload. Only count it when content was actually produced:
+        # a stream that opened and delivered nothing cost nothing to
+        # under-count, and flagging it would inflate the gap with noise.
+        if not int(attrs.get(TjAttributes.STREAM_CONTENT_CHUNKS) or 0) > 0:
+            continue
+        missing += 1
+        bucket.affected += 1
+        if session_id:
+            bucket.sessions.add(session_id)
+    return buckets, seen, missing
+
+
+def _build_call_site(key: tuple, bucket: _Bucket, at) -> StreamUsageCallSite:
+    provider, model, agent_id = key
+    remediation, snippet = _remediation_for(provider)
+    site = StreamUsageCallSite(
+        provider=provider,
+        model=model,
+        agent_id=agent_id,
+        affected_calls=bucket.affected,
+        complete_calls=bucket.complete,
+        sessions=len(bucket.sessions),
+        remediation=remediation,
+        remediation_snippet=snippet,
+    )
+    med_in = _median_int(bucket.peer_input)
+    med_out = _median_int(bucket.peer_output)
+    med_cache = _median_int(bucket.peer_cache)
+    med_cache_write = _median_int(bucket.peer_cache_write)
+    if med_out is None or not model:
+        # Nothing observed to learn the per-call size from, or no model to
+        # price it against. Both estimate fields stay None — an unmeasured
+        # gap renders an em dash, never "$0.00", which would read as "no
+        # blind spot" and is the exact lie this analyzer exists to prevent.
+        site.derivation = (
+            "No completed stream was observed for this call site in this "
+            "window, so there is no per-call baseline to size the missing "
+            "calls against and no under-count figure is claimed."
+            if med_out is None else
+            "The affected calls carry no model name, so there is no rate to "
+            "price them at and no under-count figure is claimed."
+        )
+        return site
+    site.peer_input_tokens = med_in
+    site.peer_output_tokens = med_out
+    site.peer_cache_tokens = med_cache
+    site.peer_cache_write_tokens = med_cache_write
+    per_call_tokens = (
+        (med_in or 0) + med_out + (med_cache or 0) + (med_cache_write or 0)
+    )
+    per_call_usd = calculate_cost(
+        provider, model,
+        input_tokens=med_in or 0,
+        output_tokens=med_out,
+        cache_read_tokens=med_cache or 0,
+        cache_write_tokens=med_cache_write or 0,
+        at=at,
+    )
+    site.undercounted_tokens = per_call_tokens * bucket.affected
+    site.undercounted_usd = round(per_call_usd * bucket.affected, 6)
+    site.derivation = (
+        f"{bucket.affected} streamed call"
+        f"{'s' if bucket.affected != 1 else ''} closed with no usage payload. "
+        f"Each is sized at the MEDIAN of the {bucket.complete} completed stream"
+        f"{'s' if bucket.complete != 1 else ''} for the same model in this "
+        f"window ({med_in or 0} input + {med_out} output + {med_cache or 0} "
+        f"cache-read + {med_cache_write or 0} cache-write tokens per call), "
+        f"priced at that model's rates. Estimated, not observed: the real "
+        f"counts for these calls were never reported by the provider."
+    )
+    return site
+
+
+@register("stream-usage")
+def run(ctx: AnalyzerContext) -> None:
+    """Registry entry point. Attaches a StreamUsageFinding to ctx.report.findings."""
+    try:
+        rows = _select_streaming_spans(ctx)
+    except Exception:
+        # An install whose spans predate the streaming attributes has nothing
+        # to scan; a query failure must not take the whole report down.
+        logger.debug("stream-usage span scan failed", exc_info=True)
+        rows = []
+
+    buckets, seen, missing = _bucket_rows(rows)
+
+    finding = StreamUsageFinding(
+        streams_observed=seen,
+        streams_missing_usage=missing,
+    )
+    if seen == 0:
+        finding.hint = (
+            "No streamed calls were observed in this window. Streaming usage "
+            "gaps are only visible on calls tokenjam watched as they streamed "
+            "— instrument the provider client with `patch_openai()` / "
+            "`patch_anthropic()`, or route traffic through `tj proxy`."
+        )
+        ctx.report.findings["stream-usage"] = finding
+        return
+
+    sites = [
+        _build_call_site(key, bucket, ctx.until)
+        for key, bucket in buckets.items()
+        if bucket.affected > 0
+    ]
+    # Largest blind spot first; unpriced sites sort last rather than as zero.
+    sites.sort(key=lambda s: (s.undercounted_usd is None, -(s.undercounted_usd or 0.0)))
+    finding.call_sites = sites
+
+    priced = [s for s in sites if s.undercounted_usd is not None]
+    if priced:
+        finding.undercounted_usd = round(sum(s.undercounted_usd or 0.0 for s in priced), 6)
+        finding.undercounted_tokens = sum(s.undercounted_tokens or 0 for s in priced)
+        unpriced = len(sites) - len(priced)
+        finding.estimate_basis = (
+            f"{missing} of {seen} observed streams closed without a usage "
+            f"payload. Each is sized at the median per-call token usage of the "
+            f"completed streams for the same model in this window and priced at "
+            f"that model's rates"
+            + (
+                f"; {unpriced} call site{'s' if unpriced != 1 else ''} had no "
+                f"completed stream to size against and contribute"
+                f"{'' if unpriced != 1 else 's'} nothing to this figure."
+                if unpriced else "."
+            )
+        )
+    elif sites:
+        finding.estimate_basis = (
+            f"{missing} of {seen} observed streams closed without a usage "
+            f"payload, and no completed stream was observed for any affected "
+            f"model in this window — so the size of the gap is not estimated "
+            f"here, only its existence."
+        )
+
+    ctx.report.findings["stream-usage"] = finding

--- a/tokenjam/core/optimize/analyzers/stream_usage.py
+++ b/tokenjam/core/optimize/analyzers/stream_usage.py
@@ -228,7 +228,7 @@ def _bucket_rows(rows: list[tuple]) -> tuple[dict, int, int]:
         # No usage payload. Only count it when content was actually produced:
         # a stream that opened and delivered nothing cost nothing to
         # under-count, and flagging it would inflate the gap with noise.
-        if not int(attrs.get(TjAttributes.STREAM_CONTENT_CHUNKS) or 0) > 0:
+        if int(attrs.get(TjAttributes.STREAM_CONTENT_CHUNKS) or 0) <= 0:
             continue
         missing += 1
         bucket.affected += 1

--- a/tokenjam/core/optimize/runner.py
+++ b/tokenjam/core/optimize/runner.py
@@ -42,6 +42,7 @@ ANALYZER_ORDER: list[str] = [
     "relearn",
     "verbosity",
     "deadweight",
+    "stream-usage",
 ]
 
 # Analyzers that have NO fix a user of that persona can actually apply.
@@ -128,6 +129,16 @@ PERSONA_DISABLED_ANALYZERS: dict[str, frozenset[str]] = {
         # this corpus; the SDK case is a separate, unmeasured question and is
         # deliberately left ungated.
         "reuse",
+        # Stream-usage flags streamed calls that closed before the provider
+        # emitted its usage payload, so their spend went unrecorded. Its fix
+        # is a request-side change — `stream_options={"include_usage": True}`,
+        # or draining the stream server-side — to code that constructs the
+        # provider call. An interactive coding agent's harness constructs that
+        # call, which puts the lever on the other side of the actionable
+        # ceiling; and the harness drains its own streams, so the failure mode
+        # does not arise here in the first place. This is an SDK-persona
+        # finding: it stays enabled for `sdk` / `mixed` / `unknown`.
+        "stream-usage",
     }),
     # An SDK/API window has no on-disk Claude Code transcript and never
     # populates `sub_agent_id` (no Task-tool subagent-dispatch concept in
@@ -542,6 +553,7 @@ def _build_finding_classes() -> dict:
     from tokenjam.core.optimize.analyzers.subagent_rightsizing import (
         SubagentRightsizingFinding,
     )
+    from tokenjam.core.optimize.analyzers.stream_usage import StreamUsageFinding
     from tokenjam.core.optimize.analyzers.summarize import SummarizeFinding
     from tokenjam.core.optimize.analyzers.workflow_restructure import (
         WorkflowRestructureFinding,
@@ -560,6 +572,7 @@ def _build_finding_classes() -> dict:
         "deadweight": DeadweightFinding,
         "verbosity": VerbosityFinding,
         "resend": ResendFinding,
+        "stream-usage": StreamUsageFinding,
         # Not a registered analyzer name of its own: the downsize analyzer
         # attaches the batch-placement check under this key. It still needs an
         # entry, or the finding is dropped on the daemon path (every consumer

--- a/tokenjam/otel/semconv.py
+++ b/tokenjam/otel/semconv.py
@@ -308,6 +308,26 @@ class TjAttributes:
     PROMPT_TEMPLATE_ID      = "tokenjam.prompt.template_id"
     PROMPT_TEMPLATE_VERSION = "tokenjam.prompt.template_version"
 
+    # -- Streaming usage data-quality --
+    # A streamed response only reports its token usage in a FINAL payload: the
+    # `message_delta`/`message_stop` pair on Anthropic, and — only when the
+    # caller opted in with `stream_options={"include_usage": true}` — a trailing
+    # usage chunk on OpenAI-compatible APIs. If the caller abandons the iterator
+    # early (a client disconnect, a `break`, an exception) or never opted in,
+    # that payload never arrives and the call is recorded with no token counts
+    # at all. Nothing about the recorded span distinguishes that from a call
+    # that genuinely cost nothing, so the spend total silently reads LOW.
+    #
+    # These three are set by every code path that observes a stream (the SDK
+    # provider patches and the proxy's SSE tap) so the `stream-usage` analyzer
+    # can tell the three states apart: not a stream at all, a stream that
+    # reported usage, and a stream that produced content and then closed
+    # without reporting any. Metadata about the observation itself, not
+    # content, so they are NOT gated by a [capture] toggle.
+    STREAMING             = "tokenjam.llm.streaming"
+    STREAM_USAGE_REPORTED = "tokenjam.llm.stream_usage_reported"
+    STREAM_CONTENT_CHUNKS = "tokenjam.llm.stream_content_chunks"
+
     # NemoClaw / OpenShell sandbox events
     SANDBOX_EVENT    = "tokenjam.sandbox.event"
     EGRESS_HOST      = "tokenjam.sandbox.egress_host"

--- a/tokenjam/proxy/app.py
+++ b/tokenjam/proxy/app.py
@@ -14,7 +14,7 @@ Safety doctrine, enforced structurally:
 from __future__ import annotations
 
 import logging
-from typing import Any
+from typing import Any, Callable
 
 import httpx
 from starlette.applications import Starlette
@@ -26,6 +26,14 @@ from starlette.routing import Route
 from tokenjam.proxy.engine import POLICY, PolicyEngine, PolicyRequest
 from tokenjam.proxy.gate import classify
 from tokenjam.proxy.observer import ProxyObserver
+from tokenjam.proxy.stream_usage import (
+    SseUsageScanner,
+    StreamUsageObservation,
+    requested_model,
+    stream_requested,
+    tap_stream,
+    usage_opt_in,
+)
 
 logger = logging.getLogger("tokenjam.proxy")
 
@@ -48,20 +56,22 @@ def _provider_for(path: str) -> str:
     return _ROUTE_PROVIDER.get(path, "unknown")
 
 
-def _policy_request(request: Request, body: bytes) -> PolicyRequest:
-    """Build the pure (HTTP-free) policy-evaluation context from a request.
-
-    The body is parsed best-effort for kind-specific evaluators to read (e.g. a
-    future budget_cap reading the model); a malformed body is simply None.
-    """
+def _parse_body(body: bytes) -> dict | None:
+    """Best-effort JSON view of the request body; a malformed body is None."""
     import json
-    parsed: dict | None = None
     try:
         loaded = json.loads(body or b"{}")
-        if isinstance(loaded, dict):
-            parsed = loaded
     except Exception:  # body parsing never breaks the request
-        parsed = None
+        return None
+    return loaded if isinstance(loaded, dict) else None
+
+
+def _policy_request(request: Request, parsed: dict | None) -> PolicyRequest:
+    """Build the pure (HTTP-free) policy-evaluation context from a request.
+
+    The parsed body is for kind-specific evaluators to read (e.g. a future
+    budget_cap reading the model).
+    """
     return PolicyRequest(
         provider=_provider_for(request.url.path),
         path=request.url.path,
@@ -96,7 +106,9 @@ def _response_headers(upstream: httpx.Response) -> list[tuple[bytes, bytes]]:
 def build_proxy_app(config: Any, observer: ProxyObserver | None = None,
                     client: httpx.AsyncClient | None = None,
                     engine: PolicyEngine | None = None,
-                    db: Any = None) -> Starlette:
+                    db: Any = None,
+                    stream_sink: Callable[[StreamUsageObservation], None] | None = None,
+                    ) -> Starlette:
     """Build the Starlette proxy app.
 
     ``observer``, ``client``, ``engine`` and ``db`` are injectable for testing —
@@ -115,7 +127,8 @@ def build_proxy_app(config: Any, observer: ProxyObserver | None = None,
             state["client"] = httpx.AsyncClient(timeout=httpx.Timeout(600.0))
         return state["client"]
 
-    async def _forward(request: Request, base_url: str, body: bytes) -> StreamingResponse:
+    async def _forward(request: Request, base_url: str, body: bytes,
+                       parsed_body: dict | None = None) -> StreamingResponse:
         client_ = await _get_client()
         url = base_url + request.url.path
         if request.url.query:
@@ -124,8 +137,22 @@ def build_proxy_app(config: Any, observer: ProxyObserver | None = None,
             request.method, url, headers=_forward_headers(request), content=body,
         )
         upstream = await client_.send(upstream_req, stream=True)
+        # Streaming data-quality tap. Only armed for a request
+        # that actually asked to stream — a non-streamed response reports its
+        # usage in the body and cannot exhibit the gap, so there is nothing to
+        # watch and no reason to pay for the scan. The bytes relayed are
+        # unchanged either way; the tap only observes.
+        provider = _provider_for(request.url.path)
+        stream_body: Any = upstream.aiter_raw()
+        if stream_requested(parsed_body):
+            scanner = SseUsageScanner(
+                provider,
+                model=requested_model(parsed_body),
+                opt_in=usage_opt_in(provider, parsed_body),
+            )
+            stream_body = tap_stream(stream_body, scanner, stream_sink)
         return StreamingResponse(
-            upstream.aiter_raw(),
+            stream_body,
             status_code=upstream.status_code,
             headers={k.decode("latin-1"): v.decode("latin-1")
                      for k, v in _response_headers(upstream)},
@@ -146,8 +173,10 @@ def build_proxy_app(config: Any, observer: ProxyObserver | None = None,
         except Exception:  # never let our logic break traffic
             logger.exception("proxy gate classification failed; forwarding unmodified")
 
-        # Read the body once — needed both for forwarding and for policy context.
+        # Read the body once — needed for forwarding, for policy context, and
+        # for the streaming tap (which reads `stream` / `stream_options`).
         body = await request.body()
+        parsed_body = _parse_body(body)
 
         # POLICY-path branch (#220): ONLY api/usage-billed traffic reaches the
         # engine — the api-only guard inside the engine is belt-and-suspenders
@@ -156,7 +185,7 @@ def build_proxy_app(config: Any, observer: ProxyObserver | None = None,
         envelope = None
         if decision is not None and decision.path == POLICY:
             try:
-                envelope = engine.evaluate(decision, _policy_request(request, body))
+                envelope = engine.evaluate(decision, _policy_request(request, parsed_body))
             except Exception:  # engine never breaks traffic
                 logger.exception("policy engine failed; forwarding unmodified")
 
@@ -171,7 +200,7 @@ def build_proxy_app(config: Any, observer: ProxyObserver | None = None,
 
         # Forward UNMODIFIED. Suggest mode enforces nothing on EITHER path — the
         # envelope only records what a policy WOULD do; the request is untouched.
-        response = await _forward(request, base_url, body)
+        response = await _forward(request, base_url, body, parsed_body)
         _safe_record(observer, request, decision, forwarded=True, envelope=envelope)
         return response
 

--- a/tokenjam/proxy/server.py
+++ b/tokenjam/proxy/server.py
@@ -40,12 +40,23 @@ class ProxyRunner:
                 sink = AuditSink(db, pipeline=pipeline)
             observer = ProxyObserver(sink=sink)
         self.observer = observer
+        # Streaming data-quality sink: one span per observed stream, recording
+        # whether its usage payload ever arrived. Needs somewhere to write, so
+        # it stays None when the proxy runs without a DB (tests, dry runs) —
+        # the tap then observes nothing and the relay is unchanged.
+        self.stream_sink = None
+        if db is not None:
+            from tokenjam.proxy.stream_usage import StreamUsageSink
+            self.stream_sink = StreamUsageSink(db, pipeline=pipeline)
         self._server: uvicorn.Server | None = None
         self._task: asyncio.Task | None = None
 
     def start(self) -> None:
         """Schedule the proxy server on the running event loop (non-blocking)."""
-        app = build_proxy_app(self.config, observer=self.observer, db=self.db)
+        app = build_proxy_app(
+            self.config, observer=self.observer, db=self.db,
+            stream_sink=self.stream_sink,
+        )
         uconfig = uvicorn.Config(
             app,
             host=self.config.proxy.host,

--- a/tokenjam/proxy/stream_usage.py
+++ b/tokenjam/proxy/stream_usage.py
@@ -1,0 +1,243 @@
+"""Streaming usage-payload observation for the pass-through proxy.
+
+A streamed provider response reports its token usage only in a FINAL payload.
+On Anthropic that is the trailing ``message_delta``; on OpenAI-compatible APIs
+it is an extra trailing chunk that is emitted **only** when the request carried
+``stream_options={"include_usage": true}``. If the caller never opted in, or
+the connection drops before the final payload arrives, the call is recorded
+with no token counts — which is indistinguishable from a call that cost
+nothing, so the spend total silently reads LOW.
+
+This module gives the proxy a way to notice that, without changing what it
+forwards. :class:`SseUsageScanner` watches the bytes as they pass through and
+answers three questions — was this a stream, did a usage payload arrive, was
+any content produced — and :func:`stream_usage_span` records the answers as a
+span the ``stream-usage`` analyzer reads later.
+
+Pass-through is sacred (see ``proxy/app.py``): every function here swallows its
+own errors. A malformed chunk makes the scanner less certain, never breaks the
+relay.
+"""
+from __future__ import annotations
+
+import json
+import logging
+from dataclasses import dataclass
+from typing import Any, AsyncIterator, Callable
+
+from tokenjam.core.models import NormalizedSpan, SpanKind, SpanStatus
+from tokenjam.otel.semconv import GenAIAttributes, TjAttributes
+from tokenjam.utils.ids import new_span_id, new_trace_id
+from tokenjam.utils.time_parse import utcnow
+
+logger = logging.getLogger("tokenjam.proxy")
+
+# The span the proxy emits per observed stream. Distinct from the policy
+# self-observation span so the two never share a row: this one is about data
+# quality, that one is about enforcement.
+STREAM_USAGE_SPAN_NAME = "tokenjam.stream.usage"
+
+
+@dataclass(frozen=True)
+class StreamUsageObservation:
+    """What one streamed response through the proxy turned out to be."""
+    provider:        str
+    model:           str | None
+    usage_reported:  bool
+    content_chunks:  int
+    # OpenAI-compatible only: did the request opt in to a usage chunk at all?
+    # None for providers where the flag does not exist (Anthropic always
+    # reports usage on a completed stream), which keeps "the caller did not
+    # ask" distinguishable from "the caller asked and it never arrived" —
+    # they have different remediations.
+    usage_opt_in:    bool | None = None
+
+    @property
+    def usage_missing(self) -> bool:
+        """The signature: content was produced and no usage payload arrived."""
+        return self.content_chunks > 0 and not self.usage_reported
+
+
+def stream_requested(body: dict | None) -> bool:
+    """True when the request body asked for a streamed response."""
+    return bool((body or {}).get("stream"))
+
+
+def usage_opt_in(provider: str, body: dict | None) -> bool | None:
+    """Whether an OpenAI-compatible request opted in to the usage chunk.
+
+    None for providers that have no such flag — see
+    :attr:`StreamUsageObservation.usage_opt_in`.
+    """
+    if provider == "anthropic":
+        return None
+    options = (body or {}).get("stream_options")
+    if not isinstance(options, dict):
+        return False
+    return bool(options.get("include_usage"))
+
+
+def requested_model(body: dict | None) -> str | None:
+    model = (body or {}).get("model")
+    return model if isinstance(model, str) and model else None
+
+
+def _event_reports_usage(provider: str, event: dict) -> bool:
+    """True when this SSE event is the one carrying final token counts."""
+    usage = event.get("usage")
+    if not isinstance(usage, dict):
+        return False
+    if provider == "anthropic":
+        # `message_start` also carries a `usage` block, but its `output_tokens`
+        # is a placeholder for a response that has not been generated yet. Only
+        # the trailing `message_delta` reports the real total, so accepting any
+        # usage block here would mark every interrupted stream as complete.
+        return event.get("type") == "message_delta"
+    return any(k in usage for k in ("completion_tokens", "total_tokens", "output_tokens"))
+
+
+def _event_carries_content(event: dict) -> bool:
+    """True when this SSE event delivered generated output to the caller."""
+    delta = event.get("delta")
+    if isinstance(delta, dict) and (delta.get("text") or delta.get("partial_json")):
+        return True
+    for choice in event.get("choices") or []:
+        if not isinstance(choice, dict):
+            continue
+        choice_delta = choice.get("delta")
+        if isinstance(choice_delta, dict) and (
+            choice_delta.get("content") or choice_delta.get("tool_calls")
+        ):
+            return True
+    return False
+
+
+class SseUsageScanner:
+    """Accumulates SSE bytes and answers whether a usage payload arrived.
+
+    Line-buffered, because a provider chunk boundary can fall anywhere — a
+    naive per-chunk parse would miss a usage payload split across two reads and
+    report a healthy stream as broken.
+    """
+
+    def __init__(self, provider: str, model: str | None = None,
+                 opt_in: bool | None = None) -> None:
+        self._provider = provider
+        self._model = model
+        self._opt_in = opt_in
+        self._buffer = b""
+        self._usage_reported = False
+        self._content_chunks = 0
+
+    def feed(self, chunk: bytes) -> None:
+        """Scan one relayed chunk. Never raises — the relay comes first."""
+        try:
+            self._feed(chunk)
+        except Exception:  # scanning must never break pass-through
+            logger.debug("proxy stream-usage scan failed (ignored)", exc_info=True)
+
+    def _feed(self, chunk: bytes) -> None:
+        self._buffer += chunk
+        *lines, self._buffer = self._buffer.split(b"\n")
+        for line in lines:
+            self._scan_line(line)
+
+    def _scan_line(self, line: bytes) -> None:
+        stripped = line.strip()
+        if not stripped.startswith(b"data:"):
+            return
+        payload = stripped[len(b"data:"):].strip()
+        if not payload or payload == b"[DONE]":
+            return
+        try:
+            event = json.loads(payload)
+        except (ValueError, UnicodeDecodeError):
+            return
+        if not isinstance(event, dict):
+            return
+        if _event_reports_usage(self._provider, event):
+            self._usage_reported = True
+        if _event_carries_content(event):
+            self._content_chunks += 1
+
+    def result(self) -> StreamUsageObservation:
+        return StreamUsageObservation(
+            provider=self._provider,
+            model=self._model,
+            usage_reported=self._usage_reported,
+            content_chunks=self._content_chunks,
+            usage_opt_in=self._opt_in,
+        )
+
+
+async def tap_stream(
+    source: AsyncIterator[bytes],
+    scanner: SseUsageScanner,
+    sink: Callable[[StreamUsageObservation], None] | None,
+) -> AsyncIterator[bytes]:
+    """Relay ``source`` verbatim while ``scanner`` watches it go past.
+
+    The ``finally`` is the whole point: it runs when the response completes AND
+    when the client disconnects mid-stream (the generator is closed), so the
+    disconnect case — the one that under-counts — is the case that is recorded.
+    """
+    try:
+        async for chunk in source:
+            scanner.feed(chunk)
+            yield chunk
+    finally:
+        if sink is not None:
+            try:
+                sink(scanner.result())
+            except Exception:  # recording must never break pass-through
+                logger.exception("proxy stream-usage recording failed (ignored)")
+
+
+def stream_usage_span(obs: StreamUsageObservation, *, ts: Any = None) -> NormalizedSpan:
+    """Build the data-quality span for one observed stream.
+
+    Deliberately carries NO token counts: the whole point is that the real
+    counts were never reported, and writing an estimate onto the span would
+    feed a guess into the cost engine as though it were observed.
+    """
+    ts = ts or utcnow()
+    attrs: dict[str, Any] = {
+        TjAttributes.STREAMING: True,
+        TjAttributes.STREAM_USAGE_REPORTED: obs.usage_reported,
+        TjAttributes.STREAM_CONTENT_CHUNKS: obs.content_chunks,
+        GenAIAttributes.PROVIDER_NAME: obs.provider,
+    }
+    if obs.model:
+        attrs[GenAIAttributes.REQUEST_MODEL] = obs.model
+    return NormalizedSpan(
+        span_id=new_span_id(),
+        trace_id=new_trace_id(),
+        name=STREAM_USAGE_SPAN_NAME,
+        kind=SpanKind.INTERNAL,
+        status_code=SpanStatus.OK,
+        start_time=ts,
+        end_time=ts,
+        duration_ms=0.0,
+        attributes=attrs,
+        provider=obs.provider,
+        model=obs.model,
+        billing_account=obs.provider,
+    )
+
+
+class StreamUsageSink:
+    """Persists each observed stream as a span. Best-effort, like AuditSink."""
+
+    def __init__(self, db: Any, pipeline: Any = None) -> None:
+        self.db = db
+        self.pipeline = pipeline
+
+    def __call__(self, obs: StreamUsageObservation) -> None:
+        try:
+            span = stream_usage_span(obs)
+            if self.pipeline is not None:
+                self.pipeline.process(span)
+            else:
+                self.db.insert_span(span)
+        except Exception:  # persistence must never break the proxy
+            logger.exception("proxy stream-usage span emit failed (ignored)")

--- a/tokenjam/sdk/integrations/anthropic.py
+++ b/tokenjam/sdk/integrations/anthropic.py
@@ -12,7 +12,7 @@ from typing import Any
 
 from opentelemetry import trace
 
-from tokenjam.otel.semconv import GenAIAttributes
+from tokenjam.otel.semconv import GenAIAttributes, TjAttributes
 from tokenjam.sdk.attribution import stamp_span_attribution
 from tokenjam.sdk.integrations._request_capture import (
     extract_anthropic_completion,
@@ -180,29 +180,75 @@ class AnthropicIntegration:
         self.installed = False
 
 
+def _event_carries_content(event: Any) -> bool:
+    """True when a streamed event delivered generated output to the caller.
+
+    Structural and defensive — an unrecognised event shape counts as no content
+    rather than raising into the caller's iteration.
+    """
+    delta = getattr(event, "delta", None)
+    if delta is None:
+        return False
+    return bool(getattr(delta, "text", None) or getattr(delta, "partial_json", None))
+
+
 class _StreamWrapper:
-    """Wraps an Anthropic stream to capture final usage and end the span."""
+    """Wraps an Anthropic stream to capture final usage and end the span.
+
+    Also records the streaming data-quality signature (see
+    ``TjAttributes.STREAMING``). Anthropic reports output tokens only in the
+    trailing ``message_delta`` / ``message_stop`` pair, which
+    ``get_final_message()`` reads — so a caller that breaks out of the loop or
+    is disconnected mid-response leaves this span with no token counts, which
+    is indistinguishable from a free call unless the span says so itself.
+    """
 
     def __init__(self, stream, span):
         self._stream = stream
         self._span = span
+        self._content_events = 0
 
     def __enter__(self):
         self._stream.__enter__()
         return self
 
+    def _final_usage(self) -> Any:
+        """The final message's usage, or None when the stream never finished.
+
+        ``get_final_message()`` raises when the stream was not consumed to
+        completion, which is exactly the case being detected — so the raise is
+        an answer, not an error, and must not escape ``__exit__``.
+        """
+        getter = getattr(self._stream, "get_final_message", None)
+        if getter is None:
+            return None
+        try:
+            final_message = getter()
+        except Exception:
+            return None
+        return getattr(final_message, "usage", None)
+
     def __exit__(self, exc_type, exc_val, exc_tb):
         result = self._stream.__exit__(exc_type, exc_val, exc_tb)
-        final_message = getattr(self._stream, "get_final_message", lambda: None)()
-        if final_message and hasattr(final_message, "usage"):
+        usage = self._final_usage()
+        if usage is not None:
             self._span.set_attribute(
                 GenAIAttributes.INPUT_TOKENS,
-                final_message.usage.input_tokens,
+                usage.input_tokens,
             )
             self._span.set_attribute(
                 GenAIAttributes.OUTPUT_TOKENS,
-                final_message.usage.output_tokens,
+                usage.output_tokens,
             )
+        # Stamped unconditionally, including on the happy path: the analyzer
+        # needs the complete streams as the peer baseline it estimates the
+        # missing ones against, so "usage reported" is as load-bearing a fact
+        # as "usage missing".
+        self._span.set_attribute(TjAttributes.STREAMING, True)
+        self._span.set_attribute(TjAttributes.STREAM_USAGE_REPORTED, usage is not None)
+        self._span.set_attribute(
+            TjAttributes.STREAM_CONTENT_CHUNKS, self._content_events,
+        )
         if exc_type is None:
             self._span.set_status(trace.Status(trace.StatusCode.OK))
         else:
@@ -211,10 +257,16 @@ class _StreamWrapper:
         return result
 
     def __iter__(self):
-        return iter(self._stream)
+        for event in self._stream:
+            if _event_carries_content(event):
+                self._content_events += 1
+            yield event
 
     def __next__(self):
-        return next(self._stream)
+        event = next(self._stream)
+        if _event_carries_content(event):
+            self._content_events += 1
+        return event
 
 
 def patch_anthropic() -> None:

--- a/tokenjam/sdk/integrations/openai.py
+++ b/tokenjam/sdk/integrations/openai.py
@@ -15,7 +15,7 @@ from typing import Any
 
 from opentelemetry import trace
 
-from tokenjam.otel.semconv import GenAIAttributes
+from tokenjam.otel.semconv import GenAIAttributes, TjAttributes
 from tokenjam.sdk.attribution import stamp_span_attribution
 from tokenjam.sdk.integrations._request_capture import (
     extract_openai_completion,
@@ -115,13 +115,42 @@ class OpenAIIntegration:
         self.installed = False
 
 
+def _chunk_carries_content(chunk: Any) -> bool:
+    """True when a streamed chunk delivered generated output to the caller.
+
+    Deliberately structural and defensive: the point is only to separate "this
+    stream produced something the user was billed for" from "this stream was
+    empty", so an unrecognised chunk shape counts as no content rather than
+    raising into the caller's iteration.
+    """
+    choices = getattr(chunk, "choices", None)
+    if not choices:
+        return False
+    for choice in choices:
+        delta = getattr(choice, "delta", None)
+        if delta is None:
+            continue
+        if getattr(delta, "content", None) or getattr(delta, "tool_calls", None):
+            return True
+    return False
+
+
 class _StreamWrapper:
-    """Wraps an OpenAI stream to capture final usage chunk and end the span."""
+    """Wraps an OpenAI stream to capture final usage chunk and end the span.
+
+    Also records the streaming data-quality signature (see
+    ``TjAttributes.STREAMING``): an OpenAI-compatible API emits usage ONLY when
+    the request carried ``stream_options={"include_usage": true}`` AND the
+    caller drains the iterator to the trailing chunk. Either omission leaves
+    this span with no token counts, which is indistinguishable from a free call
+    unless the span says so itself.
+    """
 
     def __init__(self, stream, span):
         self._stream = stream
         self._span = span
         self._usage = None
+        self._content_chunks = 0
 
     def __iter__(self):
         _ok = False
@@ -129,6 +158,8 @@ class _StreamWrapper:
             for chunk in self._stream:
                 if hasattr(chunk, "usage") and chunk.usage:
                     self._usage = chunk.usage
+                if _chunk_carries_content(chunk):
+                    self._content_chunks += 1
                 yield chunk
             _ok = True
         except Exception as exc:
@@ -144,6 +175,17 @@ class _StreamWrapper:
                     GenAIAttributes.OUTPUT_TOKENS,
                     self._usage.completion_tokens,
                 )
+            # Stamped unconditionally, including on the happy path: the
+            # analyzer needs the complete streams as the peer baseline it
+            # estimates the missing ones against, so "usage reported" is as
+            # load-bearing a fact as "usage missing".
+            self._span.set_attribute(TjAttributes.STREAMING, True)
+            self._span.set_attribute(
+                TjAttributes.STREAM_USAGE_REPORTED, self._usage is not None,
+            )
+            self._span.set_attribute(
+                TjAttributes.STREAM_CONTENT_CHUNKS, self._content_chunks,
+            )
             if _ok:
                 self._span.set_status(trace.Status(trace.StatusCode.OK))
             self._span.end()


### PR DESCRIPTION
A streamed response reports its token usage only in a **final** payload. Two ordinary things stop that payload arriving, and when it does not arrive the call is recorded with no token counts at all — which is indistinguishable from a call that cost nothing. The spend total silently reads low, and no surface says so.

## Summary

- Every path that watches a stream now stamps the signature on the span: the OpenAI and Anthropic provider patches, and a new SSE tap in the proxy.
- A new `stream-usage` analyzer reports the gap, names the affected call sites and provider, estimates the unrecorded spend with its derivation stated, and emits the **provider-correct** remediation snippet.
- The estimate is a **data-quality** figure and is kept structurally out of the recoverable-waste total.
- The analyzer is gated off for the `claude-code` persona; this is an SDK-persona failure mode.

## Why the payload goes missing

| Provider | Where usage lives | What stops it |
|---|---|---|
| OpenAI-compatible | a trailing chunk with an empty `choices` list | emitted **only** when the request carried `stream_options={"include_usage": true}`, and only if the iterator is drained to that last chunk |
| Anthropic | the trailing `message_delta` (`get_final_message()`) | a caller that breaks out of the loop or is disconnected never reaches it — `get_final_message()` then raises rather than returning counts |

The two remediations are therefore different, and offering the wrong one is advice that cannot work. The card emits the right one per detected provider.

## Detection

Three new `TjAttributes` — `tokenjam.llm.streaming`, `stream_usage_reported`, `stream_content_chunks` — stamped by:

- **`sdk/integrations/openai.py`** — `_StreamWrapper` already tracked the usage chunk; it now also counts content-bearing chunks and stamps the three attributes in its `finally`, so an abandoned iterator records the gap rather than vanishing.
- **`sdk/integrations/anthropic.py`** — same, plus `get_final_message()` raising because the stream was not drained is now read as *the answer* (usage missing) instead of being allowed to escape `__exit__`. `__iter__` / `__next__` count content events.
- **`proxy/stream_usage.py`** (new) — an SSE tap that watches the relayed bytes. It is line-buffered because a provider chunk boundary can fall mid-JSON, and a per-chunk parse would miss a split usage payload and report a healthy stream as broken. Its `finally` runs on client disconnect too, which is the case that under-counts. Pass-through stays sacred: the tap alters no byte and swallows its own errors.

The tap is armed only for a request that actually asked to stream — a non-streamed response reports usage in the body and cannot exhibit the gap.

One trap worth naming: Anthropic's `message_start` also carries a `usage` block, but its `output_tokens` is a placeholder for a response that has not been generated yet. Accepting any usage block would mark **every** interrupted stream complete, i.e. silently disable the whole analyzer. There is a test for exactly that.

## The estimate and its derivation

Each missing call is sized at the **median per-call usage of the completed streams for the same model in the same window** — all four token types, including both `cache_tokens` and `cache_write_tokens` — and priced through `core.cost.calculate_cost`. The derivation is printed on the card, not merely implied.

Two degrade rules:

- A call site with **no completed peer** to size against gets `None` on **both** the token and the dollar field, never zero on one and a number on the other (Critical Rule 28's symmetric degrade). The unpriced part is then disclosed in words in the basis string rather than folded in as zero.
- A stream that produced **no content** is not counted: it under-counted nothing, and flagging it would inflate the gap with noise.

## Accounting: why this is not a saving

This is the unusual part of the PR and the part most worth reviewing.

What the analyzer measures is spend that **already happened and was already billed**. Capturing the usage payload makes the spend figure *correct*; it does not make it *smaller*. A figure derived that way must never reach the recoverable-waste total, whose whole meaning is "money that could have been avoided" — mixing populations there is a first-order bug per Critical Rules 27 and 30.

It is kept out **structurally**, via the only two mechanisms that could pull it in:

1. The finding carries **no `past_overspend_*` field**. That name is the canonical avoidable-spend field, and `past_overspend_rollup` is generic over analyzers — it picks a figure up by field presence. The quantity here is named `undercounted_usd` / `undercounted_tokens` instead.
2. `stream-usage` is **absent from `COST_ANALYZERS`**, the independent second selection surface feeding the Review inbox, so no cost proposal is ever minted from it.

A test builds a report end to end (`build_report` → `cost_proposals_from_report` → `past_overspend_rollup`), asserts the gap figure is real and non-zero, and asserts the rollup total cannot see it. A second test asserts the *serialized* payload has no `past_overspend_usd` key, because the Overview's recoverable-waste band keys off presence in the payload rather than on the dataclass — the dataclass-level assertion alone would not have covered the surface that mints a tile.

A `DATA_QUALITY_NOTE` rides on the finding as a dataclass default (the `MODEL_DOWNGRADE_CAVEAT` device) so a renderer cannot drop it, and the CLI prints it verbatim rather than summarising it.

## Persona gating

`stream-usage` is added to `PERSONA_DISABLED_ANALYZERS["claude-code"]` with an inline reason, and runs for `sdk` / `mixed` / `unknown`. An interactive coding agent does not proxy end-user streaming chat and its harness drains its own streams, so the failure mode does not arise; and the fix is a request-side change to code that constructs the provider call, which is on the harness's side of the actionable ceiling. No mirror in `COST_ANALYZERS` is needed precisely because the name was never in it.

The gate pin in `tests/unit/test_persona_analyzer_gate.py` is updated deliberately, as that file requires.

## Tests / Verification

`tests/unit/test_stream_usage_capture.py` (14) — the three observation paths:

- OpenAI stream with no usage chunk → gap recorded; with a trailing usage chunk → complete; **abandoned mid-iteration** → gap recorded.
- Anthropic stream interrupted before `message_delta` → gap recorded; drained to completion → complete; a raising `get_final_message()` never escapes the wrapper.
- SSE scanner: OpenAI without/with the usage chunk, Anthropic's `message_start` placeholder rejected, `message_delta` accepted, a usage payload split across chunk boundaries still found, malformed bytes never raise.
- The tap records on client disconnect, and relays bytes byte-for-byte unmodified.

`tests/unit/test_stream_usage_analyzer.py` (16) — detection, per-provider remediation, the estimate and its derivation, both cache token types in the baseline, the implied-rate check, symmetric degrade, and the accounting separation above.

The implied-rate test is worth a look: it asserts `usd / tokens` equals the **exact blend** the basis advertises, not merely that it lands in a price band. A band spanning cache-read to output rates happily admits a 2x basis mismatch (dollars multiplied per call, tokens left one-time) — verified by mutating the code and watching the band-only version stay green.

Each new guard was mutation-checked: the Anthropic placeholder trap, the symmetric degrade, and the basis mismatch each fail their test when the implementation is broken.

Full suite (`pytest tests/unit/ tests/synthetic/ tests/agents/ tests/integration/`) green. `ruff check tokenjam/` and `mypy tokenjam/` clean.

## What's NOT in this PR

- **`_StreamWrapper.__next__` on the OpenAI patch bypasses the generator entirely**, so a consumer that calls `next()` directly never records usage and never ends the span. Pre-existing, orthogonal to this change, and fixing it means restructuring that wrapper — left alone rather than folded into a data-quality PR.
- **No backfill of historical spans.** The signature is only present on streams observed after this lands; the analyzer says so in its empty-state hint rather than implying a clean window.
- **No web-UI card.** The finding is deliberately kept off the recoverable-waste band, and giving a non-recoverable figure its own Overview surface is a product decision, not a mechanical follow-on. The CLI renders it and `--json` carries it in full.
- **No minimum-calls floor for `sdk` / `mixed` windows.** Every affected call site is reported; whether a floor is wanted is a judgement best made against a real SDK corpus, which this repo's corpus is not.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
