### PR TITLE
fix(tests): restore SDK tracer after full_stack fixture teardown

### DIFF
--- a/tests/integration/test_full_pipeline.py
+++ b/tests/integration/test_full_pipeline.py
@@ -133,7 +133,9 @@ def full_stack():
 
     ocw_exporter = TjSpanExporter(pipeline)
 
-    # Create a local TracerProvider (not global) and bind the SDK tracer to it
+    # Create a local TracerProvider (not global) and bind the SDK tracer to it.
+    # Save/restore so later tests in the same pytest process keep the default tracer.
+    original_tracer = agent_mod._tracer
     provider = TracerProvider()
     provider.add_span_processor(SimpleSpanProcessor(ocw_exporter))
     agent_mod._tracer = provider.get_tracer("tokenjam.sdk")
@@ -156,6 +158,7 @@ def full_stack():
     yield stack
 
     provider.shutdown()
+    agent_mod._tracer = original_tracer
     db.close()
 
 


### PR DESCRIPTION
## Summary

The `full_stack` integration fixture rebinds `agent_mod._tracer` to a fixture-local `TracerProvider` but never restored the original tracer after shutdown. Later tests in the same pytest process (notably `tests/unit/test_ping.py`) then routed spans through a shut-down provider, causing four ping tests to fail when `tests/integration/` ran before `tests/unit/`.

Save and restore the module tracer in teardown, matching the pattern already used in `tests/agents/test_record_outcome.py`.

## Related issue

Closes #581

## Checklist

- [x] Tests pass (`pytest tests/integration/test_full_pipeline.py tests/unit/test_ping.py` — 21 passed; issue reproduction command now green)
- [x] Lint clean on changed file (`ruff check tests/integration/test_full_pipeline.py` — only pre-existing unused-import warnings in file header)
- [x] Type check clean (`mypy tokenjam/`)
- [ ] CLAUDE.md updated (if architecture changed) — N/A
- [ ] Test spans use `tests/factories.py` (not raw `NormalizedSpan`) — N/A
- [x] Requested `@anilmurty` as reviewer

## Tests

- `pytest tests/integration/test_full_pipeline.py tests/unit/test_ping.py` — **21 passed** (was 4 failed before fix)
- `pytest tests/unit/ tests/synthetic/ tests/agents/ tests/integration/` — 4340 passed, 5 failed (pre-existing unrelated failures in `test_backfill_progress.py`, `test_quickstart.py`, `test_sdk_config_discovery.py`)

## Notes

Reviewed with composer-2.5: **APPROVE**. Minimal three-line fix; teardown order (`provider.shutdown()` then restore) is correct.