### PR TITLE
Fix Drift showing unjudgeable baselines and wire the Alerts acknowledge control

### DIFF
--- a/tests/integration/test_api.py
+++ b/tests/integration/test_api.py
@@ -964,6 +964,139 @@ async def test_get_drift_without_agent_id_returns_all(client):
     assert "agents" in data
 
 
+def _drift_baseline(agent_id: str):
+    """A baseline row for `agent_id` with realistic-looking spread."""
+    from tokenjam.core.models import DriftBaseline
+    from tokenjam.utils.time_parse import utcnow
+
+    return DriftBaseline(
+        agent_id=agent_id,
+        sessions_sampled=12,
+        computed_at=utcnow(),
+        avg_input_tokens=4200.0,
+        stddev_input_tokens=310.0,
+        avg_output_tokens=800.0,
+        stddev_output_tokens=90.0,
+        avg_session_duration_s=45.0,
+        stddev_session_duration=6.0,
+        avg_tool_call_count=3.0,
+        stddev_tool_call_count=0.0,
+    )
+
+
+@pytest.mark.asyncio
+async def test_drift_list_excludes_interactive_coding_agent_baselines(tmp_path):
+    """A legacy coding-agent baseline must never render as a drift card.
+
+    `DriftDetector.on_session_end` already refuses to build one, but baselines
+    are written once and never recomputed, so a row from before that skip (or
+    from an id reclassified since) survives forever. The read path applies the
+    same persona gate so the two cannot disagree.
+    """
+    from tokenjam.core.db import DuckDBBackend
+    from tokenjam.core.config import StorageConfig
+
+    db = DuckDBBackend(StorageConfig(path=str(tmp_path / "t.duckdb")))
+    try:
+        config = TjConfig(
+            version="1",
+            security=SecurityConfig(ingest_secret=INGEST_SECRET),
+            api=ApiConfig(auth=ApiAuthConfig(enabled=False)),
+        )
+        pipeline = IngestPipeline(db=db, config=config)
+        db.upsert_baseline(_drift_baseline("claude-code"))
+        db.upsert_baseline(_drift_baseline("codex-cli"))
+        db.upsert_baseline(_drift_baseline("prod-summarizer"))
+
+        app = create_app(config=config, db=db, ingest_pipeline=pipeline)
+        transport = httpx.ASGITransport(app=app)
+        async with httpx.AsyncClient(transport=transport, base_url="http://test") as c:
+            resp = await c.get("/api/v1/drift")
+            assert resp.status_code == 200
+            agent_ids = [a["agent_id"] for a in resp.json()["agents"]]
+            assert agent_ids == ["prod-summarizer"]
+    finally:
+        db.close()
+
+
+@pytest.mark.asyncio
+async def test_drift_for_a_single_coding_agent_returns_no_baseline(tmp_path):
+    """The explicit `?agent_id=` path applies the same gate as the list path."""
+    from tokenjam.core.db import DuckDBBackend
+    from tokenjam.core.config import StorageConfig
+
+    db = DuckDBBackend(StorageConfig(path=str(tmp_path / "t.duckdb")))
+    try:
+        config = TjConfig(
+            version="1",
+            security=SecurityConfig(ingest_secret=INGEST_SECRET),
+            api=ApiConfig(auth=ApiAuthConfig(enabled=False)),
+        )
+        pipeline = IngestPipeline(db=db, config=config)
+        db.upsert_baseline(_drift_baseline("claude-code"))
+
+        app = create_app(config=config, db=db, ingest_pipeline=pipeline)
+        transport = httpx.ASGITransport(app=app)
+        async with httpx.AsyncClient(transport=transport, base_url="http://test") as c:
+            resp = await c.get("/api/v1/drift", params={"agent_id": "claude-code"})
+            assert resp.status_code == 200
+            body = resp.json()
+            assert body["baseline"] is None
+            assert body["baseline_skipped_reason"] == "interactive_coding_agent"
+    finally:
+        db.close()
+
+
+@pytest.mark.asyncio
+async def test_acknowledging_an_alert_drops_it_from_the_unread_list(tmp_path):
+    """The contract the Alerts screen's Acknowledge button relies on.
+
+    The endpoint existed with no control wired to it, so nothing exercised the
+    acknowledge-then-refetch round trip the UI performs: PATCH with a JSON body,
+    then re-read with `unread=true` and expect the alert to be gone.
+    """
+    from tokenjam.core.db import DuckDBBackend
+    from tokenjam.core.config import StorageConfig
+    from tokenjam.core.models import Alert, AlertType, Severity
+    from tokenjam.utils.time_parse import utcnow
+
+    db = DuckDBBackend(StorageConfig(path=str(tmp_path / "t.duckdb")))
+    try:
+        config = TjConfig(
+            version="1",
+            security=SecurityConfig(ingest_secret=INGEST_SECRET),
+            api=ApiConfig(auth=ApiAuthConfig(enabled=False)),
+        )
+        pipeline = IngestPipeline(db=db, config=config)
+        alert = Alert(
+            alert_id="ack-me",
+            fired_at=utcnow(),
+            type=AlertType.SESSION_DURATION,
+            severity=Severity.WARNING,
+            title="Long session",
+            detail={},
+            agent_id="prod-summarizer",
+            acknowledged=False,
+        )
+        db.insert_alert(alert)
+
+        app = create_app(config=config, db=db, ingest_pipeline=pipeline)
+        transport = httpx.ASGITransport(app=app)
+        async with httpx.AsyncClient(transport=transport, base_url="http://test") as c:
+            resp = await c.get("/api/v1/alerts", params={"unread": "true"})
+            assert [a["alert_id"] for a in resp.json()["alerts"]] == ["ack-me"]
+
+            resp = await c.patch("/api/v1/alerts/ack-me/acknowledge", json={})
+            assert resp.status_code == 200
+            assert resp.json() == {"acknowledged": True, "alert_id": "ack-me"}
+
+            resp = await c.get("/api/v1/alerts", params={"unread": "true"})
+            assert resp.json()["alerts"] == []
+            resp = await c.get("/api/v1/alerts")
+            assert resp.json()["alerts"][0]["acknowledged"] is True
+    finally:
+        db.close()
+
 # ── API key auth ───────────────────────────────────────────────────────────
 
 async def test_get_endpoint_requires_api_key_when_auth_enabled(auth_client):

--- a/tests/unit/test_lens_ui_regression.py
+++ b/tests/unit/test_lens_ui_regression.py
@@ -4853,3 +4853,67 @@ def test_analyzer_guide_makes_no_guaranteed_saving_claim(html):
         assert banned not in guide, f"guide copy must not contain {banned!r}"
     assert "estimates from your own history" in guide
     assert "review before you act on them" in guide
+
+
+def test_drift_zero_variance_row_is_neutral_not_a_drift_verdict(html):
+    """A baseline with no spread cannot judge anything.
+
+    `z_score()` in `core/drift.py` deliberately returns inf when stddev is 0 and
+    the value moved, and the UI used to mirror that literally: a metric whose
+    every sampled session had the same value (tool calls `0.0 +/- 0.0`) rendered
+    `inf` under a red `drift` badge. That is an absence of evidence, not a
+    regression. The row now reads as "cannot judge". The Python helper is
+    unchanged; this is a display decision only.
+    """
+    start = html.index("function DriftView({ params })")
+    end = html.index("// Budget View", start)
+    view = _no_comments(html[start:end])
+    assert "const noVariance =" in view
+    assert "'no baseline variance'" in view
+    assert "badge-neutral" in view
+    # The old inf-as-maximum-anomaly rendering is gone.
+    assert "zDisplay = 'inf'" not in view
+    assert "z = Infinity" not in view
+
+
+def test_drift_empty_state_explains_why_there_is_no_baseline(html):
+    """"None yet" is not an answer when two of the three reasons are permanent.
+
+    Interactive coding sessions are never baselined (the API applies the same
+    persona gate the detector does) and backfilled history never builds one, so
+    the empty state names both alongside the session-count requirement.
+    """
+    start = html.index("function DriftView({ params })")
+    end = html.index("// Budget View", start)
+    view = _no_comments(html[start:end])
+    assert "drift-empty-why" in view
+    assert "compares a service against its own past behavior" in view
+    assert "Interactive coding sessions are not baselined" in view
+    assert "Baselines build only from live sessions" in view
+    # No em dashes in user-facing copy.
+    why_start = view.index("drift-empty-why")
+    why_end = view.index("</div>\n    </div>", why_start)
+    assert "—" not in view[why_start:why_end]
+
+
+def test_alerts_view_wires_the_acknowledge_endpoint(html):
+    """`PATCH /alerts/{id}/acknowledge` existed with no control to reach it.
+
+    Rule 24 in `tokenjam/CLAUDE.md`: a capability is only real if a user has a
+    path to it. The Alerts table now carries a Status column with an
+    Acknowledge button, and reloads afterwards so the "Unread only" filter
+    stays honest.
+    """
+    start = html.index("function AlertsView({ params })")
+    end = html.index("// Drift View", start)
+    view = _no_comments(html[start:end])
+    assert "/acknowledge" in view
+    assert "apiPatch(" in view
+    assert "const acknowledge = useCallback" in view
+    # Acknowledged alerts read as acknowledged, and the detail row still spans
+    # the full width after the Status column was added.
+    assert "badge-neutral" in view
+    assert 'colspan="7"' in view
+    assert 'colspan="6"' not in view
+    # apiPatch is a real helper, not a call into nothing.
+    assert "async function apiPatch(path, body)" in html

--- a/tokenjam/api/routes/drift.py
+++ b/tokenjam/api/routes/drift.py
@@ -14,6 +14,16 @@ is therefore ``None`` for that window. That null is accompanied by
 ``latest_session_outside_window`` and the timestamp that fell outside, because a
 bare null here reads as "this agent never ran" when the truth is "it ran, just
 not inside the window you asked about". The baseline itself is never hidden.
+
+One exception, and it is a persona exception rather than a window one:
+interactive coding agents are never baselined. ``DriftDetector.on_session_end``
+already refuses to build a baseline for them, because a single mean/stddev over
+a heterogeneous, human-driven workload measures nothing. That is a WRITE-path
+skip, and baselines are only ever built once and never recomputed, so a row
+written before that skip existed (or by an id that has since been reclassified)
+outlives it and still renders. This route therefore applies the same gate on the
+READ path, through the same ``is_interactive_coding_agent`` helper, so the two
+paths cannot disagree and a legacy row cannot surface as a drift verdict.
 """
 from __future__ import annotations
 
@@ -22,6 +32,7 @@ from typing import Any
 from fastapi import APIRouter, Depends, HTTPException, Query, Request
 
 from tokenjam.api.deps import require_api_key
+from tokenjam.core.alerts import is_interactive_coding_agent
 from tokenjam.core.data_span import available_data_span
 from tokenjam.utils.time_parse import parse_since
 
@@ -47,6 +58,16 @@ def _iso(value: Any) -> str | None:
 
 def _build_agent_drift(db: Any, agent_id: str, since: Any = None) -> dict:
     """Build drift info dict for a single agent, bounded to ``since``."""
+    if is_interactive_coding_agent(agent_id):
+        # Read-path mirror of the write-path skip in DriftDetector.on_session_end.
+        # A stale row from before that skip must not render as a drift verdict.
+        return {
+            "agent_id": agent_id,
+            "baseline": None,
+            "latest_session": None,
+            "baseline_skipped_reason": "interactive_coding_agent",
+        }
+
     baseline = db.get_baseline(agent_id)
     if baseline is None:
         return {"agent_id": agent_id, "baseline": None, "latest_session": None}
@@ -133,5 +154,11 @@ async def get_drift(
     rows = conn.execute(
         "SELECT DISTINCT agent_id FROM drift_baselines ORDER BY agent_id"
     ).fetchall()
-    agents = [_build_agent_drift(db, row[0], since_dt) for row in rows]
+    # Filtered in Python, not in SQL, so the prefix list stays in exactly one
+    # place (core/alerts.py) instead of being restated as a LIKE clause here.
+    agents = [
+        _build_agent_drift(db, row[0], since_dt)
+        for row in rows
+        if not is_interactive_coding_agent(row[0])
+    ]
     return {"agents": agents, "window": window, "data_span": data_span}

--- a/tokenjam/ui/index.html
+++ b/tokenjam/ui/index.html
@@ -375,7 +375,7 @@ tr.clickable:hover td.chevron { color: var(--accent); }
 .badge-active { background: rgba(12,228,144,0.15); color: var(--success); }
 .badge-idle { background: rgba(245,166,35,0.15); color: var(--warn); }
 .badge-stale { background: rgba(245,166,35,0.12); color: var(--warn); }
-.badge-closed { background: rgba(140,140,140,0.15); color: var(--text-dim); }
+.badge-closed, .badge-neutral { background: rgba(140,140,140,0.15); color: var(--text-dim); }
 .badge-critical { background: rgba(238,0,0,0.15); color: var(--error); }
 .badge-warning { background: rgba(245,166,35,0.15); color: var(--warn); }
 .badge-info { background: rgba(61,142,255,0.15); color: var(--info); }
@@ -740,6 +740,19 @@ table.archive-list .a-id { color: var(--text); }
   font-weight: 700;
   margin-bottom: 12px;
 }
+/* The "why there is nothing here" block under the Drift empty state. */
+.drift-empty-why {
+  max-width: 620px;
+  margin: 16px auto 0;
+  text-align: left;
+  font-family: 'Geist Mono', monospace;
+  font-size: 12px;
+  line-height: 1.6;
+  color: var(--text-faint);
+  border-left: 2px solid var(--border);
+  padding-left: 12px;
+}
+.drift-empty-why div + div { margin-top: 8px; }
 
 /* Empty state */
 .empty {
@@ -760,6 +773,16 @@ table.archive-list .a-id { color: var(--text); }
 .expand-toggle.open { transform: rotate(90deg); }
 
 /* Alert detail expand */
+.alerts-ack-error {
+  margin-bottom: 12px;
+  padding: 8px 12px;
+  border: 1px solid var(--error);
+  border-radius: 6px;
+  background: rgba(238,0,0,0.08);
+  font-family: 'Geist Mono', monospace;
+  font-size: 12px;
+  color: var(--error);
+}
 .alert-detail {
   background: var(--bg);
   border: 1px solid var(--border);
@@ -1849,6 +1872,21 @@ async function apiPost(path, body) {
   if (WRITE_TOKEN) headers['X-TJ-Local-Token'] = WRITE_TOKEN;
   const resp = await fetch('/api/v1' + path, {
     method: 'POST', headers, body: JSON.stringify(body),
+  });
+  // Any mutation invalidates cached reads so stale data never lingers.
+  clearApiCache();
+  if (!resp.ok) throw new Error(`API ${resp.status}`);
+  return resp.json();
+}
+
+// PATCH sibling of apiPost, for endpoints that flip a flag on an existing row
+// (alert acknowledgement). Same header + cache-invalidation contract.
+async function apiPatch(path, body) {
+  const headers = { 'Content-Type': 'application/json' };
+  if (API_KEY) headers['Authorization'] = 'Bearer ' + API_KEY;
+  if (WRITE_TOKEN) headers['X-TJ-Local-Token'] = WRITE_TOKEN;
+  const resp = await fetch('/api/v1' + path, {
+    method: 'PATCH', headers, body: JSON.stringify(body || {}),
   });
   // Any mutation invalidates cached reads so stale data never lingers.
   clearApiCache();
@@ -6419,6 +6457,8 @@ function AlertsView({ params }) {
 
   const [alerts, setAlerts] = useState([]);
   const [expanded, setExpanded] = useState(null);
+  const [acking, setAcking] = useState(null);
+  const [ackError, setAckError] = useState(null);
 
   const load = useCallback(async () => {
     const d = await api('/alerts', {
@@ -6431,6 +6471,22 @@ function AlertsView({ params }) {
   }, [severity, unread, agentId, since]);
 
   useEffect(() => { load(); const t = setInterval(load, 10000); return () => clearInterval(t); }, [load]);
+
+  // Acknowledge flips `acknowledged` server-side; reloading afterwards is what
+  // keeps the "Unread only" filter honest, since an acknowledged alert is no
+  // longer unread and must drop out of that list.
+  const acknowledge = useCallback(async (alertId) => {
+    setAcking(alertId);
+    setAckError(null);
+    try {
+      await apiPatch(`/alerts/${encodeURIComponent(alertId)}/acknowledge`);
+      await load();
+    } catch (e) {
+      setAckError(`Could not acknowledge alert: ${e.message}`);
+    } finally {
+      setAcking(null);
+    }
+  }, [load]);
 
   return html`
     <div class="page-title">Alerts</div>
@@ -6448,9 +6504,10 @@ function AlertsView({ params }) {
       ${agentId ? html`<button class="btn" onClick=${() => setFilter('agent_id', '')}>agent: ${agentId} ✕</button>` : null}
       <button class="btn" onClick=${load}>Refresh</button>
     </div>
+    ${ackError ? html`<div class="alerts-ack-error">${ackError}</div>` : null}
     ${alerts.length === 0 ? html`<div class="empty">No alerts fired. Configure sensitive actions in ${'`tj.toml`'}.</div>` : html`
       <div class="table-wrap"><table>
-        <thead><tr><th></th><th>Time</th><th>Severity</th><th>Type</th><th>Title</th><th>Agent</th></tr></thead>
+        <thead><tr><th></th><th>Time</th><th>Severity</th><th>Type</th><th>Title</th><th>Agent</th><th>Status</th></tr></thead>
         <tbody>
           ${alerts.map(a => html`
             <tr class="clickable" onClick=${() => setExpanded(expanded === a.alert_id ? null : a.alert_id)}>
@@ -6460,8 +6517,16 @@ function AlertsView({ params }) {
               <td>${friendlyAlertType(a.type)}</td>
               <td>${a.title}</td>
               <td class="mono">${a.agent_id || '-'}</td>
+              <td onClick=${e => e.stopPropagation()}>
+                ${a.acknowledged
+                  ? html`<span class="badge badge-neutral">acknowledged</span>`
+                  : html`<button class="btn" disabled=${acking === a.alert_id}
+                      onClick=${() => acknowledge(a.alert_id)}>
+                      ${acking === a.alert_id ? 'Acknowledging...' : 'Acknowledge'}
+                    </button>`}
+              </td>
             </tr>
-            ${expanded === a.alert_id ? html`<tr><td colspan="6"><div class="alert-detail">${JSON.stringify(a.detail, null, 2)}</div></td></tr>` : null}
+            ${expanded === a.alert_id ? html`<tr><td colspan="7"><div class="alert-detail">${JSON.stringify(a.detail, null, 2)}</div></td></tr>` : null}
           `)}
         </tbody>
       </table></div>
@@ -6489,7 +6554,20 @@ function DriftView({ params }) {
 
   // /drift returns a single-agent shape when agent_id is set; normalize to a list.
   const agents = data.agents || (data.agent_id ? [data] : []);
-  if (!agents.length) return html`<div class="empty">No drift baselines built yet. Run at least 10 completed live sessions for a single agent to establish its behavioral baseline (note: drift baselines are computed per-agent, and only from live sessions, so historical backfilled sessions will not build a baseline).</div>`;
+  // An honest empty state says WHY there is nothing here, not just that there is
+  // nothing. Two of the three reasons are permanent for most users: interactive
+  // coding agents are deliberately never baselined (the API applies the same
+  // persona gate the detector does), and backfilled history never builds one.
+  if (!agents.length) return html`
+    <div class="page-title">Drift Detection</div>
+    <div class="empty">
+      <div>No drift baselines to compare against.</div>
+      <div class="drift-empty-why">
+        <div>Drift compares a service against its own past behavior, so it needs a baseline: at least 10 completed sessions for one agent.</div>
+        <div>Interactive coding sessions are not baselined. A Claude Code or Codex session varies by design; one mean and standard deviation over that workload measures nothing, so no baseline is built or shown for those agents.</div>
+        <div>Baselines build only from live sessions. Backfilled history is not baselined, so importing past transcripts will not produce one.</div>
+      </div>
+    </div>`;
 
   const metrics = [
     ['Input tokens', 'avg_input_tokens', 'stddev_input_tokens', 'input_tokens'],
@@ -6516,29 +6594,32 @@ function DriftView({ params }) {
                 const latest = a.latest_session ? a.latest_session[latestKey] : null;
                 let z = null;
                 let zDisplay = '-';
-                if (avg != null && latest != null) {
-                  if (std != null && std > 0) {
-                    z = (latest - avg) / std;
-                    zDisplay = z.toFixed(2);
-                  } else if (std === 0 || std == null) {
-                    // Match drift.py z_score: inf when stddev=0 and value != mean
-                    if (latest !== avg) {
-                      z = Infinity;
-                      zDisplay = 'inf';
-                    } else {
-                      z = 0;
-                      zDisplay = '0.00';
-                    }
-                  }
+                // A baseline with zero spread cannot judge anything. Every
+                // sampled session had the same value, so any movement divides by
+                // zero and reads as an infinite deviation. That is an absence of
+                // evidence, not a regression, so this renders a neutral "cannot
+                // judge" row rather than a red drift verdict with `inf` in it.
+                // The Python z_score() is unchanged; this is a display decision.
+                const noVariance = avg != null && latest != null && (std == null || std === 0);
+                if (avg != null && latest != null && std != null && std > 0) {
+                  z = (latest - avg) / std;
+                  zDisplay = z.toFixed(2);
+                } else if (noVariance) {
+                  zDisplay = 'n/a';
                 }
-                const pass = z == null || (Number.isFinite(z) && Math.abs(z) < 2);
+                const pass = !noVariance && (z == null || Math.abs(z) < 2);
+                const zColor = noVariance
+                  ? 'var(--text-dim)'
+                  : (pass ? 'var(--success)' : 'var(--error)');
+                const badgeClass = noVariance ? 'badge-neutral' : (pass ? 'badge-ok' : 'badge-critical');
+                const badgeLabel = noVariance ? 'no baseline variance' : (pass ? 'pass' : 'drift');
                 return html`
                   <tr>
                     <td>${label}</td>
                     <td class="mono">${avg != null ? avg.toFixed(1) : '-'}${std != null ? ' +/- ' + std.toFixed(1) : ''}</td>
                     <td class="mono">${latest != null ? (typeof latest === 'number' ? latest.toFixed(1) : latest) : '-'}</td>
-                    <td class="mono" style="color:${pass ? 'var(--success)' : 'var(--error)'}">${zDisplay}</td>
-                    <td><span class="badge ${pass ? 'badge-ok' : 'badge-critical'}">${pass ? 'pass' : 'drift'}</span></td>
+                    <td class="mono" style="color:${zColor}" title=${noVariance ? 'Every sampled session had the same value, so there is no spread to measure a deviation against.' : ''}>${zDisplay}</td>
+                    <td><span class="badge ${badgeClass}">${badgeLabel}</span></td>
                   </tr>
                 `;
               })}


### PR DESCRIPTION
The Drift screen was rendering findings it has no basis for, and the Alerts screen was missing the only control its acknowledge endpoint exists for. This PR stops the pages from displaying nonsense. It is a display-level fix by design; see "What's NOT in this PR".

## Summary
- `GET /api/v1/drift` applies the same interactive-coding-agent gate the drift detector already applies on the write path, so a stale or legacy coding-agent baseline can never render.
- A baseline with zero variance renders a neutral "no baseline variance" row instead of `inf` under a red `drift` badge.
- The Drift empty state explains why there is no baseline instead of only saying there is none.
- The Alerts table gains an Acknowledge control wired to the existing `PATCH /api/v1/alerts/{id}/acknowledge`.

## Drift: read path disagreed with write path

`DriftDetector.on_session_end` already hard-skips baselining for interactive coding agents via `is_interactive_coding_agent()`. The reason is in the code: a single mean and standard deviation over a heterogeneous, arg-less, human-driven workload measures nothing.

That is a **write-path** skip. Baselines are built once and never recomputed (`on_session_end` only calls `build_baseline` when `get_baseline()` returns `None`), so a row written by a build predating the gate, or under an agent id that has since been reclassified, persists forever and still renders. The symptom on screen was a Drift card titled `claude-code`.

The read path now applies the same gate, reusing the same helper as the single source of truth so the prefix strings live in exactly one place. The list path filters in Python rather than restating the prefixes as a `LIKE` clause in SQL. The single-agent path (`?agent_id=`) returns `baseline: null` plus a `baseline_skipped_reason` so the null is not mistaken for "this agent has no history".

## Drift: zero variance is not a regression

`z_score()` deliberately returns `inf` when the baseline standard deviation is 0 and the value moved, and the UI reimplemented that guard literally. The result on screen: a metric whose baseline was constant (tool calls `0.0 +/- 0.0`) rendered `inf` in red with a `drift` badge.

Every sampled session having held the same value is an absence of evidence, not a finding. The row now renders `n/a` in the z-score column under a neutral `no baseline variance` badge, so it reads as "cannot judge" rather than "regression detected". `z_score()` in `core/drift.py` is unchanged, and `GET /api/v1/drift` emits no verdict of its own, so this is purely the render path.

## Drift: honest empty state

The empty state said only that no baselines had been built yet. Two of the three reasons are permanent for most users, so it now names all three: drift compares a service against its own past behavior and needs at least 10 completed sessions for one agent; interactive coding sessions vary by design and are never baselined; baselines build only from live sessions, so backfilled history does not create one.

## Alerts: acknowledge was a dangling backend

`PATCH /api/v1/alerts/{id}/acknowledge` existed and was reachable from the MCP server, but no control in `AlertsView` called it. Per Rule 24 in `tokenjam/CLAUDE.md`, a capability is only real if a user has a path to it.

The table gains a Status column: an unacknowledged alert shows an Acknowledge button, an acknowledged one shows a neutral badge. The handler calls the endpoint via a new `apiPatch` helper (same header and cache-invalidation contract as `apiPost`), then refetches, which is what keeps the "Unread only" filter honest since an acknowledged alert is no longer unread. Failures surface a message rather than failing silently. No redesign of the page.

## Tests / Verification

- `tests/integration/test_api.py` — `test_drift_list_excludes_interactive_coding_agent_baselines` and `test_drift_for_a_single_coding_agent_returns_no_baseline` seed real baselines into a DuckDB backend and assert coding-agent rows never reach the wire. Both were confirmed to FAIL against the unpatched route and pass with it.
- `tests/integration/test_api.py` — `test_acknowledging_an_alert_drops_it_from_the_unread_list` pins the exact round trip the UI performs: PATCH, then re-read with `unread=true` and expect the alert gone.
- `tests/unit/test_lens_ui_regression.py` — three static guards (the repo's convention for UI fixes, since the Python CI job cannot run JS): the neutral zero-variance row with the old `inf` rendering asserted absent, the empty-state wording, and the acknowledge wiring including the widened `colspan`.
- Full suite: `pytest tests/unit/ tests/integration/` — 4562 passed, 5 skipped. Two failures in `tests/integration/test_relearn_window_api.py` (`test_the_days_of_data_available_measure_is_served`, `test_an_ancient_row_does_not_inflate_the_served_span`) are pre-existing and unrelated; verified failing identically on a stashed working tree.
- `ruff check tokenjam/` — all checks passed. `mypy tokenjam/` — success, no issues in 237 source files.
- `node --check` on the extracted UI module block — clean.

## What's NOT in this PR

Two real underlying defects are deliberately left alone and tracked separately:

- **The drift input-token metric omits the cache read and cache write token classes.** The baseline and the latest-session comparison both read `input_tokens` alone, so any workload with meaningful caching is compared on a partial figure. Fixing that changes how baselines are computed and would invalidate every stored baseline.
- **Baselines are never recomputed once written.** `on_session_end` builds one only when none exists, so a baseline is frozen at whatever the agent's first 10 sessions looked like and no amount of later behavior updates it. This is the mechanism that let a pre-gate coding-agent baseline survive in the first place; this PR stops it from rendering, it does not stop it from existing.

Neither is a display bug, and both need a decision about baseline invalidation and migration that does not belong in a quick fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
