### PR TITLE
UI corrections: FAQ page, rescan control, Summarize gate, inbox action rows (plus daily budgets and drift/alerts)

### DIFF
--- a/tests/integration/test_api.py
+++ b/tests/integration/test_api.py
@@ -964,6 +964,139 @@ async def test_get_drift_without_agent_id_returns_all(client):
     assert "agents" in data
 
 
+def _drift_baseline(agent_id: str):
+    """A baseline row for `agent_id` with realistic-looking spread."""
+    from tokenjam.core.models import DriftBaseline
+    from tokenjam.utils.time_parse import utcnow
+
+    return DriftBaseline(
+        agent_id=agent_id,
+        sessions_sampled=12,
+        computed_at=utcnow(),
+        avg_input_tokens=4200.0,
+        stddev_input_tokens=310.0,
+        avg_output_tokens=800.0,
+        stddev_output_tokens=90.0,
+        avg_session_duration_s=45.0,
+        stddev_session_duration=6.0,
+        avg_tool_call_count=3.0,
+        stddev_tool_call_count=0.0,
+    )
+
+
+@pytest.mark.asyncio
+async def test_drift_list_excludes_interactive_coding_agent_baselines(tmp_path):
+    """A legacy coding-agent baseline must never render as a drift card.
+
+    `DriftDetector.on_session_end` already refuses to build one, but baselines
+    are written once and never recomputed, so a row from before that skip (or
+    from an id reclassified since) survives forever. The read path applies the
+    same persona gate so the two cannot disagree.
+    """
+    from tokenjam.core.db import DuckDBBackend
+    from tokenjam.core.config import StorageConfig
+
+    db = DuckDBBackend(StorageConfig(path=str(tmp_path / "t.duckdb")))
+    try:
+        config = TjConfig(
+            version="1",
+            security=SecurityConfig(ingest_secret=INGEST_SECRET),
+            api=ApiConfig(auth=ApiAuthConfig(enabled=False)),
+        )
+        pipeline = IngestPipeline(db=db, config=config)
+        db.upsert_baseline(_drift_baseline("claude-code"))
+        db.upsert_baseline(_drift_baseline("codex-cli"))
+        db.upsert_baseline(_drift_baseline("prod-summarizer"))
+
+        app = create_app(config=config, db=db, ingest_pipeline=pipeline)
+        transport = httpx.ASGITransport(app=app)
+        async with httpx.AsyncClient(transport=transport, base_url="http://test") as c:
+            resp = await c.get("/api/v1/drift")
+            assert resp.status_code == 200
+            agent_ids = [a["agent_id"] for a in resp.json()["agents"]]
+            assert agent_ids == ["prod-summarizer"]
+    finally:
+        db.close()
+
+
+@pytest.mark.asyncio
+async def test_drift_for_a_single_coding_agent_returns_no_baseline(tmp_path):
+    """The explicit `?agent_id=` path applies the same gate as the list path."""
+    from tokenjam.core.db import DuckDBBackend
+    from tokenjam.core.config import StorageConfig
+
+    db = DuckDBBackend(StorageConfig(path=str(tmp_path / "t.duckdb")))
+    try:
+        config = TjConfig(
+            version="1",
+            security=SecurityConfig(ingest_secret=INGEST_SECRET),
+            api=ApiConfig(auth=ApiAuthConfig(enabled=False)),
+        )
+        pipeline = IngestPipeline(db=db, config=config)
+        db.upsert_baseline(_drift_baseline("claude-code"))
+
+        app = create_app(config=config, db=db, ingest_pipeline=pipeline)
+        transport = httpx.ASGITransport(app=app)
+        async with httpx.AsyncClient(transport=transport, base_url="http://test") as c:
+            resp = await c.get("/api/v1/drift", params={"agent_id": "claude-code"})
+            assert resp.status_code == 200
+            body = resp.json()
+            assert body["baseline"] is None
+            assert body["baseline_skipped_reason"] == "interactive_coding_agent"
+    finally:
+        db.close()
+
+
+@pytest.mark.asyncio
+async def test_acknowledging_an_alert_drops_it_from_the_unread_list(tmp_path):
+    """The contract the Alerts screen's Acknowledge button relies on.
+
+    The endpoint existed with no control wired to it, so nothing exercised the
+    acknowledge-then-refetch round trip the UI performs: PATCH with a JSON body,
+    then re-read with `unread=true` and expect the alert to be gone.
+    """
+    from tokenjam.core.db import DuckDBBackend
+    from tokenjam.core.config import StorageConfig
+    from tokenjam.core.models import Alert, AlertType, Severity
+    from tokenjam.utils.time_parse import utcnow
+
+    db = DuckDBBackend(StorageConfig(path=str(tmp_path / "t.duckdb")))
+    try:
+        config = TjConfig(
+            version="1",
+            security=SecurityConfig(ingest_secret=INGEST_SECRET),
+            api=ApiConfig(auth=ApiAuthConfig(enabled=False)),
+        )
+        pipeline = IngestPipeline(db=db, config=config)
+        alert = Alert(
+            alert_id="ack-me",
+            fired_at=utcnow(),
+            type=AlertType.SESSION_DURATION,
+            severity=Severity.WARNING,
+            title="Long session",
+            detail={},
+            agent_id="prod-summarizer",
+            acknowledged=False,
+        )
+        db.insert_alert(alert)
+
+        app = create_app(config=config, db=db, ingest_pipeline=pipeline)
+        transport = httpx.ASGITransport(app=app)
+        async with httpx.AsyncClient(transport=transport, base_url="http://test") as c:
+            resp = await c.get("/api/v1/alerts", params={"unread": "true"})
+            assert [a["alert_id"] for a in resp.json()["alerts"]] == ["ack-me"]
+
+            resp = await c.patch("/api/v1/alerts/ack-me/acknowledge", json={})
+            assert resp.status_code == 200
+            assert resp.json() == {"acknowledged": True, "alert_id": "ack-me"}
+
+            resp = await c.get("/api/v1/alerts", params={"unread": "true"})
+            assert resp.json()["alerts"] == []
+            resp = await c.get("/api/v1/alerts")
+            assert resp.json()["alerts"][0]["acknowledged"] is True
+    finally:
+        db.close()
+
 # ── API key auth ───────────────────────────────────────────────────────────
 
 async def test_get_endpoint_requires_api_key_when_auth_enabled(auth_client):

--- a/tests/integration/test_storage_backend_parity.py
+++ b/tests/integration/test_storage_backend_parity.py
@@ -109,6 +109,7 @@ SHIM_NOT_IMPLEMENTED = {
     "delete_spans_before",
     "get_active_session",
     "get_cost_delta_by_group",
+    "get_daily_cost_for_agents",
     "get_distinct_agent_ids",
     "get_policy_decisions",
     "get_savings_entries",

--- a/tests/synthetic/test_alert_rules.py
+++ b/tests/synthetic/test_alert_rules.py
@@ -19,7 +19,9 @@ from tokenjam.core.config import (
     AlertChannelConfig,
     AlertsConfig,
     BudgetConfig,
+    CodingGroupConfig,
     DefaultsConfig,
+    GroupBudgetConfig,
     TjConfig,
     SensitiveAction,
 )
@@ -244,6 +246,101 @@ def test_cost_budget_daily_inherits_from_defaults_when_agent_has_only_session():
     alerts = [call[0][0] for call in db.insert_alert.call_args_list]
     daily_alerts = [a for a in alerts if a.type == AlertType.COST_BUDGET_DAILY]
     assert len(daily_alerts) == 1
+
+
+# ── Coding-tool group daily budget ──────────────────────────────────────────
+# A coding agent_id (claude-code / claude-code-<project> / codex_exec) is
+# checked against its GROUP's summed daily spend, not its own agent_id alone
+# -- core/agent_kind.py classifies the id, core/alerts.py's
+# _check_coding_group_daily_budget sums across every member.
+
+def test_coding_group_daily_budget_fires_on_summed_group_spend():
+    config = _make_config()
+    config.coding_agents = {
+        "claude-code": CodingGroupConfig(budget=GroupBudgetConfig(daily_usd=50.0)),
+    }
+    engine, db = _make_engine(config)
+    db.get_distinct_agent_ids.return_value = [
+        f"claude-code-proj-{i}" for i in range(20)
+    ]
+    db.get_daily_cost_for_agents.return_value = 60.0  # 20 agents * $3, no single one over $50
+    session = make_session(agent_id="claude-code-proj-0")
+    engine.evaluate_session_end(session)
+    alerts = [call[0][0] for call in db.insert_alert.call_args_list]
+    daily_alerts = [a for a in alerts if a.type == AlertType.COST_BUDGET_DAILY]
+    assert len(daily_alerts) == 1
+    assert daily_alerts[0].detail["group"] == "claude-code"
+    assert daily_alerts[0].detail["daily_cost"] == 60.0
+    # The per-agent daily path (get_daily_cost) must NOT be used for a coding agent.
+    db.get_daily_cost.assert_not_called()
+
+
+def test_coding_group_daily_budget_does_not_fire_under_group_cap():
+    config = _make_config()
+    config.coding_agents = {
+        "claude-code": CodingGroupConfig(budget=GroupBudgetConfig(daily_usd=100.0)),
+    }
+    engine, db = _make_engine(config)
+    db.get_distinct_agent_ids.return_value = ["claude-code-proj-a"]
+    db.get_daily_cost_for_agents.return_value = 10.0
+    session = make_session(agent_id="claude-code-proj-a")
+    engine.evaluate_session_end(session)
+    daily_alerts = [
+        c[0][0] for c in db.insert_alert.call_args_list
+        if c[0][0].type == AlertType.COST_BUDGET_DAILY
+    ]
+    assert daily_alerts == []
+
+
+def test_coding_group_daily_budget_inherits_coding_zone_default():
+    """A tool with no explicit [coding_agents.<id>] entry yet still gets
+    capped, from [defaults.coding_budget] -- never arrives uncapped."""
+    config = _make_config()
+    config.defaults.coding_budget = GroupBudgetConfig(daily_usd=25.0)
+    engine, db = _make_engine(config)
+    db.get_distinct_agent_ids.return_value = ["codex_exec"]
+    db.get_daily_cost_for_agents.return_value = 30.0
+    session = make_session(agent_id="codex_exec")
+    engine.evaluate_session_end(session)
+    daily_alerts = [
+        c[0][0] for c in db.insert_alert.call_args_list
+        if c[0][0].type == AlertType.COST_BUDGET_DAILY
+    ]
+    assert len(daily_alerts) == 1
+    assert daily_alerts[0].detail["group"] == "codex"
+
+
+def test_coding_group_daily_budget_includes_agent_ids_not_yet_in_distinct_list():
+    """A brand-new agent_id whose own row hasn't landed in
+    get_distinct_agent_ids() yet is still included in the summed group."""
+    config = _make_config()
+    config.coding_agents = {
+        "claude-code": CodingGroupConfig(budget=GroupBudgetConfig(daily_usd=5.0)),
+    }
+    engine, db = _make_engine(config)
+    db.get_distinct_agent_ids.return_value = []  # brand new agent not listed yet
+    db.get_daily_cost_for_agents.return_value = 6.0
+    session = make_session(agent_id="claude-code-brand-new")
+    engine.evaluate_session_end(session)
+    db.get_daily_cost_for_agents.assert_called_once()
+    called_ids = db.get_daily_cost_for_agents.call_args[0][0]
+    assert "claude-code-brand-new" in called_ids
+
+
+def test_sdk_agent_daily_budget_unchanged_by_coding_group_logic():
+    """An SDK workflow (not claude-code/codex) keeps the original per-agent
+    daily check and never touches the group-sum path."""
+    config = _make_config(agents={
+        "sdk-workflow-1": AgentConfig(budget=BudgetConfig(daily_usd=10.0)),
+    })
+    engine, db = _make_engine(config)
+    db.get_daily_cost.return_value = 12.0
+    session = make_session(agent_id="sdk-workflow-1")
+    engine.evaluate_session_end(session)
+    db.insert_alert.assert_called()
+    alert: Alert = db.insert_alert.call_args[0][0]
+    assert alert.type == AlertType.COST_BUDGET_DAILY
+    db.get_daily_cost_for_agents.assert_not_called()
 
 
 # ── Session duration ────���─────────────────────────────────────���────────────

--- a/tests/unit/test_agent_kind.py
+++ b/tests/unit/test_agent_kind.py
@@ -1,0 +1,69 @@
+"""Unit tests for tokenjam.core.agent_kind — the single source of truth for
+classifying an agent_id into a coding-tool GROUP (claude-code / codex) or an
+SDK workflow, used by both the budget API route and the alert engine's
+group-scoped daily-cap enforcement.
+"""
+from __future__ import annotations
+
+import pytest
+
+from tokenjam.core.agent_kind import (
+    AgentKind,
+    classify_agent_kind,
+    coding_group_id,
+    group_agent_ids,
+    is_coding_agent,
+    present_coding_groups,
+    sdk_agent_ids,
+)
+
+
+@pytest.mark.parametrize("agent_id,expected", [
+    ("claude-code", AgentKind(is_coding=True, group="claude-code")),
+    ("claude-code-my-project", AgentKind(is_coding=True, group="claude-code")),
+    ("claude-code-tokenjam", AgentKind(is_coding=True, group="claude-code")),
+    ("codex_exec", AgentKind(is_coding=True, group="codex")),
+    # Codex hardcodes codex_exec globally — no per-project variant exists, so
+    # a hypothetical "codex-something" must NOT collapse into the codex group.
+    ("codex-myrepo", AgentKind(is_coding=False, group=None)),
+    ("codex", AgentKind(is_coding=False, group=None)),
+    ("billing-agent", AgentKind(is_coding=False, group=None)),
+    ("sdk-workflow-7", AgentKind(is_coding=False, group=None)),
+    (None, AgentKind(is_coding=False, group=None)),
+    ("", AgentKind(is_coding=False, group=None)),
+])
+def test_classify_agent_kind_margin_cases(agent_id, expected):
+    assert classify_agent_kind(agent_id) == expected
+
+
+def test_is_coding_agent_matches_classify():
+    assert is_coding_agent("claude-code-foo") is True
+    assert is_coding_agent("codex_exec") is True
+    assert is_coding_agent("sdk-thing") is False
+
+
+def test_coding_group_id():
+    assert coding_group_id("claude-code-foo") == "claude-code"
+    assert coding_group_id("codex_exec") == "codex"
+    assert coding_group_id("sdk-thing") is None
+
+
+def test_group_agent_ids_filters_to_the_named_group():
+    ids = ["claude-code-a", "claude-code-b", "codex_exec", "sdk-x", "claude-code"]
+    assert set(group_agent_ids(ids, "claude-code")) == {
+        "claude-code-a", "claude-code-b", "claude-code",
+    }
+    assert group_agent_ids(ids, "codex") == ["codex_exec"]
+
+
+def test_sdk_agent_ids_excludes_both_coding_groups():
+    ids = ["claude-code-a", "codex_exec", "sdk-x", "sdk-y"]
+    assert set(sdk_agent_ids(ids)) == {"sdk-x", "sdk-y"}
+
+
+def test_present_coding_groups_only_lists_groups_actually_seen():
+    assert present_coding_groups(["claude-code-a", "sdk-x"]) == ["claude-code"]
+    assert present_coding_groups(["codex_exec"]) == ["codex"]
+    assert present_coding_groups(["sdk-x"]) == []
+    # Order is always claude-code before codex when both present.
+    assert present_coding_groups(["codex_exec", "claude-code"]) == ["claude-code", "codex"]

--- a/tests/unit/test_budget_group_cost.py
+++ b/tests/unit/test_budget_group_cost.py
@@ -1,0 +1,73 @@
+"""Unit tests for DuckDBBackend.get_daily_cost_for_agents — the summed-daily-
+cost-over-a-SET-of-agent_ids query that a coding-tool GROUP budget cap
+(e.g. every claude-code-<project> variant) is checked against, generalizing
+the existing single-agent get_daily_cost.
+"""
+from __future__ import annotations
+
+from datetime import timedelta
+
+import pytest
+
+from tokenjam.core.db import InMemoryBackend
+from tokenjam.utils.time_parse import utcnow
+from tests.factories import make_llm_span
+
+
+@pytest.fixture
+def db():
+    backend = InMemoryBackend()
+    yield backend
+    backend.close()
+
+
+def _seed(db, agent_id, cost_usd, when=None):
+    span = make_llm_span(agent_id=agent_id, cost_usd=cost_usd, start_time=when or utcnow())
+    db.insert_span(span)
+
+
+def test_sums_cost_across_multiple_agent_ids_same_day(db):
+    today = utcnow().date()
+    _seed(db, "claude-code-proj-a", 3.0)
+    _seed(db, "claude-code-proj-b", 4.5)
+    _seed(db, "claude-code-proj-c", 0.5)
+    total = db.get_daily_cost_for_agents(
+        ["claude-code-proj-a", "claude-code-proj-b", "claude-code-proj-c"], today,
+    )
+    assert total == pytest.approx(8.0)
+
+
+def test_group_cap_trips_on_summed_spend_where_no_single_member_would(db):
+    """The load-bearing case: 20 agents at a small individual spend each,
+    none of which alone crosses a per-agent-sized cap, must still sum past a
+    group cap sized for the tool as a whole."""
+    today = utcnow().date()
+    member_ids = [f"claude-code-proj-{i}" for i in range(20)]
+    for aid in member_ids:
+        _seed(db, aid, 3.0)  # $3 each; no individual agent exceeds e.g. a $10 cap
+    total = db.get_daily_cost_for_agents(member_ids, today)
+    assert total == pytest.approx(60.0)
+    group_cap = 50.0
+    assert total > group_cap  # trips the group cap
+    assert all(db.get_daily_cost(aid, today) < group_cap for aid in member_ids)  # no individual would
+
+
+def test_only_sums_the_named_agent_ids_not_others(db):
+    today = utcnow().date()
+    _seed(db, "claude-code-proj-a", 3.0)
+    _seed(db, "some-other-agent", 999.0)
+    total = db.get_daily_cost_for_agents(["claude-code-proj-a"], today)
+    assert total == pytest.approx(3.0)
+
+
+def test_excludes_spend_from_a_different_day(db):
+    today = utcnow().date()
+    yesterday = utcnow() - timedelta(days=1)
+    _seed(db, "claude-code-proj-a", 3.0, when=yesterday)
+    _seed(db, "claude-code-proj-a", 2.0, when=utcnow())
+    total = db.get_daily_cost_for_agents(["claude-code-proj-a"], today)
+    assert total == pytest.approx(2.0)
+
+
+def test_empty_agent_id_list_returns_zero(db):
+    assert db.get_daily_cost_for_agents([], utcnow().date()) == 0.0

--- a/tests/unit/test_budget_route.py
+++ b/tests/unit/test_budget_route.py
@@ -23,6 +23,7 @@ from tokenjam.core.config import (
     CodingGroupConfig,
     DefaultsConfig,
     GroupBudgetConfig,
+    load_config,
     TjConfig,
     active_config_path,
 )
@@ -160,6 +161,76 @@ def test_post_sdk_agent_scope_unchanged_daily_and_session(tmp_path, db):
     sdk = resp.json()["sdk"]["agents"]["sdk-workflow-x"]
     assert sdk["configured"]["daily_usd"] == 12.0
     assert sdk["configured"]["session_usd"] == 3.0
+
+
+def test_get_response_is_a_superset_carrying_the_legacy_top_level_shape(tmp_path, db):
+    """The still-committed old BudgetView reads `data.defaults.daily_usd` /
+    `data.defaults.session_usd` (unguarded) and `Object.entries(data.agents)`
+    directly off the GET response -- not the new `coding`/`sdk` zones. Until
+    that view is rewritten (a separate, in-flight change on this same
+    branch), the response MUST still carry those two top-level keys with the
+    exact old per-agent-flat-row values, or the page throws on render."""
+    db.upsert_session(make_session(agent_id="claude-code-proj-a", session_id="s1"))
+    db.upsert_session(make_session(agent_id="sdk-workflow-a", session_id="s2"))
+    config = _config(
+        tmp_path,
+        defaults=DefaultsConfig(budget=BudgetConfig(daily_usd=9.0, session_usd=2.0)),
+        agents={"sdk-workflow-a": AgentConfig(budget=BudgetConfig(daily_usd=4.0, session_usd=1.0))},
+    )
+    with _client(config, db) as client:
+        resp = client.get("/api/v1/budget")
+    body = resp.json()
+
+    # Legacy top-level "defaults" — exactly the old {daily_usd, session_usd} shape.
+    assert body["defaults"] == {"daily_usd": 9.0, "session_usd": 2.0}
+
+    # Legacy top-level "agents" — ONE FLAT ROW PER agent_id, coding and SDK
+    # alike, un-grouped (the pre-redesign behavior), each with
+    # configured/effective sub-objects.
+    assert set(body["agents"].keys()) == {"claude-code-proj-a", "sdk-workflow-a"}
+    assert body["agents"]["sdk-workflow-a"]["configured"] == {"daily_usd": 4.0, "session_usd": 1.0}
+    assert body["agents"]["sdk-workflow-a"]["effective"] == {"daily_usd": 4.0, "session_usd": 1.0}
+    # A coding agent with no per-agent override still gets a flat legacy row,
+    # falling back to the legacy defaults (not the new coding-group default).
+    assert body["agents"]["claude-code-proj-a"]["configured"] == {"daily_usd": None, "session_usd": None}
+    assert body["agents"]["claude-code-proj-a"]["effective"] == {"daily_usd": 9.0, "session_usd": 2.0}
+
+
+def test_legacy_shaped_post_roundtrips_through_the_new_schema(tmp_path, db):
+    """Exactly the payload the still-committed old BudgetView.handleSave
+    sends: {scope, daily_usd, session_usd}, with scope either "defaults" or
+    a literal agent_id -- including a claude-code-<project> id, since the
+    old UI has no concept of coding-tool grouping and writes one row per
+    agent_id it saw. Must persist through the NEW config schema (BudgetConfig
+    on config.agents[<id>].budget, unchanged) and the response must still
+    reflect it under the legacy top-level "agents" key."""
+    config = _config(tmp_path)
+    with _client(config, db) as client:
+        # Legacy defaults-scope save.
+        resp = client.post(
+            "/api/v1/budget", json={"scope": "defaults", "daily_usd": 15.0, "session_usd": 3.0},
+        )
+        assert resp.status_code == 200
+        assert resp.json()["defaults"] == {"daily_usd": 15.0, "session_usd": 3.0}
+
+        # Legacy per-agent save on a literal coding-project agent_id, exactly
+        # as the un-rewritten UI still does (one row per project it observed).
+        resp2 = client.post(
+            "/api/v1/budget",
+            json={"scope": "claude-code-my-project", "daily_usd": 6.0, "session_usd": 1.25},
+        )
+        assert resp2.status_code == 200
+        body2 = resp2.json()
+        assert body2["agents"]["claude-code-my-project"]["configured"] == {
+            "daily_usd": 6.0, "session_usd": 1.25,
+        }
+
+    # And it actually persisted to config, not just the in-memory response.
+    reloaded = load_config(str(config.config_path))
+    assert reloaded.defaults.budget.daily_usd == 15.0
+    assert reloaded.defaults.budget.session_usd == 3.0
+    assert reloaded.agents["claude-code-my-project"].budget.daily_usd == 6.0
+    assert reloaded.agents["claude-code-my-project"].budget.session_usd == 1.25
 
 
 def test_post_daily_only_preserves_an_existing_session_usd(tmp_path, db):

--- a/tests/unit/test_budget_route.py
+++ b/tests/unit/test_budget_route.py
@@ -1,0 +1,177 @@
+"""GET/POST /api/v1/budget — the redesigned Budget page's two-zone response.
+
+Pins the response SHAPE (`coding` zone grouped by tool, `sdk` zone grouped by
+literal agent_id) and the write paths for each: a coding-tool group's daily
+cap (`scope: "group:<id>"`), the coding-zone default (`scope:
+"defaults_coding"`), the SDK-zone default (`scope: "defaults"`), and an SDK
+workflow's own agent_id. Does not touch `POST /budget/provider` (a separate,
+unrelated forecast concept).
+"""
+from __future__ import annotations
+
+from datetime import date
+
+import pytest
+from fastapi.testclient import TestClient
+
+from tokenjam.api.app import create_app
+from tokenjam.core.config import (
+    ApiAuthConfig,
+    ApiConfig,
+    AgentConfig,
+    BudgetConfig,
+    CodingGroupConfig,
+    DefaultsConfig,
+    GroupBudgetConfig,
+    TjConfig,
+    active_config_path,
+)
+from tokenjam.core.db import InMemoryBackend
+from tokenjam.core.ingest import build_default_pipeline
+from tests.factories import make_session
+
+
+def _config(tmp_path, **kwargs) -> TjConfig:
+    cfg = TjConfig(version="1", api=ApiConfig(auth=ApiAuthConfig(enabled=False)), **kwargs)
+    path = tmp_path / "tokenjam.toml"
+    path.write_text('version = "1"\n')
+    cfg.config_path = path
+    return cfg
+
+
+def _client(config, db):
+    app = create_app(config=config, db=db, ingest_pipeline=build_default_pipeline(db, config))
+    return TestClient(app)
+
+
+@pytest.fixture
+def db():
+    backend = InMemoryBackend()
+    yield backend
+    backend.close()
+
+
+def test_get_budget_shape_has_coding_and_sdk_zones(tmp_path, db):
+    config = _config(tmp_path)
+    with _client(config, db) as client:
+        resp = client.get("/api/v1/budget")
+    assert resp.status_code == 200
+    body = resp.json()
+    assert "coding" in body
+    assert "sdk" in body
+    assert "groups" in body["coding"]
+    assert "defaults" in body["coding"]
+    assert "agents" in body["sdk"]
+    assert "defaults" in body["sdk"]
+    # Unchanged, unrelated concept — still present.
+    assert "provider_budgets" in body
+    assert "framing" in body
+
+
+def test_coding_zone_groups_claude_code_projects_into_one_row(tmp_path, db):
+    for aid in ["claude-code-proj-a", "claude-code-proj-b", "claude-code"]:
+        db.upsert_session(make_session(agent_id=aid, session_id=f"s-{aid}"))
+    config = _config(tmp_path)
+    with _client(config, db) as client:
+        resp = client.get("/api/v1/budget")
+    groups = resp.json()["coding"]["groups"]
+    assert set(groups.keys()) == {"claude-code"}
+    assert set(groups["claude-code"]["members"]) == {
+        "claude-code-proj-a", "claude-code-proj-b", "claude-code",
+    }
+
+
+def test_codex_exact_id_forms_its_own_group_separate_from_claude_code(tmp_path, db):
+    db.upsert_session(make_session(agent_id="claude-code-proj-a", session_id="s1"))
+    db.upsert_session(make_session(agent_id="codex_exec", session_id="s2"))
+    config = _config(tmp_path)
+    with _client(config, db) as client:
+        resp = client.get("/api/v1/budget")
+    groups = resp.json()["coding"]["groups"]
+    assert set(groups.keys()) == {"claude-code", "codex"}
+    assert groups["codex"]["members"] == ["codex_exec"]
+
+
+def test_sdk_workflow_gets_its_own_row_not_grouped(tmp_path, db):
+    db.upsert_session(make_session(agent_id="sdk-workflow-a", session_id="s1"))
+    db.upsert_session(make_session(agent_id="sdk-workflow-b", session_id="s2"))
+    config = _config(tmp_path)
+    with _client(config, db) as client:
+        resp = client.get("/api/v1/budget")
+    sdk_agents = resp.json()["sdk"]["agents"]
+    assert set(sdk_agents.keys()) == {"sdk-workflow-a", "sdk-workflow-b"}
+
+
+def test_only_present_or_explicitly_configured_groups_are_returned(tmp_path, db):
+    """No data at all for codex, but it IS explicitly configured -- still
+    shown (so a pre-set cap survives before the first session lands).
+    claude-code has data but no explicit config -- also shown. Nothing else
+    invented."""
+    db.upsert_session(make_session(agent_id="claude-code-proj-a", session_id="s1"))
+    config = _config(
+        tmp_path,
+        coding_agents={"codex": CodingGroupConfig(budget=GroupBudgetConfig(daily_usd=20.0))},
+    )
+    with _client(config, db) as client:
+        resp = client.get("/api/v1/budget")
+    groups = resp.json()["coding"]["groups"]
+    assert set(groups.keys()) == {"claude-code", "codex"}
+    assert groups["codex"]["members"] == []
+    assert groups["codex"]["configured"]["daily_usd"] == 20.0
+
+
+def test_post_group_scope_writes_the_group_cap(tmp_path, db):
+    config = _config(tmp_path)
+    with _client(config, db) as client:
+        resp = client.post("/api/v1/budget", json={"scope": "group:claude-code", "daily_usd": 50.0})
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["coding"]["groups"]["claude-code"]["configured"]["daily_usd"] == 50.0
+    assert body["coding"]["groups"]["claude-code"]["effective"]["daily_usd"] == 50.0
+
+
+def test_post_group_scope_rejects_session_usd(tmp_path, db):
+    config = _config(tmp_path)
+    with _client(config, db) as client:
+        resp = client.post(
+            "/api/v1/budget",
+            json={"scope": "group:claude-code", "daily_usd": 50.0, "session_usd": 5.0},
+        )
+    assert resp.status_code == 400
+    assert "session_usd" in resp.json()["error"]
+
+
+def test_post_defaults_coding_scope_writes_the_zone_default(tmp_path, db):
+    config = _config(tmp_path)
+    with _client(config, db) as client:
+        resp = client.post("/api/v1/budget", json={"scope": "defaults_coding", "daily_usd": 25.0})
+    assert resp.status_code == 200
+    assert resp.json()["coding"]["defaults"]["daily_usd"] == 25.0
+
+
+def test_post_sdk_agent_scope_unchanged_daily_and_session(tmp_path, db):
+    config = _config(tmp_path)
+    with _client(config, db) as client:
+        resp = client.post(
+            "/api/v1/budget",
+            json={"scope": "sdk-workflow-x", "daily_usd": 12.0, "session_usd": 3.0},
+        )
+    assert resp.status_code == 200
+    sdk = resp.json()["sdk"]["agents"]["sdk-workflow-x"]
+    assert sdk["configured"]["daily_usd"] == 12.0
+    assert sdk["configured"]["session_usd"] == 3.0
+
+
+def test_post_daily_only_preserves_an_existing_session_usd(tmp_path, db):
+    """A save that only touches daily_usd must not erase a session_usd the
+    user already had configured on that same SDK agent scope."""
+    config = _config(
+        tmp_path,
+        agents={"legacy-agent": AgentConfig(budget=BudgetConfig(daily_usd=5.0, session_usd=1.5))},
+    )
+    with _client(config, db) as client:
+        resp = client.post("/api/v1/budget", json={"scope": "legacy-agent", "daily_usd": 8.0})
+    assert resp.status_code == 200
+    sdk = resp.json()["sdk"]["agents"]["legacy-agent"]
+    assert sdk["configured"]["daily_usd"] == 8.0
+    assert sdk["configured"]["session_usd"] == 1.5

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -7,7 +7,9 @@ from tokenjam.core.config import (
     find_config_file, load_config, resolve_config_path, _parse, _serialise,
     TjConfig, AgentConfig, BudgetConfig, DefaultsConfig, SensitiveAction,
     SecurityConfig, CaptureConfig, OptimizeConfig, StorageConfig,
-    resolve_effective_budget, validate_budget_value, validate_cycle_start_day,
+    CodingGroupConfig, GroupBudgetConfig,
+    resolve_effective_budget, resolve_group_budget,
+    validate_budget_value, validate_cycle_start_day,
 )
 
 
@@ -429,6 +431,88 @@ class TestResolveEffectiveBudget:
         eff = resolve_effective_budget("a", config)
         assert eff.daily_usd == 10.0
         assert eff.session_usd == 5.0
+
+
+class TestCodingAgentGroupBudget:
+    """[coding_agents.<group_id>.budget] — daily-only ceilings for a coding
+    TOOL group ("claude-code" / "codex"), a separate top-level TOML table
+    from [agents.*] so a group id like "claude-code" never collides with a
+    literal per-agent [agents.claude-code] entry."""
+
+    def test_group_roundtrip(self):
+        config = TjConfig(
+            version="1",
+            coding_agents={
+                "claude-code": CodingGroupConfig(budget=GroupBudgetConfig(daily_usd=50.0)),
+                "codex": CodingGroupConfig(budget=GroupBudgetConfig(daily_usd=20.0)),
+            },
+        )
+        serialised = _serialise(config)
+        assert serialised["coding_agents"]["claude-code"]["budget"]["daily_usd"] == 50.0
+        restored = _parse(serialised)
+        assert restored.coding_agents["claude-code"].budget.daily_usd == 50.0
+        assert restored.coding_agents["codex"].budget.daily_usd == 20.0
+
+    def test_absent_coding_agents_section_parses_empty(self):
+        assert _parse({"version": "1"}).coding_agents == {}
+
+    def test_group_namespace_does_not_collide_with_bare_agent_of_same_name(self):
+        """A literal [agents.claude-code] entry (bare agent_id) and a
+        [coding_agents.claude-code] group cap must coexist independently."""
+        raw = {
+            "version": "1",
+            "agents": {"claude-code": {"description": "literal bare agent"}},
+            "coding_agents": {"claude-code": {"budget": {"daily_usd": 42.0}}},
+        }
+        config = _parse(raw)
+        assert config.agents["claude-code"].description == "literal bare agent"
+        assert config.coding_agents["claude-code"].budget.daily_usd == 42.0
+
+    def test_defaults_coding_budget_roundtrip(self):
+        config = TjConfig(
+            version="1",
+            defaults=DefaultsConfig(coding_budget=GroupBudgetConfig(daily_usd=100.0)),
+        )
+        restored = _parse(_serialise(config))
+        assert restored.defaults.coding_budget.daily_usd == 100.0
+
+
+class TestResolveGroupBudget:
+    def test_group_override_wins_over_defaults(self):
+        config = TjConfig(
+            version="1",
+            defaults=DefaultsConfig(coding_budget=GroupBudgetConfig(daily_usd=10.0)),
+            coding_agents={"claude-code": CodingGroupConfig(budget=GroupBudgetConfig(daily_usd=50.0))},
+        )
+        assert resolve_group_budget("claude-code", config).daily_usd == 50.0
+
+    def test_unconfigured_group_inherits_zone_default(self):
+        """A newly-appearing tool with no [coding_agents.<id>] entry yet
+        inherits the coding-zone default instead of arriving uncapped."""
+        config = TjConfig(
+            version="1",
+            defaults=DefaultsConfig(coding_budget=GroupBudgetConfig(daily_usd=25.0)),
+        )
+        assert resolve_group_budget("codex", config).daily_usd == 25.0
+
+    def test_no_defaults_no_override_returns_none(self):
+        config = TjConfig(version="1")
+        assert resolve_group_budget("claude-code", config).daily_usd is None
+
+
+class TestBackwardCompatSessionUsd:
+    def test_existing_session_usd_survives_a_roundtrip_that_also_touches_daily(self):
+        """A POST that only changes daily_usd must not erase a session_usd
+        the user already had configured on the same scope."""
+        config = TjConfig(
+            version="1",
+            agents={"legacy-agent": AgentConfig(budget=BudgetConfig(daily_usd=5.0, session_usd=1.5))},
+        )
+        # Simulate a write that only touches daily_usd, as the redesigned UI does.
+        config.agents["legacy-agent"].budget.daily_usd = 8.0
+        restored = _parse(_serialise(config))
+        assert restored.agents["legacy-agent"].budget.daily_usd == 8.0
+        assert restored.agents["legacy-agent"].budget.session_usd == 1.5
 
 
 class TestValidateBudgetValue:

--- a/tests/unit/test_lens_ui_regression.py
+++ b/tests/unit/test_lens_ui_regression.py
@@ -572,11 +572,79 @@ def test_budget_view_failure_does_not_blank_content_it_already_has(html):
     assert 'class="band-msg err"' in budget
     assert "Couldn't refresh budget data." in budget
     assert "setError(null);" in budget
-    # The per-agent and provider tables still render below the banner --
+    # The coding, SDK, and provider tables still render below the banner --
     # the banner never replaces them.
     banner_idx = budget.index('class="band-msg err"')
-    assert budget.index("Per-agent budget caps", banner_idx) > banner_idx
+    assert budget.index("Coding-tool budget caps", banner_idx) > banner_idx
+    assert budget.index("SDK workflow budget caps", banner_idx) > banner_idx
     assert budget.index("Provider spend forecast", banner_idx) > banner_idx
+
+
+def test_budget_view_has_two_daily_only_zones_no_session_column(html):
+    """The Budget-page redesign (api/routes/budget.py) splits the old single
+    "Per-agent budget caps" table into two zones -- coding-tool groups
+    (Claude Code / Codex, one row per TOOL) and SDK workflow agents (one row
+    per agent_id) -- and drops the per-session column from the page
+    entirely: a per-session cap on a coding agent has no reliable meaning at
+    session start, and it crowded one ceiling-per-tool into noisy
+    one-row-per-project rows. The backend still honors an already-configured
+    session_usd; this screen just never offers a way to set a new one."""
+    budget = _budget_src(html)
+
+    # Old single-zone heading + its false claim are gone.
+    assert "Per-agent budget caps" not in budget
+    assert "Fires a real-time alert the moment" not in budget
+
+    # Both new zone headings render.
+    assert "Coding-tool budget caps" in budget
+    assert "SDK workflow budget caps" in budget
+
+    # Enforcement is described accurately: session end, not the instant
+    # spend crosses the line.
+    assert "session end" in budget
+
+    # Per-session column and its handling are gone from BudgetView / its row
+    # component -- no sessionVal state, no session_usd sent on save (a
+    # comment may still name session_usd to explain why it's absent, but no
+    # payload field or JS binding does), no "Per-session (USD)" header.
+    assert "Per-session (USD)" not in budget
+    assert "sessionVal" not in budget
+    assert "session_usd:" not in budget
+    assert "session_usd,\n" not in budget
+
+    # Both zones read the coding/sdk superset, never the legacy top-level keys.
+    assert "data.coding.groups" in budget
+    assert "data.coding.defaults" in budget
+    assert "data.sdk.agents" in budget
+    assert "data.sdk.defaults" in budget
+    assert "data.agents" not in budget
+
+    # Coding zone posts group / defaults_coding scopes; SDK zone keeps
+    # posting plain agent_id / "defaults" scopes.
+    assert '"group:" + gid' in budget or "'group:' + gid" in budget
+    assert 'scope="defaults_coding"' in budget
+    assert 'scope="defaults"' in budget
+
+    # No em dashes in the new zone copy this redesign wrote (the untouched
+    # Provider spend forecast paragraph below it keeps its own pre-existing
+    # em dash and is out of scope here).
+    coding_idx = budget.index("Coding-tool budget caps")
+    sdk_end = budget.index("</div>", budget.index("SDK workflow budget caps"))
+    zones_copy = budget[coding_idx:sdk_end]
+    assert "—" not in zones_copy
+
+
+def test_budget_row_component_is_daily_only(html):
+    """DailyBudgetRow (the shared row for both zones) never renders a
+    per-session input -- only BudgetRow's replacement should exist."""
+    assert "function DailyBudgetRow(" in html
+    assert "function BudgetRow(" not in html
+    row_start = html.index("function DailyBudgetRow(")
+    row_end = html.index("\nfunction ", row_start + 1)
+    row = html[row_start:row_end]
+    assert "sessionVal" not in row
+    assert "session_usd" not in row
+    assert row.count("<input") == 1
 
 
 def test_overview_error_handling_is_asymmetric(html):

--- a/tests/unit/test_lens_ui_regression.py
+++ b/tests/unit/test_lens_ui_regression.py
@@ -4720,26 +4720,27 @@ def test_optimize_view_renders_a_cold_state_instead_of_empty_cards(html):
 
 
 def test_analyzer_guide_nav_entry_is_unconditional_not_a_nav_child(html):
-    """The bug this pins actually shipped. The guide was a `nav-child`, and
-    App()'s route effect sets `el.style.display = (v === view) ? 'flex' : 'none'`
-    for EVERY `.nav-child` -- so the entry existed in the file, a grep-style test
-    passed, and the sidebar still showed nothing on Traces / Cost / Alerts /
-    Drift / Budget. A string-presence assertion cannot tell those apart, so this
-    asserts the property that differs: the entry must not be a nav-child, and
-    must not carry a data-param (the attribute the child-visibility rule keys
-    on). Reachability has to hold from wherever the user is, not just from the
-    one screen the page explains."""
+    """The bug this pins actually shipped. The guide (now labeled FAQ, living
+    in the Improve lens) was a `nav-child`, and App()'s route effect sets
+    `el.style.display = (v === view) ? 'flex' : 'none'` for EVERY `.nav-child`
+    -- so the entry existed in the file, a grep-style test passed, and the
+    sidebar still showed nothing on Traces / Cost / Alerts / Drift / Budget. A
+    string-presence assertion cannot tell those apart, so this asserts the
+    property that differs: the entry must not be a nav-child, and must not
+    carry a data-param (the attribute the child-visibility rule keys on).
+    Reachability has to hold from wherever the user is, not just from the one
+    screen the page explains."""
     line = next(
         ln for ln in html.splitlines()
-        if 'href="#/guide"' in ln and "nav-link" in ln
+        if 'href="#/faq"' in ln and "nav-link" in ln
     )
     assert "nav-child" not in line, (
-        "the guide nav entry is a nav-child again -- it will be display:none "
+        "the FAQ nav entry is a nav-child again -- it will be display:none "
         "everywhere except its parent section"
     )
     assert "data-param=" not in line
-    assert 'data-view="guide"' in line
-    assert 'data-lens="observe"' in line
+    assert 'data-view="faq"' in line
+    assert 'data-lens="improve"' in line
     # No CSS rule scoped to this entry may reintroduce a display condition.
     css_rules = [ln for ln in html.splitlines() if ln.startswith(".sidebar a.nav-reference")]
     assert css_rules, "the nav-reference styling vanished"
@@ -4751,7 +4752,7 @@ def test_analyzer_guide_nav_entry_is_unconditional_not_a_nav_child(html):
     eff = eff[:eff.index("}, [route.view, route.param]);")]
     display_lines = [ln for ln in eff.splitlines() if "style.display" in ln]
     assert len(display_lines) == 1, (
-        "a second display mutation appeared in the nav effect; the guide entry "
+        "a second display mutation appeared in the nav effect; the FAQ entry "
         "may now be hidden by the active view"
     )
     # ...and that single mutation lives inside the nav-child branch.
@@ -4759,27 +4760,49 @@ def test_analyzer_guide_nav_entry_is_unconditional_not_a_nav_child(html):
     assert eff.index("el.classList.contains('nav-child')") < eff.index(display_lines[0])
 
 
+def test_faq_nav_entry_is_last_in_improve_and_absent_from_observe(html):
+    """The founder's ask: FAQ moved out of Observe entirely and became the
+    LAST entry in the Improve lens sidebar, keeping the pinned-to-bottom
+    nav-reference treatment it had under Observe."""
+    nav_lines = [
+        ln for ln in html.splitlines()
+        if 'class="nav-link' in ln and 'data-lens="improve"' in ln
+    ]
+    assert nav_lines, "no Improve-lens nav links found"
+    assert 'data-view="faq"' in nav_lines[-1], (
+        "FAQ must be the last nav-link in the Improve lens group"
+    )
+    # Must not appear under Observe at all.
+    observe_lines = [
+        ln for ln in html.splitlines()
+        if 'class="nav-link' in ln and 'data-lens="observe"' in ln
+    ]
+    assert not any('data-view="faq"' in ln for ln in observe_lines)
+    assert not any('href="#/guide"' in ln for ln in observe_lines)
+
+
 def test_analyzer_guide_is_reachable_from_the_optimize_screen(html):
     """The contextual entry point, on the screen whose cards it explains. It
     renders before any `st.opt` / `scan.known` guard, so a cold or failed store
     still offers the way in."""
     fn_start = html.index("function OptimizeView({ params })")
-    fn_end = html.index("// Optimize \u25b8 Guide", fn_start)
+    fn_end = html.index("// FAQ (formerly Optimize \u25b8 Guide)", fn_start)
     fn = html[fn_start:fn_end]
-    assert 'href="#/guide"' in fn
+    assert 'href="#/faq"' in fn
     title_at = fn.index("Optimize <${PlanBadge}")
-    link_at = fn.index('href="#/guide"')
-    assert link_at - title_at < 600, "guide link drifted out of the always-rendered title block"
+    link_at = fn.index('href="#/faq"')
+    assert link_at - title_at < 600, "FAQ link drifted out of the always-rendered title block"
 
 
 def test_analyzer_guide_routes_resolve_and_old_hash_still_works(html):
-    """`#/guide` is canonical; `#/optimize/guide` is the retired spelling and
-    must keep working for anything already pointing at it."""
-    assert "['guide',     AnalyzerGuideView]," in html
-    assert "guide: 'observe'," in html, "the guide must sit in the Observe lens"
-    assert "if (v === 'optimize' && route.param === 'guide') return 'guide';" in html
+    """`#/faq` is canonical; `#/optimize/guide` and `#/guide` are the retired
+    spellings and must keep working for anything already pointing at them."""
+    assert "['faq',       AnalyzerGuideView]," in html
+    assert "faq: 'improve'," in html, "FAQ must sit in the Improve lens"
+    assert "if (v === 'optimize' && route.param === 'guide') return 'faq';" in html
+    assert "if (v === 'guide') return 'faq';" in html
     assert "function isLegacyGuideRoute(route)" in html
-    assert "history.replaceState(null, '', '#/guide');" in html
+    assert "history.replaceState(null, '', '#/faq');" in html
 
 
 def test_analyzer_guide_reads_the_gate_from_the_server_not_a_js_copy(html):

--- a/tests/unit/test_lens_ui_regression.py
+++ b/tests/unit/test_lens_ui_regression.py
@@ -4675,13 +4675,87 @@ def test_budgets_at_risk_cannot_report_ready_off_a_cold_store(html):
 
 
 def test_both_analyzer_surfaces_carry_provenance_and_a_rescan_control(html):
-    # The Dashboard band and the Optimize view both mount the shared ScanBar, so
-    # neither can render figures without saying when they were computed.
-    assert html.count("<${ScanBar}") >= 2
+    # The Dashboard band, the Optimize view and the Review inbox all mount the
+    # shared ScanBar, so none of the three can render figures without saying
+    # when they were computed.
+    assert html.count("<${ScanBar}") >= 3
     # A rescan that FAILED must not look like one that succeeded, so the POST
     # goes through the helper that surfaces the server's reason.
     assert "apiPostOrDetail('/optimize/rescan', {})" in html
     assert "rescan failed: " in html
+
+
+def test_rescan_control_is_a_prominent_accessible_button_not_a_bare_link(html):
+    """Founder constraints: prominent, not dark blue, real hover/active/disabled/
+    focus states, keyboard-operable. A styled <span onClick> link is none of
+    that; a <button> with a dedicated class is."""
+    fn_start = html.index("function ScanBar({ scan, busy, error, onRescan })")
+    fn_end = html.index("\n// A rescan button plus the state", fn_start)
+    fn = html[fn_start:fn_end]
+    assert '<button type="button" class="rescan-ctl' in fn
+    assert "disabled=${scanning}" in fn
+
+    css_start = html.index(".rescan-ctl {")
+    css_end = html.index(".btn-restore {", css_start)
+    css = html[css_start:css_end]
+    # Monochrome accent, never the brand blue used for logo/category fills.
+    assert "var(--brand)" not in css
+    assert "var(--accent)" in css
+    assert ":hover:not(:disabled)" in css
+    assert ":active:not(:disabled)" in css
+    assert ":focus-visible" in css
+    assert ":disabled" in css
+
+
+def test_rescan_control_sits_top_right_of_each_heading_row(html):
+    """Placement requirement: top right of the content area, aligned with the
+    page heading row -- not buried in a filters row or a sub-band."""
+    # Optimize: ScanBar is a sibling of the page-title block inside a
+    # space-between flex row, not inside `.filters` any more.
+    opt_start = html.index("function OptimizeView({ params })")
+    opt_end = html.index("\n// Two lenses, one router", opt_start)
+    opt_fn = html[opt_start:opt_end]
+    head_start = opt_fn.index("justify-content:space-between")
+    filters_start = opt_fn.index('<div class="filters">')
+    scanbar_in_head = opt_fn.index("<${ScanBar}", head_start)
+    assert head_start < scanbar_in_head < filters_start, (
+        "Optimize's ScanBar must render in the heading row, before .filters"
+    )
+
+    # Dashboard: ScanBar renders inside `.ov-head`, alongside the window
+    # picker, not inside the "Recoverable waste" band label any more.
+    dash_start = html.index("function DashboardView({ params })")
+    dash_end = html.index("\nfunction ", dash_start + 1)
+    dash_fn = html[dash_start:dash_end]
+    ov_head_start = dash_fn.index('<div class="ov-head">')
+    ov_head_end = dash_fn.index("</div>\n    </div>", ov_head_start)
+    assert "<${ScanBar}" in dash_fn[ov_head_start:ov_head_end]
+    assert '<div class="band-label">Recoverable waste</div>' in dash_fn
+
+    # Review inbox: ScanBar renders beside the "Inbox" page-title, not as a
+    # bespoke sz-link.
+    inbox_start = html.index("function ReviewInboxView({ params })")
+    inbox_end = html.index("\nfunction ", inbox_start + 1)
+    inbox_fn = html[inbox_start:inbox_end]
+    title_at = inbox_fn.index('<div class="page-title" style="margin-bottom:0">Inbox</div>')
+    scanbar_at = inbox_fn.index("<${ScanBar}", title_at)
+    tab_bar_at = inbox_fn.index('<div class="tab-bar"', title_at)
+    assert title_at < scanbar_at < tab_bar_at
+
+
+def test_review_inbox_rescan_reuses_the_shared_hook_and_surfaces_failure(html):
+    """The inbox re-runs two stores (relearn + cost-advisory) rather than
+    `/optimize/rescan`, but it must still go through apiPostOrDetail (not the
+    silently-swallowing apiPost) so a refused POST reaches the shared
+    ScanBar's error prop instead of failing invisibly."""
+    fn_start = html.index("function ReviewInboxView({ params })")
+    fn_end = html.index("\nfunction ", fn_start + 1)
+    fn = html[fn_start:fn_end]
+    assert "apiPostOrDetail('/relearn/refresh', {})" in fn
+    assert "apiPostOrDetail('/relearn/cost-proposals/refresh', {})" in fn
+    assert "Promise.allSettled" in fn
+    assert "setRefreshError(" in fn
+    assert "error=${refreshError}" in fn
 
 
 def test_auto_rescan_is_visibility_gated_and_killable(html):

--- a/tests/unit/test_lens_ui_regression.py
+++ b/tests/unit/test_lens_ui_regression.py
@@ -4853,3 +4853,67 @@ def test_analyzer_guide_makes_no_guaranteed_saving_claim(html):
         assert banned not in guide, f"guide copy must not contain {banned!r}"
     assert "estimates from your own history" in guide
     assert "review before you act on them" in guide
+
+
+def test_drift_zero_variance_row_is_neutral_not_a_drift_verdict(html):
+    """A baseline with no spread cannot judge anything.
+
+    `z_score()` in `core/drift.py` deliberately returns inf when stddev is 0 and
+    the value moved, and the UI used to mirror that literally: a metric whose
+    every sampled session had the same value (tool calls `0.0 +/- 0.0`) rendered
+    `inf` under a red `drift` badge. That is an absence of evidence, not a
+    regression. The row now reads as "cannot judge". The Python helper is
+    unchanged; this is a display decision only.
+    """
+    start = html.index("function DriftView({ params })")
+    end = html.index("// Budget View", start)
+    view = _no_comments(html[start:end])
+    assert "const noVariance =" in view
+    assert "'no baseline variance'" in view
+    assert "badge-neutral" in view
+    # The old inf-as-maximum-anomaly rendering is gone.
+    assert "zDisplay = 'inf'" not in view
+    assert "z = Infinity" not in view
+
+
+def test_drift_empty_state_explains_why_there_is_no_baseline(html):
+    """"None yet" is not an answer when two of the three reasons are permanent.
+
+    Interactive coding sessions are never baselined (the API applies the same
+    persona gate the detector does) and backfilled history never builds one, so
+    the empty state names both alongside the session-count requirement.
+    """
+    start = html.index("function DriftView({ params })")
+    end = html.index("// Budget View", start)
+    view = _no_comments(html[start:end])
+    assert "drift-empty-why" in view
+    assert "compares a service against its own past behavior" in view
+    assert "Interactive coding sessions are not baselined" in view
+    assert "Baselines build only from live sessions" in view
+    # No em dashes in user-facing copy.
+    why_start = view.index("drift-empty-why")
+    why_end = view.index("</div>\n    </div>", why_start)
+    assert "—" not in view[why_start:why_end]
+
+
+def test_alerts_view_wires_the_acknowledge_endpoint(html):
+    """`PATCH /alerts/{id}/acknowledge` existed with no control to reach it.
+
+    Rule 24 in `tokenjam/CLAUDE.md`: a capability is only real if a user has a
+    path to it. The Alerts table now carries a Status column with an
+    Acknowledge button, and reloads afterwards so the "Unread only" filter
+    stays honest.
+    """
+    start = html.index("function AlertsView({ params })")
+    end = html.index("// Drift View", start)
+    view = _no_comments(html[start:end])
+    assert "/acknowledge" in view
+    assert "apiPatch(" in view
+    assert "const acknowledge = useCallback" in view
+    # Acknowledged alerts read as acknowledged, and the detail row still spans
+    # the full width after the Status column was added.
+    assert "badge-neutral" in view
+    assert 'colspan="7"' in view
+    assert 'colspan="6"' not in view
+    # apiPatch is a real helper, not a call into nothing.
+    assert "async function apiPatch(path, body)" in html

--- a/tests/unit/test_lens_ui_regression.py
+++ b/tests/unit/test_lens_ui_regression.py
@@ -2613,6 +2613,18 @@ def test_summarize_nav_child_and_route(html):
     assert "el.style.display = (v === view) ? 'flex' : 'none';" in html
 
 
+def test_summarize_tj_keep_not_double_escaped(html):
+    """htm/Preact tagged templates build static text children via
+    `createTextNode`, so an HTML entity written directly into the template
+    (e.g. `&lt;tj-keep&gt;`) is never decoded -- it renders on screen as the
+    literal text `&lt;tj-keep&gt;` rather than `<tj-keep>`. The fix is
+    JS-expression interpolation (`${'<tj-keep>'}`), which Preact assigns as a
+    real text node instead of re-parsing; both `tj-keep` mentions in the file
+    must use that form, and the escaped form must not appear anywhere."""
+    assert "&lt;tj-keep&gt;" not in html, "tj-keep must not be HTML-entity-escaped"
+    assert html.count("${'<tj-keep>'}") == 2
+
+
 def test_summarize_component_present(html):
     assert "function SummarizeView" in html
     # The four-phase flow (engine gate → curate → run → review) is what makes the
@@ -4584,15 +4596,22 @@ def test_summarize_engine_view_has_no_unrendered_backticks(html):
 
 
 def test_summarize_tj_keep_token_is_escaped_and_code_styled(html):
-    # `<tj-keep>` used to be interpolated as a bare JS string (`${'<tj-keep>'}`)
-    # which rendered as plain, unstyled angle-bracket text sitting oddly in
-    # the sentence. It's still inserted as escaped text (never a real
-    # unknown-tag risk to htm's parser), but now explicitly HTML-escaped and
-    # wrapped in <code> so it reads as a token, not stray prose.
+    # This test previously asserted the token was written as the literal
+    # markup `<code>&lt;tj-keep&gt;</code>` -- but htm/Preact tagged
+    # templates build STATIC text children via `createTextNode`, which never
+    # decodes HTML entities (that only happens when a browser parses real
+    # HTML, which htm does not do). That "fix" was itself the double-escaping
+    # bug: it rendered on screen as the literal text `&lt;tj-keep&gt;`
+    # instead of `<tj-keep>`. The actual fix is JS-expression interpolation
+    # (`${'<tj-keep>'}`), still wrapped in <code> for styling -- the same
+    # idiom already used a few hundred lines later in the diff-review phase's
+    # own "unchanged lines are kept verbatim" note, which this test also pins
+    # so the two can't drift apart again.
     view = _summarize_engine_view(html)
-    assert "<code>&lt;tj-keep&gt;</code>" in view
-    assert "${'<tj-keep>'}" not in view
-    assert "Rewrites prose only: code, tables, and <code>&lt;tj-keep&gt;</code> blocks stay verbatim." in view
+    assert "&lt;tj-keep&gt;" not in view, "the entity-escaped form must never render"
+    assert "<code>${'<tj-keep>'}</code>" in view
+    assert "Rewrites prose only: code, tables, and <code>${'<tj-keep>'}</code> blocks stay verbatim." in view
+    assert html.count("${'<tj-keep>'}") == 2, "both mentions must use the same interpolation idiom"
 
 
 def test_summarize_engine_intro_uses_colon_not_em_dash(html):
@@ -4794,6 +4813,64 @@ def test_analyzer_guide_is_reachable_from_the_optimize_screen(html):
     assert link_at - title_at < 600, "FAQ link drifted out of the always-rendered title block"
 
 
+def test_analyzer_guide_heading_has_no_optimize_backlink(html):
+    """The founder asked for the "See these on the Optimize screen ->" link
+    next to the FAQ heading to be deleted entirely -- the heading row is just
+    the heading now. This is the FAQ page's OWN title block, distinct from
+    the forward link OptimizeView renders pointing AT the FAQ (that one, and
+    its `sz-link` class, are unrelated and must stay)."""
+    view_start = html.index("function AnalyzerGuideView()")
+    view_end = html.index("// Optimize ▸ Summarize (Track B)", view_start)
+    view = html[view_start:view_end]
+    assert "See these on the Optimize screen" not in view
+    assert '<div class="page-title">FAQ</div>' in view
+    assert "sz-link" not in view
+
+
+def test_analyzer_guide_content_is_fully_static_no_fetch_no_loading_state(html):
+    """The page used to fetch `/optimize/analyzers` and `/optimize` before it
+    knew which checks to show, which needed a loading state. It now carries a
+    card for EVERY registered analyzer, in a fixed order, with each card's
+    live/gated status written into its own static prose -- so which checks
+    exist and which are gated for Claude Code are both already decided in
+    code (`ANALYZER_REGISTRY`, `PERSONA_DISABLED_ANALYZERS`) at build time,
+    not at request time. Nothing on this page depends on a network read
+    answering, so it renders immediately: no `useState`, no `useEffect`, no
+    `api(...)` call, and no shimmer/skeleton of any kind."""
+    view_start = html.index("function AnalyzerGuideView()")
+    view_end = html.index("// Optimize ▸ Summarize (Track B)", view_start)
+    view = html[view_start:view_end]
+    assert "useState" not in view
+    assert "useEffect" not in view
+    assert "useCallback" not in view
+    assert "api(" not in view
+    assert "shimmer" not in view
+    assert "st.loading" not in view
+    assert "st.error" not in view
+    assert '<div class="page-title">FAQ</div>' in view
+    assert "<${GuideBody} />" in view
+
+
+def test_analyzer_guide_prose_fills_the_card_width(html):
+    """The founder's complaint: the prose inside each FAQ card (and the intro
+    paragraph) was clamped to a ~74ch editorial measure while the card itself
+    spanned the full page width, leaving a large empty column on the right.
+    `.guide-prose` is used ONLY on the FAQ page (never by any other screen),
+    so widening it here cannot affect anything else; `.opt-line`, which every
+    OTHER Optimize-family card uses for its body text, carries no such
+    clamp, and that is the width this page should match. Card padding
+    (`.opt-section`) must stay intact -- the fix is the text filling the
+    card, not touching its edges."""
+    assert re.search(r"\.guide-prose\s*\{[^}]*\}", html)
+    assert not re.search(r"\.guide-prose\s*\{[^}]*max-width[^}]*\}", html), (
+        "the FAQ card prose must not be clamped to an editorial measure"
+    )
+    # The persona callout banner class is retired along with the box itself.
+    assert ".guide-banner" not in html
+    # Card padding untouched.
+    assert ".opt-section { background: var(--surface); border: 1px solid var(--border); border-radius: 8px; padding: 16px 18px; margin-bottom: 14px; }" in html
+
+
 def test_analyzer_guide_routes_resolve_and_old_hash_still_works(html):
     """`#/faq` is canonical; `#/optimize/guide` and `#/guide` are the retired
     spellings and must keep working for anything already pointing at them."""
@@ -4805,70 +4882,186 @@ def test_analyzer_guide_routes_resolve_and_old_hash_still_works(html):
     assert "history.replaceState(null, '', '#/faq');" in html
 
 
-def test_analyzer_guide_reads_the_gate_from_the_server_not_a_js_copy(html):
-    """Which checks apply is Python's answer (`PERSONA_DISABLED_ANALYZERS` ->
-    `/optimize/analyzers`). The guide may own PROSE keyed by analyzer name, but
-    never a membership decision -- a JS copy of the map desyncs the first time
-    the Python side changes."""
-    fn_start = html.index("function GuideBody({ persona, sets })")
-    fn_end = html.index("function AnalyzerGuideView()", fn_start)
-    fn = html[fn_start:fn_end]
-    # Membership comes from the payload on both sides: what runs, what is gated.
-    assert "sets.runs" in fn
-    assert "sets.disabled" in fn
-    view_start = html.index("function AnalyzerGuideView()")
-    view_end = html.index("// Optimize ▸ Summarize (Track B)", view_start)
-    view = html[view_start:view_end]
-    assert "api('/optimize/analyzers')" in view
-    # No persona-keyed analyzer-name list anywhere in the guide's own source:
-    # the prose maps are keyed by name, but nothing decides membership from
-    # a persona conditional in JS.
-    guide_start = html.index("const GUIDE_PERSONA_LABELS = {")
-    guide = _no_comments(html[guide_start:view_end])
-    assert "PERSONA_DISABLED_ANALYZERS" not in guide
-    assert "disabled_analyzers_for_persona" not in guide
+def test_analyzer_guide_persona_box_is_gone_and_helper_retired(html):
+    """The founder asked for the persona callout box ("Written for **Claude
+    Code**, which is what your recent sessions look like.") to be deleted
+    entirely, render path and all -- not just its text. `GUIDE_PERSONA_LABELS`
+    fed only that box (and its two sibling variants: the "uncovered" and
+    "unclassified" cases), so it retires with it rather than staying as a
+    dead helper. The persona VALUE itself (`GUIDE_ENTRIES['claude-code']`)
+    still drives which card set and order render, and that use stays."""
+    assert "GUIDE_PERSONA_LABELS" not in html
+    assert "Written for" not in html
+    assert "which is what your recent sessions look like" not in html
+    assert "has not been written yet" not in html
+    assert "Nothing has classified this install yet" not in html
+    assert "uncovered" not in html
+
+
+def test_analyzer_guide_covers_every_registered_analyzer(html):
+    """The founder's ask: a real card for every analyzer, not just the subset
+    live for this persona -- derived from the registry (source of truth),
+    never from memory or from the retired hidden-checks card's text. Live
+    (Claude-Code-runnable) analyzers come first, gated ones after, and the
+    two groups must not interleave. `placement` is a sub-check `downsize`
+    attaches, not its own registry entry, so it must NOT get its own card."""
+    from tokenjam.core.optimize import ANALYZER_REGISTRY
+    from tokenjam.core.optimize.runner import disabled_analyzers_for_persona
+
+    registered = sorted(ANALYZER_REGISTRY)
+    assert registered, "the registry itself must not be empty"
+    disabled = disabled_analyzers_for_persona("claude-code")
+    # `placement` is a documented non-registry exception (attached to
+    # `downsize`); everything else `disabled_analyzers_for_persona` names for
+    # claude-code must be a real registered analyzer.
+    assert disabled - {"placement"} <= set(registered)
+
+    entries_start = html.index("const GUIDE_ENTRIES = {")
+    entries_end = html.index("function GuideCheck({ name, entry })", entries_start)
+    entries_block = html[entries_start:entries_end]
+
+    order_match = re.search(r"order:\s*\[(.*?)\],\n\s*entries:", entries_block, re.S)
+    assert order_match, "could not find claude-code's `order` array"
+    order_names = re.findall(r"'([a-z][a-z-]*)'", order_match.group(1))
+
+    for name in registered:
+        assert name in order_names, f"{name} has no entry in the FAQ's order list"
+        assert re.search(r"(^|\s)'?%s'?:\s*\{" % re.escape(name), entries_block), (
+            f"{name} is listed in `order` but has no entries[...] card"
+        )
+    assert "placement" not in order_names, (
+        "placement is a downsize sub-check, not its own registry entry, "
+        "and must not get its own card"
+    )
+
+    live = [n for n in order_names if n in registered and n not in disabled]
+    gated = [n for n in order_names if n in registered and n in disabled]
+    assert live and gated, "expect at least one live and one gated analyzer for claude-code"
+    # Not interleaved: every live name's index precedes every gated name's.
+    assert max(order_names.index(n) for n in live) < min(order_names.index(n) for n in gated), (
+        "live and gated analyzer cards must not be interleaved"
+    )
+
+
+def test_analyzer_guide_no_longer_carries_a_hidden_checks_card(html):
+    """The founder asked for the "Checks that are not shown here" card to be
+    deleted entirely, not just hidden -- along with the old gated-analyzer
+    prose map (`hidden:`) that used to feed it. Gated analyzers now get a
+    real card each (`test_analyzer_guide_covers_every_registered_analyzer`),
+    not a bundled list."""
+    guide_start = html.index("const GUIDE_ENTRIES = {")
+    guide_end = html.index("function GuideCheck({ name, entry })", guide_start)
+    entries = html[guide_start:guide_end]
+    assert "hidden:" not in entries
+    body_start = html.index("function GuideBody()")
+    body_end = html.index("function AnalyzerGuideView()", body_start)
+    body = html[body_start:body_end]
+    assert "guide-not-shown" not in body
+    assert "hiddenNames" not in body
+    assert "Checks that are not shown here" not in html
+    assert "guide-hidden-list" not in html
 
 
 def test_analyzer_guide_states_the_downsize_vs_subagent_distinction(html):
-    """The founder could not tell these two apart; that is the page's whole
-    reason to exist. The contrast must be stated as WHERE vs WHO, and must say
-    that a session can only trip one of them."""
-    start = html.index("const GUIDE_KEY_CONTRAST = {")
-    end = html.index("const GUIDE_ENTRIES = {", start)
-    block = html[start:end]
-    assert "Downsize is about WHERE the work happened." in block
-    assert "Subagent is about WHO did it" in block
-    assert "only considers sessions that never delegated at all" in block
-    # Rendered ABOVE the per-check cards, not buried in one of them.
-    body_start = html.index("function GuideBody({ persona, sets })")
-    body_end = html.index("function AnalyzerGuideView()", body_start)
-    body = html[body_start:body_end]
-    assert body.index("GUIDE_KEY_CONTRAST.title") < body.index("GuideCheck")
+    """The founder could not tell these two apart; that used to be answered by
+    a separate callout card, which is now gone. The distinction (WHERE vs WHO,
+    and that a session can only trip one of them) must instead live inside
+    EACH of the two sections' own descriptions, so either stands alone."""
+    assert "GUIDE_KEY_CONTRAST" not in html, "the retired callout must not come back"
+    assert ".guide-key {" not in html, "the retired callout's CSS must not come back"
+
+    entries_start = html.index("const GUIDE_ENTRIES = {")
+    entries_end = html.index("function GuideCheck({ name, entry })", entries_start)
+
+    downsize_start = html.index("downsize: {", entries_start)
+    assert downsize_start < entries_end
+    downsize_end = html.index("subagent: {", downsize_start)
+    downsize = html[downsize_start:downsize_end]
+    assert "Downsize is about WHERE the work happened" in downsize
+    assert "never dispatched a subagent" in downsize
+    assert "Subagent check answers instead" in downsize
+
+    subagent_start = downsize_end
+    subagent_end = html.index("resend: {", subagent_start)
+    subagent = html[subagent_start:subagent_end]
+    assert "Subagent is about WHO did the work" in subagent
+    assert "only ever looks at spans already dispatched to a worker" in subagent
+    assert "moves out of Downsize" in subagent
 
 
-def test_analyzer_guide_ships_no_unwritten_persona_as_placeholder_prose(html):
-    """Only Claude Code content was validated. An unwritten persona gets a
-    banner naming the gap -- never invented copy, and never a silent fallback
-    that reads as if it were written for the reader's setup."""
-    start = html.index("const GUIDE_ENTRIES = {")
-    end = html.index("function guideMissingEntry(name)", start)
-    entries = html[start:end]
-    # Exactly one persona is populated.
-    assert entries.count("    order: [") == 1
-    assert "'claude-code': {" in entries
-    for absent in ("'sdk': {", "'mixed': {", "'unknown': {"):
-        assert absent not in entries, f"{absent} must not carry unvalidated prose"
-    view_start = html.index("function AnalyzerGuideView()")
-    view = html[view_start:html.index("// Optimize ▸ Summarize (Track B)", view_start)]
-    assert "has not been written yet" in view
-    assert "Nothing has classified this install yet" in view
+def test_analyzer_guide_downsize_subagent_claim_matches_the_analyzers(html):
+    """The distinction rewritten into the Downsize/Subagent sections makes a
+    factual claim about how the underlying analyzers are scoped (never
+    delegated / already delegated). Pin the claim against the analyzer source
+    so a future change to either analyzer's scoping is forced to revisit this
+    prose instead of leaving it to quietly go stale."""
+    repo_root = _UI.parent.parent.parent
+    downgrade_src = (
+        repo_root / "tokenjam/core/optimize/analyzers/model_downgrade.py"
+    ).read_text()
+    # The driver-role case (Downsize's flagship detection) is documented, in
+    # its own basis string shown to users, as requiring zero delegation.
+    assert "never dispatched a subagent" in downgrade_src
+    assert "these sessions dispatch no subagent, so they carry no subagent spans" in downgrade_src
+
+    subagent_src = (
+        repo_root / "tokenjam/core/optimize/analyzers/subagent_rightsizing.py"
+    ).read_text()
+    # subagent_rightsizing only ever reads spans already tagged as dispatched
+    # to a worker.
+    assert "sub_agent_id IS NOT NULL" in subagent_src
+
+
+def test_analyzer_guide_card_has_one_heading_one_description(html):
+    """Every card on the page gets exactly one heading and one description,
+    no "WHAT IT LOOKS FOR" / "WHAT TO DO ABOUT IT" sub-headings inside it.
+    The description may still be several paragraphs of prose -- that
+    plurality is how the WHERE/WHO enrichment (and every card's former
+    blurb+mistake+fix) fits -- but there is exactly one `opt-title` per
+    `GuideCheck` and no `guide-lead` sub-heading class left anywhere in the
+    file. Applies to gated-analyzer cards too, and their descriptions must
+    stay noticeably shorter than a live card's (no padding to match length)."""
+    assert "guide-lead" not in html, "sub-heading class must be fully retired"
+    assert "What it looks for" not in html
+    assert "What to do about it" not in html
+
+    fn_start = html.index("function GuideCheck({ name, entry })")
+    fn_end = html.index("function GuideBody()", fn_start)
+    fn = html[fn_start:fn_end]
+    assert fn.count("opt-title") == 1
+    assert "entry.blurb" not in fn
+    assert "entry.mistake" not in fn
+    assert "entry.fix" not in fn
+    assert "entry.description" in fn
+
+    # Every entry (live and gated) carries a `description` array, not the old
+    # three-field shape, and there is exactly one per registered analyzer
+    # (14, per `test_analyzer_guide_covers_every_registered_analyzer`).
+    entries_start = html.index("const GUIDE_ENTRIES = {")
+    entries_end = html.index("function GuideCheck({ name, entry })", entries_start)
+    entries = html[entries_start:entries_end]
+    assert "blurb: '" not in entries
+    assert "mistake: '" not in entries
+    assert "fix: '" not in entries
+    assert entries.count("description: [") == 14
+
+    # Gated cards stay brief: at most 2 short paragraphs (what it looks for,
+    # why it is off here), never the 3-paragraph enrichment a live card like
+    # Downsize/Subagent carries.
+    for name in ("cache", "cache-recommend", "reuse", "script", "stream-usage", "trim", "verbosity"):
+        needle = f"{name}: {{" if re.match(r"^[a-z][a-z0-9]*$", name) else f"'{name}': {{"
+        entry_start = entries.index(needle)
+        desc_start = entries.index("description: [", entry_start)
+        desc_end = entries.index("],", desc_start)
+        paragraphs = re.findall(r"^\s+'", entries[desc_start:desc_end], re.M)
+        assert len(paragraphs) <= 2, f"{name}'s gated-card description should stay brief"
 
 
 def test_analyzer_guide_makes_no_guaranteed_saving_claim(html):
     """Honesty discipline (Critical Rule 14) governs every user-visible string:
     estimates are candidates to review, never a promised saving, and the page
     never discusses how a figure was derived."""
-    start = html.index("const GUIDE_PERSONA_LABELS = {")
+    start = html.index("const GUIDE_ENTRIES = {")
     end = html.index("// Optimize ▸ Summarize (Track B)", start)
     guide = html[start:end]
     for banned in ("saves you", "you will save", "guaranteed", "realization rate",

--- a/tests/unit/test_lens_ui_regression.py
+++ b/tests/unit/test_lens_ui_regression.py
@@ -2615,20 +2615,72 @@ def test_summarize_nav_child_and_route(html):
 
 def test_summarize_component_present(html):
     assert "function SummarizeView" in html
-    # The four-phase flow (engine gate → curate → run → review) is what makes the
-    # screen worth more than the all-or-nothing CLI (DEC-034 granularity).
-    assert "const [phase, setPhase] = useState('engine')" in html
+    # Looking is free: the screen lands on the candidate list (curate) with no
+    # engine choice required. The engine is only demanded inline at the
+    # Finish/Approve step, the moment a rewrite is actually requested.
+    assert "const [phase, setPhase] = useState('curate')" in html
+    assert "const [phase, setPhase] = useState('engine')" not in html
     for phase in ("phase === 'review'", "phase === 'run'", "phase === 'curate'"):
         assert phase in html, f"missing phase branch {phase}"
 
 
 def test_summarize_engine_gate_is_capabilities_driven(html):
-    # The page starts on a capability-gated engine chooser (never defaulted), so a
+    # The engine chooser (rendered inline at the Finish/Approve step, not on
+    # its own landing page) is capability-gated and never defaulted, so a
     # dead engine (no key / no `claude`) is disabled with its reason.
     assert "api('/summarize/capabilities')" in html
     assert "const avail = cap ? cap.available : false;" in html
     # all three engines are offered; claude_p is normalized to the wire's claude-p
     assert "id === 'claude_p' ? 'claude-p' : id" in html
+
+
+def test_summarize_candidates_render_with_no_engine_selected(html):
+    # Looking is free: the landing phase is 'curate' (the candidate list), and
+    # nothing about rendering that list depends on an engine having been
+    # picked. Only producing a rewrite (Finish -> Approve) demands a tool.
+    start = html.index("function SummarizeView")
+    end = html.index("\n}\n", start)
+    body = html[start:end]
+    assert "const [phase, setPhase] = useState('curate')" in body
+    # the candidate table's render guard is `!loading` only -- no `engine`
+    # check gates whether the list (as opposed to a gate page) is shown.
+    listbox_at = body.index('<div class="cur-listbox">\n      <table class="cur-table">')
+    guard_at = body.rindex("${!loading ? html`", 0, listbox_at)
+    guard_to_list = body[guard_at:listbox_at]
+    assert "engine" not in guard_to_list
+
+
+def test_summarize_load_scan_runs_on_mount(html):
+    # The scan used to be deferred until an engine was picked (pickEngine ->
+    # loadScan()), which is exactly the gate this ticket removes. The mount
+    # effect must now kick off loadScan() unconditionally alongside caps/
+    # staged/backups, with no engine precondition anywhere in that effect.
+    assert "useEffect(() => { loadScan(); loadCaps(); loadStaged(); loadBackups(); }, []);" in html
+    assert "const pickEngine" not in html
+
+
+def test_summarize_scan_loading_state_precedes_any_count_or_empty_copy(html):
+    # Root anti-pattern 22: no count and no empty-state string may render
+    # while the scan fetch is unresolved. `loading` must start true (the
+    # mount effect always fires a scan, so the very first render -- before
+    # the effect has run -- must not be able to reach the empty-state /
+    # count branch), and every count/empty-state string for the candidate
+    # list must live behind the `!loading` guard, never unconditionally.
+    assert "const [loading, setLoading] = useState(true);" in html
+    start = html.index("function SummarizeView")
+    end = html.index("\n}\n", start)
+    body = html[start:end]
+    # the "N shown" count and the "No summarizable files found" empty-state
+    # copy are both inside the same `${!loading ? html`...` : null}` block.
+    loading_gate_at = body.index("${!loading ? html`")
+    shown_at = body.index("${visible.length} shown", loading_gate_at)
+    empty_at = body.index("No summarizable files found.", loading_gate_at)
+    assert loading_gate_at < shown_at
+    assert loading_gate_at < empty_at
+    # and the gate must close (` : null}`) only after both, i.e. loading is
+    # not flipped back to allow either to leak out from under it.
+    gate_close_at = body.index("` : null}", empty_at)
+    assert shown_at < gate_close_at and empty_at < gate_close_at
 
 
 def test_summarize_curator_wires_to_candidates_scan(html):
@@ -4488,11 +4540,23 @@ def test_dashboard_use_tokens_is_local_only(html):
 
 
 def _summarize_engine_view(html: str) -> str:
-    """The `phase === 'engine'` render — the back link, heading, intro
-    paragraph, and the three API/Claude CLI/Manual mode cards."""
-    start = html.index("if (phase === 'engine') {")
-    end = html.index("if (phase === 'run' && engine !== 'manual') {", start)
-    return html[start:end]
+    """The engine-choice surface: the curate (landing) header — back link,
+    heading, intro paragraph — plus the inline engine picker that now renders
+    at the Finish/Approve step, inside the approve modal, instead of on its
+    own `phase === 'engine'` gate page. Deliberately excludes the rest of
+    curate (filters, candidate table, staged/backups tallies) so this stays
+    scoped to the content that actually moved, not everything now sharing
+    the same `curate` return statement."""
+    h_start = html.index("// phase === 'curate'")
+    h_end = html.index("<div class=${'cur-tally'", h_start)
+    header = html[h_start:h_end]
+    e_start = html.index("const eng = (id, name, tag, desc) => {")
+    e_end = html.index("\n  };", e_start) + len("\n  };")
+    eng_fn = html[e_start:e_end]
+    p_start = html.index("${modal === 'approve' && !engine ? html`", h_end)
+    p_end = html.index("` : html`", p_start)
+    picker = html[p_start:p_end]
+    return header + eng_fn + picker
 
 
 def test_summarize_back_link_is_not_the_brand_blue_sz_link(html):

--- a/tests/unit/test_lens_ui_regression.py
+++ b/tests/unit/test_lens_ui_regression.py
@@ -3626,6 +3626,74 @@ def test_no_row_renders_a_dead_end(html):
     assert "optimizeFindingHref(prop.analyzer)" in card
 
 
+def test_dismiss_uses_the_shared_action_row_treatment_on_every_card_kind(html):
+    # The MCP-remove card (`mcp_remove`'s "Remove this MCP server entry", the
+    # `hasApplyKind` branch below) used to render Dismiss as a bare blue link
+    # OUTSIDE the card's inner `opt-section` panel, on its own line underneath
+    # it, via one trailing `${canApply ? html\`<div ...>Dismiss</div>\` : null}`
+    # shared by all three apply-capable branches (needsSourcePath / hasApplyKind
+    # / the workspace-note fallback). Every other card kind already rendered
+    # Dismiss inline, beside its primary button, in `var(--text)` (white) rather
+    # than the `.sz-link` default brand blue. Fixed by giving each branch its
+    # own Dismiss in the same row as its primary button, using the identical
+    # treatment — so this asserts the shared treatment rather than one card's
+    # markup, to catch a future branch that reintroduces the divergence.
+    card = html[html.index("function CostProposalCard"):html.index("function InboxStatTiles")]
+
+    # The old outside-the-panel fallback must be gone.
+    assert "canApply ? html`<div style=\"margin-top:8px\">" not in card
+
+    # Every `onDismiss(prop.signature)` call site renders through the exact
+    # same white-text `.sz-link` markup — one shared treatment, not a
+    # per-branch reimplementation that could drift.
+    dismiss_calls = re.findall(r'<span class="sz-link".*?Dismiss</span>', card)
+    assert len(dismiss_calls) >= 6, "expected a Dismiss control on every card branch"
+    for call in dismiss_calls:
+        assert 'style="color:var(--text)"' in call, (
+            f"Dismiss must use the shared white treatment, not brand-blue: {call}"
+        )
+
+    # The three apply-capable branches (needsSourcePath, hasApplyKind incl.
+    # mcp_remove, and the workspace-note fallback) each carry Dismiss INSIDE
+    # their own action row, alongside Preview/Apply, not in a separate div.
+    for anchor in (
+        "registerSourcePath(true)}>Apply swap →</button>",
+        "applyKindFix(true)}>${akCopy.button} →</button>",
+        "applyWorkspace(true)}>Apply note →</button>",
+    ):
+        pos = card.index(anchor)
+        row_end = card.index("</div>", pos)
+        row_tail = card[pos:row_end]
+        assert "onDismiss(prop.signature)}>Dismiss</span>" in row_tail, (
+            f"Dismiss must sit in the same action row as: {anchor}"
+        )
+
+
+def test_review_inbox_action_rows_are_right_aligned(html):
+    # Every card-footer action row (primary button + Dismiss, and the Preview
+    # button where present) is right aligned within the card, not left aligned
+    # under the card body. Rows with a path input use the input's `flex:1` to
+    # push the buttons flush right instead of an explicit `justify-content`,
+    # since the input already claims the row's full width.
+    card = html[html.index("function CostProposalCard"):html.index("function InboxStatTiles")]
+    for anchor in (
+        '<a class="cur-btn primary" style="text-decoration:none" href=${(prop.target_key && prop.target_key.href) || \'#/optimize/summarize\'}>Review in Summarize →</a>',
+        "<button class=\"cur-btn primary\" disabled=${busy} onClick=${() => onMark(prop)}>${busy ? 'Marking…' : 'Mark applied'}</button>",
+        '<a class="sz-link" href=${optimizeFindingHref(prop.analyzer)}>See the full analysis →</a>',
+    ):
+        row_start = card.rindex('<div style="display:flex', 0, card.index(anchor))
+        row_line_end = card.index(">", row_start)
+        assert "justify-content:flex-end" in card[row_start:row_line_end], (
+            f"action row for {anchor[:40]!r}... must be right aligned"
+        )
+
+    row = html[html.index("function RecurringMistakeRow"):html.index("function RelearnApplyModal")]
+    approve_anchor = "Approve & write →</button>"
+    row_start = row.rindex('<div style="display:flex', 0, row.index(approve_anchor))
+    row_line_end = row.index(">", row_start)
+    assert "justify-content:flex-end" in row[row_start:row_line_end]
+
+
 def test_inbox_row_text_is_uncapped_without_lifting_the_global_measure(html):
     # Founder feedback on the running page: a row's description stopped well short
     # of the card edge, leaving a wide empty gutter with the amount stranded in the

--- a/tests/unit/test_lens_ui_regression.py
+++ b/tests/unit/test_lens_ui_regression.py
@@ -4898,23 +4898,56 @@ def test_analyzer_guide_persona_box_is_gone_and_helper_retired(html):
     assert "uncovered" not in html
 
 
-def test_analyzer_guide_covers_every_registered_analyzer(html):
-    """The founder's ask: a real card for every analyzer, not just the subset
-    live for this persona -- derived from the registry (source of truth),
-    never from memory or from the retired hidden-checks card's text. Live
-    (Claude-Code-runnable) analyzers come first, gated ones after, and the
-    two groups must not interleave. `placement` is a sub-check `downsize`
-    attaches, not its own registry entry, so it must NOT get its own card."""
-    from tokenjam.core.optimize import ANALYZER_REGISTRY
-    from tokenjam.core.optimize.runner import disabled_analyzers_for_persona
+# The page's inclusion rule is NOT "is it in the analyzer registry" -- it is
+# "does the check end in a fix a user could apply". `budget-projection` (a
+# spend forecast against a ceiling, no fix claimed -- see
+# ANALYZER-PERSONA-MATRIX.md line 95) and `stream-usage` (corrects a spend
+# FIGURE, recovers nothing) both live in the registry and both fail that
+# rule, so neither gets a card even though they're gated-off-for-nobody
+# (they run for every persona). This is a REVIEWED, human-curated list, not
+# something a rule can derive from the registry alone -- so a newly
+# registered analyzer must show up in exactly one of the two sets below
+# before this test will pass, forcing a human decision instead of letting
+# the page silently drift (either by never gaining a card, or by gaining an
+# unreviewed one).
+_FAQ_SHOWN_ANALYZERS = {
+    "downsize", "subagent", "resend", "summarize", "deadweight", "relearn",
+    "cache", "cache-recommend", "reuse", "script", "trim", "verbosity",
+}
+_FAQ_EXCLUDED_ANALYZERS = {
+    "budget-projection": "informational forecast against a ceiling, no fix claimed (ANALYZER-PERSONA-MATRIX.md)",
+    "stream-usage": "corrects a spend FIGURE (a data-quality gap); recovers nothing, ends in no fix",
+}
 
-    registered = sorted(ANALYZER_REGISTRY)
+
+def test_analyzer_guide_covers_the_reviewed_user_facing_analyzer_list(html):
+    """A real card for every analyzer that ends in a fix a user could apply,
+    derived from the registry but filtered through a human-reviewed
+    inclusion rule -- never "every registry name" and never memory or the
+    retired hidden-checks card's text. Live (Claude-Code-runnable) analyzers
+    come first, gated ones after, never interleaved. `placement` is a
+    sub-check `downsize` attaches, not its own registry entry, so it must
+    NOT get its own card. Fails loudly, naming the analyzer, if a
+    newly-registered one is in neither `_FAQ_SHOWN_ANALYZERS` nor
+    `_FAQ_EXCLUDED_ANALYZERS` -- that is the point: a human has to triage it,
+    the page must never silently do nothing or silently add an unreviewed
+    card."""
+    from tokenjam.core.optimize import ANALYZER_REGISTRY
+
+    registered = set(ANALYZER_REGISTRY)
     assert registered, "the registry itself must not be empty"
-    disabled = disabled_analyzers_for_persona("claude-code")
-    # `placement` is a documented non-registry exception (attached to
-    # `downsize`); everything else `disabled_analyzers_for_persona` names for
-    # claude-code must be a real registered analyzer.
-    assert disabled - {"placement"} <= set(registered)
+
+    reviewed = _FAQ_SHOWN_ANALYZERS | set(_FAQ_EXCLUDED_ANALYZERS)
+    unreviewed = registered - reviewed
+    assert not unreviewed, (
+        f"analyzer(s) {sorted(unreviewed)} are registered but neither shown "
+        "on the FAQ page nor explicitly excluded -- triage each against the "
+        "\"ends in a fix\" rule and add it to _FAQ_SHOWN_ANALYZERS or "
+        "_FAQ_EXCLUDED_ANALYZERS (with a reason) before this test can pass"
+    )
+    # Every excluded name really is registered (no stale exclusion entries).
+    stale_exclusions = set(_FAQ_EXCLUDED_ANALYZERS) - registered
+    assert not stale_exclusions, f"stale exclusion(s), no longer registered: {stale_exclusions}"
 
     entries_start = html.index("const GUIDE_ENTRIES = {")
     entries_end = html.index("function GuideCheck({ name, entry })", entries_start)
@@ -4924,8 +4957,15 @@ def test_analyzer_guide_covers_every_registered_analyzer(html):
     assert order_match, "could not find claude-code's `order` array"
     order_names = re.findall(r"'([a-z][a-z-]*)'", order_match.group(1))
 
-    for name in registered:
-        assert name in order_names, f"{name} has no entry in the FAQ's order list"
+    assert set(order_names) == _FAQ_SHOWN_ANALYZERS, (
+        "the FAQ's `order` list must match the reviewed shown-analyzer set exactly"
+    )
+    for name in _FAQ_EXCLUDED_ANALYZERS:
+        assert name not in order_names, f"{name} is excluded but still has a card"
+        assert re.search(r"(^|\s)'?%s'?:\s*\{" % re.escape(name), entries_block) is None, (
+            f"{name} is excluded but still has an entries[...] card"
+        )
+    for name in order_names:
         assert re.search(r"(^|\s)'?%s'?:\s*\{" % re.escape(name), entries_block), (
             f"{name} is listed in `order` but has no entries[...] card"
         )
@@ -4934,8 +4974,10 @@ def test_analyzer_guide_covers_every_registered_analyzer(html):
         "and must not get its own card"
     )
 
-    live = [n for n in order_names if n in registered and n not in disabled]
-    gated = [n for n in order_names if n in registered and n in disabled]
+    from tokenjam.core.optimize.runner import disabled_analyzers_for_persona
+    disabled = disabled_analyzers_for_persona("claude-code")
+    live = [n for n in order_names if n not in disabled]
+    gated = [n for n in order_names if n in disabled]
     assert live and gated, "expect at least one live and one gated analyzer for claude-code"
     # Not interleaved: every live name's index precedes every gated name's.
     assert max(order_names.index(n) for n in live) < min(order_names.index(n) for n in gated), (
@@ -5035,20 +5077,20 @@ def test_analyzer_guide_card_has_one_heading_one_description(html):
     assert "entry.description" in fn
 
     # Every entry (live and gated) carries a `description` array, not the old
-    # three-field shape, and there is exactly one per registered analyzer
-    # (14, per `test_analyzer_guide_covers_every_registered_analyzer`).
+    # three-field shape, and there is exactly one per shown analyzer (per
+    # `test_analyzer_guide_covers_the_reviewed_user_facing_analyzer_list`).
     entries_start = html.index("const GUIDE_ENTRIES = {")
     entries_end = html.index("function GuideCheck({ name, entry })", entries_start)
     entries = html[entries_start:entries_end]
     assert "blurb: '" not in entries
     assert "mistake: '" not in entries
     assert "fix: '" not in entries
-    assert entries.count("description: [") == 14
+    assert entries.count("description: [") == len(_FAQ_SHOWN_ANALYZERS)
 
     # Gated cards stay brief: at most 2 short paragraphs (what it looks for,
     # why it is off here), never the 3-paragraph enrichment a live card like
     # Downsize/Subagent carries.
-    for name in ("cache", "cache-recommend", "reuse", "script", "stream-usage", "trim", "verbosity"):
+    for name in ("cache", "cache-recommend", "reuse", "script", "trim", "verbosity"):
         needle = f"{name}: {{" if re.match(r"^[a-z][a-z0-9]*$", name) else f"'{name}': {{"
         entry_start = entries.index(needle)
         desc_start = entries.index("description: [", entry_start)

--- a/tokenjam/api/routes/budget.py
+++ b/tokenjam/api/routes/budget.py
@@ -1,12 +1,29 @@
 """GET /api/v1/budget — read budgets. POST /api/v1/budget — update budgets.
 
-Two genuinely distinct budget concepts live here, both surfaced on this one
-screen so a user setting a budget can see both ceilings in one place:
+Three genuinely distinct budget concepts live here:
 
-  - Per-agent ENFORCEMENT caps (`config.defaults.budget` / `config.agents[id].budget`,
-    `BudgetConfig.daily_usd` / `session_usd`). Checked synchronously on every
-    ingested span (`AlertEngine._check_cost_budgets`) and fire a real-time alert
-    the moment an agent's spend crosses the line. Scope: one agent, one day/session.
+  - Coding-tool GROUP daily caps (`config.defaults.coding_budget` /
+    `config.coding_agents[group_id].budget`, `GroupBudgetConfig.daily_usd`).
+    One row per coding TOOL (claude-code / codex — see
+    `tokenjam.core.agent_kind`), not per project and not per session: a group
+    cap ceilings the SUM of today's spend across every member agent_id
+    (e.g. every `claude-code-<project>` variant). Daily-only — a per-session
+    cap has no meaning once many sessions across many projects share one row.
+    Enforced in `AlertEngine._check_coding_group_daily_budget`, checked at
+    SESSION END (not the moment spend crosses the line — see module note
+    on the UI copy this feeds).
+
+  - SDK-workflow per-agent caps (`config.defaults.budget` /
+    `config.agents[id].budget`, `BudgetConfig.daily_usd` / `session_usd`).
+    One row per SDK-declared agent_id, unchanged from the original per-agent
+    design. `session_usd` is kept fully functional for backward
+    compatibility with already-configured caps (`AlertEngine._check_cost_budgets`
+    still fires COST_BUDGET_SESSION), but this screen no longer offers a way
+    to set a NEW one — a per-session cap on a heterogeneous, human-driven
+    coding session isn't a coherent product decision, and SDK workflows have
+    always been able to express what they need with `daily_usd` alone.
+    Enforced in `AlertEngine._check_agent_daily_budget` (daily) and the
+    unchanged session_usd path (session).
 
   - Per-provider spend FORECASTS (`config.budgets[provider]`, `ProviderBudget.usd`,
     TOML `[budget.<provider>]`). A recurring monthly ceiling the Optimize
@@ -15,11 +32,12 @@ screen so a user setting a budget can see both ceilings in one place:
     whole cycle, not a single agent/day. See
     `tokenjam/core/optimize/analyzers/budget_projection.py`.
 
-These were previously two disconnected objects: this screen showed only the
-per-agent caps, while the Optimize projection read a provider ceiling this
-screen never displayed or let you edit. Both are now returned by GET /budget
-and both are writable here — `POST /budget` for the per-agent caps (unchanged
-shape), `POST /budget/provider` for the per-provider forecast ceiling.
+All three are returned by GET /budget. `POST /budget` writes the first two
+(coding-group and SDK-workflow caps, both daily-only from this endpoint's
+perspective — session_usd is read-only here, never accepted on a write, so a
+save can never invent a NEW per-session cap even though an old one keeps
+being honoured if already present); `POST /budget/provider` writes the
+per-provider forecast ceiling.
 """
 from __future__ import annotations
 
@@ -30,20 +48,36 @@ from fastapi.responses import JSONResponse
 from pydantic import BaseModel
 
 from tokenjam.api.deps import require_api_key
+from tokenjam.core.agent_kind import (
+    CODING_AGENT_GROUPS,
+    group_agent_ids,
+    present_coding_groups,
+    sdk_agent_ids,
+)
 from tokenjam.core.framing import WindowSummary, compute_framing
 from tokenjam.core.config import (
     AgentConfig,
     BudgetConfig,
+    CodingGroupConfig,
+    GroupBudgetConfig,
     ProviderBudget,
     active_config_path,
     resolve_config_path,
     resolve_effective_budget,
+    resolve_group_budget,
     validate_budget_value,
     validate_cycle_start_day,
     write_config,
 )
 
 router = APIRouter(dependencies=[Depends(require_api_key)])
+
+# Scope prefix for POST /budget targeting a coding-tool group cap, e.g.
+# "group:claude-code". Distinguishes a group scope from an SDK agent_id scope
+# without needing a second request field — see BudgetUpdate.scope.
+_GROUP_SCOPE_PREFIX = "group:"
+_DEFAULTS_SCOPE = "defaults"
+_DEFAULTS_CODING_SCOPE = "defaults_coding"
 
 
 def _write_target(config) -> "str | Path | None":
@@ -68,16 +102,56 @@ def _provider_budget_dict(pb: ProviderBudget) -> dict:
     }
 
 
-def _budget_payload(config, agent_ids: list[str]) -> dict:
-    def _b(b):
-        return {"daily_usd": b.daily_usd, "session_usd": b.session_usd}
+def _b(b) -> dict:
+    """Serialise a BudgetConfig (daily_usd + session_usd)."""
+    return {"daily_usd": b.daily_usd, "session_usd": b.session_usd}
 
-    agents = {}
-    for aid in agent_ids:
+
+def _gb(gb) -> dict:
+    """Serialise a GroupBudgetConfig (daily_usd only — no session concept at
+    group scope)."""
+    return {"daily_usd": gb.daily_usd}
+
+
+def _budget_payload(config, agent_ids: list[str]) -> dict:
+    """Two budget zones, per the Budget-page redesign:
+
+    - `coding`: one row per coding TOOL (claude-code / codex), grouping every
+      member agent_id (e.g. every claude-code-<project> variant) under one
+      daily-only cap that ceilings their SUMMED spend. Only tools actually
+      present in `agent_ids`, plus any explicitly configured in
+      `config.coding_agents` even if not yet present in the data (so a
+      pre-set cap survives before the first session lands).
+    - `sdk`: one row per SDK-declared workflow agent_id, unchanged from the
+      original per-agent design (daily + session, session read-only here —
+      see module docstring).
+    """
+    present_groups = set(present_coding_groups(agent_ids))
+    all_groups = sorted(present_groups | set(config.coding_agents))
+    # Stable, deterministic order: claude-code before codex before any custom
+    # future group name, alphabetically.
+    ordered_groups = [g for g in CODING_AGENT_GROUPS if g in all_groups] + sorted(
+        g for g in all_groups if g not in CODING_AGENT_GROUPS
+    )
+
+    groups = {}
+    for gid in ordered_groups:
+        group_cfg = config.coding_agents.get(gid)
+        configured = _gb(group_cfg.budget) if group_cfg else _gb(GroupBudgetConfig())
+        effective = _gb(resolve_group_budget(gid, config))
+        groups[gid] = {
+            "members": group_agent_ids(agent_ids, gid),
+            "configured": configured,
+            "effective": effective,
+        }
+
+    sdk_ids = sorted(sdk_agent_ids(agent_ids))
+    sdk_agents = {}
+    for aid in sdk_ids:
         agent_cfg = config.agents.get(aid)
         raw = _b(agent_cfg.budget) if agent_cfg else _b(BudgetConfig())
         eff = _b(resolve_effective_budget(aid, config))
-        agents[aid] = {"configured": raw, "effective": eff}
+        sdk_agents[aid] = {"configured": raw, "effective": eff}
 
     # Plan-tier framing block (#110). The budget surface has no time window, so
     # framing falls back to the user's declared plan (compute_framing reads it
@@ -85,11 +159,17 @@ def _budget_payload(config, agent_ids: list[str]) -> dict:
     framing = compute_framing(config, WindowSummary())
 
     return {
-        "defaults": _b(config.defaults.budget),
-        "agents": agents,
+        "coding": {
+            "defaults": _gb(config.defaults.coding_budget),
+            "groups": groups,
+        },
+        "sdk": {
+            "defaults": _b(config.defaults.budget),
+            "agents": sdk_agents,
+        },
         # The provider spend-forecast ceilings Optimize's Budget projection
         # reads — surfaced here so they're visible/editable where users
-        # otherwise only see the per-agent enforcement caps above.
+        # otherwise only see the enforcement caps above.
         "provider_budgets": {
             provider: _provider_budget_dict(pb) for provider, pb in config.budgets.items()
         },
@@ -116,8 +196,14 @@ async def get_budget(request: Request) -> dict:
 
 
 class BudgetUpdate(BaseModel):
-    scope: str           # "defaults" or an agent_id
+    # "defaults" (SDK-zone default) | "defaults_coding" (coding-zone default)
+    # | "group:<group_id>" (a coding-tool group cap) | an SDK agent_id.
+    scope: str
     daily_usd: float | None = None
+    # Read-only from this endpoint's perspective: accepted ONLY for SDK-agent
+    # / "defaults" scopes (backward compat with an already-configured cap);
+    # rejected outright for a coding-group scope, which has no per-session
+    # concept. The redesigned UI never sends this field on a new save.
     session_usd: float | None = None
 
 
@@ -128,8 +214,24 @@ async def post_budget(request: Request, body: BudgetUpdate):
     if config_path_str is None:
         return JSONResponse(status_code=400, content={"error": "No config file found"})
 
-    if body.scope == "defaults":
+    is_group_scope = body.scope == _DEFAULTS_CODING_SCOPE or body.scope.startswith(_GROUP_SCOPE_PREFIX)
+    if is_group_scope and body.session_usd is not None:
+        return JSONResponse(
+            status_code=400,
+            content={"error": "session_usd is not applicable to a coding-tool group cap"},
+        )
+
+    if body.scope == _DEFAULTS_SCOPE:
         budget = config.defaults.budget
+    elif body.scope == _DEFAULTS_CODING_SCOPE:
+        budget = config.defaults.coding_budget
+    elif body.scope.startswith(_GROUP_SCOPE_PREFIX):
+        group_id = body.scope[len(_GROUP_SCOPE_PREFIX):]
+        if not group_id:
+            return JSONResponse(status_code=400, content={"error": "group id must not be empty"})
+        if group_id not in config.coding_agents:
+            config.coding_agents[group_id] = CodingGroupConfig()
+        budget = config.coding_agents[group_id].budget
     else:
         if body.scope not in config.agents:
             config.agents[body.scope] = AgentConfig()

--- a/tokenjam/api/routes/budget.py
+++ b/tokenjam/api/routes/budget.py
@@ -158,6 +158,21 @@ def _budget_payload(config, agent_ids: list[str]) -> dict:
     # from config when the window mix is empty).
     framing = compute_framing(config, WindowSummary())
 
+    # LEGACY top-level `defaults` / `agents` keys — the pre-redesign shape,
+    # computed exactly as `_budget_payload` used to (one flat row per
+    # agent_id, coding and SDK alike, no grouping). Kept as a STRICT SUPERSET
+    # alongside `coding`/`sdk` so the still-committed old BudgetView (reads
+    # `data.defaults.daily_usd` unguarded, and `data.agents`) keeps rendering
+    # and saving correctly while the UI rewrite is in flight on a branch that
+    # cannot yet touch this file's own PR. Remove only once that rewrite
+    # lands and nothing reads these two keys anymore.
+    legacy_agents = {}
+    for aid in agent_ids:
+        agent_cfg = config.agents.get(aid)
+        raw = _b(agent_cfg.budget) if agent_cfg else _b(BudgetConfig())
+        eff = _b(resolve_effective_budget(aid, config))
+        legacy_agents[aid] = {"configured": raw, "effective": eff}
+
     return {
         "coding": {
             "defaults": _gb(config.defaults.coding_budget),
@@ -167,6 +182,9 @@ def _budget_payload(config, agent_ids: list[str]) -> dict:
             "defaults": _b(config.defaults.budget),
             "agents": sdk_agents,
         },
+        # -- legacy superset (see comment above) --
+        "defaults": _b(config.defaults.budget),
+        "agents": legacy_agents,
         # The provider spend-forecast ceilings Optimize's Budget projection
         # reads — surfaced here so they're visible/editable where users
         # otherwise only see the enforcement caps above.

--- a/tokenjam/api/routes/drift.py
+++ b/tokenjam/api/routes/drift.py
@@ -14,6 +14,16 @@ is therefore ``None`` for that window. That null is accompanied by
 ``latest_session_outside_window`` and the timestamp that fell outside, because a
 bare null here reads as "this agent never ran" when the truth is "it ran, just
 not inside the window you asked about". The baseline itself is never hidden.
+
+One exception, and it is a persona exception rather than a window one:
+interactive coding agents are never baselined. ``DriftDetector.on_session_end``
+already refuses to build a baseline for them, because a single mean/stddev over
+a heterogeneous, human-driven workload measures nothing. That is a WRITE-path
+skip, and baselines are only ever built once and never recomputed, so a row
+written before that skip existed (or by an id that has since been reclassified)
+outlives it and still renders. This route therefore applies the same gate on the
+READ path, through the same ``is_interactive_coding_agent`` helper, so the two
+paths cannot disagree and a legacy row cannot surface as a drift verdict.
 """
 from __future__ import annotations
 
@@ -22,6 +32,7 @@ from typing import Any
 from fastapi import APIRouter, Depends, HTTPException, Query, Request
 
 from tokenjam.api.deps import require_api_key
+from tokenjam.core.alerts import is_interactive_coding_agent
 from tokenjam.core.data_span import available_data_span
 from tokenjam.utils.time_parse import parse_since
 
@@ -47,6 +58,16 @@ def _iso(value: Any) -> str | None:
 
 def _build_agent_drift(db: Any, agent_id: str, since: Any = None) -> dict:
     """Build drift info dict for a single agent, bounded to ``since``."""
+    if is_interactive_coding_agent(agent_id):
+        # Read-path mirror of the write-path skip in DriftDetector.on_session_end.
+        # A stale row from before that skip must not render as a drift verdict.
+        return {
+            "agent_id": agent_id,
+            "baseline": None,
+            "latest_session": None,
+            "baseline_skipped_reason": "interactive_coding_agent",
+        }
+
     baseline = db.get_baseline(agent_id)
     if baseline is None:
         return {"agent_id": agent_id, "baseline": None, "latest_session": None}
@@ -133,5 +154,11 @@ async def get_drift(
     rows = conn.execute(
         "SELECT DISTINCT agent_id FROM drift_baselines ORDER BY agent_id"
     ).fetchall()
-    agents = [_build_agent_drift(db, row[0], since_dt) for row in rows]
+    # Filtered in Python, not in SQL, so the prefix list stays in exactly one
+    # place (core/alerts.py) instead of being restated as a LIKE clause here.
+    agents = [
+        _build_agent_drift(db, row[0], since_dt)
+        for row in rows
+        if not is_interactive_coding_agent(row[0])
+    ]
     return {"agents": agents, "window": window, "data_span": data_span}

--- a/tokenjam/core/agent_kind.py
+++ b/tokenjam/core/agent_kind.py
@@ -1,0 +1,104 @@
+"""Single source of truth for classifying an ``agent_id`` into a budget KIND:
+a coding-tool GROUP (one row per tool, never per project or session) or an
+SDK workflow (one row per literal ``agent_id``).
+
+Why this exists: a real corpus renders one ``sessions.agent_id`` row per
+Claude Code *project*, because that is how the id is minted
+(``core/backfill.py::_agent_id_from_cwd`` derives ``claude-code-<cwd-basename>``
+per project). From a budget-ceiling standpoint that is one tool, not N
+projects, so this module collapses all of a tool's ids into one GROUP id
+before any cap is applied or displayed.
+
+Two coding-tool groups are recognized today, each via its OWN naming
+convention — do not merge their matching rules, they come from different
+runtimes with different id-minting behavior:
+
+  - ``claude-code``: the bare ``"claude-code"`` id (used before
+    ``_agent_id_from_cwd`` runs, or by onboarding paths that attach no cwd),
+    plus every ``"claude-code-<project>"`` variant it derives. Prefix match.
+  - ``codex``: Codex hardcodes ``service.name=codex_exec`` globally in the
+    OTel resource it emits — there is no per-project variant to collapse, so
+    the match is an EXACT id, not a prefix.
+
+Anything that matches neither pattern is an SDK workflow: an arbitrary id a
+caller declared via ``@watch()``. SDK workflows are never grouped — each
+keeps its own row, keyed by its own ``agent_id``, exactly as configured.
+
+This module is intentionally NOT the same thing as
+``tokenjam.core.alerts.is_interactive_coding_agent``, an older, broader,
+prefix-only boolial predicate (``"claude-code"`` OR ``"codex"`` prefix) with
+five existing call sites (``alerts.py``, ``drift.py``, ``framing.py``,
+``relearn_otel.py``, ``api/routes/status.py``) and a pinned margin-case test
+(``tests/unit/test_alerts.py::test_is_interactive_coding_agent_margin_cases``,
+which asserts ``"codex-cli-session"`` classifies as a coding agent under
+THAT predicate). Retightening codex to an exact match there would silently
+change behavior for all five unrelated call sites and break that pinned
+test. Budget-group classification needs the tighter, more accurate rule
+(Codex truly never varies its service name), so it lives here, scoped to the
+one feature that needs it, rather than mutating the older shared predicate.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+# claude-code: bare id, or "claude-code-<project>" (core/backfill.py::_agent_id_from_cwd).
+_CLAUDE_CODE_BARE_ID = "claude-code"
+_CLAUDE_CODE_PROJECT_PREFIX = "claude-code-"
+
+# codex: Codex hardcodes service.name=codex_exec globally — exact match only,
+# no per-project variant exists to collapse.
+_CODEX_EXACT_ID = "codex_exec"
+
+# Ordered so "claude-code" always renders before "codex" when both are present.
+CODING_AGENT_GROUPS: tuple[str, ...] = ("claude-code", "codex")
+
+
+@dataclass(frozen=True)
+class AgentKind:
+    """Classification of one agent_id.
+
+    ``group`` is set if and only if ``is_coding`` is True, and names the
+    coding TOOL ("claude-code" / "codex") — never a project, never a session.
+    An SDK workflow's identity IS its own agent_id; callers use ``agent_id``
+    directly for that case rather than reading a group field here.
+    """
+    is_coding: bool
+    group: str | None = None
+
+
+def classify_agent_kind(agent_id: str | None) -> AgentKind:
+    """Classify a single agent_id into a coding-tool group or an SDK workflow."""
+    if not agent_id:
+        return AgentKind(is_coding=False, group=None)
+    if agent_id == _CLAUDE_CODE_BARE_ID or agent_id.startswith(_CLAUDE_CODE_PROJECT_PREFIX):
+        return AgentKind(is_coding=True, group="claude-code")
+    if agent_id == _CODEX_EXACT_ID:
+        return AgentKind(is_coding=True, group="codex")
+    return AgentKind(is_coding=False, group=None)
+
+
+def is_coding_agent(agent_id: str | None) -> bool:
+    """True for an agent_id belonging to a coding-tool group (see module docstring)."""
+    return classify_agent_kind(agent_id).is_coding
+
+
+def coding_group_id(agent_id: str | None) -> str | None:
+    """The coding-tool group id for `agent_id`, or None (including for SDK workflows)."""
+    return classify_agent_kind(agent_id).group
+
+
+def group_agent_ids(agent_ids: list[str], group_id: str) -> list[str]:
+    """The subset of `agent_ids` that belong to coding-tool group `group_id`."""
+    return [a for a in agent_ids if classify_agent_kind(a).group == group_id]
+
+
+def sdk_agent_ids(agent_ids: list[str]) -> list[str]:
+    """The subset of `agent_ids` that are SDK workflows (not any coding group)."""
+    return [a for a in agent_ids if not classify_agent_kind(a).is_coding]
+
+
+def present_coding_groups(agent_ids: list[str]) -> list[str]:
+    """Coding-tool groups that have at least one member in `agent_ids`, in
+    `CODING_AGENT_GROUPS` order."""
+    present = {classify_agent_kind(a).group for a in agent_ids}
+    return [g for g in CODING_AGENT_GROUPS if g in present]

--- a/tokenjam/core/alerts.py
+++ b/tokenjam/core/alerts.py
@@ -12,7 +12,13 @@ from typing import TYPE_CHECKING, Any
 
 import httpx
 
-from tokenjam.core.config import AlertChannelConfig, TjConfig, resolve_effective_budget
+from tokenjam.core.agent_kind import classify_agent_kind, group_agent_ids
+from tokenjam.core.config import (
+    AlertChannelConfig,
+    TjConfig,
+    resolve_effective_budget,
+    resolve_group_budget,
+)
 from tokenjam.core.models import Alert, AlertType, Severity
 from tokenjam.otel.semconv import GenAIAttributes, TjAttributes
 from tokenjam.utils.formatting import console, severity_colour
@@ -358,13 +364,24 @@ class AlertEngine:
     # ── Per-session checks ─────────────────────────────────────────────────
 
     def _check_cost_budgets(self, session: SessionRecord) -> None:
-        """Check daily and session cost thresholds against the agent's budget config."""
-        from tokenjam.core.config import BudgetConfig
-        budget = resolve_effective_budget(session.agent_id, self.config)
-        if budget == BudgetConfig():
-            return
+        """Check daily and session cost thresholds.
 
-        # Session budget
+        Daily enforcement branches on agent KIND (``core/agent_kind.py``): a
+        coding-tool agent (claude-code / codex) is checked against its
+        GROUP's summed daily spend across every member agent_id (e.g. every
+        ``claude-code-<project>`` variant) — a group cap ceilings the tool as
+        a whole, not any one project, so 20 members at $3 each must trip a
+        $50 group cap even though no single member crosses it alone. An SDK
+        workflow keeps the original per-agent daily check.
+
+        Session-cap enforcement (COST_BUDGET_SESSION) is UNCHANGED and
+        per-agent for both kinds — kept alive for backward compatibility
+        with any already-configured `session_usd`, even though the
+        redesigned Budget UI no longer offers a way to set a new one.
+        """
+        budget = resolve_effective_budget(session.agent_id, self.config)
+
+        # Session budget (per-agent, both kinds; backward-compat only).
         if budget.session_usd is not None and session.total_cost_usd is not None:
             if session.total_cost_usd > budget.session_usd:
                 alert = Alert(
@@ -383,26 +400,70 @@ class AlertEngine:
                 )
                 self._fire(alert)
 
-        # Daily budget
-        if budget.daily_usd is not None:
-            today = utcnow().date()
-            daily_cost = self.db.get_daily_cost(session.agent_id, today)
-            if daily_cost > budget.daily_usd:
-                alert = Alert(
-                    alert_id=new_uuid(),
-                    fired_at=utcnow(),
-                    type=AlertType.COST_BUDGET_DAILY,
-                    severity=Severity.CRITICAL,
-                    title=f"cost_budget_daily — {session.agent_id}",
-                    detail={
-                        "daily_cost": daily_cost,
-                        "budget": budget.daily_usd,
-                        "message": f"Daily cost ${daily_cost:.4f} exceeds budget ${budget.daily_usd:.4f}",
-                    },
-                    agent_id=session.agent_id,
-                    session_id=session.session_id,
-                )
-                self._fire(alert)
+        kind = classify_agent_kind(session.agent_id)
+        if kind.is_coding and kind.group:
+            self._check_coding_group_daily_budget(session, kind.group)
+        else:
+            self._check_agent_daily_budget(session, budget)
+
+    def _check_coding_group_daily_budget(self, session: SessionRecord, group_id: str) -> None:
+        """Daily cap for a coding-tool GROUP: compares the SUM of today's
+        spend across every agent_id that classifies into `group_id` (not
+        just `session.agent_id` alone) against the group's resolved cap."""
+        group_budget = resolve_group_budget(group_id, self.config)
+        if group_budget.daily_usd is None:
+            return
+        today = utcnow().date()
+        member_ids = group_agent_ids(self.db.get_distinct_agent_ids(), group_id)
+        if session.agent_id not in member_ids:
+            # A brand-new agent_id whose first span/session hasn't landed in
+            # get_distinct_agent_ids() yet (e.g. same-transaction ingest).
+            member_ids = [*member_ids, session.agent_id]
+        daily_cost = self.db.get_daily_cost_for_agents(member_ids, today)
+        if daily_cost > group_budget.daily_usd:
+            alert = Alert(
+                alert_id=new_uuid(),
+                fired_at=utcnow(),
+                type=AlertType.COST_BUDGET_DAILY,
+                severity=Severity.CRITICAL,
+                title=f"cost_budget_daily — {group_id} (group)",
+                detail={
+                    "daily_cost": daily_cost,
+                    "budget": group_budget.daily_usd,
+                    "group": group_id,
+                    "member_agent_ids": member_ids,
+                    "message": (
+                        f"Daily cost ${daily_cost:.4f} across the {group_id} "
+                        f"group exceeds budget ${group_budget.daily_usd:.4f}"
+                    ),
+                },
+                agent_id=session.agent_id,
+                session_id=session.session_id,
+            )
+            self._fire(alert)
+
+    def _check_agent_daily_budget(self, session: SessionRecord, budget) -> None:
+        """Daily cap for an SDK workflow: unchanged, per-agent."""
+        if budget.daily_usd is None:
+            return
+        today = utcnow().date()
+        daily_cost = self.db.get_daily_cost(session.agent_id, today)
+        if daily_cost > budget.daily_usd:
+            alert = Alert(
+                alert_id=new_uuid(),
+                fired_at=utcnow(),
+                type=AlertType.COST_BUDGET_DAILY,
+                severity=Severity.CRITICAL,
+                title=f"cost_budget_daily — {session.agent_id}",
+                detail={
+                    "daily_cost": daily_cost,
+                    "budget": budget.daily_usd,
+                    "message": f"Daily cost ${daily_cost:.4f} exceeds budget ${budget.daily_usd:.4f}",
+                },
+                agent_id=session.agent_id,
+                session_id=session.session_id,
+            )
+            self._fire(alert)
 
     def _check_session_duration(self, session: SessionRecord) -> None:
         """Fire SESSION_DURATION if session wall time exceeds threshold.

--- a/tokenjam/core/config.py
+++ b/tokenjam/core/config.py
@@ -27,6 +27,22 @@ class BudgetConfig:
 
 
 @dataclass
+class GroupBudgetConfig:
+    """A coding-tool GROUP's daily cap — e.g. one ceiling covering every
+    claude-code-<project> variant summed together. Daily-only: a per-session
+    cap has no meaning at group scope (there is no single session to cap),
+    and the UI never offers a per-session field for these rows. Kept as its
+    own dataclass rather than reusing BudgetConfig so a `session_usd` can
+    never be silently written here and silently ignored."""
+    daily_usd: float | None = None
+
+
+@dataclass
+class CodingGroupConfig:
+    budget: GroupBudgetConfig = field(default_factory=GroupBudgetConfig)
+
+
+@dataclass
 class DriftConfig:
     enabled:            bool  = True
     baseline_sessions:  int   = 10
@@ -57,7 +73,12 @@ class AgentConfig:
 
 @dataclass
 class DefaultsConfig:
+    # SDK-workflow zone default (per-agent daily + session cap).
     budget: BudgetConfig = field(default_factory=BudgetConfig)
+    # Coding-agent zone default: the daily group cap a newly-appearing coding
+    # tool (a claude-code/codex group with no [coding_agents.<id>] entry yet)
+    # inherits, so it starts capped instead of arriving uncapped.
+    coding_budget: GroupBudgetConfig = field(default_factory=GroupBudgetConfig)
 
 
 @dataclass
@@ -432,6 +453,15 @@ class TjConfig:
     version:  str
     defaults: DefaultsConfig          = field(default_factory=DefaultsConfig)
     agents:   dict[str, AgentConfig]  = field(default_factory=dict)
+    # Coding-tool GROUP caps ([coding_agents.<group_id>.budget] in TOML), keyed
+    # by group id ("claude-code" / "codex" — see core/agent_kind.py). A
+    # deliberately SEPARATE namespace from `agents`: a group id like
+    # "claude-code" would otherwise collide with a literal per-agent
+    # [agents.claude-code] entry (the bare agent_id some setups still emit).
+    # Keeping groups in their own top-level TOML table means both can be
+    # configured independently with no ambiguity about which one a given
+    # section name refers to.
+    coding_agents: dict[str, CodingGroupConfig] = field(default_factory=dict)
     storage:  StorageConfig           = field(default_factory=StorageConfig)
     export:   ExportConfig            = field(default_factory=ExportConfig)
     alerts:   AlertsConfig            = field(default_factory=AlertsConfig)
@@ -802,7 +832,24 @@ def _parse(raw: dict) -> TjConfig:
 
     defaults_raw = raw.get("defaults", {})
     defaults_budget_raw = defaults_raw.get("budget", {})
-    defaults = DefaultsConfig(budget=BudgetConfig(**defaults_budget_raw))
+    defaults_coding_budget_raw = defaults_raw.get("coding_budget", {})
+    defaults = DefaultsConfig(
+        budget=BudgetConfig(**defaults_budget_raw),
+        coding_budget=GroupBudgetConfig(**defaults_coding_budget_raw),
+    )
+
+    # [coding_agents.<group_id>.budget] — daily-only ceilings for a coding
+    # TOOL group ("claude-code" / "codex"), summed across every member
+    # agent_id. Separate top-level table from [agents.*] on purpose: see
+    # TjConfig.coding_agents docstring for the collision this avoids.
+    coding_agents: dict[str, CodingGroupConfig] = {}
+    for group_id, group_raw in raw.get("coding_agents", {}).items():
+        if not isinstance(group_raw, dict):
+            continue
+        group_budget_raw = group_raw.get("budget", {})
+        coding_agents[group_id] = CodingGroupConfig(
+            budget=GroupBudgetConfig(**group_budget_raw)
+        )
 
     # [budget.<provider>] sections — periodic monthly ceilings used by tj optimize.
     # Distinct from [defaults.budget] / [agents.X.budget] (per-agent alert thresholds).
@@ -839,6 +886,7 @@ def _parse(raw: dict) -> TjConfig:
         version=raw.get("version", "1"),
         defaults=defaults,
         agents=agents,
+        coding_agents=coding_agents,
         storage=storage,
         export=export,
         alerts=alerts,
@@ -893,6 +941,16 @@ def _serialise(config: TjConfig) -> dict:
         agents_out[agent_id] = _dc_to_dict(agent_cfg)
     d["agents"] = agents_out
 
+    # coding_agents is a dict of str -> CodingGroupConfig, handle specially
+    # (same reason as `agents`/`budgets`: the generic dict branch above would
+    # assign the raw dataclass objects instead of recursing into them).
+    d.pop("coding_agents", None)
+    coding_agents_out: dict = {}
+    for group_id, group_cfg in config.coding_agents.items():
+        coding_agents_out[group_id] = _dc_to_dict(group_cfg)
+    if coding_agents_out:
+        d["coding_agents"] = coding_agents_out
+
     # budgets is a dict of str -> ProviderBudget, handle specially
     budgets_out: dict = {}
     for provider, prov_cfg in config.budgets.items():
@@ -924,6 +982,24 @@ def resolve_effective_budget(agent_id: str, config: TjConfig) -> BudgetConfig:
     return BudgetConfig(
         daily_usd=ab.daily_usd if ab.daily_usd is not None else defaults.daily_usd,
         session_usd=ab.session_usd if ab.session_usd is not None else defaults.session_usd,
+    )
+
+
+def resolve_group_budget(group_id: str, config: TjConfig) -> GroupBudgetConfig:
+    """Return the effective daily cap for a coding-tool GROUP (see
+    core/agent_kind.py for what a "group" is), merging any
+    [coding_agents.<group_id>.budget] override over
+    [defaults.coding_budget] — same per-field-fallback shape as
+    resolve_effective_budget, just for the group namespace instead of the
+    per-agent one.
+    """
+    defaults = config.defaults.coding_budget
+    group_cfg = config.coding_agents.get(group_id)
+    if group_cfg is None:
+        return GroupBudgetConfig(daily_usd=defaults.daily_usd)
+    gb = group_cfg.budget
+    return GroupBudgetConfig(
+        daily_usd=gb.daily_usd if gb.daily_usd is not None else defaults.daily_usd,
     )
 
 

--- a/tokenjam/core/db.py
+++ b/tokenjam/core/db.py
@@ -104,6 +104,7 @@ class StorageBackend(Protocol):
         self, agent_id: str | None, since: datetime | None, tool_name: str | None,
     ) -> list[dict]: ...
     def get_daily_cost(self, agent_id: str, date: date) -> float: ...
+    def get_daily_cost_for_agents(self, agent_ids: list[str], date: date) -> float: ...
     def get_session_cost(self, session_id: str) -> float: ...
     def get_recent_spans(self, session_id: str, limit: int) -> list[NormalizedSpan]: ...
     # Issue #309: methods that callers (CostEngine, cmd_status, cost compare)
@@ -2709,6 +2710,23 @@ class DuckDBBackend:
             "SELECT COALESCE(SUM(cost_usd), 0.0) FROM spans "
             "WHERE agent_id = $1 AND CAST(start_time AT TIME ZONE 'UTC' AS DATE) = $2",
             [agent_id, date],
+        ).fetchone()
+        return float(result[0]) if result else 0.0
+
+    def get_daily_cost_for_agents(self, agent_ids: list[str], date: date) -> float:
+        """Summed daily cost across a SET of agent_ids for one UTC calendar
+        day — generalizes `get_daily_cost` for a coding-tool GROUP cap
+        (e.g. every `claude-code-<project>` variant), where the ceiling
+        applies to the group's combined spend, not any one member alone.
+        """
+        if not agent_ids:
+            return 0.0
+        placeholders = ", ".join(f"${i + 2}" for i in range(len(agent_ids)))
+        result = self.conn.execute(
+            "SELECT COALESCE(SUM(cost_usd), 0.0) FROM spans "
+            f"WHERE agent_id IN ({placeholders}) "
+            "AND CAST(start_time AT TIME ZONE 'UTC' AS DATE) = $1",
+            [date, *agent_ids],
         ).fetchone()
         return float(result[0]) if result else 0.0
 

--- a/tokenjam/ui/index.html
+++ b/tokenjam/ui/index.html
@@ -1016,10 +1016,10 @@ a.health-tile.attn { border-color: var(--warn); }
 .opt-table tr.flagged td { color: var(--warn); }
 .opt-caveat { font-size: 12px; font-style: italic; color: var(--warn); margin-top: 10px; }
 
-/* Analyzer guide (Observe ▸ Optimize ▸ Guide). Reading surface, not a data
-   surface: one column capped at a comfortable measure, generous leading. It
-   reuses .opt-section for the card frame so it can never drift from the
-   Optimize cards it explains. */
+/* FAQ (Improve ▸ FAQ, formerly Observe ▸ Optimize ▸ Guide). Reading surface,
+   not a data surface: one column capped at a comfortable measure, generous
+   leading. It reuses .opt-section for the card frame so it can never drift
+   from the Optimize cards it explains. */
 .guide-prose { font-size: 13.5px; line-height: 1.65; color: var(--text); max-width: 74ch; margin: 6px 0; }
 .guide-prose.dim { color: var(--text-dim); }
 .guide-lead { font-size: 12px; font-weight: 600; letter-spacing: .04em; text-transform: uppercase; color: var(--text-dim); margin: 12px 0 2px; }
@@ -1729,13 +1729,6 @@ code.md-code {
        while a session detail is open. #/status survives as a silent route alias
        for old bookmarks. -->
   <a href="#/sessions" class="nav-link" data-view="sessions" data-lens="improve"><span class="icon">&#9707;</span> Sessions</a>
-  <a href="#/traces" class="nav-link" data-view="traces" data-lens="observe"><span class="icon">&diamond;</span> Traces</a>
-  <a href="#/cost" class="nav-link" data-view="cost" data-lens="observe"><span class="icon">$</span> Cost</a>
-  <a href="#/alerts" class="nav-link" data-view="alerts" data-lens="observe"><span class="icon">!</span> Alerts</a>
-  <a href="#/drift" class="nav-link" data-view="drift" data-lens="observe"><span class="icon">~</span> Drift</a>
-  <a href="#/optimize" class="nav-link" data-view="optimize" data-lens="observe"><span class="icon">&#9889;</span> Optimize</a>
-  <a href="#/optimize/summarize" class="nav-link nav-child" data-view="optimize" data-param="summarize" data-lens="observe"><span class="icon">&#8627;</span> Summarize <span class="nav-badge">new</span></a>
-  <a href="#/budget" class="nav-link" data-view="budget" data-lens="observe"><span class="icon">$</span> Budget</a>
   <!-- TOP-LEVEL, never a nav-child. A nav-child is display:none unless its
        parent section is the active view (see App()'s route effect), so as a
        child of Optimize this entry was invisible from Traces / Cost / Alerts /
@@ -1744,10 +1737,17 @@ code.md-code {
        be told what the analyzers are. The route resolved and something did
        link to it, but only conditionally, and "a user has a path to it" has to
        hold from wherever the user actually is.
-       Last in the Observe group and separated, because it is a reference page
+       Last in the Improve group and separated, because it is a reference page
        rather than a live data view: it reads no window, has no filters, and
        does not belong interleaved with the screens that do. -->
-  <a href="#/guide" class="nav-link nav-reference" data-view="guide" data-lens="observe"><span class="icon">?</span> Analyzer guide</a>
+  <a href="#/faq" class="nav-link nav-reference" data-view="faq" data-lens="improve"><span class="icon">?</span> FAQ</a>
+  <a href="#/traces" class="nav-link" data-view="traces" data-lens="observe"><span class="icon">&diamond;</span> Traces</a>
+  <a href="#/cost" class="nav-link" data-view="cost" data-lens="observe"><span class="icon">$</span> Cost</a>
+  <a href="#/alerts" class="nav-link" data-view="alerts" data-lens="observe"><span class="icon">!</span> Alerts</a>
+  <a href="#/drift" class="nav-link" data-view="drift" data-lens="observe"><span class="icon">~</span> Drift</a>
+  <a href="#/optimize" class="nav-link" data-view="optimize" data-lens="observe"><span class="icon">&#9889;</span> Optimize</a>
+  <a href="#/optimize/summarize" class="nav-link nav-child" data-view="optimize" data-param="summarize" data-lens="observe"><span class="icon">&#8627;</span> Summarize <span class="nav-badge">new</span></a>
+  <a href="#/budget" class="nav-link" data-view="budget" data-lens="observe"><span class="icon">$</span> Budget</a>
   <div class="sidebar-footer">
     <a href="/docs" target="_blank" class="footer-link"><span class="icon">&#x2737;</span> API docs</a>
     <a href="https://github.com/Metabuilder-Labs/tokenjam" target="_blank" class="footer-link"><span class="icon">&#x2197;</span> GitHub</a>
@@ -7733,12 +7733,12 @@ function OptimizeView({ params }) {
           branch — so it is there while the store is cold, while a scan is in
           flight, and after a failed read, which are the states a reader is most
           likely to be wondering what these checks are. The sidebar carries the
-          guide as a top-level Observe entry (that is what makes it reachable
+          FAQ as a top-level Improve entry (that is what makes it reachable
           from anywhere at all); this link is the contextual one, offered on the
           screen whose cards it explains. */ ''}
     <div class="page-title" style="display:flex;align-items:center;gap:10px;flex-wrap:wrap">
       Optimize <${PlanBadge} framing=${framing} />
-      <a class="sz-link" href="#/guide" style="font-size:13px;font-weight:400">What do these checks mean? →</a>
+      <a class="sz-link" href="#/faq" style="font-size:13px;font-weight:400">What do these checks mean? →</a>
     </div>
     <div class="filters">
       <select value=${since} onChange=${e => setFilter('since', e.target.value)}>
@@ -7862,7 +7862,7 @@ function OptimizeView({ params }) {
 }
 
 // ============================
-// Optimize ▸ Guide — what each check looks for, in plain language.
+// FAQ (formerly Optimize ▸ Guide) — what each check looks for, in plain language.
 // ============================
 // This page exists for one question that kept getting asked: how are `downsize`
 // and `subagent` different? They sit next to each other on the Optimize screen,
@@ -8070,8 +8070,8 @@ function AnalyzerGuideView() {
 
   return html`
     <div class="page-title" style="display:flex;align-items:center;gap:12px;flex-wrap:wrap">
-      Analyzer guide
-      ${/* Forward, not "back": this is a top-level Observe page now, reachable
+      FAQ
+      ${/* Forward, not "back": this is a top-level Improve page now, reachable
             from any screen, so a reader may well have arrived without ever
             visiting Optimize. Pointing AT the cards is true from anywhere;
             "back" would be a guess about where they came from. */ ''}
@@ -11947,8 +11947,9 @@ function DashboardView({ params }) {
 // existing view still renders, this only decides which nav group frames it.
 const VIEW_LENS = {
   review: 'improve', dashboard: 'improve', status: 'improve', sessions: 'improve', runs: 'improve',
+  faq: 'improve',
   traces: 'observe', cost: 'observe', alerts: 'observe', drift: 'observe',
-  optimize: 'observe', budget: 'observe', guide: 'observe',
+  optimize: 'observe', budget: 'observe',
 };
 
 // ============================
@@ -11972,8 +11973,8 @@ const PRIMARY_VIEWS = [
   ['drift',     DriftView],
   ['optimize',  OptimizeView],
   ['summarize', SummarizeView],
-  ['guide',     AnalyzerGuideView],
   ['budget',    BudgetView],
+  ['faq',       AnalyzerGuideView],
 ];
 const PRIMARY_KEYS = new Set(PRIMARY_VIEWS.map(([k]) => k));
 const EMPTY_PARAMS = new URLSearchParams();
@@ -11984,26 +11985,28 @@ const WARM_STAGGER_MS = 120;   // gap between mounting each warmed-on-boot view
 // screen was the same AnalyticsView the Dashboard already embeds as its
 // "Explore" section, so the separate route was a second door to one room);
 // #/status and #/runs are silent aliases for Sessions (they render the same
-// StatusView); #/optimize/summarize is the Summarize sub-view. The analyzer
-// guide is a TOP-LEVEL route (#/guide) — it was briefly a sub-view of Optimize,
-// which made its sidebar entry a nav-child and therefore invisible from every
-// other screen; `#/optimize/guide` survives as a silent alias so any link that
-// already points at the old hash keeps working (the effect in App() rewrites
-// the address bar to the canonical form). Anything else is its own view key.
+// StatusView); #/optimize/summarize is the Summarize sub-view. The FAQ (nee
+// analyzer guide) is a TOP-LEVEL route (#/faq) — it was briefly a sub-view of
+// Optimize, which made its sidebar entry a nav-child and therefore invisible
+// from every other screen; `#/optimize/guide` and `#/guide` both survive as
+// silent aliases so any link that already points at an old hash keeps working
+// (the effect in App() rewrites the address bar to the canonical form).
+// Anything else is its own view key.
 function primaryKeyFor(route) {
   const v = route.view;
   if (v === 'overview' || v === 'analytics') return 'dashboard';
   if (v === 'status' || v === 'runs') return 'sessions';
   if (v === 'optimize' && route.param === 'summarize') return 'summarize';
-  if (v === 'optimize' && route.param === 'guide') return 'guide';
+  if (v === 'optimize' && route.param === 'guide') return 'faq';
+  if (v === 'guide') return 'faq';
   return v;
 }
 
-// True for the retired `#/optimize/guide` hash only. Kept as a named predicate
-// so the alias is stated once and both the router and the canonicalising effect
-// read the same rule.
+// True for the retired `#/optimize/guide` and `#/guide` hashes only. Kept as a
+// named predicate so the alias is stated once and both the router and the
+// canonicalising effect read the same rule.
 function isLegacyGuideRoute(route) {
-  return route.view === 'optimize' && route.param === 'guide';
+  return (route.view === 'optimize' && route.param === 'guide') || route.view === 'guide';
 }
 
 // Detail overlay for an id-keyed drill-in (mounts fresh per id), else null.
@@ -12038,16 +12041,16 @@ function App() {
     }
   }, []);
 
-  // Canonicalise the retired `#/optimize/guide` hash to `#/guide`. The router
-  // already renders the right view for either (primaryKeyFor), so this exists
-  // for the SIDEBAR: the guide's nav entry keys on `data-view="guide"`, and on
-  // the legacy hash the active view is still `optimize`, which would light up
-  // the wrong row. replaceState leaves no history entry (so Back does not
-  // bounce between the two spellings) and fires no hashchange, hence the
-  // explicit re-read.
+  // Canonicalise the retired `#/optimize/guide` and `#/guide` hashes to
+  // `#/faq`. The router already renders the right view for any of the three
+  // (primaryKeyFor), so this exists for the SIDEBAR: the FAQ nav entry keys on
+  // `data-view="faq"`, and on either legacy hash the active view is still
+  // `optimize` or `guide`, which would light up the wrong row (or none).
+  // replaceState leaves no history entry (so Back does not bounce between the
+  // spellings) and fires no hashchange, hence the explicit re-read.
   useEffect(() => {
     if (isLegacyGuideRoute(route)) {
-      history.replaceState(null, '', '#/guide');
+      history.replaceState(null, '', '#/faq');
       setRoute(getRoute());
     }
   }, [route.view, route.param]);

--- a/tokenjam/ui/index.html
+++ b/tokenjam/ui/index.html
@@ -10019,7 +10019,7 @@ function RecurringMistakeRow({ cluster, checked, onToggle, onExpand, onDismiss, 
         <div class="sz-note" style="font-size:12px;margin-top:10px">There is nothing to apply here yet. The example sessions are what we have.</div>
       ` : null}
 
-      <div style="display:flex;gap:12px;align-items:center;margin-top:12px">
+      <div style="display:flex;gap:12px;align-items:center;justify-content:flex-end;margin-top:12px">
         ${canApply ? html`
           ${/* Plain ampersand, not `&amp;`: htm assigns text content rather than
                 parsing HTML entities, so an entity here renders literally. */ ''}
@@ -10684,11 +10684,16 @@ function CostProposalCard({ prop, mechanism, busy, focused, onMark, onDismiss, o
                 model is as good", not harder (Critical Rule 14). */ ''}
           ${prop.apply_caveat ? html`
             <div class="opt-caveat" style="margin-top:6px">${prop.apply_caveat}</div>` : null}
-          <div style="display:flex;gap:8px;margin-top:6px;flex-wrap:wrap">
+          <div style="display:flex;gap:8px;margin-top:6px;flex-wrap:wrap;align-items:center">
             <input class="rename-input" style="flex:1;min-width:280px" value=${spTarget}
               placeholder="/absolute/path/to/the/agent/checkout" onInput=${e => setSpTarget(e.target.value)} />
             <button class="cur-btn" disabled=${spBusy || !spTarget.trim()} onClick=${() => registerSourcePath(false)}>${spBusy ? 'working…' : 'Preview'}</button>
             <button class="cur-btn primary" disabled=${spBusy || !spTarget.trim()} onClick=${() => registerSourcePath(true)}>Apply swap →</button>
+            ${/* Same shared action-row treatment every other card kind uses: plain
+                  white text beside the primary button, not a stray blue link
+                  dropped below the panel. See the trailing `canApply` block this
+                  replaced, below. */ ''}
+            <span class="sz-link" style="color:var(--text)" onClick=${() => onDismiss(prop.signature)}>Dismiss</span>
           </div>
           ${spResolved ? html`<div class="dim" style="font-size:11.5px;margin-top:4px">would edit ${spResolved}</div>` : null}
           ${spPreview ? html`<pre class="rev-diff" style="margin:8px 0 0;white-space:pre-wrap;font-size:11.5px">${spPreview}</pre>` : null}
@@ -10698,11 +10703,15 @@ function CostProposalCard({ prop, mechanism, busy, focused, onMark, onDismiss, o
         <div class="opt-section" style="margin:10px 0 0">
           <div class="opt-title" style="font-size:12.5px;margin-bottom:2px">${akCopy.title}</div>
           <div style="font-size:12.5px;margin:0 0 4px"><span class="dim" style="font-weight:400">${akCopy.hint}</span></div>
-          <div style="display:flex;gap:8px;margin-top:0;flex-wrap:wrap">
+          <div style="display:flex;gap:8px;margin-top:0;flex-wrap:wrap;align-items:center">
             <input class="rename-input" style="flex:1;min-width:280px" value=${akTarget}
               placeholder="/absolute/path/to/target" onInput=${e => setAkTarget(e.target.value)} />
             <button class="cur-btn" disabled=${akBusy} onClick=${() => applyKindFix(false)}>${akBusy ? 'working…' : 'Preview'}</button>
             <button class="cur-btn primary" disabled=${akBusy} onClick=${() => applyKindFix(true)}>${akCopy.button} →</button>
+            ${/* mcp_remove ("Remove this MCP server entry") lands here too — this
+                  is the shared action-row treatment, same as every other card
+                  kind: white Dismiss beside the primary button, same row. */ ''}
+            <span class="sz-link" style="color:var(--text)" onClick=${() => onDismiss(prop.signature)}>Dismiss</span>
           </div>
           ${akPreview ? html`<pre class="rev-diff" style="margin:8px 0 0;white-space:pre-wrap;font-size:11.5px">${akPreview}</pre>` : null}
           ${akWarning ? html`<div class="opt-caveat" style="color:var(--warn)">${akWarning} <span class="sz-link" onClick=${() => applyKindFix(true, true)}>Apply anyway →</span></div>` : null}
@@ -10727,11 +10736,12 @@ function CostProposalCard({ prop, mechanism, busy, focused, onMark, onDismiss, o
             <span class="dim" style="font-weight:400">writes a reversible rung-1 note to the project ${prop.target_path ? 'below' : html`<code>CLAUDE.md</code> you paste below, or register it once with <code>tj onboard --add-project</code>`}</span>
             ${!prop.target_path ? html`<${CopySnippetButton} text="tj onboard --add-project" />` : null}
           </div>
-          <div style="display:flex;gap:8px;margin-top:0;flex-wrap:wrap">
+          <div style="display:flex;gap:8px;margin-top:0;flex-wrap:wrap;align-items:center">
             <input class="rename-input" style="flex:1;min-width:280px" value=${target}
               placeholder="/absolute/path/to/project/CLAUDE.md" onInput=${e => setTarget(e.target.value)} />
             <button class="cur-btn" disabled=${wbusy || !target.trim()} onClick=${() => applyWorkspace(false)}>${wbusy ? 'working…' : 'Preview note'}</button>
             <button class="cur-btn primary" disabled=${wbusy || !target.trim()} onClick=${() => applyWorkspace(true)}>Apply note →</button>
+            <span class="sz-link" style="color:var(--text)" onClick=${() => onDismiss(prop.signature)}>Dismiss</span>
           </div>
           ${preview ? html`<pre class="rev-diff" style="margin:8px 0 0;white-space:pre-wrap;font-size:11.5px">${preview}</pre>` : null}
           ${werr ? html`<div style="color:var(--error);font-size:12px;margin-top:6px">${werr}</div>` : null}
@@ -10742,14 +10752,14 @@ function CostProposalCard({ prop, mechanism, busy, focused, onMark, onDismiss, o
               applied" here would be a second, disconnected ledger for the
               same state. The card's one affordance is the link to that
               surface, worded as a review action, never a claimable "Apply". */ ''}
-        <div style="display:flex;gap:12px;align-items:center;margin-top:12px">
+        <div style="display:flex;gap:12px;align-items:center;justify-content:flex-end;margin-top:12px">
           <a class="cur-btn primary" style="text-decoration:none" href=${(prop.target_key && prop.target_key.href) || '#/optimize/summarize'}>Review in Summarize →</a>
           <span class="sz-link" style="color:var(--text)" onClick=${() => onDismiss(prop.signature)}>Dismiss</span>
         </div>
       ` : hasSnippet ? html`
         ${/* The snippet block above IS this card's fix; "Mark applied" is the
               follow-up that records having done it, not the fix itself. */ ''}
-        <div style="display:flex;gap:12px;align-items:center;margin-top:12px">
+        <div style="display:flex;gap:12px;align-items:center;justify-content:flex-end;margin-top:12px">
           <button class="cur-btn primary" disabled=${busy} onClick=${() => onMark(prop)}>${busy ? 'Marking…' : 'Mark applied'}</button>
           ${/* Dismiss is the secondary, discarding action: plain text, so the
                 blue belongs to the one action the card is asking for. */ ''}
@@ -10770,13 +10780,12 @@ function CostProposalCard({ prop, mechanism, busy, focused, onMark, onDismiss, o
               a blank action area reading as a bug. */ ''}
         <div style="margin-top:12px">
           ${!blockedReason && !description ? html`<div class="sz-note" style="font-size:12px">There is no ready-made change to apply here yet. What this cost is measured; the fix is not something tokenjam can hand over.</div>` : null}
-          <div style="display:flex;gap:12px;align-items:center">
+          <div style="display:flex;gap:12px;align-items:center;justify-content:flex-end">
             <a class="sz-link" href=${optimizeFindingHref(prop.analyzer)}>See the full analysis →</a>
             <span class="sz-link" style="color:var(--text)" onClick=${() => onDismiss(prop.signature)}>Dismiss</span>
           </div>
         </div>
       `}
-      ${canApply ? html`<div style="margin-top:8px"><span class="sz-link" onClick=${() => onDismiss(prop.signature)}>Dismiss</span></div>` : null}
     </div>`;
 }
 

--- a/tokenjam/ui/index.html
+++ b/tokenjam/ui/index.html
@@ -1016,21 +1016,14 @@ a.health-tile.attn { border-color: var(--warn); }
 .opt-table tr.flagged td { color: var(--warn); }
 .opt-caveat { font-size: 12px; font-style: italic; color: var(--warn); margin-top: 10px; }
 
-/* FAQ (Improve ▸ FAQ, formerly Observe ▸ Optimize ▸ Guide). Reading surface,
-   not a data surface: one column capped at a comfortable measure, generous
-   leading. It reuses .opt-section for the card frame so it can never drift
-   from the Optimize cards it explains. */
-.guide-prose { font-size: 13.5px; line-height: 1.65; color: var(--text); max-width: 74ch; margin: 6px 0; }
-.guide-prose.dim { color: var(--text-dim); }
-.guide-lead { font-size: 12px; font-weight: 600; letter-spacing: .04em; text-transform: uppercase; color: var(--text-dim); margin: 12px 0 2px; }
+/* FAQ (Improve ▸ FAQ, formerly Observe ▸ Optimize ▸ Guide). It reuses
+   .opt-section for the card frame so it can never drift from the Optimize
+   cards it explains, and (like .opt-line on those cards) the prose fills the
+   card's full content width -- no editorial measure clamp. `.guide-prose` is
+   used ONLY on this page, so widening it here cannot affect any other
+   screen. */
+.guide-prose { font-size: 13.5px; line-height: 1.65; color: var(--text); margin: 6px 0; }
 .guide-name { font-family: 'Geist Mono', monospace; font-size: 12px; color: var(--text-dim); font-weight: 400; }
-/* The downsize-vs-subagent contrast. Accented because telling those two apart
-   is the single question this page exists to answer. */
-.guide-key { border-left: 3px solid var(--accent); background: var(--surface2); border-radius: 0 8px 8px 0; padding: 14px 18px; margin-bottom: 14px; }
-.guide-banner { font-size: 13px; line-height: 1.6; color: var(--text-dim); background: var(--surface2); border: 1px solid var(--border); border-radius: 8px; padding: 12px 16px; margin-bottom: 14px; max-width: 74ch; }
-.guide-hidden-list { list-style: none; padding: 0; margin: 8px 0 0; }
-.guide-hidden-list li { font-size: 13px; line-height: 1.6; color: var(--text-dim); padding: 4px 0; border-bottom: 1px solid var(--border); }
-.guide-hidden-list li:last-child { border-bottom: 0; }
 
 /* Session Story */
 .story-callout {
@@ -7889,220 +7882,180 @@ function OptimizeView({ params }) {
 // today. An unwritten persona gets an honest banner naming the gap, never
 // invented copy: text describing an SDK user's levers, written from a corpus of
 // interactive coding sessions, would be fabrication.
-const GUIDE_PERSONA_LABELS = {
-  'claude-code': 'Claude Code',
-  'sdk': 'SDK and API',
-  'mixed': 'mixed (Claude Code and SDK)',
-  'unknown': 'unclassified',
-};
-
-// The contrast the page is built around. Rendered before the per-check list.
-const GUIDE_KEY_CONTRAST = {
-  personas: ['claude-code'],
-  title: 'Downsize and Subagent are not the same check',
-  paras: [
-    'Downsize is about WHERE the work happened. It looks at work carried out inline, in the main thread, on an expensive model, when it could have been handed to a worker instead.',
-    'Subagent is about WHO did it, once you had already decided to delegate. The work went to a worker; the worker was simply bigger than the job needed.',
-    'A session can only trip one of them. Downsize only considers sessions that never delegated at all, so the moment a worker is involved the question stops being "should this have been delegated" and becomes "was the right worker chosen".',
-  ],
-};
-
-// Per-check prose. `mistake` is what the check looks for; `fix` is what you do
-// about it. Deliberately no numbers, no field names, no thresholds: those live
-// on the cards, which is where a reader can see them against their own data.
+// Per-check prose: one heading, one description (a few paragraphs of flowing
+// text). Deliberately no numbers, no field names, no thresholds: those live on
+// the cards, which is where a reader can see them against their own data.
+//
+// Downsize and Subagent used to share a separate callout card stating the
+// distinction between them (WHERE the work happened vs. WHO did it); that
+// card is gone, and the distinction is written into each of their own
+// descriptions instead, so either section stands alone. The WHERE/WHO framing
+// and the "a session can only trip one of them" claim are grounded in how
+// `model_downgrade.py`'s driver-role case and `subagent_rightsizing.py` are
+// actually scoped: the driver-role case (the bulk of what Downsize flags) only
+// admits sessions that never dispatched a subagent at all, and
+// `subagent_rightsizing` only ever reads spans already tagged with a
+// `sub_agent_id` (i.e. already dispatched to a worker), so the two describe
+// disjoint populations for the flagship detection each card reports on.
+//
+// This is a card for EVERY registered analyzer (`ANALYZER_REGISTRY` in
+// `core/optimize/`), not only the ones that produce cards on the Optimize
+// screen for the Claude Code persona -- `order` below lists the live ones
+// first, then the ones gated off for Claude Code, and the two groups are
+// never interleaved. The live/gated split and the reasoning inside each
+// gated entry's description are grounded in
+// `.claude/product-state/ANALYZER-PERSONA-MATRIX.md` (the durable decision
+// record for persona gating) plus the gated analyzer's own module docstring,
+// not re-derived here. `placement` is a sub-check `downsize` attaches, not
+// its own registry entry, so it has no card of its own -- it is covered
+// inside Downsize's description of what the driver-role case claims.
+//
+// Static and complete by construction, so this page needs no server fetch:
+// which analyzers exist and which are gated for Claude Code are both decided
+// in code (the analyzer registry and the persona gate map in
+// `core/optimize/runner.py`), not at runtime.
+// `tests/unit/test_lens_ui_regression.py` cross-checks this object against
+// the live registry so a newly-registered analyzer with no entry here fails
+// CI instead of silently falling behind.
 const GUIDE_ENTRIES = {
   'claude-code': {
-    order: ['downsize', 'subagent', 'resend', 'summarize', 'deadweight', 'relearn', 'budget-projection'],
+    order: [
+      // Live for Claude Code: these produce cards on the Optimize screen.
+      'downsize', 'subagent', 'resend', 'summarize', 'deadweight', 'relearn', 'budget-projection',
+      // Gated off for Claude Code: documented here, never shown as an empty
+      // card on Optimize.
+      'cache', 'cache-recommend', 'reuse', 'script', 'stream-usage', 'trim', 'verbosity',
+    ],
     entries: {
       downsize: {
         title: 'Downsize',
-        blurb: 'Heavy work done inline that a worker should have taken',
-        mistake: 'A context-heavy piece of work is carried out in the main thread, on an expensive model, rather than handed to a worker. Everything read in the main thread stays in the main thread, and is sent again on every turn that follows, so the cost of that reading keeps compounding for as long as the session runs. The longer the session, the more the original decision costs.',
-        fix: 'A standing rule that sends context-heavy sub-tasks to a worker, so the reading lands in the worker and only its conclusion comes back. Pair it with a cheaper model pinned for that worker.',
+        description: [
+          'Downsize is about WHERE the work happened: a context-heavy piece of work carried out inline, in the main thread, on an expensive model, rather than handed to a worker. Everything read in the main thread stays in the main thread, and is sent again on every turn that follows, so the cost of that reading keeps compounding for as long as the session runs. The longer the session, the more the original decision costs.',
+          'The main way this check flags a session requires that the session never dispatched a subagent at all. The moment a worker gets involved, the question this check is asking (should this have been delegated) is no longer open; whether the worker chosen was the right size is a different question, and it is what the Subagent check answers instead.',
+          'The fix is a standing rule that sends context-heavy sub-tasks to a worker, so the reading lands in the worker and only its conclusion comes back. Pair it with a cheaper model pinned for that worker.',
+        ],
       },
       subagent: {
         title: 'Subagent',
-        blurb: 'Delegated, but to a worker larger than the job',
-        mistake: 'The work was delegated, which was the right call, but the worker was over-sized for it: a premium model where a cheaper one would have done, or far more context handed over than the task ever needed.',
-        fix: 'Pin a cheaper model for that worker. The delegation stays; only the size of what you dispatched changes.',
+        description: [
+          'Subagent is about WHO did the work, once delegation had already happened: the work went to a worker, which was the right call, but the worker itself was over-sized for the job, a premium model where a cheaper one would have done, or far more context handed over than the task ever needed.',
+          'This check only ever looks at spans already dispatched to a worker, so it never asks whether the work should have been delegated in the first place; that question belongs to Downsize, which (for the case that carries most of its money) only considers sessions where no worker was ever dispatched. A session that delegates moves out of Downsize\'s territory and into Subagent\'s instead of tripping both.',
+          'The fix is to pin a cheaper model for that worker. The delegation stays; only the size of what you dispatched changes.',
+        ],
       },
       resend: {
         title: 'Context resend',
-        blurb: 'The same context, charged again every turn',
-        mistake: 'Context accumulates in the main thread and is re-sent with every subsequent turn, long after the turn that actually needed it. Nothing about it is re-read by you, but all of it travels with each request.',
-        fix: 'Move the work that produced it to a worker, so its output never lands in your thread in the first place. Then right-size that worker so the offload is not simply a more expensive way to read the same files.',
+        description: [
+          'The same context, charged again every turn: context accumulates in the main thread and is re-sent with every subsequent turn, long after the turn that actually needed it. Nothing about it is re-read by you, but all of it travels with each request.',
+          'The fix is to move the work that produced it to a worker, so its output never lands in your thread in the first place. Then right-size that worker so the offload is not simply a more expensive way to read the same files.',
+        ],
       },
       summarize: {
         title: 'Summarize',
-        blurb: 'Always-loaded instruction files that run long',
-        mistake: 'Instruction files that are always in context, such as CLAUDE.md, rules and skills, carry more prose than they need. Length there is not paid once; it is paid on every call of every session that loads the file.',
-        fix: 'A reviewed rewrite that shortens the prose and keeps the structure exactly as it was. Each rewrite is shown as a diff you approve file by file, and nothing is written until you say so.',
+        description: [
+          'Always-loaded instruction files that run long: files that are always in context, such as CLAUDE.md, rules and skills, carry more prose than they need. Length there is not paid once; it is paid on every call of every session that loads the file.',
+          'The fix is a reviewed rewrite that shortens the prose and keeps the structure exactly as it was. Each rewrite is shown as a diff you approve file by file, and nothing is written until you say so.',
+        ],
       },
       deadweight: {
         title: 'Deadweight',
-        blurb: 'A connected tool nothing ever calls',
-        mistake: 'An MCP server is connected but never actually used. Its tool definitions still ship with every request, so you pay to describe capabilities that go untouched.',
-        fix: 'Remove the server, or disable it for the projects that do not use it.',
+        description: [
+          'A connected tool nothing ever calls: an MCP server is connected but never actually used. Its tool definitions still ship with every request, so you pay to describe capabilities that go untouched.',
+          'The fix is to remove the server, or disable it for the projects that do not use it.',
+        ],
       },
       relearn: {
         title: 'Relearn',
-        blurb: 'The same mistake, session after session',
-        mistake: 'The agent runs into the same class of problem repeatedly across sessions and works it out again each time, because nothing carried the answer forward.',
-        fix: 'Write it down once, as a rule, a skill or a hook, so the next session starts already knowing. Each proposal is shown with the recurrences behind it before anything is written.',
+        description: [
+          'The same mistake, session after session: the agent runs into the same class of problem repeatedly across sessions and works it out again each time, because nothing carried the answer forward.',
+          'The fix is to write it down once, as a rule, a skill or a hook, so the next session starts already knowing. Each proposal is shown with the recurrences behind it before anything is written.',
+        ],
       },
       'budget-projection': {
         title: 'Budget projection',
-        blurb: 'A forecast, not a mistake',
-        mistake: 'This one is not looking for a mistake at all. It compares your current run rate against the monthly ceiling you configured for a provider, and flags when the two are heading for a collision.',
-        fix: 'There is nothing here to apply. It tells you about exposure; the response is to spend less or to raise the ceiling.',
+        description: [
+          'A forecast, not a mistake: this one is not looking for a mistake at all. It compares your current run rate against the monthly ceiling you configured for a provider, and flags when the two are heading for a collision.',
+          'There is nothing here to apply. It tells you about exposure; the response is to spend less or to raise the ceiling.',
+        ],
       },
-    },
-    // Why a check the reader may have heard of is absent for this setup. Keyed
-    // by the name the server reports as gated off, so the copy and the gate can
-    // never disagree about which ones need an explanation.
-    hidden: {
-      cache: 'How a request reuses earlier context is decided by the harness that builds the request, not by you.',
-      'cache-recommend': 'Same reason: the setting this would ask you to change is not one a coding-agent user can reach.',
-      placement: 'Moving work onto a slower, cheaper lane only makes sense when nobody is waiting on the answer, which is never true of an interactive session.',
-      trim: 'Shortening a prompt template needs a prompt template you can edit, and an interactive coding agent writes its own.',
-      verbosity: 'The only available remedy is a blanket instruction to answer in fewer words, which buys tokens by making the agent less useful everywhere. That is not a trade this product makes.',
-      script: 'Its way of recognising a repeated workflow did not hold up against real coding sessions, where one extra file read is enough to break the match.',
-      reuse: 'It rests on a claim telemetry cannot support for interactive work: that two pieces of planning were interchangeable. The idea is worth rebuilding; the current version is not shown.',
+      // ---- Gated off for Claude Code, documented rather than hidden ---- //
+      cache: {
+        title: 'Cache',
+        description: [
+          'Cache checks how much of a request is served from the model provider\'s cache instead of billed fresh, and flags a provider and model whose reuse rate is sitting below where it should be.',
+          'It does not show up here: which part of a request gets cached is decided by the harness that builds the request, not by you, so there is no lever this check could hand you. It is still off, not missing; it will not appear later.',
+        ],
+      },
+      'cache-recommend': {
+        title: 'Cache recommend',
+        description: [
+          'Cache recommend looks for a stable, repeated prefix worth marking for explicit caching, such as project instructions that stay the same across turns.',
+          'It does not show up here, for the same reason as Cache: setting that flag on a request is something the harness does, not something you can reach. It is off on purpose, not broken and not pending.',
+        ],
+      },
+      reuse: {
+        title: 'Reuse',
+        description: [
+          'Reuse looks for a session that re-planned work an earlier session had already planned, on the idea that the second pass could have reused the first instead of starting over.',
+          'It does not show up here: measured against real interactive sessions, the claim that two planning passes were actually interchangeable does not hold up, so this check stays off rather than offer a fix built on a foundation that is not there.',
+        ],
+      },
+      script: {
+        title: 'Script',
+        description: [
+          'Script looks for a tool-call pattern repeated often enough, in the exact same order, to be worth replacing with a small deterministic script instead of asking the agent to redo it by hand each time.',
+          'It does not show up here: its match requires a session\'s entire ordered call sequence to repeat exactly, and on real coding sessions one extra file read is enough to break the match, so it essentially never fires. It is off because it cannot fire, not because it was turned off.',
+        ],
+      },
+      'stream-usage': {
+        title: 'Stream usage',
+        description: [
+          'Stream usage is not a savings check. A streamed call can close without ever reporting how many tokens it used, which makes your spend total read LOW rather than high; this check flags that gap so the figure can be corrected, not shrunk.',
+          'It does not show up here: an interactive coding agent drains its own streams rather than proxying someone else\'s, so this gap does not occur for it, and there would be no request-side setting to change even if it did.',
+        ],
+      },
+      trim: {
+        title: 'Trim',
+        description: [
+          'Trim looks for low-value tokens inside a prompt template that are worth cutting to shorten every call built from that template.',
+          'It does not show up here: it needs a prompt template you can edit, and an interactive coding agent constructs and sends its own prompts, so there is no template file this check could point you at.',
+        ],
+      },
+      verbosity: {
+        title: 'Verbosity',
+        description: [
+          'Verbosity flags a session whose output ran noticeably longer than similarly-shaped sessions, on the idea that some of that length was not necessary.',
+          'It does not show up here: the only available fix is a blanket instruction to answer in fewer words everywhere, which trades away how useful the agent is just to save tokens, and that is not a trade this product makes.',
+        ],
+      },
     },
   },
 };
-
-// Prose for a check the server says runs but this file has no entry for. Better
-// than dropping it silently: the reader was just told it runs.
-function guideMissingEntry(name) {
-  return {
-    title: capitalize(name),
-    blurb: 'Not written up yet',
-    mistake: 'This check runs for your setup, but its plain-language write-up has not been added to this guide yet. Its card on the Optimize screen states what it found.',
-    fix: null,
-  };
-}
 
 function GuideCheck({ name, entry }) {
   return html`<section class="opt-section" id=${'guide-' + name}>
     <div class="opt-title">
       <span>${entry.title} <span class="guide-name">${name}</span></span>
     </div>
-    <div class="guide-prose dim" style="margin-top:-4px">${entry.blurb}</div>
-    <div class="guide-lead">What it looks for</div>
-    <div class="guide-prose">${entry.mistake}</div>
-    ${entry.fix ? html`
-      <div class="guide-lead">What to do about it</div>
-      <div class="guide-prose">${entry.fix}</div>` : null}
+    ${entry.description.map((p, i) => html`<div key=${i} class="guide-prose">${p}</div>`)}
   </section>`;
 }
 
-// One persona's guide: the contrast callout, then a card per check the server
-// says runs, then the deliberately-absent list. `runs` and `hidden` both come
-// straight from `/optimize/analyzers`; this function chooses order and words,
-// never membership.
-function GuideBody({ persona, sets }) {
-  const guide = GUIDE_ENTRIES[persona];
-  if (!guide || !sets) return null;
-  const runs = sets.runs || [];
-  const ordered = [
-    ...guide.order.filter(n => runs.includes(n)),
-    ...runs.filter(n => !guide.order.includes(n)),
-  ];
-  const hiddenNames = (sets.disabled || []).filter(n => guide.hidden[n]);
-  // Only worth stating where both halves of the contrast actually run — and
-  // the server decides that, not this file. On a setup where one of them is
-  // gated off there are no two things to tell apart.
-  const contrast = GUIDE_KEY_CONTRAST.personas.includes(persona) &&
-    runs.includes('downsize') && runs.includes('subagent');
+// One card per registered analyzer, in `guide.order` (live-for-Claude-Code
+// first, gated-off-for-Claude-Code after, never interleaved). Fully static:
+// see the comment above `GUIDE_ENTRIES` for why this needs no server fetch.
+function GuideBody() {
+  const guide = GUIDE_ENTRIES['claude-code'];
   return html`
-    ${contrast ? html`
-      <div class="guide-key">
-        <div class="opt-title" style="margin-bottom:6px"><span>${GUIDE_KEY_CONTRAST.title}</span></div>
-        ${GUIDE_KEY_CONTRAST.paras.map((p, i) => html`<div key=${i} class="guide-prose">${p}</div>`)}
-      </div>` : null}
-    ${ordered.map(n => html`<${GuideCheck} key=${n} name=${n} entry=${guide.entries[n] || guideMissingEntry(n)} />`)}
-    ${hiddenNames.length ? html`
-      <section class="opt-section" id="guide-not-shown">
-        <div class="opt-title"><span>Checks that are not shown here</span></div>
-        <div class="guide-prose">tokenjam has more checks than the ones above. The rest are held back for this setup on purpose, because their only remedy is a setting a ${GUIDE_PERSONA_LABELS[persona] || persona} user does not control, or because they did not earn their place. A check with no reachable fix is a diagnosis you can do nothing with, so it is left off rather than shown as an empty card.</div>
-        <ul class="guide-hidden-list">
-          ${hiddenNames.map(n => html`<li key=${n}><b>${(ANALYZER_META[n] && ANALYZER_META[n].title) || capitalize(n)}</b>. ${guide.hidden[n]}</li>`)}
-        </ul>
-      </section>` : null}
+    ${guide.order.map(n => html`<${GuideCheck} key=${n} name=${n} entry=${guide.entries[n]} />`)}
   `;
 }
 
 function AnalyzerGuideView() {
-  const [st, setSt] = useState({ loading: true, error: null, sets: null, persona: null });
-
-  const load = useCallback(async () => {
-    setSt(s => ({ ...s, loading: true, error: null }));
-    try {
-      // The gate, always. Static config, so it answers on a cold store too.
-      const sets = await api('/optimize/analyzers');
-      // The persona of the stored report, when there IS one. Best-effort: a
-      // cold or failed read means "not classified yet", which the banner says
-      // in words rather than defaulting to a persona nobody measured.
-      const opt = await api('/optimize').catch(() => null);
-      const persona = (opt && opt.report_available !== false && opt.persona) || null;
-      setSt({ loading: false, error: null, sets, persona });
-    } catch (e) {
-      setSt({ loading: false, error: e.message || String(e), sets: null, persona: null });
-    }
-  }, []);
-
-  useEffect(() => { load(); }, [load]);
-
-  // Which persona's guide is actually rendered, and why. Three cases, each with
-  // its own honest sentence:
-  //   written        the resolved persona has a guide -> show it, no caveat
-  //   unclassified   nothing has classified this install -> show the default
-  //                  guide, say that it is the default
-  //   unwritten      resolved to a persona with no guide -> say so plainly and
-  //                  show the written one clearly labelled as another setup's
-  const DEFAULT_PERSONA = 'claude-code';
-  const resolved = st.persona;
-  const written = resolved && GUIDE_ENTRIES[resolved];
-  const shown = written ? resolved : DEFAULT_PERSONA;
-  const sets = st.sets && st.sets.personas ? st.sets.personas[shown] : null;
-  const uncovered = st.sets && st.sets.personas && shown === DEFAULT_PERSONA && resolved && !written;
-
   return html`
-    <div class="page-title" style="display:flex;align-items:center;gap:12px;flex-wrap:wrap">
-      FAQ
-      ${/* Forward, not "back": this is a top-level Improve page now, reachable
-            from any screen, so a reader may well have arrived without ever
-            visiting Optimize. Pointing AT the cards is true from anywhere;
-            "back" would be a guess about where they came from. */ ''}
-      <a class="sz-link" href="#/optimize" style="font-size:13px;font-weight:400">See these on the Optimize screen →</a>
-    </div>
-
-    ${st.error ? html`<div class="chart-card" style="border-color:var(--error)">
-      <div style="color:var(--error);font-size:13px;margin-bottom:10px">Couldn't load the analyzer list: ${st.error}</div>
-      <button class="btn" onClick=${load}>Retry</button>
-    </div>` : null}
-    ${st.loading ? html`<div class="shimmer" style="height:200px"></div>` : null}
-
-    ${!st.loading && !st.error && sets ? html`
-      <div class="guide-prose" style="margin-bottom:14px">Every card on the Optimize screen comes from one of the checks below. Each one looks for a different way tokens get spent without buying anything, and each ends in something you can change. Figures on the cards are estimates from your own history, offered as candidates to review before you act on them.</div>
-
-      ${written && !uncovered ? html`
-        <div class="guide-banner">Written for <b>${GUIDE_PERSONA_LABELS[shown]}</b>, which is what your recent sessions look like.</div>
-      ` : uncovered ? html`
-        <div class="guide-banner">Your recent sessions look like a <b>${GUIDE_PERSONA_LABELS[resolved] || resolved}</b> setup, and a guide for that setup has not been written yet. What follows describes <b>${GUIDE_PERSONA_LABELS[shown]}</b>, so parts of it may not match how you work. The checks that actually run for you are still decided by your own setup, not by this page.</div>
-      ` : html`
-        ${/* Names the thing that is actually missing: the analyzer SCAN, not
-              the data. "Nothing has classified this install yet" reads as "you
-              have no sessions", which on a corpus of thousands would be the
-              page claiming less than its data supports — the same defect class
-              as claiming more. Wording deliberately mirrors the Optimize
-              screen's own cold state so the two agree. */ ''}
-        <div class="guide-banner">No analyzer scan has completed yet, so your setup has not been classified. What follows is the <b>${GUIDE_PERSONA_LABELS[shown]}</b> guide; once a scan has run, this page describes whichever setup your sessions turn out to match.</div>
-      `}
-
-      <${GuideBody} persona=${shown} sets=${sets} />
-    ` : null}
+    <div class="page-title">FAQ</div>
+    <div class="guide-prose" style="margin-bottom:14px">Below is every check tokenjam can run, in two groups: first the ones that actually produce cards on the Optimize screen for this setup, then the ones that are turned off for it, with the reason why. Figures on a live check's card are estimates from your own history, offered as candidates to review before you act on them.</div>
+    <${GuideBody} />
   `;
 }
 
@@ -8436,7 +8389,7 @@ function SummarizeView({ params }) {
     return html`
       <div style="margin:0 0 16px"><a class="sz-back-link" href="#/optimize">← Optimize</a></div>
       <div class="page-title">Summarize <span class="sz-sub">· structure-aware prompt summarization</span></div>
-      <div class="sz-note">Rewrites prose only: code, tables, and <code>&lt;tj-keep&gt;</code> blocks stay verbatim. Nothing is written until you review each rewrite and Apply.</div>
+      <div class="sz-note">Rewrites prose only: code, tables, and <code>${'<tj-keep>'}</code> blocks stay verbatim. Nothing is written until you review each rewrite and Apply.</div>
       ${staged.length ? html`<div class="cur-tally" style="cursor:pointer;margin-top:14px" onClick=${() => setPhase('review')}>
         <div class="cur-tally-head">
           <div class="cur-tally-count">${staged.length} <small>staged rewrite(s) ready to review; no engine needed</small></div>

--- a/tokenjam/ui/index.html
+++ b/tokenjam/ui/index.html
@@ -7979,33 +7979,46 @@ function OptimizeView({ params }) {
 // `sub_agent_id` (i.e. already dispatched to a worker), so the two describe
 // disjoint populations for the flagship detection each card reports on.
 //
-// This is a card for EVERY registered analyzer (`ANALYZER_REGISTRY` in
-// `core/optimize/`), not only the ones that produce cards on the Optimize
-// screen for the Claude Code persona -- `order` below lists the live ones
-// first, then the ones gated off for Claude Code, and the two groups are
-// never interleaved. The live/gated split and the reasoning inside each
-// gated entry's description are grounded in
-// `.claude/product-state/ANALYZER-PERSONA-MATRIX.md` (the durable decision
-// record for persona gating) plus the gated analyzer's own module docstring,
-// not re-derived here. `placement` is a sub-check `downsize` attaches, not
-// its own registry entry, so it has no card of its own -- it is covered
-// inside Downsize's description of what the driver-role case claims.
+// This is a card for every analyzer whose check ends in a fix a user could
+// apply -- NOT every name in `ANALYZER_REGISTRY` (`core/optimize/`). Those
+// are different lists: `budget-projection` and `stream-usage` both live in
+// the registry, but neither ends in anything to change (budget-projection is
+// a spend forecast against a ceiling; stream-usage corrects a spend FIGURE,
+// it recovers nothing), so neither gets a card. The other 6 gated-off names
+// below (cache, cache-recommend, reuse, script, trim, verbosity) DO end in a
+// fix in the abstract -- they are gated off for Claude Code specifically
+// (no lever that persona can reach, or the check cannot fire for it), which
+// is a different, narrower kind of exclusion than "has no fix at all". A
+// newly-registered analyzer must be triaged against this same rule by a
+// human before it gets a card here; see
+// `test_analyzer_guide_covers_the_reviewed_user_facing_analyzer_list` in
+// `tests/unit/test_lens_ui_regression.py`, which fails loudly (naming the
+// analyzer) when a registry name is in neither this object's `order` nor its
+// own explicit excluded list, rather than silently doing nothing or
+// silently adding a card.
+//
+// `order` below lists the live-for-Claude-Code ones first, then the ones
+// gated off for Claude Code, and the two groups are never interleaved. The
+// live/gated split and the reasoning inside each gated entry's description
+// are grounded in `.claude/product-state/ANALYZER-PERSONA-MATRIX.md` (the
+// durable decision record for persona gating) plus the gated analyzer's own
+// module docstring, not re-derived here. `placement` is a sub-check
+// `downsize` attaches, not its own registry entry, so it has no card of its
+// own -- it is covered inside Downsize's description of what the
+// driver-role case claims.
 //
 // Static and complete by construction, so this page needs no server fetch:
 // which analyzers exist and which are gated for Claude Code are both decided
 // in code (the analyzer registry and the persona gate map in
 // `core/optimize/runner.py`), not at runtime.
-// `tests/unit/test_lens_ui_regression.py` cross-checks this object against
-// the live registry so a newly-registered analyzer with no entry here fails
-// CI instead of silently falling behind.
 const GUIDE_ENTRIES = {
   'claude-code': {
     order: [
       // Live for Claude Code: these produce cards on the Optimize screen.
-      'downsize', 'subagent', 'resend', 'summarize', 'deadweight', 'relearn', 'budget-projection',
+      'downsize', 'subagent', 'resend', 'summarize', 'deadweight', 'relearn',
       // Gated off for Claude Code: documented here, never shown as an empty
       // card on Optimize.
-      'cache', 'cache-recommend', 'reuse', 'script', 'stream-usage', 'trim', 'verbosity',
+      'cache', 'cache-recommend', 'reuse', 'script', 'trim', 'verbosity',
     ],
     entries: {
       downsize: {
@@ -8052,13 +8065,6 @@ const GUIDE_ENTRIES = {
           'The fix is to write it down once, as a rule, a skill or a hook, so the next session starts already knowing. Each proposal is shown with the recurrences behind it before anything is written.',
         ],
       },
-      'budget-projection': {
-        title: 'Budget projection',
-        description: [
-          'A forecast, not a mistake: this one is not looking for a mistake at all. It compares your current run rate against the monthly ceiling you configured for a provider, and flags when the two are heading for a collision.',
-          'There is nothing here to apply. It tells you about exposure; the response is to spend less or to raise the ceiling.',
-        ],
-      },
       // ---- Gated off for Claude Code, documented rather than hidden ---- //
       cache: {
         title: 'Cache',
@@ -8086,13 +8092,6 @@ const GUIDE_ENTRIES = {
         description: [
           'Script looks for a tool-call pattern repeated often enough, in the exact same order, to be worth replacing with a small deterministic script instead of asking the agent to redo it by hand each time.',
           'It does not show up here: its match requires a session\'s entire ordered call sequence to repeat exactly, and on real coding sessions one extra file read is enough to break the match, so it essentially never fires. It is off because it cannot fire, not because it was turned off.',
-        ],
-      },
-      'stream-usage': {
-        title: 'Stream usage',
-        description: [
-          'Stream usage is not a savings check. A streamed call can close without ever reporting how many tokens it used, which makes your spend total read LOW rather than high; this check flags that gap so the figure can be corrected, not shrunk.',
-          'It does not show up here: an interactive coding agent drains its own streams rather than proxying someone else\'s, so this gap does not occur for it, and there would be no request-side setting to change even if it did.',
         ],
       },
       trim: {
@@ -8135,7 +8134,7 @@ function GuideBody() {
 function AnalyzerGuideView() {
   return html`
     <div class="page-title">FAQ</div>
-    <div class="guide-prose" style="margin-bottom:14px">Below is every check tokenjam can run, in two groups: first the ones that actually produce cards on the Optimize screen for this setup, then the ones that are turned off for it, with the reason why. Figures on a live check's card are estimates from your own history, offered as candidates to review before you act on them.</div>
+    <div class="guide-prose" style="margin-bottom:14px">Below is every check that ends in something you could change, in two groups: first the ones that actually produce cards on the Optimize screen for this setup, then the ones that are turned off for it, with the reason why. Figures on a live check's card are estimates from your own history, offered as candidates to review before you act on them.</div>
     <${GuideBody} />
   `;
 }

--- a/tokenjam/ui/index.html
+++ b/tokenjam/ui/index.html
@@ -525,6 +525,39 @@ table.archive-list .a-id { color: var(--text); }
 .btn:hover:not(:disabled) { border-color: var(--accent); color: var(--accent); }
 .btn:disabled { opacity: 0.5; cursor: not-allowed; }
 .btn-back { margin-bottom: 16px; }
+/* The rescan control (ScanBar) — mounted top-right of the heading row on every
+   analyzer-fed surface (Dashboard, Optimize, Review inbox). Prominent on
+   purpose: this is the one action that turns a stale answer into a fresh
+   one, so it reads as a real button rather than one more inline text link.
+   Deliberately monochrome (var(--accent), not var(--brand)) — brand-blue is
+   reserved for logo/category fills elsewhere, and a rescan is a neutral
+   "run this" action, not a branded one. */
+.rescan-bar { display: inline-flex; align-items: center; gap: 10px; flex-wrap: wrap; font-weight: 400; }
+.rescan-ctl {
+  display: inline-flex;
+  align-items: center;
+  gap: 7px;
+  background: var(--surface2);
+  border: 1px solid var(--accent);
+  color: var(--accent);
+  padding: 7px 16px;
+  border-radius: 6px;
+  cursor: pointer;
+  font-family: 'Geist Mono', monospace;
+  font-size: 12px;
+  font-weight: 600;
+  transition: background .15s, color .15s, border-color .15s;
+}
+.rescan-ctl-icon { display: inline-block; }
+.rescan-ctl:hover:not(:disabled) { background: rgba(var(--accent-rgb),0.12); }
+.rescan-ctl:active:not(:disabled) { background: rgba(var(--accent-rgb),0.2); }
+.rescan-ctl:focus-visible { outline: 2px solid var(--accent); outline-offset: 2px; }
+.rescan-ctl:disabled, .rescan-ctl.scanning { opacity: 0.6; cursor: not-allowed; }
+.rescan-ctl.scanning .rescan-ctl-icon { animation: rescan-spin 1s linear infinite; }
+@keyframes rescan-spin { from { transform: rotate(0deg); } to { transform: rotate(360deg); } }
+.scan-provenance { font-size: 11px; color: var(--text-dim); font-family: 'Geist Mono', monospace; white-space: nowrap; }
+.scan-error { font-size: 11px; color: var(--error); }
+.scan-degraded { font-size: 11px; color: var(--warn); }
 .btn-restore { padding: 3px 8px; font-size: 11px; white-space: nowrap; position: relative; display: inline-flex; align-items: center; gap: 5px; }
 .btn-restore.copied { border-color: var(--success); color: var(--success); }
 .btn-restore svg { width: 12px; height: 12px; flex-shrink: 0; }
@@ -858,6 +891,7 @@ a.rec-tile.ok:hover { border-color: var(--success); }
    placeholder because the gradient stays. */
 @media (prefers-reduced-motion: reduce) {
   .shimmer { animation: none; }
+  .rescan-ctl.scanning .rescan-ctl-icon { animation: none; }
 }
 
 /* Overview + Optimize (issue #114) */
@@ -7135,35 +7169,50 @@ async function rescanAnalyzers() { return apiPostOrDetail('/optimize/rescan', {}
 // stored artifacts with different cadences (this report and the relearn
 // detector's own cache) can legitimately disagree; each stating its own
 // computed-at is what makes that difference explicable rather than a mystery.
+//
+// One component, mounted top-right of the heading row on every analyzer-fed
+// surface (Dashboard, Optimize, Review inbox) so the same provenance text and
+// the same button render everywhere rather than each screen growing its own
+// rescan link. A real <button>, not a styled span, so it is keyboard-operable
+// and gets a focus ring for free; `disabled` while a scan is in flight is
+// what makes "scanning\u2026" actually true rather than just its label.
 function ScanBar({ scan, busy, error, onRescan }) {
+  const scanning = !!(busy || scan.computing);
   const when = scan.fetchFailed ? 'scan state unavailable'
     : scan.computedAt
       ? 'computed ' + fmtAgo(scan.computedAt) + (scan.windowDays ? ' \u00b7 ' + scan.windowDays + 'd window' : '')
       : (scan.status === 'error' ? 'no scan has succeeded yet' : 'never computed');
-  return html`<span style="display:inline-flex;align-items:baseline;gap:10px;flex-wrap:wrap;font-weight:400">
-    <span class="dim" style="font-size:11px">${when}</span>
-    <span class="sz-link" onClick=${onRescan}>\u27f3 ${(busy || scan.computing) ? 'scanning\u2026' : 'Rescan'}</span>
-    ${error ? html`<span style="font-size:11px;color:var(--error)">rescan failed: ${error}</span>` : null}
-    ${scan.degraded ? html`<span style="font-size:11px;color:var(--error)" title=${scan.lastError || ''}>last refresh failed</span>` : null}
+  return html`<span class="rescan-bar">
+    <span class="scan-provenance">${when}</span>
+    <button type="button" class="rescan-ctl${scanning ? ' scanning' : ''}" onClick=${onRescan} disabled=${scanning}
+      aria-label=${scanning ? 'Scanning\u2026' : 'Rescan'}>
+      <span aria-hidden="true" class="rescan-ctl-icon">\u27f3</span>${scanning ? 'Scanning\u2026' : 'Rescan'}
+    </button>
+    ${error ? html`<span class="scan-error">rescan failed: ${error}</span>` : null}
+    ${scan.degraded ? html`<span class="scan-degraded" title=${scan.lastError || ''}>last refresh failed</span>` : null}
   </span>`;
 }
 
-// A rescan button plus the state it needs, shared by both surfaces that carry
-// one. Surfaces the failure: a rescan whose POST was refused reports the
-// server's reason instead of silently looking like a success.
-function useRescan(reload) {
+// A rescan button plus the state it needs, shared by every surface that
+// carries one. `action` defaults to the analyzer-report rescan
+// (`POST /optimize/rescan`); the Review inbox passes its own two-endpoint
+// refresh instead, so all three surfaces share this hook's busy/error/timing
+// behaviour even though what they re-run differs. Surfaces the failure: a
+// rescan whose POST was refused reports the server's reason instead of
+// silently looking like a success.
+function useRescan(reload, action = rescanAnalyzers) {
   const [busy, setBusy] = useState(false);
   const [error, setError] = useState(null);
   const rescan = useCallback(async () => {
     setBusy(true);
     setError(null);
     try {
-      await rescanAnalyzers();
+      await action();
     } catch (e) {
       setError(e.message || String(e));
     }
     setTimeout(() => { setBusy(false); reload(); }, 1500);
-  }, [reload]);
+  }, [reload, action]);
   return { busy, error, rescan };
 }
 
@@ -7736,9 +7785,12 @@ function OptimizeView({ params }) {
           guide as a top-level Observe entry (that is what makes it reachable
           from anywhere at all); this link is the contextual one, offered on the
           screen whose cards it explains. */ ''}
-    <div class="page-title" style="display:flex;align-items:center;gap:10px;flex-wrap:wrap">
-      Optimize <${PlanBadge} framing=${framing} />
-      <a class="sz-link" href="#/guide" style="font-size:13px;font-weight:400">What do these checks mean? →</a>
+    <div style="display:flex;align-items:baseline;justify-content:space-between;gap:12px;flex-wrap:wrap;margin-bottom:20px">
+      <div class="page-title" style="display:flex;align-items:center;gap:10px;flex-wrap:wrap;margin-bottom:0">
+        Optimize <${PlanBadge} framing=${framing} />
+        <a class="sz-link" href="#/guide" style="font-size:13px;font-weight:400">What do these checks mean? →</a>
+      </div>
+      <${ScanBar} scan=${scan} busy=${rescanning} error=${rescanError} onRescan=${doRescan} />
     </div>
     <div class="filters">
       <select value=${since} onChange=${e => setFilter('since', e.target.value)}>
@@ -7754,7 +7806,6 @@ function OptimizeView({ params }) {
       </select>
       ${agentId ? html`<button class="btn" onClick=${() => setFilter('agent_id', '')}>agent: ${agentId} ✕</button>` : null}
       <button class="btn" onClick=${load}>Refresh</button>
-      <${ScanBar} scan=${scan} busy=${rescanning} error=${rescanError} onRescan=${doRescan} />
     </div>
     ${/* The picker above scopes the SPEND chart; the analyzer findings come
           from the background scan's own window. Saying so beats letting a 7d
@@ -10953,6 +11004,7 @@ function ReviewInboxView({ params }) {
   const [reviewQueue, setReviewQueue] = useState([]);
   const [reviewTotal, setReviewTotal] = useState(0);
   const [refreshing, setRefreshing] = useState(false);
+  const [refreshError, setRefreshError] = useState(null); // a rescan POST that was refused, honestly surfaced
   const [applied, setApplied] = useState([]);
   const [appliedSigs, setAppliedSigs] = useState(() => new Set());   // hide from pending immediately
   const [costProps, setCostProps] = useState([]);          // advise-only cost proposals
@@ -11044,13 +11096,42 @@ function ReviewInboxView({ params }) {
     if (el) el.scrollIntoView({ behavior: 'smooth', block: 'start' });
   }, [analyzerFocus, costProps]);
 
+  // Two stores, one rescan press: relearn's own cache and the cost-advisory
+  // cache recompute on the same cadence, so one control re-runs both. Unlike
+  // the old fire-and-forget version, a refused POST is not swallowed — the
+  // shared ScanBar control needs an honest error to show (Critical Rule: a
+  // rescan that failed must not look like one that succeeded).
   const doRefresh = useCallback(async () => {
     setRefreshing(true);
-    try { await apiPost('/relearn/refresh', {}); } catch (e) { /* surfaced via next load()'s status */ }
-    // The cost proposals recompute on the same cadence.
-    try { await apiPost('/relearn/cost-proposals/refresh', {}); } catch (e) { /* degrade quietly */ }
+    setRefreshError(null);
+    const results = await Promise.allSettled([
+      apiPostOrDetail('/relearn/refresh', {}),
+      apiPostOrDetail('/relearn/cost-proposals/refresh', {}),
+    ]);
+    const failed = results.filter(r => r.status === 'rejected');
+    if (failed.length) {
+      setRefreshError(failed.map(r => (r.reason && (r.reason.message || String(r.reason))) || 'unknown error').join('; '));
+    }
     setTimeout(() => { setRefreshing(false); load(); loadCost(); }, 1500);
   }, [load, loadCost]);
+
+  // A scan-state shape ScanBar can render, built from the inbox's own two
+  // reads rather than from `/optimize` — same control, different store. The
+  // relearn cache's own computed_at is the header's provenance (it already
+  // was, before this reused the shared component); `degraded`/`lastError`
+  // come from the cost-advisory half, since that is the one that already
+  // tracked a failed-but-not-fatal recompute.
+  const inboxScan = {
+    fetchFailed: false,
+    computedAt: d.computedAt,
+    windowDays: null,
+    computing: d.status === 'computing' || costStatus === 'computing',
+    degraded: costDegraded,
+    lastError: costLastError,
+    status: (d.status === 'never_run' && costStatus === 'never_run')
+      ? 'never_run'
+      : (d.status === 'error' || costStatus === 'error' ? 'error' : 'ready'),
+  };
 
   const markCostApplied = useCallback(async (prop) => {
     setMarking(prop.signature);
@@ -11256,11 +11337,12 @@ function ReviewInboxView({ params }) {
     <div style="display:flex;align-items:baseline;justify-content:space-between;gap:12px;flex-wrap:wrap">
       <div class="page-title" style="margin-bottom:0">Inbox</div>
       ${/* Scan provenance belongs beside the control that re-runs it, not in a
-            per-tab header: it describes the whole inbox, and the Rescan link is
-            already the one place that reports scan state. */ ''}
-      <span style="display:flex;align-items:baseline;gap:12px;flex-wrap:wrap">
-        ${d.computedAt ? html`<span class="dim" style="font-size:12px">last scanned ${d.computedAt.slice(0, 16).replace('T', ' ')} UTC${d.sessionsScanned != null ? ' · ' + d.sessionsScanned + ' sessions scanned' : ''}</span>` : null}
-        <span class="sz-link" onClick=${doRefresh}>⟳ ${refreshing || d.status === 'computing' || costStatus === 'computing' ? 'scanning…' : 'Rescan now'}</span>
+            per-tab header: it describes the whole inbox, and the shared
+            rescan control (ScanBar, also on the Dashboard and Optimize
+            screens) is already the one place that reports scan state. */ ''}
+      <span style="display:flex;align-items:baseline;gap:10px;flex-wrap:wrap">
+        ${d.sessionsScanned != null ? html`<span class="scan-provenance">${d.sessionsScanned} sessions scanned</span>` : null}
+        <${ScanBar} scan=${inboxScan} busy=${refreshing} error=${refreshError} onRescan=${doRefresh} />
       </span>
     </div>
     <div class="sz-note">Waste you're paying for more than once: mistakes your agents keep repeating, and cost fixes ready to apply.</div>
@@ -11779,7 +11861,10 @@ function DashboardView({ params }) {
         <div class="page-title" style="margin:0">Dashboard</div>
         <${PlanBadge} framing=${framing} />
       </div>
-      <div class="filters" style="margin:0">${winPicker}</div>
+      <div style="display:flex;align-items:center;gap:16px;flex-wrap:wrap">
+        <div class="filters" style="margin:0">${winPicker}</div>
+        <${ScanBar} scan=${scan} busy=${rescanning} error=${rescanError} onRescan=${doRescan} />
+      </div>
     </div>
     ${/* A past-overspend hero band rendered here once. Removed: it read as heavy
           at the top of the page, and the figure now lives as a compact tile on
@@ -11828,10 +11913,7 @@ function DashboardView({ params }) {
         ${html`
             <div class="dash-triage">
               <div class="dash-col">
-                <div class="band-label" style="display:flex;align-items:baseline;justify-content:space-between;gap:12px;flex-wrap:wrap">
-                  <span>Recoverable waste</span>
-                  <${ScanBar} scan=${scan} busy=${rescanning} error=${rescanError} onRescan=${doRescan} />
-                </div>
+                <div class="band-label">Recoverable waste</div>
                 ${/* recoverableBandState() decided which of the six states this
                       is; the branches below only render. The ONE branch allowed
                       to say there is nothing recoverable is 'none', which

--- a/tokenjam/ui/index.html
+++ b/tokenjam/ui/index.html
@@ -6661,16 +6661,19 @@ function DriftView({ params }) {
 // ============================
 // Budget View
 // ============================
-function BudgetRow({ scope, label, daily, session, effectiveDaily, effectiveSession, onSave }) {
+// Daily-only budget row, shared by both zones (coding-tool groups and SDK
+// workflow agents). A per-session cap already configured in a user's TOML
+// keeps being enforced (see api/routes/budget.py's module docstring) but
+// this row never offers a way to set a new one.
+function DailyBudgetRow({ scope, label, sublabel, daily, effectiveDaily, onSave }) {
   const [dailyVal, setDailyVal] = useState(daily != null ? String(daily) : '');
-  const [sessionVal, setSessionVal] = useState(session != null ? String(session) : '');
   const [saving, setSaving] = useState(false);
   const [saved, setSaved] = useState(false);
 
   const save = async () => {
     setSaving(true);
     try {
-      await onSave(scope, dailyVal, sessionVal);
+      await onSave(scope, dailyVal);
       setSaved(true);
       setTimeout(() => setSaved(false), 2000);
     } catch (e) {
@@ -6682,20 +6685,16 @@ function BudgetRow({ scope, label, daily, session, effectiveDaily, effectiveSess
 
   const dailyPlaceholder = (effectiveDaily != null && daily == null)
     ? `default: $${effectiveDaily}` : 'no limit';
-  const sessionPlaceholder = (effectiveSession != null && session == null)
-    ? `default: $${effectiveSession}` : 'no limit';
 
   return html`
     <tr>
-      <td class="mono">${label}</td>
+      <td class="mono">
+        ${label}
+        ${sublabel ? html`<div style="color:var(--text-dim);font-size:11px;margin-top:2px">${sublabel}</div>` : null}
+      </td>
       <td>
         <input type="number" min="0" step="0.01" placeholder=${dailyPlaceholder}
           value=${dailyVal} onInput=${e => setDailyVal(e.target.value)}
-          style="width:120px;background:var(--surface);border:1px solid var(--border);border-radius:4px;padding:4px 6px;color:var(--text);font-size:13px" />
-      </td>
-      <td>
-        <input type="number" min="0" step="0.01" placeholder=${sessionPlaceholder}
-          value=${sessionVal} onInput=${e => setSessionVal(e.target.value)}
           style="width:120px;background:var(--surface);border:1px solid var(--border);border-radius:4px;padding:4px 6px;color:var(--text);font-size:13px" />
       </td>
       <td>
@@ -6709,7 +6708,7 @@ function BudgetRow({ scope, label, daily, session, effectiveDaily, effectiveSess
 }
 
 // Provider spend-forecast ceiling — the OTHER budget object on this screen.
-// Distinct from BudgetRow (per-agent daily/session ALERT caps, checked on
+// Distinct from DailyBudgetRow (per-agent/group daily ALERT caps, checked on
 // every ingested span): this is a per-provider recurring monthly ceiling that
 // Optimize's Budget projection analyzer projects the current run rate
 // against. Editing it here means the projection can never point at a ceiling
@@ -6794,15 +6793,14 @@ function BudgetView({ params }) {
     if (el) el.scrollIntoView({ behavior: 'smooth', block: 'center' });
   }, [provider, data]);
 
-  const handleSave = async (scope, dailyStr, sessionStr) => {
+  // Daily-only save, both zones. A coding-group scope ("group:<id>" /
+  // "defaults_coding") rejects session_usd outright server-side; an SDK
+  // scope keeps honoring an already-configured session_usd, this screen
+  // just never sends one on a save. See api/routes/budget.py's docstring.
+  const handleSave = async (scope, dailyStr) => {
     // Empty field means "no limit" — send 0 so the server runs validate_budget_value(0) → None.
     const daily = dailyStr !== '' ? parseFloat(dailyStr) : 0;
-    const session = sessionStr !== '' ? parseFloat(sessionStr) : 0;
-    const updated = await apiPost('/budget', {
-      scope,
-      daily_usd: daily,
-      session_usd: session,
-    });
+    const updated = await apiPost('/budget', { scope, daily_usd: daily });
     setData(updated);
   };
 
@@ -6840,9 +6838,16 @@ function BudgetView({ params }) {
   if (error && !data) return html`<div class="empty" style="color:var(--error)">${error}</div>`;
   if (!data) return html`
     <div class="page-title">Budget</div>
-    ${TableRowsSkeleton(['Scope', 'Daily (USD)', 'Per-session (USD)', ''], 4)}`;
+    ${TableRowsSkeleton(['Scope', 'Daily (USD)', ''], 6)}`;
 
-  const agentEntries = Object.entries(data.agents || {});
+  // Two zones per the Budget-page redesign (see api/routes/budget.py):
+  // coding-tool groups (one row per TOOL, summed across every member
+  // agent_id, e.g. every claude-code-<project> variant) and SDK workflow
+  // agents (one row per declared agent_id, unchanged). Neither zone reads
+  // the legacy top-level `defaults`/`agents` keys — those exist only so an
+  // old, already-shipped client build doesn't crash.
+  const codingGroups = Object.entries(data.coding.groups || {});
+  const sdkAgents = Object.entries(data.sdk.agents || {});
   const providerBudgets = data.provider_budgets || {};
   // Every provider we know about: configured + the one deep-linked from
   // Optimize's projection (even with no ceiling set yet) + any just-added
@@ -6863,37 +6868,71 @@ function BudgetView({ params }) {
       </div>` : null}
     ${provider ? html`<div class="filters"><button class="btn" onClick=${() => navigate('budget', {}, {})}>provider: ${provider} ✕</button></div>` : null}
 
-    <div style="font-size:13px;font-weight:600;margin-bottom:8px">Per-agent budget caps</div>
+    <div style="font-size:13px;font-weight:600;margin-bottom:8px">Coding-tool budget caps</div>
     <div style="color:var(--text-dim);font-size:12px;margin-bottom:12px">
-      An enforcement ceiling per agent, per day/session. Fires a real-time alert the moment an
-      agent's spend crosses the line. Clear a field or enter 0 to remove a limit. Changes are
-      written to your config file immediately.
+      One daily ceiling per coding tool (Claude Code, Codex), checked against every session that
+      tool runs today summed together, including every Claude Code project variant under one row.
+      Enforcement runs at session end, not the instant spend crosses the line. Clear a field or
+      enter 0 to remove a limit. Changes are written to your config file immediately.
     </div>
     <div class="table-wrap"><table>
-      <thead><tr><th>Scope</th><th>Daily (USD)</th><th>Per-session (USD)</th><th></th></tr></thead>
+      <thead><tr><th>Tool</th><th>Daily (USD)</th><th></th></tr></thead>
       <tbody>
-        <${BudgetRow}
-          scope="defaults"
+        <${DailyBudgetRow}
+          scope="defaults_coding"
           label="defaults"
-          daily=${data.defaults.daily_usd}
-          session=${data.defaults.session_usd}
+          daily=${data.coding.defaults.daily_usd}
           onSave=${handleSave}
         />
-        ${agentEntries.map(([id, b]) => html`
-          <${BudgetRow}
+        ${codingGroups.map(([gid, g]) => html`
+          <${DailyBudgetRow}
+            key=${gid}
+            scope=${'group:' + gid}
+            label=${gid}
+            sublabel=${g.members.length > 1 ? g.members.length + ' agent ids merged into this cap' : null}
+            daily=${g.configured.daily_usd}
+            effectiveDaily=${g.effective.daily_usd}
+            onSave=${handleSave}
+          />
+        `)}
+        ${codingGroups.length === 0 ? html`
+          <tr><td colspan="3" style="color:var(--text-dim);font-size:13px;padding:12px 0">
+            No coding-tool sessions recorded yet. Run Claude Code or Codex once to register it.
+          </td></tr>
+        ` : null}
+      </tbody>
+    </table></div>
+
+    <div style="font-size:13px;font-weight:600;margin-top:28px;margin-bottom:8px">SDK workflow budget caps</div>
+    <div style="color:var(--text-dim);font-size:12px;margin-bottom:12px">
+      One daily ceiling per SDK-declared workflow agent, checked at session end. A per-session cap
+      already set in your config file keeps being enforced; it is no longer editable from this
+      screen, since a per-session ceiling has no reliable meaning at the start of a coding session.
+      Clear a field or enter 0 to remove the daily limit. Changes are written to your config file
+      immediately.
+    </div>
+    <div class="table-wrap"><table>
+      <thead><tr><th>Agent</th><th>Daily (USD)</th><th></th></tr></thead>
+      <tbody>
+        <${DailyBudgetRow}
+          scope="defaults"
+          label="defaults"
+          daily=${data.sdk.defaults.daily_usd}
+          onSave=${handleSave}
+        />
+        ${sdkAgents.map(([id, b]) => html`
+          <${DailyBudgetRow}
             key=${id}
             scope=${id}
             label=${id}
             daily=${b.configured.daily_usd}
-            session=${b.configured.session_usd}
             effectiveDaily=${b.effective.daily_usd}
-            effectiveSession=${b.effective.session_usd}
             onSave=${handleSave}
           />
         `)}
-        ${agentEntries.length === 0 ? html`
-          <tr><td colspan="4" style="color:var(--text-dim);font-size:13px;padding:12px 0">
-            No agents configured yet. Run your agent once to register it.
+        ${sdkAgents.length === 0 ? html`
+          <tr><td colspan="3" style="color:var(--text-dim);font-size:13px;padding:12px 0">
+            No SDK workflow agents configured yet. Declare one with @watch() and run it once.
           </td></tr>
         ` : null}
       </tbody>
@@ -6965,7 +7004,6 @@ function BudgetView({ params }) {
       `}
   `;
 }
-
 // ============================
 // Overview + Optimize (issue #114)
 // ============================

--- a/tokenjam/ui/index.html
+++ b/tokenjam/ui/index.html
@@ -8143,10 +8143,11 @@ function diffBlocks(diffText) {
 }
 
 function SummarizeView({ params }) {
-  // Flow: engine (capability gate) → curate → run → review. The engine is
-  // chosen per visit (page starts on the gate, never defaulted).
-  const [phase, setPhase] = useState('engine');
-  const [engine, setEngine] = useState(null);          // 'api' | 'claude-p' | 'manual'
+  // Flow: curate (landing — candidates load immediately, no tool choice) →
+  // run → review. Looking is free; the engine is only demanded inline, at
+  // the Finish/Approve step, the moment a rewrite is actually requested.
+  const [phase, setPhase] = useState('curate');
+  const [engine, setEngine] = useState(null);          // 'api' | 'claude-p' | 'manual'; chosen at Approve time
   const [caps, setCaps] = useState(null);
   const [capErr, setCapErr] = useState(null);
 
@@ -8155,7 +8156,9 @@ function SummarizeView({ params }) {
   const [staged, setStaged] = useState([]);            // staged records (CheckVerdict + source_sha256)
   const [backups, setBackups] = useState([]);          // applied files that still have a gzip backup (undo surface)
   const [dataErr, setDataErr] = useState(null);
-  const [loading, setLoading] = useState(false);
+  // Starts true: the mount effect always kicks off a scan, so the very first
+  // render must show the loading treatment, never an unearned "no candidates".
+  const [loading, setLoading] = useState(true);
   const [recursive, setRecursive] = useState(false);
   const [repoScope, setRepoScope] = useState(false);
   const scanSeq = useRef(0);   // discards a slower earlier scan's response (out-of-order landing)
@@ -8232,10 +8235,12 @@ function SummarizeView({ params }) {
     catch (e) { /* backups are a convenience surface; don't block the screen on them */ }
   };
 
-  // Mount: capabilities (which engines work) + any already-staged work, so the
-  // start screen can offer "review N staged" WITHOUT forcing an engine choice
-  // (reviewing/applying staged rewrites needs no LLM — only running does).
-  useEffect(() => { loadCaps(); loadStaged(); loadBackups(); }, []);
+  // Mount: candidates (so the landing view is the list, not a gate), engine
+  // capabilities (needed once the user reaches Approve), and any already-staged
+  // work, so the screen can also offer "review N staged" WITHOUT forcing an
+  // engine choice (reviewing/applying staged rewrites needs no LLM — only
+  // running does; looking never needed one either).
+  useEffect(() => { loadScan(); loadCaps(); loadStaged(); loadBackups(); }, []);
 
   // While a batch run is in flight, tick once a second so the in-flight row shows
   // live elapsed time (a claude-p file can take 30-90s; silence reads as "hung").
@@ -8246,7 +8251,22 @@ function SummarizeView({ params }) {
     return () => clearInterval(id);
   }, [runActive]);
 
-  const pickEngine = e => { setEngine(e); setPhase('curate'); loadScan(); };
+  // Engine card renderer, shared by the inline picker inside the Approve
+  // modal (the only place a tool is ever demanded — see the Finish/Approve
+  // footer below). Picking a card just sets `engine`; the picker step and the
+  // "run via X" confirm step stay separate clicks so an unavailable engine's
+  // reason is visible before anything runs.
+  const eng = (id, name, tag, desc) => {
+    const cap = caps ? caps[id] : null;
+    const avail = cap ? cap.available : false;
+    const val = id === 'claude_p' ? 'claude-p' : id;
+    return html`<button class="sz-engine" disabled=${!avail} onClick=${() => avail && setEngine(val)}>
+      <div class="sz-eng-name">${name}</div>
+      <div class="sz-eng-tag">${tag}</div>
+      <div class="sz-eng-desc">${desc}</div>
+      ${!avail && cap && cap.reason ? html`<div class="sz-eng-off badge badge-closed">${cap.reason}</div>` : null}
+    </button>`;
+  };
 
   // ---- curator ----
   const seg = (val, set, opts, label) => html`
@@ -8421,41 +8441,6 @@ function SummarizeView({ params }) {
   };
 
   // ======================= RENDER =======================
-  if (phase === 'engine') {
-    const eng = (id, name, tag, desc) => {
-      const cap = caps ? caps[id] : null;
-      const avail = cap ? cap.available : false;
-      const val = id === 'claude_p' ? 'claude-p' : id;
-      return html`<button class="sz-engine" disabled=${!avail} onClick=${() => avail && pickEngine(val)}>
-        <div class="sz-eng-name">${name}</div>
-        <div class="sz-eng-tag">${tag}</div>
-        <div class="sz-eng-desc">${desc}</div>
-        ${!avail && cap && cap.reason ? html`<div class="sz-eng-off badge badge-closed">${cap.reason}</div>` : null}
-      </button>`;
-    };
-    return html`
-      <div style="margin:0 0 16px"><a class="sz-back-link" href="#/optimize">← Optimize</a></div>
-      <div class="page-title">Summarize <span class="sz-sub">· structure-aware prompt summarization</span></div>
-      <div class="sz-note">Rewrites prose only: code, tables, and <code>&lt;tj-keep&gt;</code> blocks stay verbatim. Nothing is written until you review each rewrite and Apply.</div>
-      ${staged.length ? html`<div class="cur-tally" style="cursor:pointer;margin-top:14px" onClick=${() => setPhase('review')}>
-        <div class="cur-tally-head">
-          <div class="cur-tally-count">${staged.length} <small>staged rewrite(s) ready to review; no engine needed</small></div>
-          <div class="cur-tally-hint">Review & apply →</div>
-        </div>
-      </div>` : null}
-      ${backups.filter(b => b.undoable).length ? html`<div class="dim" style="font-size:12px;margin-top:8px">${backups.filter(b => b.undoable).length} applied summary(ies) can be undone: <span class="sz-link" onClick=${() => setPhase('review')}>review & undo →</span></div>` : null}
-      <div class="sz-sub" style="font-weight:600;margin:18px 0 2px">Summarize new files</div>
-      <div class="sz-note" style="margin-bottom:6px">How to produce the summaries:</div>
-      ${capErr ? html`<div class="chart-card" style="border-color:var(--error)"><div style="color:var(--error);font-size:13px">Couldn't load engine availability: ${capErr}</div></div>` : null}
-      ${!caps && !capErr ? html`<div class="shimmer" style="height:140px"></div>` : null}
-      ${caps ? html`<div class="sz-engines">
-        ${eng('api', 'API', '$ at cost · your key', 'Calls Anthropic with your key. Billed per rewrite; the review shows cost and break-even.')}
-        ${eng('claude_p', 'Claude CLI', 'against your Claude limits', html`Runs the local <code>claude</code> CLI against your Claude limits, with no dollar cost. Local host only.`)}
-        ${eng('manual', 'Manual', 'no outbound calls', 'Copy a ready-made prompt into any Claude session, paste the reply back. Nothing leaves this machine.')}
-      </div>` : null}
-    `;
-  }
-
   if (phase === 'run' && engine !== 'manual') {
     const rs = runState || { total: runList.length, done: 0, current: null, results: [], running: true };
     const pct = rs.total ? Math.round(rs.done / rs.total * 100) : 100;
@@ -8522,7 +8507,7 @@ function SummarizeView({ params }) {
     const mst = mf ? stOf(mf.path) : null;
     const mfBlocks = mf ? diffBlocks(mf.diff) : [];
     return html`
-      <div style="margin:0 0 4px"><span class="sz-link" onClick=${() => setPhase(engine ? 'curate' : 'engine')}>← ${engine ? 'back to curator' : 'back to start'}</span></div>
+      <div style="margin:0 0 4px"><span class="sz-link" onClick=${() => setPhase('curate')}>← back to curator</span></div>
       <div class="page-title">Summarize <span class="sz-sub">· review & apply</span></div>
       <div class="sz-note rev-note">${revRows.length} staged. Structure is guaranteed; <b>meaning may change</b> — click a row for its diff. <b>Apply</b> writes the file (backs up first); <b>Reject</b> dismisses it here.</div>
       ${dataErr ? html`<div class="chart-card" style="border-color:var(--error)"><div style="color:var(--error);font-size:13px">${dataErr}</div></div>` : null}
@@ -8565,7 +8550,7 @@ function SummarizeView({ params }) {
         <span class="dim" style="font-size:12px">Click a row for its diff.</span>
         <a class="cur-btn" style="margin-left:auto;text-decoration:none" href="#/optimize">Done → Optimize</a>
       </div>
-      ${revRows.length > 0 && stagedCount === 0 ? html`<div class="opt-caveat" style="font-style:normal;color:var(--success);margin-top:12px">✓ All ${revRows.length} rewrite(s) resolved — ${appliedCount} applied, ${rejectedCount} rejected${revertedCount ? ', ' + revertedCount + ' reverted' : ''}.${appliedCount ? ' Applied one you didn\'t want? Undo it below.' : ''} <a class="sz-link" href="#/optimize">Back to Optimize</a> · <span class="sz-link" onClick=${() => setPhase(engine ? 'curate' : 'engine')}>summarize more →</span></div>` : null}
+      ${revRows.length > 0 && stagedCount === 0 ? html`<div class="opt-caveat" style="font-style:normal;color:var(--success);margin-top:12px">✓ All ${revRows.length} rewrite(s) resolved — ${appliedCount} applied, ${rejectedCount} rejected${revertedCount ? ', ' + revertedCount + ' reverted' : ''}.${appliedCount ? ' Applied one you didn\'t want? Undo it below.' : ''} <a class="sz-link" href="#/optimize">Back to Optimize</a> · <span class="sz-link" onClick=${() => setPhase('curate')}>summarize more →</span></div>` : null}
 
       ${backups.length ? html`<div class="opt-section" style="margin:16px 0 4px">
         <div class="opt-title" style="font-size:14px;margin-bottom:2px">Applied earlier — undo</div>
@@ -8614,10 +8599,15 @@ function SummarizeView({ params }) {
     `;
   }
 
-  // phase === 'curate'
+  // phase === 'curate': the landing view. Candidates are fetched on mount
+  // (see the useEffect above) and shown here with no engine choice required:
+  // looking is free, only producing a rewrite (Finish → Approve, below) asks
+  // which tool to use.
   return html`
-    <div style="margin:0 0 4px"><a class="sz-link" href="#/optimize">← Optimize</a> <span class="dim" style="font-size:12px">· engine: ${engine} · <span class="sz-link" onClick=${() => setPhase('engine')}>change</span></span></div>
-    <div class="page-title">Summarize <span class="sz-sub">· curator — pick files to summarize</span></div>
+    <div style="margin:0 0 16px"><a class="sz-back-link" href="#/optimize">← Optimize</a></div>
+    <div class="page-title">Summarize <span class="sz-sub">· structure-aware prompt summarization</span></div>
+    <div class="sz-note">Rewrites prose only: code, tables, and <code>&lt;tj-keep&gt;</code> blocks stay verbatim. Nothing is written until you review each rewrite and Apply.</div>
+    ${engine ? html`<div class="dim" style="font-size:12px;margin-top:4px">engine: ${engine} · <span class="sz-link" onClick=${() => setEngine(null)}>change</span></div>` : null}
 
     <div class=${'cur-tally' + (addedList.length ? '' : ' empty')} onClick=${() => addedList.length && openModal('review')}>
       <div class="cur-tally-head">
@@ -8628,6 +8618,7 @@ function SummarizeView({ params }) {
     </div>
 
     ${staged.length ? html`<div class="opt-caveat" style="font-style:normal">${staged.length} file(s) already staged from an earlier run or the <code>tj summarize</code> CLI — <span class="sz-link" onClick=${() => setPhase('review')}>Review & apply →</span></div>` : null}
+    ${backups.filter(b => b.undoable).length ? html`<div class="dim" style="font-size:12px;margin-top:4px">${backups.filter(b => b.undoable).length} applied summary(ies) can be undone: <span class="sz-link" onClick=${() => setPhase('review')}>review & undo →</span></div>` : null}
 
     <div class="cur-filters">
       ${seg(kind, setKind, [{ v: 'all', t: 'All' }, { v: 'prompt', t: 'Prompt' }, { v: 'other', t: 'Other' }], 'Kind')}
@@ -8683,31 +8674,46 @@ function SummarizeView({ params }) {
     </div>
     ` : null}
 
-    <div class="sz-note" style="font-size:12px;margin-top:14px"><b>Finish → Approve</b> runs the summarizer${engine === 'manual' ? ' (you paste each result back)' : ' via ' + engine} — you review each rewrite before applying.</div>
+    <div class="sz-note" style="font-size:12px;margin-top:14px"><b>Finish → Approve</b> ${engine ? html`runs the summarizer${engine === 'manual' ? ' (you paste each result back)' : ' via ' + engine}` : 'asks which tool to use, then runs the summarizer'} — you review each rewrite before applying.</div>
 
     ${modal ? html`
       <div class="cur-overlay" onClick=${() => setModal(null)}>
         <div class="cur-modal" onClick=${e => e.stopPropagation()}>
           <div class="cur-modal-head">
-            <span class="cur-modal-title">${modal === 'approve' ? 'Approve ' + added.size + ' file' + (added.size === 1 ? '' : 's') + ' to summarize?' : 'Basket — ' + added.size + ' file' + (added.size === 1 ? '' : 's')}</span>
+            <span class="cur-modal-title">${modal === 'approve' ? (engine ? 'Approve ' + added.size + ' file' + (added.size === 1 ? '' : 's') + ' to summarize?' : 'How should we summarize ' + added.size + ' file' + (added.size === 1 ? '' : 's') + '?') : 'Basket — ' + added.size + ' file' + (added.size === 1 ? '' : 's')}</span>
             <button class="cur-modal-x" onClick=${() => setModal(null)} title="Close — go back and change">✕</button>
           </div>
           <div class="cur-modal-body">
-            <input class="cur-search" style="width:100%;margin-bottom:10px" placeholder="search basket…" value=${mQuery} onInput=${e => setMQuery(e.target.value)} />
-            ${modalList.length === 0
-              ? html`<div class="dim" style="padding:14px;text-align:center">${added.size === 0 ? 'Basket is empty.' : 'No items match.'}</div>`
-              : modalList.map((c, i) => html`<div class="cur-mrow" key=${i}>
-                  <span class="path">${c.path}</span>
-                  <span class="dim mono" style="font-size:12px">~${c.est_tokens_saved} tok/call</span>
-                  <button class="rm" title="Remove from basket" onClick=${() => removeAdded(c.path)}>✕</button>
-                </div>`)}
+            ${modal === 'approve' && !engine ? html`
+              <div class="sz-note" style="margin:0 0 10px">Looking is free; producing a rewrite needs a tool. How to produce the summaries:</div>
+              ${capErr ? html`<div class="chart-card" style="border-color:var(--error)"><div style="color:var(--error);font-size:13px">Couldn't load engine availability: ${capErr}</div></div>` : null}
+              ${!caps && !capErr ? html`<div class="shimmer" style="height:140px"></div>` : null}
+              ${caps ? html`<div class="sz-engines">
+                ${eng('api', 'API', '$ at cost · your key', 'Calls Anthropic with your key. Billed per rewrite; the review shows cost and break-even.')}
+                ${eng('claude_p', 'Claude CLI', 'against your Claude limits', html`Runs the local <code>claude</code> CLI against your Claude limits, with no dollar cost. Local host only.`)}
+                ${eng('manual', 'Manual', 'no outbound calls', 'Copy a ready-made prompt into any Claude session, paste the reply back. Nothing leaves this machine.')}
+              </div>` : null}
+            ` : html`
+              <input class="cur-search" style="width:100%;margin-bottom:10px" placeholder="search basket…" value=${mQuery} onInput=${e => setMQuery(e.target.value)} />
+              ${modalList.length === 0
+                ? html`<div class="dim" style="padding:14px;text-align:center">${added.size === 0 ? 'Basket is empty.' : 'No items match.'}</div>`
+                : modalList.map((c, i) => html`<div class="cur-mrow" key=${i}>
+                    <span class="path">${c.path}</span>
+                    <span class="dim mono" style="font-size:12px">~${c.est_tokens_saved} tok/call</span>
+                    <button class="rm" title="Remove from basket" onClick=${() => removeAdded(c.path)}>✕</button>
+                  </div>`)}
+            `}
           </div>
           <div class="cur-modal-foot">
-            <button class="cur-btn" disabled=${modalList.length === 0} onClick=${clearShownModal}>Clear shown</button>
-            <button class="cur-btn" disabled=${added.size === 0} onClick=${clearAll}>Clear all</button>
-            ${modal === 'approve'
-              ? html`<button class="cur-btn primary" style="margin-left:auto" disabled=${added.size === 0} onClick=${approve}>${engine === 'manual' ? 'Approve ' + added.size + ' — prep first →' : 'Approve ' + added.size + ' — run via ' + engine + ' →'}</button>`
-              : html`<button class="cur-btn primary" style="margin-left:auto" onClick=${() => setModal(null)}>Done</button>`}
+            ${modal === 'approve' && !engine ? html`
+              <button class="cur-btn" style="margin-left:auto" onClick=${() => setModal(null)}>Cancel</button>
+            ` : html`
+              <button class="cur-btn" disabled=${modalList.length === 0} onClick=${clearShownModal}>Clear shown</button>
+              <button class="cur-btn" disabled=${added.size === 0} onClick=${clearAll}>Clear all</button>
+              ${modal === 'approve'
+                ? html`<button class="cur-btn primary" style="margin-left:auto" disabled=${added.size === 0} onClick=${approve}>${engine === 'manual' ? 'Approve ' + added.size + ' — prep first →' : 'Approve ' + added.size + ' — run via ' + engine + ' →'}</button>`
+                : html`<button class="cur-btn primary" style="margin-left:auto" onClick=${() => setModal(null)}>Done</button>`}
+            `}
           </div>
         </div>
       </div>` : null}

--- a/tokenjam/ui/index.html
+++ b/tokenjam/ui/index.html
@@ -375,7 +375,7 @@ tr.clickable:hover td.chevron { color: var(--accent); }
 .badge-active { background: rgba(12,228,144,0.15); color: var(--success); }
 .badge-idle { background: rgba(245,166,35,0.15); color: var(--warn); }
 .badge-stale { background: rgba(245,166,35,0.12); color: var(--warn); }
-.badge-closed { background: rgba(140,140,140,0.15); color: var(--text-dim); }
+.badge-closed, .badge-neutral { background: rgba(140,140,140,0.15); color: var(--text-dim); }
 .badge-critical { background: rgba(238,0,0,0.15); color: var(--error); }
 .badge-warning { background: rgba(245,166,35,0.15); color: var(--warn); }
 .badge-info { background: rgba(61,142,255,0.15); color: var(--info); }
@@ -740,6 +740,19 @@ table.archive-list .a-id { color: var(--text); }
   font-weight: 700;
   margin-bottom: 12px;
 }
+/* The "why there is nothing here" block under the Drift empty state. */
+.drift-empty-why {
+  max-width: 620px;
+  margin: 16px auto 0;
+  text-align: left;
+  font-family: 'Geist Mono', monospace;
+  font-size: 12px;
+  line-height: 1.6;
+  color: var(--text-faint);
+  border-left: 2px solid var(--border);
+  padding-left: 12px;
+}
+.drift-empty-why div + div { margin-top: 8px; }
 
 /* Empty state */
 .empty {
@@ -760,6 +773,16 @@ table.archive-list .a-id { color: var(--text); }
 .expand-toggle.open { transform: rotate(90deg); }
 
 /* Alert detail expand */
+.alerts-ack-error {
+  margin-bottom: 12px;
+  padding: 8px 12px;
+  border: 1px solid var(--error);
+  border-radius: 6px;
+  background: rgba(238,0,0,0.08);
+  font-family: 'Geist Mono', monospace;
+  font-size: 12px;
+  color: var(--error);
+}
 .alert-detail {
   background: var(--bg);
   border: 1px solid var(--border);
@@ -1849,6 +1872,21 @@ async function apiPost(path, body) {
   if (WRITE_TOKEN) headers['X-TJ-Local-Token'] = WRITE_TOKEN;
   const resp = await fetch('/api/v1' + path, {
     method: 'POST', headers, body: JSON.stringify(body),
+  });
+  // Any mutation invalidates cached reads so stale data never lingers.
+  clearApiCache();
+  if (!resp.ok) throw new Error(`API ${resp.status}`);
+  return resp.json();
+}
+
+// PATCH sibling of apiPost, for endpoints that flip a flag on an existing row
+// (alert acknowledgement). Same header + cache-invalidation contract.
+async function apiPatch(path, body) {
+  const headers = { 'Content-Type': 'application/json' };
+  if (API_KEY) headers['Authorization'] = 'Bearer ' + API_KEY;
+  if (WRITE_TOKEN) headers['X-TJ-Local-Token'] = WRITE_TOKEN;
+  const resp = await fetch('/api/v1' + path, {
+    method: 'PATCH', headers, body: JSON.stringify(body || {}),
   });
   // Any mutation invalidates cached reads so stale data never lingers.
   clearApiCache();
@@ -6419,6 +6457,8 @@ function AlertsView({ params }) {
 
   const [alerts, setAlerts] = useState([]);
   const [expanded, setExpanded] = useState(null);
+  const [acking, setAcking] = useState(null);
+  const [ackError, setAckError] = useState(null);
 
   const load = useCallback(async () => {
     const d = await api('/alerts', {
@@ -6431,6 +6471,22 @@ function AlertsView({ params }) {
   }, [severity, unread, agentId, since]);
 
   useEffect(() => { load(); const t = setInterval(load, 10000); return () => clearInterval(t); }, [load]);
+
+  // Acknowledge flips `acknowledged` server-side; reloading afterwards is what
+  // keeps the "Unread only" filter honest, since an acknowledged alert is no
+  // longer unread and must drop out of that list.
+  const acknowledge = useCallback(async (alertId) => {
+    setAcking(alertId);
+    setAckError(null);
+    try {
+      await apiPatch(`/alerts/${encodeURIComponent(alertId)}/acknowledge`);
+      await load();
+    } catch (e) {
+      setAckError(`Could not acknowledge alert: ${e.message}`);
+    } finally {
+      setAcking(null);
+    }
+  }, [load]);
 
   return html`
     <div class="page-title">Alerts</div>
@@ -6448,9 +6504,10 @@ function AlertsView({ params }) {
       ${agentId ? html`<button class="btn" onClick=${() => setFilter('agent_id', '')}>agent: ${agentId} ✕</button>` : null}
       <button class="btn" onClick=${load}>Refresh</button>
     </div>
+    ${ackError ? html`<div class="alerts-ack-error">${ackError}</div>` : null}
     ${alerts.length === 0 ? html`<div class="empty">No alerts fired. Configure sensitive actions in ${'`tj.toml`'}.</div>` : html`
       <div class="table-wrap"><table>
-        <thead><tr><th></th><th>Time</th><th>Severity</th><th>Type</th><th>Title</th><th>Agent</th></tr></thead>
+        <thead><tr><th></th><th>Time</th><th>Severity</th><th>Type</th><th>Title</th><th>Agent</th><th>Status</th></tr></thead>
         <tbody>
           ${alerts.map(a => html`
             <tr class="clickable" onClick=${() => setExpanded(expanded === a.alert_id ? null : a.alert_id)}>
@@ -6460,8 +6517,16 @@ function AlertsView({ params }) {
               <td>${friendlyAlertType(a.type)}</td>
               <td>${a.title}</td>
               <td class="mono">${a.agent_id || '-'}</td>
+              <td onClick=${e => e.stopPropagation()}>
+                ${a.acknowledged
+                  ? html`<span class="badge badge-neutral">acknowledged</span>`
+                  : html`<button class="btn" disabled=${acking === a.alert_id}
+                      onClick=${() => acknowledge(a.alert_id)}>
+                      ${acking === a.alert_id ? 'Acknowledging...' : 'Acknowledge'}
+                    </button>`}
+              </td>
             </tr>
-            ${expanded === a.alert_id ? html`<tr><td colspan="6"><div class="alert-detail">${JSON.stringify(a.detail, null, 2)}</div></td></tr>` : null}
+            ${expanded === a.alert_id ? html`<tr><td colspan="7"><div class="alert-detail">${JSON.stringify(a.detail, null, 2)}</div></td></tr>` : null}
           `)}
         </tbody>
       </table></div>
@@ -6489,7 +6554,20 @@ function DriftView({ params }) {
 
   // /drift returns a single-agent shape when agent_id is set; normalize to a list.
   const agents = data.agents || (data.agent_id ? [data] : []);
-  if (!agents.length) return html`<div class="empty">No drift baselines built yet. Run at least 10 completed live sessions for a single agent to establish its behavioral baseline (note: drift baselines are computed per-agent, and only from live sessions, so historical backfilled sessions will not build a baseline).</div>`;
+  // An honest empty state says WHY there is nothing here, not just that there is
+  // nothing. Two of the three reasons are permanent for most users: interactive
+  // coding agents are deliberately never baselined (the API applies the same
+  // persona gate the detector does), and backfilled history never builds one.
+  if (!agents.length) return html`
+    <div class="page-title">Drift Detection</div>
+    <div class="empty">
+      <div>No drift baselines to compare against.</div>
+      <div class="drift-empty-why">
+        <div>Drift compares a service against its own past behavior, so it needs a baseline: at least 10 completed sessions for one agent.</div>
+        <div>Interactive coding sessions are not baselined. A Claude Code or Codex session varies by design; one mean and standard deviation over that workload measures nothing, so no baseline is built or shown for those agents.</div>
+        <div>Baselines build only from live sessions. Backfilled history is not baselined, so importing past transcripts will not produce one.</div>
+      </div>
+    </div>`;
 
   const metrics = [
     ['Input tokens', 'avg_input_tokens', 'stddev_input_tokens', 'input_tokens'],
@@ -6516,29 +6594,32 @@ function DriftView({ params }) {
                 const latest = a.latest_session ? a.latest_session[latestKey] : null;
                 let z = null;
                 let zDisplay = '-';
-                if (avg != null && latest != null) {
-                  if (std != null && std > 0) {
-                    z = (latest - avg) / std;
-                    zDisplay = z.toFixed(2);
-                  } else if (std === 0 || std == null) {
-                    // Match drift.py z_score: inf when stddev=0 and value != mean
-                    if (latest !== avg) {
-                      z = Infinity;
-                      zDisplay = 'inf';
-                    } else {
-                      z = 0;
-                      zDisplay = '0.00';
-                    }
-                  }
+                // A baseline with zero spread cannot judge anything. Every
+                // sampled session had the same value, so any movement divides by
+                // zero and reads as an infinite deviation. That is an absence of
+                // evidence, not a regression, so this renders a neutral "cannot
+                // judge" row rather than a red drift verdict with `inf` in it.
+                // The Python z_score() is unchanged; this is a display decision.
+                const noVariance = avg != null && latest != null && (std == null || std === 0);
+                if (avg != null && latest != null && std != null && std > 0) {
+                  z = (latest - avg) / std;
+                  zDisplay = z.toFixed(2);
+                } else if (noVariance) {
+                  zDisplay = 'n/a';
                 }
-                const pass = z == null || (Number.isFinite(z) && Math.abs(z) < 2);
+                const pass = !noVariance && (z == null || Math.abs(z) < 2);
+                const zColor = noVariance
+                  ? 'var(--text-dim)'
+                  : (pass ? 'var(--success)' : 'var(--error)');
+                const badgeClass = noVariance ? 'badge-neutral' : (pass ? 'badge-ok' : 'badge-critical');
+                const badgeLabel = noVariance ? 'no baseline variance' : (pass ? 'pass' : 'drift');
                 return html`
                   <tr>
                     <td>${label}</td>
                     <td class="mono">${avg != null ? avg.toFixed(1) : '-'}${std != null ? ' +/- ' + std.toFixed(1) : ''}</td>
                     <td class="mono">${latest != null ? (typeof latest === 'number' ? latest.toFixed(1) : latest) : '-'}</td>
-                    <td class="mono" style="color:${pass ? 'var(--success)' : 'var(--error)'}">${zDisplay}</td>
-                    <td><span class="badge ${pass ? 'badge-ok' : 'badge-critical'}">${pass ? 'pass' : 'drift'}</span></td>
+                    <td class="mono" style="color:${zColor}" title=${noVariance ? 'Every sampled session had the same value, so there is no spread to measure a deviation against.' : ''}>${zDisplay}</td>
+                    <td><span class="badge ${badgeClass}">${badgeLabel}</span></td>
                   </tr>
                 `;
               })}


### PR DESCRIPTION
Several UI corrections that landed together in one session, plus the daily-budget work and the drift/alerts fix that were merged into this branch from parallel lanes. Grouped by area below.

## FAQ page (was "Analyzer guide")

The analyzer guide is now the **FAQ**, and it moved out of the Observe lens into Improve as its last entry. `#/faq` is canonical; `#/guide` and the already-retired `#/optimize/guide` redirect to it through the existing legacy-route mechanism, so old links and bookmarks keep working.

The page content was reworked around one rule: **one heading, one description per card**. Internal sub-headings are gone, and the prose that lived in them was folded into each card's single description.

Removed:

- The "Checks that are not shown here" card, which listed held-back checks as a footnote.
- The "Downsize and Subagent are not the same check" callout. Its substance now lives inside those two cards, verified against `model_downgrade.py` (the driver-role case requires zero delegation) and `subagent_rightsizing.py` (`sub_agent_id IS NOT NULL` only), so each card explains its own question without needing a separate comparison box.
- The "See these on the Optimize screen" link and the "Written for Claude Code" persona callout, along with the now-dead persona-label helper.

Layout and rendering:

- Dropped the `max-width: 74ch` clamp on `.guide-prose`/`.guide-banner` so the text uses the page width. These classes are FAQ-only, so no other screen changes.
- The page no longer fetches anything. Every card is static, decided by the registry and the persona gate at author time, so the loading state and its skeleton were removed rather than restyled.

Coverage now includes the analyzers that are gated for Claude Code, not just the live ones. **Inclusion rule: does the check end in a fix the user can apply**, which is not the same as "is it in the analyzers directory". `budget-projection` (informational, no fix claimed) and `stream-usage` (a telemetry-completeness diagnostic) are therefore excluded despite being registered analyzers.

The old coverage test asserted a card per registered analyzer, which encoded that wrong rule. It is replaced by explicit reviewed shown/excluded sets, so a newly registered analyzer fails the suite by name and forces a decision instead of silently appearing or silently being missed.

## Rescan control on every analyzer surface

The control existed but was inconsistent: on Optimize it sat in the filters row among the window/compare selects, on Dashboard inside the "Recoverable waste" sub-band label, and the Review inbox had a **separate bespoke implementation** hitting different endpoints with its errors swallowed.

Now one shared component on all three, top right of the heading row. It is a real `<button>` rather than a styled `<span>`, so it is keyboard-operable and focusable, with hover, active, disabled, focus-visible and in-flight states (the spinner respects `prefers-reduced-motion`). Styling uses the existing `--accent` token, deliberately not `--brand`. The inbox path now goes through `Promise.allSettled` + `apiPostOrDetail`, so a partial refresh failure surfaces through the same error prop as the other two surfaces instead of disappearing.

## Summarize: looking is free, doing needs a tool

`SummarizeView` always landed on an `engine` phase that had no candidate-rendering code at all, and `loadScan()` ran only from `pickEngine`. So the Optimize card's "see all" footer pointed at a screen showing **none** of the candidates it advertised, which reads as "nothing found" or "broken".

The view now lands on the candidate list and fetches the scan on mount. The engine picker moved into the Finish/Approve step and is asked once per session, with a link to change it. Manual is never gated, so a user with files selected can always proceed. The scan's `loading` state also started at `false`, which let the first paint fall through to the count/empty-state branch before the fetch resolved; it now starts `true` so the shimmer holds until the data is known.

## Review inbox action rows

The Dismiss control rendered as a blue link on its own line below the card panel on every apply-capable card, not just the MCP-removal one: all three branches in `CostProposalCard` shared a trailing fallback that sat outside the panel with no colour override, so it inherited `.sz-link`'s brand blue.

Dismiss now uses the shared treatment inside each card's own action row, next to the primary button, and the dead fallback is gone. Action rows are right aligned; rows containing the path input already sat flush right because the input's `flex:1` takes the slack. A test asserts every `onDismiss` call site renders identical markup so this cannot diverge again.

## Daily budgets and drift/alerts (merged in from parallel work)

Merged into this branch rather than opened separately:

- Coding-tool group budgets: an `agent_kind` classifier, a `get_daily_cost_for_agents` group-sum query, the group budget config schema, group daily-cap enforcement in the alert engine, and a two-zone `GET/POST /api/v1/budget` response kept backward compatible, with the Budget page rendered as two daily-only zones.
- Drift no longer renders unjudgeable baselines, and alert acknowledge is wired up.

Note that the drift/alerts PR was opened against this branch rather than `main`, so that fix reaches `main` only through this PR.

## Verification

Full unit suite green at each merge point; `4006 passed, 7 skipped` on the final head. `ruff check tokenjam/` clean.

Three branches edited `tokenjam/ui/index.html` concurrently, so the merges were checked for silent reverts rather than trusted. One was caught: the `<tj-keep>` double-escaping fix lived inside the engine block that the Summarize change deleted, and the intro line was recreated in the curate phase with the broken escaped form. Git auto-merged it without a conflict. It has been reapplied and is asserted by a test.

## Known and deliberately not addressed here

The Optimize card reads summarize candidates from the `/api/v1/optimize` analyzer payload while `SummarizeView` re-scans live via `/api/v1/summarize/candidates`, so the two lists can disagree. Out of scope for this PR.
