### PR TITLE
Corpus history integrity: span-driven retention with an atomic ledger, past-overspend over the available span, untimed records rejected at ingest, and a UTC day-union fix

### DIFF
--- a/tests/factories.py
+++ b/tests/factories.py
@@ -12,13 +12,21 @@ from tokenjam.otel.semconv import GenAIAttributes
 from tokenjam.utils.ids import new_uuid, new_trace_id, new_span_id
 from tokenjam.utils.time_parse import utcnow
 
+#: Distinguishes "caller said nothing about the time" (default to now, what
+#: every existing test means) from "this span is UNTIMED" (`start_time=None`,
+#: what ingest writes when a source carries no usable timestamp). A bare `None`
+#: default cannot express the second, and the second is exactly the case a test
+#: for the sentinel fix has to construct — through this factory, per Critical
+#: Rule 8, never by building a NormalizedSpan by hand.
+_UNSET = object()
+
 
 def make_invoke_agent_span(
     agent_id: str = "test-agent",
     session_id: str | None = None,
     conversation_id: str | None = None,
     duration_ms: float = 0.0,
-    start_time=None,
+    start_time=_UNSET,
     trace_id: str | None = None,
     service_namespace: str | None = None,
 ) -> NormalizedSpan:
@@ -33,8 +41,8 @@ def make_invoke_agent_span(
     ``@watch()`` path emits to bracket a whole agent run. This DOES complete the
     session.
     """
-    now = start_time or utcnow()
-    end = now + timedelta(milliseconds=duration_ms)
+    now = utcnow() if start_time is _UNSET else start_time
+    end = now + timedelta(milliseconds=duration_ms) if now else None
     return NormalizedSpan(
         span_id=new_span_id(),
         trace_id=trace_id or new_trace_id(),
@@ -63,7 +71,7 @@ def make_llm_span(
     tool_name: str | None = None,
     status: str = "ok",
     duration_ms: float = 800.0,
-    start_time=None,
+    start_time=_UNSET,
     conversation_id: str | None = None,
     trace_id: str | None = None,
     span_id: str | None = None,
@@ -100,8 +108,8 @@ def make_llm_span(
     unaffected. Tests exercising the multi-tenant cost breakdown should pass
     them explicitly.
     """
-    now = start_time or utcnow()
-    end = now + timedelta(milliseconds=duration_ms)
+    now = utcnow() if start_time is _UNSET else start_time
+    end = now + timedelta(milliseconds=duration_ms) if now else None
     attrs = extra_attributes.copy() if extra_attributes else {}
 
     return NormalizedSpan(
@@ -153,7 +161,7 @@ def make_tool_span(
     tool_input: dict | str | None = None,
     name: str = "gen_ai.tool.call",
     session_id: str | None = None,
-    start_time=None,
+    start_time=_UNSET,
     sub_agent_id: str | None = None,
 ) -> NormalizedSpan:
     """Create a NormalizedSpan representing a single tool call.
@@ -169,8 +177,8 @@ def make_tool_span(
     """
     import json as _json
 
-    now = start_time or utcnow()
-    end = now + timedelta(milliseconds=duration_ms)
+    now = utcnow() if start_time is _UNSET else start_time
+    end = now + timedelta(milliseconds=duration_ms) if now else None
     attrs: dict = {}
     if tool_input is not None:
         attrs[GenAIAttributes.TOOL_INPUT] = (

--- a/tests/factories.py
+++ b/tests/factories.py
@@ -12,21 +12,13 @@ from tokenjam.otel.semconv import GenAIAttributes
 from tokenjam.utils.ids import new_uuid, new_trace_id, new_span_id
 from tokenjam.utils.time_parse import utcnow
 
-#: Distinguishes "caller said nothing about the time" (default to now, what
-#: every existing test means) from "this span is UNTIMED" (`start_time=None`,
-#: what ingest writes when a source carries no usable timestamp). A bare `None`
-#: default cannot express the second, and the second is exactly the case a test
-#: for the sentinel fix has to construct — through this factory, per Critical
-#: Rule 8, never by building a NormalizedSpan by hand.
-_UNSET = object()
-
 
 def make_invoke_agent_span(
     agent_id: str = "test-agent",
     session_id: str | None = None,
     conversation_id: str | None = None,
     duration_ms: float = 0.0,
-    start_time=_UNSET,
+    start_time=None,
     trace_id: str | None = None,
     service_namespace: str | None = None,
 ) -> NormalizedSpan:
@@ -41,8 +33,8 @@ def make_invoke_agent_span(
     ``@watch()`` path emits to bracket a whole agent run. This DOES complete the
     session.
     """
-    now = utcnow() if start_time is _UNSET else start_time
-    end = now + timedelta(milliseconds=duration_ms) if now else None
+    now = start_time or utcnow()
+    end = now + timedelta(milliseconds=duration_ms)
     return NormalizedSpan(
         span_id=new_span_id(),
         trace_id=trace_id or new_trace_id(),
@@ -71,7 +63,7 @@ def make_llm_span(
     tool_name: str | None = None,
     status: str = "ok",
     duration_ms: float = 800.0,
-    start_time=_UNSET,
+    start_time=None,
     conversation_id: str | None = None,
     trace_id: str | None = None,
     span_id: str | None = None,
@@ -108,8 +100,8 @@ def make_llm_span(
     unaffected. Tests exercising the multi-tenant cost breakdown should pass
     them explicitly.
     """
-    now = utcnow() if start_time is _UNSET else start_time
-    end = now + timedelta(milliseconds=duration_ms) if now else None
+    now = start_time or utcnow()
+    end = now + timedelta(milliseconds=duration_ms)
     attrs = extra_attributes.copy() if extra_attributes else {}
 
     return NormalizedSpan(
@@ -161,7 +153,7 @@ def make_tool_span(
     tool_input: dict | str | None = None,
     name: str = "gen_ai.tool.call",
     session_id: str | None = None,
-    start_time=_UNSET,
+    start_time=None,
     sub_agent_id: str | None = None,
 ) -> NormalizedSpan:
     """Create a NormalizedSpan representing a single tool call.
@@ -177,8 +169,8 @@ def make_tool_span(
     """
     import json as _json
 
-    now = utcnow() if start_time is _UNSET else start_time
-    end = now + timedelta(milliseconds=duration_ms) if now else None
+    now = start_time or utcnow()
+    end = now + timedelta(milliseconds=duration_ms)
     attrs: dict = {}
     if tool_input is not None:
         attrs[GenAIAttributes.TOOL_INPUT] = (

--- a/tests/integration/test_cli.py
+++ b/tests/integration/test_cli.py
@@ -12,7 +12,7 @@ from click.testing import CliRunner
 
 from tokenjam.cli.main import cli
 from tokenjam.core.config import AgentConfig, BudgetConfig, TjConfig
-from tokenjam.core.db import InMemoryBackend
+from tokenjam.core.db import SPANS_INDEX_SQL, InMemoryBackend
 from tokenjam.core.models import (
     AgentRecord,
     Alert,
@@ -473,6 +473,12 @@ def _duckdb_with_dropped_migration_7(tmp_path):
         backend.conn.execute(f"DROP INDEX IF EXISTS {idx}")
     backend.conn.execute("ALTER TABLE spans DROP COLUMN request_params")
     backend.conn.execute("ALTER TABLE spans DROP COLUMN request_tools")
+    # DuckDB refuses to drop a column while the table carries ART indexes, so
+    # the indexes above come off first — and have to go straight back on. Left
+    # off, this fixture would additionally reproduce the SEPARATE fault doctor's
+    # index-integrity check exists for, and these tests would be asserting an
+    # exit code that has nothing to do with the missing column they are about.
+    backend.conn.execute(SPANS_INDEX_SQL)
     return backend
 
 

--- a/tests/integration/test_db.py
+++ b/tests/integration/test_db.py
@@ -212,11 +212,76 @@ def test_delete_spans_before_cutoff(db):
     db.insert_span(span_new)
 
     cutoff = now - timedelta(days=90)
-    deleted = db.delete_spans_before(cutoff)
-    assert deleted == 1
+    spans_deleted, sessions_deleted = db.delete_spans_before(cutoff)
+    assert spans_deleted == 1
 
     remaining = db.conn.execute("SELECT COUNT(*) FROM spans").fetchone()
     assert remaining[0] == 1
+    # The session straddles the cutoff and still has a live span, so it stays:
+    # a session is orphaned by the delete only once it has NO spans left.
+    assert sessions_deleted == 0
+    assert db.conn.execute("SELECT COUNT(*) FROM sessions").fetchone()[0] == 1
+
+
+def test_delete_spans_before_cutoff_takes_the_sessions_it_orphans(db):
+    """Deleting only spans left the parent sessions asserting a day had data.
+
+    `core/data_span` unions `sessions.started_at` into the day set it measures
+    the available span from, so every orphan went on claiming a day carried data
+    after the data for that day was destroyed — the deletion skewed the measure
+    of what survived it.
+    """
+    _insert_agent(db)
+    now = utcnow()
+    old = now - timedelta(days=100)
+
+    aged_out = make_session(started_at=old, ended_at=old + timedelta(minutes=1))
+    db.upsert_session(aged_out)
+    db.insert_span(make_llm_span(session_id=aged_out.session_id, start_time=old))
+
+    live = make_session()
+    db.upsert_session(live)
+    db.insert_span(make_llm_span(
+        session_id=live.session_id, start_time=now - timedelta(days=1),
+    ))
+
+    spans_deleted, sessions_deleted = db.delete_spans_before(now - timedelta(days=90))
+    assert (spans_deleted, sessions_deleted) == (1, 1)
+
+    surviving = [
+        r[0] for r in db.conn.execute("SELECT session_id FROM sessions").fetchall()
+    ]
+    assert surviving == [live.session_id]
+
+
+def test_delete_spans_before_cutoff_takes_an_aged_out_session_with_no_spans(db):
+    """A pre-cutoff session with no spans is aged-out history like any other.
+
+    Left behind it would go on asserting, to `core/data_span`, that a day
+    beyond the retention horizon carried data.
+    """
+    _insert_agent(db)
+    now = utcnow()
+    empty = make_session(
+        started_at=now - timedelta(days=100),
+        ended_at=now - timedelta(days=100) + timedelta(minutes=1),
+    )
+    db.upsert_session(empty)
+
+    spans_deleted, sessions_deleted = db.delete_spans_before(now - timedelta(days=90))
+    assert (spans_deleted, sessions_deleted) == (0, 1)
+    assert db.conn.execute("SELECT COUNT(*) FROM sessions").fetchone()[0] == 0
+
+
+def test_delete_spans_before_cutoff_keeps_a_live_session_with_no_spans_yet(db):
+    """An open session that has not written a span is not aged out."""
+    _insert_agent(db)
+    now = utcnow()
+    db.upsert_session(make_session(started_at=now, ended_at=None))
+
+    spans_deleted, sessions_deleted = db.delete_spans_before(now - timedelta(days=90))
+    assert (spans_deleted, sessions_deleted) == (0, 0)
+    assert db.conn.execute("SELECT COUNT(*) FROM sessions").fetchone()[0] == 1
 
 
 # -- Traces --

--- a/tests/integration/test_inbox_headline_total_api.py
+++ b/tests/integration/test_inbox_headline_total_api.py
@@ -67,6 +67,18 @@ def app(config, db):
             cache_tokens=400, session_id=f"s-{i}",
             start_time=now - timedelta(days=2, minutes=i),
         ))
+    # The corpus has to be 30 days WIDE, not merely 30 days' worth of rows. The
+    # inbox window is the analysis span bounded by how far back this store's
+    # oldest row actually sits, so a two-day corpus resolves to a two-day
+    # window — and the hand-built relearn buckets below, which are the point of
+    # these tests, are labelled `30d`. One row at the far edge makes the two
+    # sides name the same window without changing what any analyzer finds.
+    db.insert_span(make_llm_span(
+        agent_id="svc-a", provider="anthropic", model="claude-sonnet-5",
+        billing_account="anthropic", input_tokens=15_000, output_tokens=200,
+        cache_tokens=400, session_id="s-oldest",
+        start_time=now - timedelta(days=29),
+    ))
     pipeline = IngestPipeline(db=db, config=config)
     return create_app(config=config, db=db, ingest_pipeline=pipeline)
 

--- a/tests/integration/test_relearn_window_api.py
+++ b/tests/integration/test_relearn_window_api.py
@@ -35,6 +35,26 @@ from tests.factories import make_session
 ANCHOR = datetime(2026, 7, 27, 12, 0, tzinfo=timezone.utc)
 
 
+def utc_noon(days_ago: int) -> datetime:
+    """A seed instant that cannot straddle a day boundary, in any timezone.
+
+    The day-span measure counts DISTINCT UTC days and discards anything dated
+    later than today, so a fixture seeded at an offset from ``utcnow()`` puts
+    its rows wherever the wall clock happens to be: rows land on one calendar
+    day for part of the day and two for the rest, and a row seeded at "now" can
+    read as tomorrow under a database timezone that runs ahead of UTC. Both
+    made the assertions below go red for a few hours out of every day and green
+    again afterwards, which reads as "whoever pushed last broke it".
+
+    Noon UTC is the furthest any instant can be from both boundaries, so the
+    day a row belongs to is fixed no matter when or where the suite runs.
+    """
+    today = datetime.now(tz=timezone.utc).date()
+    return datetime(
+        today.year, today.month, today.day, 12, 0, tzinfo=timezone.utc,
+    ) - timedelta(days=days_ago)
+
+
 @pytest.fixture
 def db():
     backend = InMemoryBackend()
@@ -203,7 +223,9 @@ async def test_a_cache_without_windowed_figures_says_so_rather_than_faking_one(
 @pytest.mark.asyncio
 async def test_the_days_of_data_available_measure_is_served(client, config, db):
     _seed_relearn_cache(config)
-    db.upsert_session(make_session(session_id="s1", agent_id="claude-code-x"))
+    db.upsert_session(make_session(
+        session_id="s1", agent_id="claude-code-x", started_at=utc_noon(0),
+    ))
     async with client as c:
         body = (await c.get("/api/v1/relearn/proposals")).json()
     span = body["data_span"]
@@ -220,8 +242,9 @@ async def test_an_ancient_row_does_not_inflate_the_served_span(client, config, d
     actually carries data on.
     """
     _seed_relearn_cache(config)
-    now = datetime.now(tz=timezone.utc)
-    db.upsert_session(make_session(session_id="s1", agent_id="a", started_at=now))
+    db.upsert_session(make_session(
+        session_id="s1", agent_id="a", started_at=utc_noon(0),
+    ))
     db.upsert_session(make_session(
         session_id="ancient", agent_id="a",
         started_at=datetime(2020, 1, 1, tzinfo=timezone.utc),

--- a/tests/unit/test_analysis_span_retention.py
+++ b/tests/unit/test_analysis_span_retention.py
@@ -353,3 +353,122 @@ def test_retention_can_never_delete_underneath_the_cost_window(store):
     window = cost_window_days_for(SimpleNamespace(storage=storage), store.conn)
     assert run.retention_days == 90
     assert window <= run.retention_days
+
+
+# --- the surfaces ------------------------------------------------------------
+
+
+def test_doctor_reports_the_span_what_it_keeps_and_the_last_delete(store):
+    """The ledger is a fact on disk; this makes it a fact somebody sees."""
+    from types import SimpleNamespace
+
+    from tokenjam.cli.cmd_doctor import _check_retention
+
+    storage = StorageConfig(analysis_span="90d")
+    _seed(store, days_ago=120, session_id="outside")
+    _seed(store, days_ago=2, session_id="inside")
+    run_retention_cleanup(store, storage)
+
+    check = _check_retention(SimpleNamespace(storage=storage), store)
+
+    assert check["level"] == "ok"
+    assert "90d" in check["message"]
+    assert "kept for 90 days" in check["message"]
+    assert "removed 1 span(s) and 1 session(s)" in check["message"]
+    assert "oldest surviving span" in check["message"]
+
+
+def test_doctor_says_when_deletion_is_disabled(store):
+    from types import SimpleNamespace
+
+    from tokenjam.cli.cmd_doctor import _check_retention
+
+    check = _check_retention(
+        SimpleNamespace(storage=StorageConfig(analysis_span="all")), store,
+    )
+    assert "all available" in check["message"]
+    assert "deletion is disabled" in check["message"]
+
+
+def test_doctor_says_when_the_clamp_fired(store):
+    from types import SimpleNamespace
+
+    from tokenjam.cli.cmd_doctor import _check_retention
+
+    check = _check_retention(
+        SimpleNamespace(storage=StorageConfig(analysis_span="90d", retention_days=7)),
+        store,
+    )
+    assert "raised to match" in check["message"]
+    # And it is never an error: retention doing its job is not a fault, and the
+    # state the clamp prevents cannot be reached.
+    assert check["level"] == "ok"
+
+
+def test_doctor_distinguishes_never_run_from_deleted_nothing(store):
+    from types import SimpleNamespace
+
+    from tokenjam.cli.cmd_doctor import _check_retention
+
+    config = SimpleNamespace(storage=StorageConfig(analysis_span="90d"))
+    assert "No retention run has been recorded" in _check_retention(config, store)["message"]
+
+    _seed(store, days_ago=2, session_id="inside")
+    run_retention_cleanup(store, StorageConfig(analysis_span="90d"))
+    after = _check_retention(config, store)["message"]
+    assert "No retention run has been recorded" not in after
+    assert "removed 0 span(s) and 0 session(s)" in after
+
+
+def test_onboarding_writes_the_span_and_reconciles_retention():
+    """The coupling is enforced where the config is written, not documented."""
+    from types import SimpleNamespace
+
+    from tokenjam.cli.cmd_onboard import _apply_analysis_span
+
+    config = SimpleNamespace(storage=StorageConfig(analysis_span=None, retention_days=7))
+    _apply_analysis_span(config, "90d")
+
+    assert config.storage.analysis_span == "90d"
+    assert config.storage.retention_days == 90
+    assert retention_days_for(config.storage) == 90
+
+
+def test_onboarding_adopts_a_pre_coupling_retention_as_the_span():
+    from types import SimpleNamespace
+
+    from tokenjam.cli.cmd_onboard import _apply_analysis_span
+
+    config = SimpleNamespace(storage=StorageConfig(analysis_span=None, retention_days=45))
+    _apply_analysis_span(config)
+
+    assert config.storage.analysis_span == "45d"
+    assert config.storage.retention_days == 45
+
+
+def test_onboarding_rejects_a_span_nobody_can_parse():
+    from types import SimpleNamespace
+
+    from tokenjam.cli.cmd_onboard import _apply_analysis_span
+
+    config = SimpleNamespace(storage=StorageConfig())
+    with pytest.raises(ValueError):
+        _apply_analysis_span(config, "banana")
+    # And nothing unparseable reached the config on the way out.
+    assert config.storage.analysis_span is None
+
+
+def test_onboarding_is_idempotent_so_a_two_leg_flow_asks_once(monkeypatch):
+    """The combination flow runs two onboarders over one config file."""
+    from types import SimpleNamespace
+
+    from tokenjam.cli import cmd_onboard
+
+    monkeypatch.setattr(cmd_onboard, "_is_interactive", lambda: True)
+    monkeypatch.setattr(
+        cmd_onboard, "_prompt_analysis_span",
+        lambda current=None: pytest.fail("asked twice"),
+    )
+    config = SimpleNamespace(storage=StorageConfig(analysis_span="30d"))
+    cmd_onboard._apply_analysis_span(config)
+    assert config.storage.analysis_span == "30d"

--- a/tests/unit/test_analysis_span_retention.py
+++ b/tests/unit/test_analysis_span_retention.py
@@ -506,3 +506,61 @@ def test_onboarding_is_idempotent_so_a_two_leg_flow_asks_once(monkeypatch):
     config = SimpleNamespace(storage=StorageConfig(analysis_span="30d"))
     cmd_onboard._apply_analysis_span(config)
     assert config.storage.analysis_span == "30d"
+
+
+def test_the_ledger_counts_rows_this_run_actually_deleted(store, monkeypatch):
+    """A span arriving between the count and the delete must still be counted.
+
+    Both figures come from the DELETEs' own affected-row counts rather than a
+    preceding `COUNT(*)`, which makes this race structurally impossible instead
+    of merely narrow. A separate count is wrong even inside the transaction: an
+    ingest committing an aged-out span in that gap would have it destroyed while
+    the ledger persisted the smaller, earlier number, so `tj doctor` would
+    under-report how much history was removed.
+
+    The interception point is the `DELETE FROM spans` statement, which exists in
+    BOTH the old and new shapes — a test hooked to the vanished `COUNT(*)` would
+    pass trivially against the fix and prove nothing.
+    """
+    _seed(store, days_ago=120, session_id="outside-1")
+    _seed(store, days_ago=150, session_id="outside-2")
+
+    real_conn = store.conn
+    late_arrival = {"done": False}
+
+    class ConnWithALateArrival:
+        """Delegates everything, but slips one more aged-out span in immediately
+        BEFORE the delete runs — the window a preceding COUNT(*) leaves open."""
+
+        def __getattr__(self, name):
+            return getattr(real_conn, name)
+
+        def execute(self, sql, *args, **kwargs):
+            if not late_arrival["done"] and sql.startswith("DELETE FROM spans"):
+                late_arrival["done"] = True
+                real_conn.execute(
+                    "INSERT INTO spans (span_id, trace_id, name, kind, "
+                    "status_code, start_time) "
+                    "VALUES ('late','t','x','internal','ok',$1)",
+                    [utcnow() - timedelta(days=200)],
+                )
+            return real_conn.execute(sql, *args, **kwargs)
+
+    before = real_conn.execute("SELECT COUNT(*) FROM spans").fetchone()[0]
+    proxy = ConnWithALateArrival()
+    monkeypatch.setattr(type(store), "conn", property(lambda self: proxy))
+    try:
+        run_retention_cleanup(store, StorageConfig(analysis_span="90d"))
+    finally:
+        monkeypatch.undo()
+
+    assert late_arrival["done"], "the late arrival never fired; test proves nothing"
+    after = real_conn.execute("SELECT COUNT(*) FROM spans").fetchone()[0]
+    ledgered = real_conn.execute(
+        "SELECT spans_deleted FROM retention_events"
+    ).fetchone()[0]
+
+    # Three spans existed by the time the delete ran, and all three went.
+    assert before == 2
+    assert after == 0
+    assert ledgered == 3

--- a/tests/unit/test_analysis_span_retention.py
+++ b/tests/unit/test_analysis_span_retention.py
@@ -224,16 +224,50 @@ def test_a_disabled_run_writes_no_row_because_it_did_not_run(store):
     ).fetchone()[0] == 0
 
 
-def test_a_ledger_write_failure_never_undoes_a_delete_that_happened(store, caplog):
-    """A trimmed store plus a run reading as a failure is the worst outcome."""
-    store.conn.execute("DROP TABLE retention_events")
+def test_a_delete_can_never_commit_without_its_ledger_row(store):
+    """The delete and its ledger row are ONE transaction, so neither can outlive
+    the other.
+
+    The earlier version of this kept the delete and merely logged a failed
+    ledger write, on the reasoning that a trimmed store plus a run reading as a
+    failure was the worst outcome. It is not — history gone with nothing saying
+    so is, and it is the exact state this whole mechanism exists to prevent. The
+    same hole existed for a crash between two sequential commits, which on a
+    daemon killed mid-run is an ordinary event rather than an exotic one.
+
+    Staged by making the ledger write fail: the transaction rolls back and the
+    spans are still there. A test that only checks the happy path cannot see
+    this, because on the happy path both writes land either way.
+    """
     _seed(store, days_ago=120, session_id="outside")
+    _seed(store, days_ago=2, session_id="inside")
+    store.conn.execute("DROP TABLE retention_events")
 
-    run = run_retention_cleanup(store, StorageConfig(analysis_span="90d"))
+    with pytest.raises(Exception):
+        run_retention_cleanup(store, StorageConfig(analysis_span="90d"))
 
-    assert run.spans_deleted == 1
-    assert store.conn.execute("SELECT COUNT(*) FROM spans").fetchone()[0] == 0
-    assert "ledger row could not be written" in caplog.text
+    # Nothing was destroyed, so there is nothing that needed recording.
+    assert store.conn.execute("SELECT COUNT(*) FROM spans").fetchone()[0] == 2
+    assert store.conn.execute("SELECT COUNT(*) FROM sessions").fetchone()[0] == 2
+
+
+def test_no_deleted_history_is_ever_unaccounted_for(store):
+    """The invariant the ledger is FOR, asserted over the store.
+
+    Whatever the run did, the rows it removed are the rows the ledger says it
+    removed — there is no path that trims the store and reports nothing.
+    """
+    for days_ago in (200, 150, 120, 30, 2):
+        _seed(store, days_ago=days_ago, session_id=f"s{days_ago}")
+    before = store.conn.execute("SELECT COUNT(*) FROM spans").fetchone()[0]
+
+    run_retention_cleanup(store, StorageConfig(analysis_span="90d"))
+
+    after = store.conn.execute("SELECT COUNT(*) FROM spans").fetchone()[0]
+    ledgered = store.conn.execute(
+        "SELECT COALESCE(SUM(spans_deleted), 0) FROM retention_events"
+    ).fetchone()[0]
+    assert before - after == ledgered == 3
 
 
 def test_the_deletion_no_longer_skews_the_span_it_leaves_behind(store):

--- a/tests/unit/test_analysis_span_retention.py
+++ b/tests/unit/test_analysis_span_retention.py
@@ -1,0 +1,355 @@
+"""One span drives retention, and retention can never undercut it.
+
+There were two settings free to disagree — how much history the store KEPT and
+how much the analyzers LOOKED AT — and on a real store they did: roughly eight
+weeks of the oldest history was deleted over two days while the analyzers went
+on sizing their window against it, and the only way to see it was to measure the
+store twice, days apart, and diff. The tests here pin the coupling that makes
+that unrepresentable, plus the ledger that makes any deletion observable after
+the fact rather than only by that same diff.
+"""
+from __future__ import annotations
+
+from datetime import timedelta
+
+import pytest
+
+from tokenjam.core.analysis_span import (
+    analysis_span_days,
+    parse_analysis_span,
+    resolved_window_days,
+    retention_days_for,
+    retention_was_raised_to_span,
+    span_label,
+)
+from tokenjam.core.config import StorageConfig
+from tokenjam.core.db import DuckDBBackend
+from tokenjam.core.retention import run_retention_cleanup
+from tokenjam.utils.time_parse import utcnow
+from tests.factories import make_llm_span, make_session
+
+
+# --- the derivation ---------------------------------------------------------
+
+
+@pytest.mark.parametrize("raw,expected", [
+    ("30d", 30), ("90d", 90), ("30", 30), ("90", 90),
+    ("all", None), ("all-available", None), ("ALL", None),
+])
+def test_a_span_choice_parses_to_days_or_unbounded(raw, expected):
+    assert parse_analysis_span(raw) == expected
+
+
+@pytest.mark.parametrize("raw", ["banana", "", "0d", "-5d", None])
+def test_an_unparseable_span_raises_rather_than_defaulting(raw):
+    """Silently defaulting would make the product analyze a span nobody wrote."""
+    with pytest.raises(ValueError):
+        parse_analysis_span(raw)
+
+
+def test_retention_is_derived_from_the_span():
+    assert retention_days_for(StorageConfig(analysis_span="30d")) == 30
+    assert retention_days_for(StorageConfig(analysis_span="90d")) == 90
+
+
+def test_an_all_available_span_disables_retention_entirely():
+    storage = StorageConfig(analysis_span="all")
+    assert analysis_span_days(storage) is None
+    assert retention_days_for(storage) is None
+    assert span_label(storage) == "all available"
+
+
+def test_a_config_with_no_opinion_gets_the_default_span():
+    storage = StorageConfig()
+    assert analysis_span_days(storage) == parse_analysis_span("90d")
+    assert retention_days_for(storage) == 90
+
+
+# --- backwards compatibility ------------------------------------------------
+
+
+def test_a_pre_coupling_config_has_its_retention_read_as_the_span():
+    """Every config written before this existed sets retention_days and nothing
+    else. What such a user kept is the most the product could ever have
+    analyzed, so adopting it as the span changes nothing about their setup."""
+    storage = StorageConfig(retention_days=45)
+    assert analysis_span_days(storage) == 45
+    assert retention_days_for(storage) == 45
+    assert not retention_was_raised_to_span(storage)
+
+
+def test_keeping_more_than_you_analyze_is_left_alone():
+    """Retention longer than the span costs disk and misleads nobody."""
+    storage = StorageConfig(analysis_span="30d", retention_days=365)
+    assert retention_days_for(storage) == 365
+    assert not retention_was_raised_to_span(storage)
+
+
+def test_retention_shorter_than_the_span_is_raised_to_it():
+    """The invariant, and it is one-directional.
+
+    Lowering storage retention must not be able to silently retract a span the
+    product has already promised to analyze over, so the clamp only moves
+    retention UP — it never shortens the span to match.
+    """
+    storage = StorageConfig(analysis_span="90d", retention_days=7)
+    assert analysis_span_days(storage) == 90
+    assert retention_days_for(storage) == 90
+    assert retention_was_raised_to_span(storage)
+
+
+def test_an_all_available_span_beats_any_explicit_retention():
+    storage = StorageConfig(analysis_span="all", retention_days=7)
+    assert retention_days_for(storage) is None
+    assert retention_was_raised_to_span(storage)
+
+
+# --- the span an analyzer may actually accumulate over ----------------------
+
+
+def test_the_window_is_the_choice_bounded_by_what_the_store_holds():
+    storage = StorageConfig(analysis_span="90d")
+    assert resolved_window_days(storage, 68) == 68     # store is younger
+    assert resolved_window_days(storage, 400) == 90    # choice binds
+
+
+def test_an_unknown_available_span_narrows_nothing():
+    """`data_span` returns None for "we do not know", never for zero — an
+    unknown span must not be read as an empty one."""
+    assert resolved_window_days(StorageConfig(analysis_span="90d"), None) == 90
+    assert resolved_window_days(StorageConfig(analysis_span="all"), None) is None
+
+
+def test_an_unbounded_span_takes_the_whole_available_history():
+    assert resolved_window_days(StorageConfig(analysis_span="all"), 68) == 68
+
+
+# --- the job ----------------------------------------------------------------
+
+
+@pytest.fixture
+def store(tmp_path):
+    db = DuckDBBackend(StorageConfig(path=str(tmp_path / "telemetry.duckdb")))
+    yield db
+    db.close()
+
+
+def _seed(db, *, days_ago: float, session_id: str) -> None:
+    at = utcnow() - timedelta(days=days_ago)
+    db.upsert_session(make_session(
+        session_id=session_id, started_at=at, ended_at=at + timedelta(minutes=1),
+    ))
+    db.insert_span(make_llm_span(session_id=session_id, start_time=at))
+
+
+def test_retention_cannot_delete_inside_the_span_it_is_derived_from(store):
+    _seed(store, days_ago=60, session_id="inside")
+    _seed(store, days_ago=120, session_id="outside")
+
+    run = run_retention_cleanup(store, StorageConfig(analysis_span="90d"))
+
+    assert run.retention_days == 90
+    assert (run.spans_deleted, run.sessions_deleted) == (1, 1)
+    remaining = [
+        r[0] for r in store.conn.execute("SELECT session_id FROM sessions").fetchall()
+    ]
+    assert remaining == ["inside"]
+
+
+def test_an_all_available_span_deletes_nothing_and_says_why(store):
+    _seed(store, days_ago=3_000, session_id="ancient")
+
+    run = run_retention_cleanup(store, StorageConfig(analysis_span="all"))
+
+    assert (run.spans_deleted, run.sessions_deleted) == (0, 0)
+    assert run.cutoff is None
+    assert run.skipped_reason and "disabled" in run.skipped_reason
+    assert store.conn.execute("SELECT COUNT(*) FROM spans").fetchone()[0] == 1
+
+
+def test_a_retention_shorter_than_the_span_does_not_reach_inside_it(store):
+    """The clamp is enforced by the job, not only by the config writer.
+
+    A hand-edited config setting a 7-day retention under a 90-day span must not
+    be able to delete the history the product is still analyzing.
+    """
+    _seed(store, days_ago=60, session_id="inside")
+
+    run = run_retention_cleanup(
+        store, StorageConfig(analysis_span="90d", retention_days=7),
+    )
+
+    assert run.retention_days == 90
+    assert (run.spans_deleted, run.sessions_deleted) == (0, 0)
+    assert store.conn.execute("SELECT COUNT(*) FROM spans").fetchone()[0] == 1
+
+
+# --- the ledger -------------------------------------------------------------
+
+
+def test_every_run_leaves_a_row_saying_what_it_removed(store):
+    _seed(store, days_ago=120, session_id="outside")
+    _seed(store, days_ago=2, session_id="inside")
+
+    run_retention_cleanup(store, StorageConfig(analysis_span="90d"))
+
+    rows = store.conn.execute(
+        "SELECT retention_days, analysis_span_days, spans_deleted, "
+        "sessions_deleted, oldest_kept FROM retention_events"
+    ).fetchall()
+    assert len(rows) == 1
+    retention_days, span_days, spans_deleted, sessions_deleted, oldest_kept = rows[0]
+    assert (retention_days, span_days) == (90, 90)
+    assert (spans_deleted, sessions_deleted) == (1, 1)
+    # Read AFTER the delete, so the row states what survived rather than what
+    # the run intended to leave.
+    assert oldest_kept is not None
+    assert (utcnow() - oldest_kept).days < 90
+
+
+def test_a_run_that_deletes_nothing_still_leaves_a_row(store):
+    """Silence is the state this ledger exists to remove. A run with nothing to
+    delete is evidence the job ran; no row at all is evidence of nothing."""
+    _seed(store, days_ago=2, session_id="inside")
+    run_retention_cleanup(store, StorageConfig(analysis_span="90d"))
+    assert store.conn.execute(
+        "SELECT COUNT(*) FROM retention_events"
+    ).fetchone()[0] == 1
+
+
+def test_a_disabled_run_writes_no_row_because_it_did_not_run(store):
+    run_retention_cleanup(store, StorageConfig(analysis_span="all"))
+    assert store.conn.execute(
+        "SELECT COUNT(*) FROM retention_events"
+    ).fetchone()[0] == 0
+
+
+def test_a_ledger_write_failure_never_undoes_a_delete_that_happened(store, caplog):
+    """A trimmed store plus a run reading as a failure is the worst outcome."""
+    store.conn.execute("DROP TABLE retention_events")
+    _seed(store, days_ago=120, session_id="outside")
+
+    run = run_retention_cleanup(store, StorageConfig(analysis_span="90d"))
+
+    assert run.spans_deleted == 1
+    assert store.conn.execute("SELECT COUNT(*) FROM spans").fetchone()[0] == 0
+    assert "ledger row could not be written" in caplog.text
+
+
+def test_the_deletion_no_longer_skews_the_span_it_leaves_behind(store):
+    """The orphaned-session bug, stated as the measure it corrupted.
+
+    `available_data_span` unions `sessions.started_at` into its day set, so
+    leaving the parent rows behind made the deletion inflate the very measure of
+    how much history survived it.
+    """
+    from tokenjam.core.data_span import available_data_span
+
+    _seed(store, days_ago=200, session_id="outside")
+    _seed(store, days_ago=1, session_id="inside")
+
+    run_retention_cleanup(store, StorageConfig(analysis_span="90d"))
+
+    span = available_data_span(store.conn)
+    assert span.days_with_data == 1
+    assert span.ignored_days_before_block == 0
+
+
+# --- the past-overspend basis ----------------------------------------------
+
+
+def test_the_cost_window_follows_the_chosen_span_not_a_fixed_month(store):
+    """A rolling 30 days was the whole look-back, and it is not history.
+
+    A dead MCP server injected into hundreds of sessions with zero invocations
+    did not begin costing money 30 days ago; pricing it on a fixed month
+    understates a PAST-tense figure by however long the behaviour actually ran.
+    """
+    from tokenjam.core.optimize.cost_proposals import (
+        FALLBACK_COST_WINDOW_DAYS,
+        cost_window_days_for,
+    )
+    from types import SimpleNamespace
+
+    for days_ago in range(0, 80, 5):        # a contiguous ~80-day block
+        _seed(store, days_ago=days_ago, session_id=f"s{days_ago}")
+
+    config = SimpleNamespace(storage=StorageConfig(analysis_span="90d"))
+    days = cost_window_days_for(config, store.conn)
+
+    assert days > FALLBACK_COST_WINDOW_DAYS
+    assert days == 76                        # 0..75 days ago inclusive
+
+
+def test_the_cost_window_cannot_exceed_what_the_store_holds(store):
+    """A 90-day promise over a week-old store is answerable for a week."""
+    from types import SimpleNamespace
+
+    from tokenjam.core.optimize.cost_proposals import cost_window_days_for
+
+    for days_ago in range(0, 5):
+        _seed(store, days_ago=days_ago, session_id=f"s{days_ago}")
+
+    config = SimpleNamespace(storage=StorageConfig(analysis_span="90d"))
+    assert cost_window_days_for(config, store.conn) == 5
+
+
+def test_an_all_available_span_takes_the_measured_span(store):
+    from types import SimpleNamespace
+
+    from tokenjam.core.optimize.cost_proposals import cost_window_days_for
+
+    for days_ago in range(0, 12):
+        _seed(store, days_ago=days_ago, session_id=f"s{days_ago}")
+
+    config = SimpleNamespace(storage=StorageConfig(analysis_span="all"))
+    assert cost_window_days_for(config, store.conn) == 12
+
+
+def test_a_narrower_choice_still_binds(store):
+    from types import SimpleNamespace
+
+    from tokenjam.core.optimize.cost_proposals import cost_window_days_for
+
+    for days_ago in range(0, 80, 5):
+        _seed(store, days_ago=days_ago, session_id=f"s{days_ago}")
+
+    config = SimpleNamespace(storage=StorageConfig(analysis_span="30d"))
+    assert cost_window_days_for(config, store.conn) == 30
+
+
+def test_the_constant_is_reached_only_when_neither_bound_exists(store):
+    """An unreadable store AND an unbounded choice — the one case with no
+    answer. A window has to be a number to subtract from now."""
+    from types import SimpleNamespace
+
+    from tokenjam.core.optimize.cost_proposals import (
+        FALLBACK_COST_WINDOW_DAYS,
+        cost_window_days_for,
+    )
+
+    config = SimpleNamespace(storage=StorageConfig(analysis_span="all"))
+    assert cost_window_days_for(config, None) == FALLBACK_COST_WINDOW_DAYS
+    assert cost_window_days_for(SimpleNamespace(), None) == FALLBACK_COST_WINDOW_DAYS
+
+
+def test_retention_can_never_delete_underneath_the_cost_window(store):
+    """The two halves of the coupling, met in the middle.
+
+    The window past-overspend accumulates over and the cutoff retention deletes
+    at are derived from the same span, so the figure can never be computed over
+    a period whose data the product has already destroyed.
+    """
+    from types import SimpleNamespace
+
+    from tokenjam.core.optimize.cost_proposals import cost_window_days_for
+
+    for days_ago in range(0, 200, 5):
+        _seed(store, days_ago=days_ago, session_id=f"s{days_ago}")
+
+    storage = StorageConfig(analysis_span="90d")
+    run = run_retention_cleanup(store, storage)
+
+    window = cost_window_days_for(SimpleNamespace(storage=storage), store.conn)
+    assert run.retention_days == 90
+    assert window <= run.retention_days

--- a/tests/unit/test_cost_proposal_verbs.py
+++ b/tests/unit/test_cost_proposal_verbs.py
@@ -199,11 +199,11 @@ def test_headline_covers_relearn_rows_the_same_way_the_web_route_does(cfg):
     lands in the terminal total too -- not just the cost proposal's $12.5.
     """
     from tokenjam.core.optimize.analyzers.relearn import RelearnCluster, RelearnExample
-    from tokenjam.core.optimize.cost_proposals import DEFAULT_COST_WINDOW_DAYS
+    from tokenjam.core.optimize.cost_proposals import FALLBACK_COST_WINDOW_DAYS
     from tokenjam.core.optimize.relearn_window import RelearnWindowedObservation
 
     bucket = RelearnWindowedObservation(
-        label=f"{DEFAULT_COST_WINDOW_DAYS}d", window_days=float(DEFAULT_COST_WINDOW_DAYS),
+        label=f"{FALLBACK_COST_WINDOW_DAYS}d", window_days=float(FALLBACK_COST_WINDOW_DAYS),
         window_start="2026-06-27T12:00:00+00:00", window_end="2026-07-27T12:00:00+00:00",
         occurrences=6, sessions=3, detour_turns=4.0, undated_occurrences=0,
         tail_calls_median=3, tail_multiplier=1.4,
@@ -218,12 +218,12 @@ def test_headline_covers_relearn_rows_the_same_way_the_web_route_does(cfg):
         proposed_fix="Verify an absolute cwd before a relative Read.",
         examples=[RelearnExample(session_id="s1", repo="demo", ts=None, snippet="no such file")],
         past_overspend_tokens=486_000, past_overspend_usd=40.0,
-        past_overspend_windows={f"{DEFAULT_COST_WINDOW_DAYS}d": bucket},
+        past_overspend_windows={f"{FALLBACK_COST_WINDOW_DAYS}d": bucket},
     )
     from tokenjam.core.optimize.analyzers.relearn import RelearnFinding
     relearn_store.write_cache(
         RelearnFinding(clusters=[cluster],
-                       past_overspend_windows={f"{DEFAULT_COST_WINDOW_DAYS}d": None}),
+                       past_overspend_windows={f"{FALLBACK_COST_WINDOW_DAYS}d": None}),
         config=cfg,
     )
     _store(cfg, _advise_only())  # $12.5 cost proposal.

--- a/tests/unit/test_cost_proposals.py
+++ b/tests/unit/test_cost_proposals.py
@@ -186,7 +186,7 @@ def test_relearn_recompute_preserves_cost_window_and_excluded(tmp_path):
     """A relearn detector recompute must not silently forget a non-default
     cost window or the excluded block a prior cost-proposals recompute wrote.
 
-    Both routes fall back to the same `DEFAULT_COST_WINDOW_DAYS` today, so a
+    Both routes fall back to the same `FALLBACK_COST_WINDOW_DAYS` today, so a
     dropped `cost_window_days` was invisible on live data -- but the moment a
     caller stores a non-default window, `write_cache` (the relearn job's own
     write into the shared cache file) must round-trip it rather than reset

--- a/tests/unit/test_doctor_spans_indexes.py
+++ b/tests/unit/test_doctor_spans_indexes.py
@@ -1,0 +1,118 @@
+"""`tj doctor` must FAIL on a damaged secondary index, not merely mention it.
+
+The reason this is an error rather than a warning is a write path, not a read
+one. Retention deletes user history with `DELETE FROM spans WHERE start_time <
+?`, and DuckDB maintains every secondary index inside that transaction — so a
+damaged one can abort the statement part-way and leave it reporting fewer rows
+removed than it matched. The extent of a deletion of the user's own history then
+becomes unknowable after the fact, which is worse than the deletion itself.
+
+The column-statistics check next door is structurally blind to this: it asks one
+question about `trace_id`'s row-group statistics and answers OK on a spans table
+whose indexes have been destroyed outright. The test below pins exactly that
+asymmetry, because "doctor said OK before and after" is what let the fault sit.
+"""
+from __future__ import annotations
+
+import duckdb
+import pytest
+from click.testing import CliRunner
+
+from tokenjam.cli.cmd_doctor import _check_spans_indexes, _check_spans_stats
+from tokenjam.core.config import StorageConfig
+from tokenjam.core.db import SPANS_INDEXES, DuckDBBackend
+from tests.factories import make_llm_span
+
+
+@pytest.fixture
+def backend(tmp_path):
+    db = DuckDBBackend(StorageConfig(path=str(tmp_path / "telemetry.duckdb")))
+    db.insert_span(make_llm_span(agent_id="a", session_id="s1"))
+    yield db
+    db.close()
+
+
+def test_a_healthy_store_passes(backend):
+    check = _check_spans_indexes(backend)
+    assert check["level"] == "ok"
+    assert "repair_action" not in check
+
+
+def test_a_damaged_index_is_an_error_with_a_repair_path(backend):
+    backend.conn.execute("DROP INDEX idx_spans_start_time")
+    check = _check_spans_indexes(backend)
+    assert check["level"] == "error"
+    assert check["repair_action"] == "rebuild_spans_indexes"
+    # Names the index, so the message says which query paths are unreliable.
+    assert "idx_spans_start_time" in check["message"]
+    # And names the consequence the user cares about, not just the symptom.
+    assert "delete" in check["message"].lower()
+
+
+def test_the_column_statistics_check_cannot_see_this_fault(backend):
+    """Why the new check had to exist at all rather than extending the old one."""
+    for index_name, _ in SPANS_INDEXES:
+        backend.conn.execute(f"DROP INDEX {index_name}")
+    assert _check_spans_stats(backend)["level"] == "ok"
+    assert _check_spans_indexes(backend)["level"] == "error"
+
+
+def test_doctor_exits_nonzero_when_an_index_is_damaged(tmp_path, monkeypatch):
+    """End to end: the check has to reach the exit code, not just the report."""
+    from tokenjam.cli.main import cli
+
+    db_path = tmp_path / "telemetry.duckdb"
+    db = DuckDBBackend(StorageConfig(path=str(db_path)))
+    db.insert_span(make_llm_span(agent_id="a", session_id="s1"))
+    db.conn.execute("DROP INDEX idx_spans_agent_id")
+
+    monkeypatch.setattr("tokenjam.cli.main.open_db", lambda *a, **k: db)
+    try:
+        result = CliRunner().invoke(cli, ["doctor", "--json"])
+    finally:
+        db.close()
+
+    assert result.exit_code == 2, result.output
+    assert "idx_spans_agent_id" in result.output
+
+
+def test_repair_puts_the_index_back_and_doctor_goes_green(tmp_path):
+    from tokenjam.cli.cmd_doctor import _attempt_repairs
+
+    db = DuckDBBackend(StorageConfig(path=str(tmp_path / "telemetry.duckdb")))
+    try:
+        db.insert_span(make_llm_span(agent_id="a", session_id="s1"))
+        db.conn.execute("DROP INDEX idx_spans_tool_name")
+
+        check = _check_spans_indexes(db)
+        assert check["level"] == "error"
+        _attempt_repairs([check], db, output_json=True)
+
+        assert _check_spans_indexes(db)["level"] == "ok"
+        # The repair rebuilds indexes from the table; it must move no rows.
+        assert db.conn.execute("SELECT COUNT(*) FROM spans").fetchone()[0] == 1
+    finally:
+        db.close()
+
+
+def test_a_daemon_held_database_is_skipped_not_failed():
+    """Through the read-only HTTP shim there is no connection to probe.
+
+    An error there would be a claim about a database this process cannot see.
+    """
+    class NoConn:
+        conn = None
+
+    check = _check_spans_indexes(NoConn())
+    assert check["level"] == "info"
+    assert "repair_action" not in check
+
+
+def test_a_pre_migration_database_reports_nothing(tmp_path):
+    from tokenjam.core.db import check_spans_index_corruption
+
+    conn = duckdb.connect(str(tmp_path / "fresh.duckdb"))
+    try:
+        assert check_spans_index_corruption(conn) == []
+    finally:
+        conn.close()

--- a/tests/unit/test_ingest_otlp.py
+++ b/tests/unit/test_ingest_otlp.py
@@ -81,6 +81,9 @@ def test_parse_otlp_span_extracts_cache_read_and_write_tokens():
     """
     raw = {
         "name": "gen_ai.llm.call",
+        # An OTLP span with no startTimeUnixNano is rejected — it has no observed
+        # time. These cases are about attribute extraction, so they carry one.
+        "startTimeUnixNano": "1748736000000000000",
         "attributes": [
             {"key": GenAIAttributes.REQUEST_MODEL, "value": {"stringValue": "claude-haiku-4-5"}},
             {"key": GenAIAttributes.CACHE_READ_TOKENS, "value": {"intValue": "1000"}},
@@ -102,6 +105,7 @@ def test_parse_otlp_span_extracts_openinference_llm_span():
     """
     raw = {
         "name": "ChatOpenAI",
+        "startTimeUnixNano": "1748736000000000000",
         "attributes": [
             {"key": OpenInferenceAttributes.SPAN_KIND, "value": {"stringValue": "LLM"}},
             {"key": OpenInferenceAttributes.MODEL_NAME, "value": {"stringValue": "gpt-4o"}},
@@ -126,6 +130,7 @@ def test_parse_otlp_span_genai_wins_over_openinference():
     """When BOTH conventions are present on a span, gen_ai.* takes precedence."""
     raw = {
         "name": "ChatAnthropic",
+        "startTimeUnixNano": "1748736000000000000",
         "attributes": [
             # gen_ai.* (preferred)
             {"key": GenAIAttributes.REQUEST_MODEL, "value": {"stringValue": "claude-sonnet-4-6"}},
@@ -247,6 +252,9 @@ def test_parse_otlp_span_extracts_resource_deployment_attrs():
     }
     raw = {
         "name": "gen_ai.llm.call",
+        # An OTLP span with no startTimeUnixNano is rejected — it has no observed
+        # time. These cases are about attribute extraction, so they carry one.
+        "startTimeUnixNano": "1748736000000000000",
         "attributes": [
             {"key": GenAIAttributes.REQUEST_MODEL, "value": {"stringValue": "gpt-4o"}},
         ],
@@ -261,7 +269,11 @@ def test_parse_otlp_span_vcs_commit_sha_deprecated_fallback():
     """The current vcs.ref.head.revision wins; the older deprecated
     vcs.repository.ref.revision is read only when the current name is absent —
     so a not-yet-upgraded OTLP producer's data isn't silently missed."""
-    raw = {"name": "gen_ai.llm.call", "attributes": []}
+    raw = {
+        "name": "gen_ai.llm.call",
+        "startTimeUnixNano": "1748736000000000000",
+        "attributes": [],
+    }
     span = parse_otlp_span(
         raw, {ResourceAttributes.VCS_REPOSITORY_REF_REVISION: "deadbeef"}
     )
@@ -279,6 +291,9 @@ def test_parse_otlp_span_extracts_tenant_feature_prompt_template():
     populate tenant_id/feature/prompt_template_id/prompt_template_version."""
     raw = {
         "name": "gen_ai.llm.call",
+        # An OTLP span with no startTimeUnixNano is rejected — it has no observed
+        # time. These cases are about attribute extraction, so they carry one.
+        "startTimeUnixNano": "1748736000000000000",
         "attributes": [
             {"key": TjAttributes.TENANT_ID, "value": {"stringValue": "acme-corp"}},
             {"key": TjAttributes.FEATURE, "value": {"stringValue": "support-triage"}},
@@ -296,7 +311,11 @@ def test_parse_otlp_span_extracts_tenant_feature_prompt_template():
 def test_parse_otlp_span_attribution_dims_absent_by_default():
     """A span/producer that never sets these carries None — no forced default,
     no accidental '(none)' string landing in the DB."""
-    raw = {"name": "gen_ai.llm.call", "attributes": []}
+    raw = {
+        "name": "gen_ai.llm.call",
+        "startTimeUnixNano": "1748736000000000000",
+        "attributes": [],
+    }
     span = parse_otlp_span(raw, {})
     assert span.tenant_id is None
     assert span.feature is None

--- a/tests/unit/test_no_sentinel_timestamps.py
+++ b/tests/unit/test_no_sentinel_timestamps.py
@@ -1,0 +1,203 @@
+"""Ingest may not stamp a timestamp it did not observe.
+
+A missing source timestamp used to become `1970-01-01`, and a sentinel is not a
+neutral placeholder: it participates in `MIN()`, in `ORDER BY`, and in every day
+union, so ONE such row made a corpus with two months of usable history report a
+span in the thousands of days. `core/data_span.py` defends against it at READ
+time, which protects the surfaces that remember to and no others — a new
+aggregate doing a naive `MIN(start_time)` is wrong again on the first try.
+
+NULL is the representation that defends itself: every comparison, range filter
+and aggregate excludes it under ordinary SQL semantics, so there is no per-query
+guard to forget. The row is still ingested and still counted; it just cannot time
+anything.
+
+The paths below are live, not theoretical. Claude Code's own OTel log exporter
+sends `timeUnixNano=0` on some records, and Codex's ISO-8601 fallback can fail to
+parse — that is where the sentinels on a real store came from.
+"""
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+import pytest
+
+from tokenjam.api.routes.logs import _api_request_to_span, _ts_to_datetime
+from tokenjam.core.config import StorageConfig
+from tokenjam.core.data_span import MIN_PLAUSIBLE_YEAR, available_data_span
+from tokenjam.core.db import DuckDBBackend
+from tokenjam.otel.otlp_parsing import parse_otlp_span
+from tokenjam.otel.semconv import ClaudeCodeEvents
+
+
+# --- the logs path (Claude Code + Codex) ------------------------------------
+
+
+@pytest.mark.parametrize("timestamp_ns", [0, -1])
+def test_an_absent_log_timestamp_becomes_none_not_a_zero_epoch(timestamp_ns):
+    assert _ts_to_datetime(timestamp_ns) is None
+
+
+def test_a_real_log_timestamp_is_preserved():
+    assert _ts_to_datetime(1_800_000_000_000_000_000) == datetime.fromtimestamp(
+        1_800_000_000, tz=timezone.utc,
+    )
+
+
+def test_an_untimed_claude_code_span_carries_no_time_at_either_end():
+    """`end_time` is derived from `start_time`, so it has to degrade with it —
+    a span starting at NULL and ending at a real instant is worse than either."""
+    span = _api_request_to_span(
+        {
+            ClaudeCodeEvents.SESSION_ID: "sess-1",
+            ClaudeCodeEvents.DURATION_MS: 1_200,
+            ClaudeCodeEvents.INPUT_TOKENS: 100,
+            ClaudeCodeEvents.OUTPUT_TOKENS: 10,
+        },
+        {},
+        0,
+    )
+    assert span is not None
+    assert span.start_time is None
+    assert span.end_time is None
+
+
+# --- the OTLP path ----------------------------------------------------------
+
+
+def test_an_otlp_span_with_no_start_time_is_untimed_rather_than_now():
+    """Substituting `datetime.now()` dates historical work to whenever tj
+    happened to receive it, which reads as a real observation."""
+    span = parse_otlp_span(
+        {"spanId": "s1", "traceId": "t1", "name": "chat", "attributes": []}, {},
+    )
+    assert span.start_time is None
+    assert span.duration_ms is None
+
+
+def test_an_otlp_span_with_a_start_time_is_unaffected():
+    span = parse_otlp_span(
+        {
+            "spanId": "s1", "traceId": "t1", "name": "chat",
+            "startTimeUnixNano": "1800000000000000000",
+            "endTimeUnixNano": "1800000001000000000",
+            "attributes": [],
+        },
+        {},
+    )
+    assert span.start_time == datetime.fromtimestamp(1_800_000_000, tz=timezone.utc)
+    assert span.duration_ms == pytest.approx(1000.0)
+
+
+# --- what an untimed row does to the store ----------------------------------
+
+
+@pytest.fixture
+def store(tmp_path):
+    db = DuckDBBackend(StorageConfig(path=str(tmp_path / "telemetry.duckdb")))
+    yield db
+    db.close()
+
+
+def test_an_untimed_span_is_stored_and_counted_but_times_nothing(store):
+    from tests.factories import make_llm_span
+    from tokenjam.utils.time_parse import utcnow
+
+    store.insert_span(make_llm_span(session_id="s1", start_time=utcnow()))
+    store.insert_span(make_llm_span(session_id="s2", start_time=None))
+
+    # Kept: the row still carries tokens, cost and an agent.
+    assert store.conn.execute("SELECT COUNT(*) FROM spans").fetchone()[0] == 2
+    # But it cannot place anything on a calendar, and needs no guard to say so.
+    assert store.conn.execute(
+        "SELECT COUNT(*) FROM spans WHERE start_time IS NULL"
+    ).fetchone()[0] == 1
+    span = available_data_span(store.conn)
+    assert span.days_with_data == 1
+
+
+def test_a_naive_min_over_the_store_can_no_longer_be_dragged_to_1970(store):
+    """The generalisation, and the reason the fix is at the WRITE side.
+
+    Read-time defences only protect the queries that remember them. With NULL
+    there is nothing for an unguarded aggregate to pick up.
+    """
+    from tests.factories import make_llm_span
+    from tokenjam.utils.time_parse import utcnow
+
+    store.insert_span(make_llm_span(session_id="s1", start_time=utcnow()))
+    store.insert_span(make_llm_span(session_id="s2", start_time=None))
+
+    oldest = store.conn.execute("SELECT MIN(start_time) FROM spans").fetchone()[0]
+    assert oldest is not None
+    assert oldest.year >= MIN_PLAUSIBLE_YEAR
+
+
+def test_the_migration_deletes_sentinel_rows_rather_than_nulling_them(tmp_path):
+    """A row whose only recorded fact was a false timestamp has nothing left to
+    attribute once that is removed; keeping it would leave a row counted by
+    every COUNT(*) and placed by nothing."""
+    import duckdb
+
+    from tokenjam.core.db import MIGRATIONS, run_migrations
+
+    path = str(tmp_path / "legacy.duckdb")
+    conn = duckdb.connect(path)
+    # Migrate to just before the sentinel purge, then write what an older build
+    # would have written.
+    for version, sql in MIGRATIONS:
+        if version >= 21:
+            break
+        conn.execute(
+            "CREATE TABLE IF NOT EXISTS schema_migrations "
+            "(version INTEGER PRIMARY KEY, applied_at TIMESTAMPTZ)"
+        )
+        for statement in sql.split(";"):
+            if statement.strip():
+                conn.execute(statement.strip())
+        conn.execute(
+            "INSERT INTO schema_migrations VALUES (?, now())", [version],
+        )
+    epoch = datetime(1970, 1, 1, tzinfo=timezone.utc)
+    now = datetime.now(tz=timezone.utc)
+    conn.execute(
+        "INSERT INTO spans (span_id, trace_id, name, kind, status_code, start_time)"
+        " VALUES ('sentinel','t','x','internal','ok',?)", [epoch],
+    )
+    conn.execute(
+        "INSERT INTO spans (span_id, trace_id, name, kind, status_code, start_time)"
+        " VALUES ('real','t','x','internal','ok',?)", [now],
+    )
+    conn.execute(
+        "INSERT INTO sessions (session_id, agent_id, started_at)"
+        " VALUES ('sentinel','a',?)", [epoch],
+    )
+    conn.execute(
+        "INSERT INTO sessions (session_id, agent_id, started_at)"
+        " VALUES ('real','a',?)", [now],
+    )
+
+    run_migrations(conn)
+    try:
+        assert [r[0] for r in conn.execute(
+            "SELECT span_id FROM spans ORDER BY span_id").fetchall()] == ["real"]
+        assert [r[0] for r in conn.execute(
+            "SELECT session_id FROM sessions ORDER BY session_id").fetchall()] == ["real"]
+        # And the columns are nullable afterwards, so ingest can write NULL.
+        nullable = dict(conn.execute(
+            "SELECT column_name, is_nullable FROM information_schema.columns "
+            "WHERE (table_name = 'spans' AND column_name = 'start_time') "
+            "OR (table_name = 'sessions' AND column_name = 'started_at')"
+        ).fetchall())
+        assert set(nullable.values()) == {"YES"}
+        # The indexes the ALTER had to drop are back — DuckDB refuses to alter a
+        # column on a table carrying ART indexes, and nothing else recreates them.
+        from tokenjam.core.db import SESSIONS_INDEXES, SPANS_INDEXES
+
+        present = {
+            r[0] for r in conn.execute("SELECT index_name FROM duckdb_indexes()").fetchall()
+        }
+        for name, _ in SPANS_INDEXES + SESSIONS_INDEXES:
+            assert name in present, name
+    finally:
+        conn.close()

--- a/tests/unit/test_no_sentinel_timestamps.py
+++ b/tests/unit/test_no_sentinel_timestamps.py
@@ -1,20 +1,26 @@
-"""Ingest may not stamp a timestamp it did not observe.
+"""A record with no observed time is REJECTED, never repaired.
 
-A missing source timestamp used to become `1970-01-01`, and a sentinel is not a
-neutral placeholder: it participates in `MIN()`, in `ORDER BY`, and in every day
-union, so ONE such row made a corpus with two months of usable history report a
-span in the thousands of days. `core/data_span.py` defends against it at READ
-time, which protects the surfaces that remember to and no others — a new
-aggregate doing a naive `MIN(start_time)` is wrong again on the first try.
+Ingest had two ways of inventing a timestamp it never saw, and both were worse
+than declining the record.
 
-NULL is the representation that defends itself: every comparison, range filter
-and aggregate excludes it under ordinary SQL semantics, so there is no per-query
-guard to forget. The row is still ingested and still counted; it just cannot time
-anything.
+`1970-01-01`, from a zero epoch, is not a neutral placeholder: it participates
+in `MIN()`, in `ORDER BY`, and in every day union, so ONE such row made a corpus
+with two months of usable history report a span in the thousands of days.
+`datetime.now()`, the other substitute, is the harder one to catch — a 1970 row
+looks wrong on sight, whereas a row dated today looks like an observation, and it
+silently moved months-old spend into the present window on every backfill run.
 
-The paths below are live, not theoretical. Claude Code's own OTel log exporter
-sends `timeUnixNano=0` on some records, and Codex's ISO-8601 fallback can fail to
-parse — that is where the sentinels on a real store came from.
+The columns stay `NOT NULL`. A nullable column would move the problem into the
+~25 `ORDER BY start_time` / `ORDER BY started_at` sites whose null placement is a
+DuckDB session setting rather than a property of the query — `get_active_session`
+and `get_session_by_conversation` among them, where a null-started row winning
+`ORDER BY ... DESC LIMIT 1` would mis-attribute every subsequent span to it — and
+it would buy only the ability to retain rows that can never time anything.
+
+So the fix is at the boundary, and it is the idiom the ingest adapters already
+used (`ingest_adapters/langfuse.py`, `helicone.py`): decline, and count the
+decline. Rejections are visible on every path here; a fabricated timestamp never
+was.
 """
 from __future__ import annotations
 
@@ -22,57 +28,153 @@ from datetime import datetime, timezone
 
 import pytest
 
-from tokenjam.api.routes.logs import _api_request_to_span, _ts_to_datetime
-from tokenjam.core.config import StorageConfig
-from tokenjam.core.data_span import MIN_PLAUSIBLE_YEAR, available_data_span
-from tokenjam.core.db import DuckDBBackend
+from tokenjam.api.routes.logs import (
+    _observed_timestamp_ns,
+    _ts_to_datetime,
+    parse_log_records,
+)
+from tokenjam.core.config import StorageConfig, TjConfig
+from tokenjam.core.data_span import MIN_PLAUSIBLE_YEAR
+from tokenjam.core.db import (
+    DuckDBBackend,
+    InMemoryBackend,
+    count_sentinel_timestamp_rows,
+    purge_sentinel_timestamp_rows,
+)
+from tokenjam.core.ingest import IngestPipeline, SpanRejectedError
 from tokenjam.otel.otlp_parsing import parse_otlp_span
-from tokenjam.otel.semconv import ClaudeCodeEvents
+from tokenjam.otel.semconv import ClaudeCodeEvents, CodexEvents
 
 
 # --- the logs path (Claude Code + Codex) ------------------------------------
 
 
-@pytest.mark.parametrize("timestamp_ns", [0, -1])
-def test_an_absent_log_timestamp_becomes_none_not_a_zero_epoch(timestamp_ns):
-    assert _ts_to_datetime(timestamp_ns) is None
-
-
-def test_a_real_log_timestamp_is_preserved():
+def test_a_real_timestamp_is_taken_as_given():
+    assert _observed_timestamp_ns({"timeUnixNano": "1800000000000000000"}, {}) == \
+        1_800_000_000_000_000_000
     assert _ts_to_datetime(1_800_000_000_000_000_000) == datetime.fromtimestamp(
         1_800_000_000, tz=timezone.utc,
     )
 
 
-def test_an_untimed_claude_code_span_carries_no_time_at_either_end():
-    """`end_time` is derived from `start_time`, so it has to degrade with it —
-    a span starting at NULL and ending at a real instant is worse than either."""
-    span = _api_request_to_span(
-        {
-            ClaudeCodeEvents.SESSION_ID: "sess-1",
-            ClaudeCodeEvents.DURATION_MS: 1_200,
-            ClaudeCodeEvents.INPUT_TOKENS: 100,
-            ClaudeCodeEvents.OUTPUT_TOKENS: 10,
-        },
-        {},
-        0,
+def test_the_codex_iso_fallback_is_still_honoured():
+    """Codex sets timeUnixNano=0 and puts the real time in an attribute."""
+    ns = _observed_timestamp_ns(
+        {"timeUnixNano": "0"},
+        {CodexEvents.EVENT_TIMESTAMP: "2026-07-28T12:00:00Z"},
     )
-    assert span is not None
-    assert span.start_time is None
-    assert span.end_time is None
+    assert datetime.fromtimestamp(ns / 1e9, tz=timezone.utc) == datetime(
+        2026, 7, 28, 12, 0, tzinfo=timezone.utc,
+    )
+
+
+@pytest.mark.parametrize("record,attrs", [
+    ({}, {}),                        # field absent entirely
+    ({"timeUnixNano": "0"}, {}),     # present and zero, no fallback available
+    ({"timeUnixNano": 0}, {}),
+])
+def test_a_record_with_no_observed_time_is_rejected(record, attrs):
+    with pytest.raises(SpanRejectedError) as exc:
+        _observed_timestamp_ns(record, attrs)
+    assert "no observed timestamp" in str(exc.value)
+
+
+@pytest.mark.parametrize("record,attrs", [
+    ({"timeUnixNano": "not-a-number"}, {}),
+    ({"timeUnixNano": "0"}, {CodexEvents.EVENT_TIMESTAMP: "not-a-date"}),
+    ({"timeUnixNano": "0"}, {CodexEvents.EVENT_TIMESTAMP: 12345}),
+])
+def test_an_unparseable_timestamp_rejects_the_record_not_the_batch(record, attrs):
+    """These reads used to sit OUTSIDE the per-record guard.
+
+    A malformed `timeUnixNano` raised `ValueError` and a non-string
+    `event.timestamp` raised `AttributeError` from `.rstrip`, either of which
+    escaped the loop and failed the whole export with a 500 — one bad record
+    discarding every good one in the same batch.
+    """
+    with pytest.raises(SpanRejectedError):
+        _observed_timestamp_ns(record, attrs)
+
+
+def _log_body(records: list[dict]) -> dict:
+    return {"resourceLogs": [{
+        "resource": {"attributes": []},
+        "scopeLogs": [{"logRecords": records}],
+    }]}
+
+
+def _api_request_record(timestamp_ns, *, session_id: str = "sess-1") -> dict:
+    return {
+        "timeUnixNano": timestamp_ns,
+        "body": {"stringValue": ClaudeCodeEvents.API_REQUEST},
+        "attributes": [
+            {"key": ClaudeCodeEvents.SESSION_ID, "value": {"stringValue": session_id}},
+            {"key": ClaudeCodeEvents.DURATION_MS, "value": {"intValue": "1200"}},
+            {"key": "model", "value": {"stringValue": "claude-sonnet-5"}},
+            {"key": ClaudeCodeEvents.INPUT_TOKENS, "value": {"intValue": "100"}},
+            {"key": ClaudeCodeEvents.OUTPUT_TOKENS, "value": {"intValue": "10"}},
+        ],
+    }
+
+
+@pytest.fixture
+def pipeline():
+    db = InMemoryBackend()
+    yield IngestPipeline(db=db, config=TjConfig(version="1")), db
+    db.close()
+
+
+def test_an_untimed_record_is_counted_as_a_rejection_not_silently_dropped(pipeline):
+    """A record tj refuses is a change to what the corpus holds, so it is
+    reported the same way an accepted one is."""
+    pipe, db = pipeline
+    ingested, rejections = parse_log_records(
+        _log_body([_api_request_record("0")]), pipe,
+    )
+    assert ingested == 0
+    assert len(rejections) == 1
+    assert "no observed timestamp" in rejections[0]["reason"]
+    assert db.conn.execute("SELECT COUNT(*) FROM spans").fetchone()[0] == 0
+
+
+def test_one_bad_record_does_not_cost_the_good_ones_in_its_batch(pipeline):
+    pipe, db = pipeline
+    ingested, rejections = parse_log_records(
+        _log_body([
+            _api_request_record("not-a-number"),
+            _api_request_record("1800000000000000000"),
+            _api_request_record("0"),
+        ]),
+        pipe,
+    )
+    assert ingested == 1
+    assert len(rejections) == 2
+    stored = db.conn.execute("SELECT start_time FROM spans").fetchall()
+    assert len(stored) == 1
+    assert stored[0][0].year >= MIN_PLAUSIBLE_YEAR
+
+
+def test_no_ingested_span_can_carry_a_sentinel_year(pipeline):
+    """The property, stated over the store rather than over one converter."""
+    pipe, db = pipeline
+    parse_log_records(
+        _log_body([_api_request_record(ns) for ns in ("0", "1800000000000000000")]),
+        pipe,
+    )
+    assert count_sentinel_timestamp_rows(db.conn) == {}
 
 
 # --- the OTLP path ----------------------------------------------------------
 
 
-def test_an_otlp_span_with_no_start_time_is_untimed_rather_than_now():
-    """Substituting `datetime.now()` dates historical work to whenever tj
-    happened to receive it, which reads as a real observation."""
-    span = parse_otlp_span(
-        {"spanId": "s1", "traceId": "t1", "name": "chat", "attributes": []}, {},
-    )
-    assert span.start_time is None
-    assert span.duration_ms is None
+def test_an_otlp_span_with_no_start_time_is_rejected():
+    """Substituting `datetime.now()` dated historical work to whenever tj
+    received it, which reads as a real observation."""
+    with pytest.raises(SpanRejectedError) as exc:
+        parse_otlp_span(
+            {"spanId": "s1", "traceId": "t1", "name": "chat", "attributes": []}, {},
+        )
+    assert "no observed time" in str(exc.value)
 
 
 def test_an_otlp_span_with_a_start_time_is_unaffected():
@@ -89,7 +191,55 @@ def test_an_otlp_span_with_a_start_time_is_unaffected():
     assert span.duration_ms == pytest.approx(1000.0)
 
 
-# --- what an untimed row does to the store ----------------------------------
+# --- the transcript backfill ------------------------------------------------
+
+
+def _assistant_record(uuid_: str, ts: str | None, session_id: str = "sess-1") -> dict:
+    record = {
+        "type": "assistant", "uuid": uuid_, "sessionId": session_id, "cwd": "/repo",
+        "message": {
+            "id": f"msg-{uuid_}", "model": "claude-sonnet-4-5",
+            "usage": {"input_tokens": 100, "output_tokens": 10},
+        },
+    }
+    if ts is not None:
+        record["timestamp"] = ts
+    return record
+
+
+def test_an_undated_transcript_record_is_skipped_and_counted(tmp_path):
+    import json
+
+    from tokenjam.core.backfill import parse_claude_code_session
+
+    path = tmp_path / "sess-1.jsonl"
+    path.write_text("\n".join(json.dumps(r) for r in [
+        _assistant_record("a", "2026-07-01T10:00:00.000Z"),
+        _assistant_record("b", None),
+        _assistant_record("c", "not-a-timestamp"),
+    ]))
+
+    parsed = parse_claude_code_session(path)
+
+    assert parsed is not None
+    assert parsed.records_undated == 2
+    assert len(parsed.spans) == 1
+    assert parsed.started_at == datetime(2026, 7, 1, 10, 0, tzinfo=timezone.utc)
+
+
+def test_a_transcript_with_no_dated_record_at_all_yields_no_session(tmp_path):
+    """Returning one would invent both its start and its extent."""
+    import json
+
+    from tokenjam.core.backfill import parse_claude_code_session
+
+    path = tmp_path / "sess-2.jsonl"
+    path.write_text(json.dumps(_assistant_record("a", None, session_id="sess-2")))
+
+    assert parse_claude_code_session(path) is None
+
+
+# --- the one-shot cleanup for corpora an older build already wrote ----------
 
 
 @pytest.fixture
@@ -99,105 +249,119 @@ def store(tmp_path):
     db.close()
 
 
-def test_an_untimed_span_is_stored_and_counted_but_times_nothing(store):
-    from tests.factories import make_llm_span
-    from tokenjam.utils.time_parse import utcnow
-
-    store.insert_span(make_llm_span(session_id="s1", start_time=utcnow()))
-    store.insert_span(make_llm_span(session_id="s2", start_time=None))
-
-    # Kept: the row still carries tokens, cost and an agent.
-    assert store.conn.execute("SELECT COUNT(*) FROM spans").fetchone()[0] == 2
-    # But it cannot place anything on a calendar, and needs no guard to say so.
-    assert store.conn.execute(
-        "SELECT COUNT(*) FROM spans WHERE start_time IS NULL"
-    ).fetchone()[0] == 1
-    span = available_data_span(store.conn)
-    assert span.days_with_data == 1
-
-
-def test_a_naive_min_over_the_store_can_no_longer_be_dragged_to_1970(store):
-    """The generalisation, and the reason the fix is at the WRITE side.
-
-    Read-time defences only protect the queries that remember them. With NULL
-    there is nothing for an unguarded aggregate to pick up.
-    """
-    from tests.factories import make_llm_span
-    from tokenjam.utils.time_parse import utcnow
-
-    store.insert_span(make_llm_span(session_id="s1", start_time=utcnow()))
-    store.insert_span(make_llm_span(session_id="s2", start_time=None))
-
-    oldest = store.conn.execute("SELECT MIN(start_time) FROM spans").fetchone()[0]
-    assert oldest is not None
-    assert oldest.year >= MIN_PLAUSIBLE_YEAR
-
-
-def test_the_migration_deletes_sentinel_rows_rather_than_nulling_them(tmp_path):
-    """A row whose only recorded fact was a false timestamp has nothing left to
-    attribute once that is removed; keeping it would leave a row counted by
-    every COUNT(*) and placed by nothing."""
-    import duckdb
-
-    from tokenjam.core.db import MIGRATIONS, run_migrations
-
-    path = str(tmp_path / "legacy.duckdb")
-    conn = duckdb.connect(path)
-    # Migrate to just before the sentinel purge, then write what an older build
-    # would have written.
-    for version, sql in MIGRATIONS:
-        if version >= 21:
-            break
-        conn.execute(
-            "CREATE TABLE IF NOT EXISTS schema_migrations "
-            "(version INTEGER PRIMARY KEY, applied_at TIMESTAMPTZ)"
-        )
-        for statement in sql.split(";"):
-            if statement.strip():
-                conn.execute(statement.strip())
-        conn.execute(
-            "INSERT INTO schema_migrations VALUES (?, now())", [version],
-        )
+def _write_sentinel_rows(store) -> None:
     epoch = datetime(1970, 1, 1, tzinfo=timezone.utc)
     now = datetime.now(tz=timezone.utc)
-    conn.execute(
+    store.conn.execute(
         "INSERT INTO spans (span_id, trace_id, name, kind, status_code, start_time)"
         " VALUES ('sentinel','t','x','internal','ok',?)", [epoch],
     )
-    conn.execute(
+    store.conn.execute(
         "INSERT INTO spans (span_id, trace_id, name, kind, status_code, start_time)"
         " VALUES ('real','t','x','internal','ok',?)", [now],
     )
-    conn.execute(
+    store.conn.execute(
         "INSERT INTO sessions (session_id, agent_id, started_at)"
         " VALUES ('sentinel','a',?)", [epoch],
     )
-    conn.execute(
+    store.conn.execute(
         "INSERT INTO sessions (session_id, agent_id, started_at)"
         " VALUES ('real','a',?)", [now],
     )
 
-    run_migrations(conn)
-    try:
-        assert [r[0] for r in conn.execute(
-            "SELECT span_id FROM spans ORDER BY span_id").fetchall()] == ["real"]
-        assert [r[0] for r in conn.execute(
-            "SELECT session_id FROM sessions ORDER BY session_id").fetchall()] == ["real"]
-        # And the columns are nullable afterwards, so ingest can write NULL.
-        nullable = dict(conn.execute(
-            "SELECT column_name, is_nullable FROM information_schema.columns "
-            "WHERE (table_name = 'spans' AND column_name = 'start_time') "
-            "OR (table_name = 'sessions' AND column_name = 'started_at')"
-        ).fetchall())
-        assert set(nullable.values()) == {"YES"}
-        # The indexes the ALTER had to drop are back — DuckDB refuses to alter a
-        # column on a table carrying ART indexes, and nothing else recreates them.
-        from tokenjam.core.db import SESSIONS_INDEXES, SPANS_INDEXES
 
-        present = {
-            r[0] for r in conn.execute("SELECT index_name FROM duckdb_indexes()").fetchall()
-        }
-        for name, _ in SPANS_INDEXES + SESSIONS_INDEXES:
-            assert name in present, name
-    finally:
-        conn.close()
+def test_sentinel_rows_are_counted_per_table(store):
+    _write_sentinel_rows(store)
+    assert count_sentinel_timestamp_rows(store.conn) == {"spans": 1, "sessions": 1}
+
+
+def test_a_clean_store_reports_nothing(store):
+    store.conn.execute(
+        "INSERT INTO spans (span_id, trace_id, name, kind, status_code, start_time)"
+        " VALUES ('real','t','x','internal','ok',?)",
+        [datetime.now(tz=timezone.utc)],
+    )
+    assert count_sentinel_timestamp_rows(store.conn) == {}
+
+
+def test_the_purge_deletes_them_and_reports_how_many(store):
+    """Deleted, not corrected: there is nothing to correct TO. A row whose only
+    recorded fact about time was false has no other evidence of when it
+    happened, and keeping it would leave a row every COUNT(*) counts and nothing
+    can place on a calendar."""
+    _write_sentinel_rows(store)
+
+    removed = purge_sentinel_timestamp_rows(store.conn)
+
+    assert removed == {"spans": 1, "sessions": 1}
+    assert [r[0] for r in store.conn.execute(
+        "SELECT span_id FROM spans").fetchall()] == ["real"]
+    assert [r[0] for r in store.conn.execute(
+        "SELECT session_id FROM sessions").fetchall()] == ["real"]
+    assert count_sentinel_timestamp_rows(store.conn) == {}
+
+
+def test_the_purge_is_idempotent(store):
+    _write_sentinel_rows(store)
+    purge_sentinel_timestamp_rows(store.conn)
+    assert purge_sentinel_timestamp_rows(store.conn) == {}
+
+
+def test_doctor_offers_the_cleanup_and_repair_takes_it(store):
+    """Offered through `tj doctor`, not as a SQL snippet somebody has to be told
+    about. A warning rather than an error: the rows are inert right up until
+    something takes a naive MIN() over them."""
+    from tokenjam.cli.cmd_doctor import _attempt_repairs, _check_sentinel_timestamps
+
+    assert _check_sentinel_timestamps(store)["level"] == "ok"
+
+    _write_sentinel_rows(store)
+    check = _check_sentinel_timestamps(store)
+    assert check["level"] == "warning"
+    assert check["repair_action"] == "purge_timestamp_sentinels"
+    assert "1 in sessions" in check["message"] and "1 in spans" in check["message"]
+
+    _attempt_repairs([check], store, output_json=True)
+
+    assert _check_sentinel_timestamps(store)["level"] == "ok"
+    assert count_sentinel_timestamp_rows(store.conn) == {}
+
+
+def test_a_session_start_can_be_corrected_by_a_genuinely_earlier_span(store):
+    """`started_at` was absent from upsert_session's ON CONFLICT set list, so it
+    was WRITE-ONCE: whatever the first span to reach a session stamped was
+    permanent. Only `ended_at` ever advanced, so a session opened by an
+    out-of-order span stayed wrong forever — which is why bad session timestamps
+    accumulated in a corpus instead of healing.
+    """
+    from tests.factories import make_session
+
+    late = datetime(2026, 7, 1, 18, 0, tzinfo=timezone.utc)
+    early = datetime(2026, 7, 1, 9, 0, tzinfo=timezone.utc)
+
+    store.upsert_session(make_session(session_id="s1", started_at=late, ended_at=late))
+    store.upsert_session(make_session(session_id="s1", started_at=early, ended_at=early))
+
+    stored = store.conn.execute(
+        "SELECT started_at FROM sessions WHERE session_id = 's1'"
+    ).fetchone()[0]
+    assert stored == early
+
+
+def test_a_later_span_never_pushes_a_session_start_forward(store):
+    """A session starts when its EARLIEST observed span does, so the correction
+    is one-directional — otherwise the last writer would win and the row would
+    describe its most recent span rather than the session."""
+    from tests.factories import make_session
+
+    early = datetime(2026, 7, 1, 9, 0, tzinfo=timezone.utc)
+    late = datetime(2026, 7, 1, 18, 0, tzinfo=timezone.utc)
+
+    store.upsert_session(make_session(session_id="s1", started_at=early, ended_at=early))
+    store.upsert_session(make_session(session_id="s1", started_at=late, ended_at=late))
+
+    stored = store.conn.execute(
+        "SELECT started_at, ended_at FROM sessions WHERE session_id = 's1'"
+    ).fetchone()
+    assert stored[0] == early
+    assert stored[1] == late

--- a/tests/unit/test_onboard_backfill_scope.py
+++ b/tests/unit/test_onboard_backfill_scope.py
@@ -124,8 +124,8 @@ def test_interactive_prompt_shown_and_recent_choice_notes_complete_later(
     _isolated_claude_code_with_history, tmp_path, monkeypatch,
 ):
     monkeypatch.setattr("tokenjam.cli.cmd_onboard._is_interactive", lambda: True)
-    # Plan choice "3", budget "0", THEN backfill-scope choice "1" (recent).
-    res = _run_claude_code(tmp_path, input_str="3\n0\n1\n")
+    # Plan "3", budget "0", analysis span "2" (90d), THEN backfill scope "1".
+    res = _run_claude_code(tmp_path, input_str="3\n0\n2\n1\n")
     assert res.exit_code == 0, res.output
     flat = _flat(res.output)
     assert "Backfill your Claude Code history:" in flat
@@ -138,7 +138,7 @@ def test_interactive_prompt_everything_choice_skips_complete_later_note(
     _isolated_claude_code_with_history, tmp_path, monkeypatch,
 ):
     monkeypatch.setattr("tokenjam.cli.cmd_onboard._is_interactive", lambda: True)
-    res = _run_claude_code(tmp_path, input_str="3\n0\n2\n")
+    res = _run_claude_code(tmp_path, input_str="3\n0\n2\n2\n")
     assert res.exit_code == 0, res.output
     flat = _flat(res.output)
     assert "afterwards for your full history" not in flat

--- a/tests/unit/test_onboard_path_branch.py
+++ b/tests/unit/test_onboard_path_branch.py
@@ -121,9 +121,9 @@ def test_bare_onboard_sdk_choice_falls_through_to_generic(_routing_stubs, monkey
     )
     runner = CliRunner()
     with runner.isolated_filesystem(temp_dir=tmp_path):
-        # path=3(sdk) → plan prompt(1=api) → api ceiling(0) → daily budget(0)
+        # path=3(sdk) → daily budget(1) → analysis span(2=90d) → ceiling(0)
         res = runner.invoke(
-            cmd_onboard, ["--no-daemon"], input="3\n1\n0\n", obj={},
+            cmd_onboard, ["--no-daemon"], input="3\n1\n2\n0\n", obj={},
         )
     assert res.exit_code == 0, res.output
     # No per-path onboarder fired.

--- a/tests/unit/test_relearn_window.py
+++ b/tests/unit/test_relearn_window.py
@@ -30,7 +30,7 @@ from datetime import date, datetime, timedelta, timezone
 
 import pytest
 
-from tokenjam.core.data_span import DataSpan, data_span_from_days
+from tokenjam.core.data_span import DataSpan, available_data_span, data_span_from_days
 from tokenjam.core.optimize.analyzers.relearn import (
     GROUNDED_TOKENS_PER_OCCURRENCE,
     FailureEpisode,
@@ -400,6 +400,37 @@ def test_implausible_and_future_days_are_discarded_before_measuring():
     span = data_span_from_days(days)
     assert span.available_days == 1
     assert span.newest == today.isoformat()
+
+
+@pytest.mark.parametrize("db_timezone", ["UTC", "Asia/Kolkata", "America/Los_Angeles"])
+def test_the_day_union_reads_utc_days_whatever_the_databases_timezone_is(db_timezone):
+    """The read side must group by the SAME day boundary the filter uses.
+
+    ``_plausible_days`` drops any day later than the UTC date, so a bare
+    ``CAST(ts AS DATE)`` — which DuckDB resolves through the session timezone
+    before truncating (Critical Rule 1) — silently deletes TODAY from the span
+    for every hour the local date runs ahead of the UTC one. On a ``+05:30``
+    machine that is the last five and a half hours of every day: the served
+    ``available_days`` drops by one at 18:30 local and comes back at midnight,
+    with no change behind it. Late-in-the-UTC-day rows are the ones that
+    expose it, so the fixture pins them there rather than at ``utcnow()``.
+    """
+    import duckdb
+
+    conn = duckdb.connect()
+    conn.execute(f"SET TimeZone='{db_timezone}'")
+    conn.execute("CREATE TABLE spans (start_time TIMESTAMPTZ)")
+    conn.execute("CREATE TABLE sessions (started_at TIMESTAMPTZ)")
+
+    today = datetime.now(tz=timezone.utc).date()
+    late = datetime(today.year, today.month, today.day, 23, 30, tzinfo=timezone.utc)
+    conn.execute("INSERT INTO spans VALUES (?)", [late - timedelta(days=1)])
+    conn.execute("INSERT INTO sessions VALUES (?)", [late])
+
+    span = available_data_span(conn)
+    assert span.newest == today.isoformat()
+    assert span.days_with_data == 2
+    assert span.available_days == 2
 
 
 def test_no_data_at_all_is_unknown_not_a_zero_day_span():

--- a/tests/unit/test_spans_stats_repair.py
+++ b/tests/unit/test_spans_stats_repair.py
@@ -15,7 +15,11 @@ import duckdb
 import pytest
 
 from tokenjam.core.db import (
+    SPANS_INDEX_SQL,
+    SPANS_INDEXES,
+    check_spans_index_corruption,
     check_spans_stats_corruption,
+    repair_spans_indexes,
     repair_spans_stats,
     run_migrations,
 )
@@ -175,3 +179,108 @@ class TestRepairPreservesSchema:
         finally:
             fresh.close()
         assert repaired == expected
+
+
+class TestCheckSpansIndexCorruption:
+    """The fault the column-statistics check next door is structurally blind to.
+
+    `check_spans_stats_corruption` asks exactly one question — is `trace_id`'s
+    row-group statistics fast-path lying — and answers "healthy" for a spans
+    table whose secondary indexes have been destroyed outright. That matters
+    because the retention job deletes user history through those indexes: DuckDB
+    maintains every one of them inside the deleting transaction, so a damaged
+    index can abort the DELETE part-way and leave it reporting fewer rows
+    removed than it matched.
+    """
+
+    def test_a_healthy_table_reports_no_faults(self, conn):
+        for i in range(5):
+            _insert_minimal_span(conn, trace_id=f"trace{i:02d}", span_id=f"span{i:02d}")
+        assert check_spans_index_corruption(conn) == []
+
+    def test_an_empty_table_reports_no_faults(self, conn):
+        """Nothing to demonstrate is not the same as something to report."""
+        assert check_spans_index_corruption(conn) == []
+
+    def test_a_missing_table_reports_no_faults(self, tmp_path):
+        c = duckdb.connect(str(tmp_path / "fresh.duckdb"))
+        try:
+            assert check_spans_index_corruption(c) == []
+        finally:
+            c.close()
+
+    def test_a_dropped_index_is_reported_by_name(self, conn):
+        _insert_minimal_span(conn, trace_id="t1", span_id="s1")
+        conn.execute("DROP INDEX idx_spans_start_time")
+        faults = check_spans_index_corruption(conn)
+        assert [name for name, _ in faults] == ["idx_spans_start_time"]
+        assert "absent" in faults[0][1]
+
+    def test_every_declared_index_is_probed(self, conn):
+        """A name added to SPANS_INDEXES must be checked without a second edit.
+
+        The guard that keeps this check from falling behind the schema the way
+        a hand-kept parallel list would.
+        """
+        _insert_minimal_span(conn, trace_id="t1", span_id="s1")
+        for index_name, _ in SPANS_INDEXES:
+            conn.execute(f"DROP INDEX {index_name}")
+        assert {name for name, _ in check_spans_index_corruption(conn)} == {
+            name for name, _ in SPANS_INDEXES
+        }
+        conn.execute(SPANS_INDEX_SQL)
+
+    def test_an_index_returning_fewer_rows_than_the_table_is_reported(self):
+        """The under-reporting fault, which cannot be staged in real DuckDB.
+
+        A genuinely torn ART index is not something SQL can construct on demand,
+        so the probe's arithmetic is exercised directly: the index-served count
+        comes back below the scan-served one for the same value. Asserting on
+        the shape of the two queries rather than on a corrupted file is the only
+        way to pin this half at all, and it is the half that decides whether the
+        check can ever fire on the fault it was written for.
+        """
+        class TornIndexConn:
+            def execute(self, sql, params=None):
+                self._sql = sql
+                return self
+
+            def fetchall(self):
+                if "duckdb_indexes()" in self._sql:
+                    return [(name,) for name, _ in SPANS_INDEXES]
+                return [("probe-value",)]          # the sample lookup
+
+            def fetchone(self):
+                # The scan sees three rows; the index admits to one.
+                return (1,) if "CAST(" not in self._sql else (3,)
+
+        faults = check_spans_index_corruption(TornIndexConn())
+        assert {name for name, _ in faults} == {name for name, _ in SPANS_INDEXES}
+        assert "1 of 3" in faults[0][1]
+
+
+class TestRepairSpansIndexes:
+    def test_it_puts_a_dropped_index_back(self, conn):
+        _insert_minimal_span(conn, trace_id="t1", span_id="s1")
+        conn.execute("DROP INDEX idx_spans_conv_id")
+        repair_spans_indexes(conn)
+        assert check_spans_index_corruption(conn) == []
+
+    def test_it_moves_no_rows(self, conn):
+        for i in range(20):
+            _insert_minimal_span(conn, trace_id=f"trace{i:02d}", span_id=f"span{i:02d}")
+        before = conn.execute(
+            "SELECT span_id, trace_id, start_time FROM spans ORDER BY span_id"
+        ).fetchall()
+        conn.execute("DROP INDEX idx_spans_trace_id")
+        repair_spans_indexes(conn)
+        after = conn.execute(
+            "SELECT span_id, trace_id, start_time FROM spans ORDER BY span_id"
+        ).fetchall()
+        assert after == before
+
+    def test_it_is_idempotent_on_a_healthy_table(self, conn):
+        _insert_minimal_span(conn, trace_id="t1", span_id="s1")
+        repair_spans_indexes(conn)
+        repair_spans_indexes(conn)
+        assert check_spans_index_corruption(conn) == []

--- a/tokenjam/api/routes/logs.py
+++ b/tokenjam/api/routes/logs.py
@@ -69,7 +69,20 @@ def _parse_attrs(raw_attrs: list[dict]) -> dict[str, Any]:
     return attrs
 
 
-def _ts_to_datetime(timestamp_ns: int) -> datetime:
+def _ts_to_datetime(timestamp_ns: int) -> datetime | None:
+    """None when the record carried no usable time, never a zero epoch.
+
+    Claude Code's own OTel log exporter sends `timeUnixNano=0` on some records
+    and Codex's ISO-8601 fallback can fail to parse, so this is a live path, not
+    a defensive one. Returning `datetime.fromtimestamp(0)` wrote a 1970 stamp
+    that then participated in every MIN(), ORDER BY and day union downstream —
+    one such row was enough to make a two-month corpus report a span in the
+    thousands of days. NULL is excluded by ordinary SQL semantics instead, with
+    no per-query guard to forget; the span is still ingested and still counted,
+    it just cannot time anything.
+    """
+    if timestamp_ns <= 0:
+        return None
     return datetime.fromtimestamp(timestamp_ns / 1e9, tz=timezone.utc)
 
 
@@ -82,7 +95,7 @@ def _api_request_to_span(
     prompt_id = attrs.get(ClaudeCodeEvents.PROMPT_ID)
     duration_ms = float(attrs[ClaudeCodeEvents.DURATION_MS])
     start_time = _ts_to_datetime(timestamp_ns)
-    end_time = start_time + timedelta(milliseconds=duration_ms)
+    end_time = start_time + timedelta(milliseconds=duration_ms) if start_time else None
 
     # CACHE_CREATION_TOKENS used to land in extra_attrs as a JSON blob only.
     # It's now threaded through to cache_write_tokens (issue #93) so cache-
@@ -129,7 +142,7 @@ def _tool_result_to_span(
     prompt_id = attrs.get(ClaudeCodeEvents.PROMPT_ID)
     duration_ms = float(attrs[ClaudeCodeEvents.DURATION_MS])
     start_time = _ts_to_datetime(timestamp_ns)
-    end_time = start_time + timedelta(milliseconds=duration_ms)
+    end_time = start_time + timedelta(milliseconds=duration_ms) if start_time else None
 
     success_val = attrs.get(ClaudeCodeEvents.SUCCESS)
     # Claude Code sends success as a boolean or the string "true"
@@ -180,7 +193,7 @@ def _api_error_to_span(
     prompt_id = attrs.get(ClaudeCodeEvents.PROMPT_ID)
     duration_ms = float(attrs[ClaudeCodeEvents.DURATION_MS])
     start_time = _ts_to_datetime(timestamp_ns)
-    end_time = start_time + timedelta(milliseconds=duration_ms)
+    end_time = start_time + timedelta(milliseconds=duration_ms) if start_time else None
 
     extra_attrs: dict[str, Any] = {}
     for key in (
@@ -296,7 +309,7 @@ def _codex_api_request_to_span(
     conversation_id = str(attrs.get(CodexEvents.CONVERSATION_ID, "unknown"))
     duration_ms = float(attrs.get(CodexEvents.DURATION_MS, 0))
     start_time = _ts_to_datetime(timestamp_ns)
-    end_time = start_time + timedelta(milliseconds=duration_ms)
+    end_time = start_time + timedelta(milliseconds=duration_ms) if start_time else None
 
     extra_attrs: dict[str, Any] = {}
     for key in (CodexEvents.HTTP_STATUS, CodexEvents.ATTEMPT):
@@ -340,7 +353,7 @@ def _codex_sse_event_to_span(
     conversation_id = str(attrs.get(CodexEvents.CONVERSATION_ID, "unknown"))
     duration_ms = float(attrs.get(CodexEvents.DURATION_MS, 0))
     start_time = _ts_to_datetime(timestamp_ns)
-    end_time = start_time + timedelta(milliseconds=duration_ms)
+    end_time = start_time + timedelta(milliseconds=duration_ms) if start_time else None
 
     extra_attrs: dict[str, Any] = {}
     for key in (CodexEvents.REASONING_TOKEN_COUNT, CodexEvents.TOOL_TOKEN_COUNT):
@@ -443,7 +456,7 @@ def _codex_tool_result_to_span(
     conversation_id = str(attrs.get(CodexEvents.CONVERSATION_ID, "unknown"))
     duration_ms = float(attrs.get(CodexEvents.DURATION_MS, 0))
     start_time = _ts_to_datetime(timestamp_ns)
-    end_time = start_time + timedelta(milliseconds=duration_ms)
+    end_time = start_time + timedelta(milliseconds=duration_ms) if start_time else None
 
     success_val = attrs.get(CodexEvents.SUCCESS)
     if isinstance(success_val, bool):

--- a/tokenjam/api/routes/logs.py
+++ b/tokenjam/api/routes/logs.py
@@ -69,21 +69,55 @@ def _parse_attrs(raw_attrs: list[dict]) -> dict[str, Any]:
     return attrs
 
 
-def _ts_to_datetime(timestamp_ns: int) -> datetime | None:
-    """None when the record carried no usable time, never a zero epoch.
+def _ts_to_datetime(timestamp_ns: int) -> datetime:
+    """Convert a record timestamp. Callers must have established it is real.
 
-    Claude Code's own OTel log exporter sends `timeUnixNano=0` on some records
-    and Codex's ISO-8601 fallback can fail to parse, so this is a live path, not
-    a defensive one. Returning `datetime.fromtimestamp(0)` wrote a 1970 stamp
-    that then participated in every MIN(), ORDER BY and day union downstream —
-    one such row was enough to make a two-month corpus report a span in the
-    thousands of days. NULL is excluded by ordinary SQL semantics instead, with
-    no per-query guard to forget; the span is still ingested and still counted,
-    it just cannot time anything.
+    `_observed_timestamp_ns` below is the gate: a record with no observed time
+    is rejected before it reaches any converter, so a zero can no longer arrive
+    here and be turned into `1970-01-01`. That sentinel was not a harmless
+    placeholder — it participates in MIN(), in ORDER BY and in every day union,
+    and one such row was enough to make a corpus with two months of usable
+    history report a span in the thousands of days.
     """
-    if timestamp_ns <= 0:
-        return None
     return datetime.fromtimestamp(timestamp_ns / 1e9, tz=timezone.utc)
+
+
+def _observed_timestamp_ns(record: dict, attrs: dict[str, Any]) -> int:
+    """The record's observed time in epoch nanoseconds.
+
+    Raises `SpanRejectedError` when there is none. Both producers are live, not
+    hypothetical: Claude Code's own OTel log exporter omits `timeUnixNano` on
+    some records, and Codex sets it to 0 and puts the real timestamp in
+    `attrs["event.timestamp"]` as an ISO-8601 UTC string — which can itself be
+    absent or unparseable. Rejecting is the idiom the ingest adapters already
+    use (`ingest_adapters/langfuse.py`, `helicone.py`): a record that cannot say
+    when it happened is not ingested, rather than ingested with a made-up time.
+
+    Every parse failure in here becomes a rejection of THIS record. A malformed
+    `timeUnixNano` or a non-string `event.timestamp` used to raise out of the
+    per-record guard and fail the whole export batch with a 500.
+    """
+    try:
+        timestamp_ns = int(record.get("timeUnixNano", 0))
+    except (TypeError, ValueError) as exc:
+        raise SpanRejectedError(f"unparseable timeUnixNano: {exc}") from None
+    if timestamp_ns > 0:
+        return timestamp_ns
+
+    ts_str = attrs.get(CodexEvents.EVENT_TIMESTAMP)
+    if ts_str:
+        try:
+            dt = datetime.fromisoformat(str(ts_str).rstrip("Z") + "+00:00")
+        except (TypeError, ValueError, AttributeError) as exc:
+            raise SpanRejectedError(
+                f"unparseable {CodexEvents.EVENT_TIMESTAMP}: {exc}"
+            ) from None
+        return int(dt.timestamp() * 1e9)
+
+    raise SpanRejectedError(
+        "record carries no observed timestamp (timeUnixNano is absent or zero "
+        f"and there is no {CodexEvents.EVENT_TIMESTAMP} to fall back to)"
+    )
 
 
 def _api_request_to_span(
@@ -95,7 +129,7 @@ def _api_request_to_span(
     prompt_id = attrs.get(ClaudeCodeEvents.PROMPT_ID)
     duration_ms = float(attrs[ClaudeCodeEvents.DURATION_MS])
     start_time = _ts_to_datetime(timestamp_ns)
-    end_time = start_time + timedelta(milliseconds=duration_ms) if start_time else None
+    end_time = start_time + timedelta(milliseconds=duration_ms)
 
     # CACHE_CREATION_TOKENS used to land in extra_attrs as a JSON blob only.
     # It's now threaded through to cache_write_tokens (issue #93) so cache-
@@ -142,7 +176,7 @@ def _tool_result_to_span(
     prompt_id = attrs.get(ClaudeCodeEvents.PROMPT_ID)
     duration_ms = float(attrs[ClaudeCodeEvents.DURATION_MS])
     start_time = _ts_to_datetime(timestamp_ns)
-    end_time = start_time + timedelta(milliseconds=duration_ms) if start_time else None
+    end_time = start_time + timedelta(milliseconds=duration_ms)
 
     success_val = attrs.get(ClaudeCodeEvents.SUCCESS)
     # Claude Code sends success as a boolean or the string "true"
@@ -193,7 +227,7 @@ def _api_error_to_span(
     prompt_id = attrs.get(ClaudeCodeEvents.PROMPT_ID)
     duration_ms = float(attrs[ClaudeCodeEvents.DURATION_MS])
     start_time = _ts_to_datetime(timestamp_ns)
-    end_time = start_time + timedelta(milliseconds=duration_ms) if start_time else None
+    end_time = start_time + timedelta(milliseconds=duration_ms)
 
     extra_attrs: dict[str, Any] = {}
     for key in (
@@ -309,7 +343,7 @@ def _codex_api_request_to_span(
     conversation_id = str(attrs.get(CodexEvents.CONVERSATION_ID, "unknown"))
     duration_ms = float(attrs.get(CodexEvents.DURATION_MS, 0))
     start_time = _ts_to_datetime(timestamp_ns)
-    end_time = start_time + timedelta(milliseconds=duration_ms) if start_time else None
+    end_time = start_time + timedelta(milliseconds=duration_ms)
 
     extra_attrs: dict[str, Any] = {}
     for key in (CodexEvents.HTTP_STATUS, CodexEvents.ATTEMPT):
@@ -353,7 +387,7 @@ def _codex_sse_event_to_span(
     conversation_id = str(attrs.get(CodexEvents.CONVERSATION_ID, "unknown"))
     duration_ms = float(attrs.get(CodexEvents.DURATION_MS, 0))
     start_time = _ts_to_datetime(timestamp_ns)
-    end_time = start_time + timedelta(milliseconds=duration_ms) if start_time else None
+    end_time = start_time + timedelta(milliseconds=duration_ms)
 
     extra_attrs: dict[str, Any] = {}
     for key in (CodexEvents.REASONING_TOKEN_COUNT, CodexEvents.TOOL_TOKEN_COUNT):
@@ -456,7 +490,7 @@ def _codex_tool_result_to_span(
     conversation_id = str(attrs.get(CodexEvents.CONVERSATION_ID, "unknown"))
     duration_ms = float(attrs.get(CodexEvents.DURATION_MS, 0))
     start_time = _ts_to_datetime(timestamp_ns)
-    end_time = start_time + timedelta(milliseconds=duration_ms) if start_time else None
+    end_time = start_time + timedelta(milliseconds=duration_ms)
 
     success_val = attrs.get(CodexEvents.SUCCESS)
     if isinstance(success_val, bool):
@@ -580,7 +614,6 @@ def parse_log_records(
 
         for scope_log in resource_log.get("scopeLogs", []):
             for record in scope_log.get("logRecords", []):
-                timestamp_ns = int(record.get("timeUnixNano", 0))
                 body_val = record.get("body", {})
                 event_name = _otlp_value(body_val) if isinstance(body_val, dict) else body_val
 
@@ -596,25 +629,19 @@ def parse_log_records(
                 if not isinstance(event_name, str):
                     continue
 
-                # Codex CLI sets timeUnixNano=0 and puts the real timestamp in
-                # attrs["event.timestamp"] as an ISO-8601 UTC string.
-                if timestamp_ns == 0:
-                    ts_str = attrs.get(CodexEvents.EVENT_TIMESTAMP)
-                    if ts_str:
-                        try:
-                            dt = datetime.fromisoformat(ts_str.rstrip("Z") + "+00:00")
-                            timestamp_ns = int(dt.timestamp() * 1e9)
-                        except ValueError:
-                            pass
-
                 converter = _CONVERTERS.get(event_name)
                 if converter is None:
                     # Unknown event — skip silently
                     continue
 
-                record_id = f"{event_name}:{timestamp_ns}"
-
+                # Inside the per-record guard, deliberately: an unparseable
+                # timestamp rejects THIS record. Read outside it, a malformed
+                # `timeUnixNano` or a non-string `event.timestamp` raised
+                # straight out of the loop and failed the whole export batch.
+                record_id = event_name
                 try:
+                    timestamp_ns = _observed_timestamp_ns(record, attrs)
+                    record_id = f"{event_name}:{timestamp_ns}"
                     span = converter(attrs, resource_attrs, timestamp_ns)
                     if span is None:
                         continue

--- a/tokenjam/api/routes/runs.py
+++ b/tokenjam/api/routes/runs.py
@@ -227,7 +227,10 @@ async def get_run_detail(request: Request, run_id: str):
     total_spans = sum(s["span_count"] for s in summaries)
 
     starts = [s.started_at for s in sessions if s.started_at]
-    ends = [s.ended_at or s.started_at for s in sessions if (s.ended_at or s.started_at)]
+    # Both timestamps are nullable (a span whose source carried no usable
+    # time writes NULL rather than a 1970 sentinel), so filter through a
+    # generator the type checker can narrow rather than repeating the `or`.
+    ends = [e for e in (s.ended_at or s.started_at for s in sessions) if e is not None]
     started_at = min(starts) if starts else None
     last_activity = max(ends) if ends else None
     time_span_seconds = (

--- a/tokenjam/api/routes/runs.py
+++ b/tokenjam/api/routes/runs.py
@@ -227,10 +227,7 @@ async def get_run_detail(request: Request, run_id: str):
     total_spans = sum(s["span_count"] for s in summaries)
 
     starts = [s.started_at for s in sessions if s.started_at]
-    # Both timestamps are nullable (a span whose source carried no usable
-    # time writes NULL rather than a 1970 sentinel), so filter through a
-    # generator the type checker can narrow rather than repeating the `or`.
-    ends = [e for e in (s.ended_at or s.started_at for s in sessions) if e is not None]
+    ends = [s.ended_at or s.started_at for s in sessions if (s.ended_at or s.started_at)]
     started_at = min(starts) if starts else None
     last_activity = max(ends) if ends else None
     time_span_seconds = (

--- a/tokenjam/api/routes/sessions.py
+++ b/tokenjam/api/routes/sessions.py
@@ -1075,7 +1075,10 @@ def _run_card(
         for s in members
     ]
     starts = [s.started_at for s in members if s.started_at]
-    ends = [s.ended_at or s.started_at for s in members if (s.ended_at or s.started_at)]
+    # Both timestamps are nullable (a span whose source carried no usable
+    # time writes NULL rather than a 1970 sentinel), so filter through a
+    # generator the type checker can narrow rather than repeating the `or`.
+    ends = [e for e in (s.ended_at or s.started_at for s in members) if e is not None]
     return {
         "run_id": run_id,
         "source": source,

--- a/tokenjam/api/routes/sessions.py
+++ b/tokenjam/api/routes/sessions.py
@@ -1075,10 +1075,7 @@ def _run_card(
         for s in members
     ]
     starts = [s.started_at for s in members if s.started_at]
-    # Both timestamps are nullable (a span whose source carried no usable
-    # time writes NULL rather than a 1970 sentinel), so filter through a
-    # generator the type checker can narrow rather than repeating the `or`.
-    ends = [e for e in (s.ended_at or s.started_at for s in members) if e is not None]
+    ends = [s.ended_at or s.started_at for s in members if (s.ended_at or s.started_at)]
     return {
         "run_id": run_id,
         "source": source,

--- a/tokenjam/cli/cmd_doctor.py
+++ b/tokenjam/cli/cmd_doctor.py
@@ -8,6 +8,7 @@ from rich.markup import escape
 
 from tokenjam.cli.json_option import json_option, resolve_output_json
 from tokenjam.core.config import load_config, resolve_config_path
+from tokenjam.core.data_span import MIN_PLAUSIBLE_YEAR
 from tokenjam.core.db import SPANS_INDEXES
 from tokenjam.utils.formatting import console, display_path
 
@@ -90,6 +91,9 @@ def cmd_doctor(ctx: click.Context, output_json_flag: bool, repair: bool) -> None
 
     # 18. Duplicate call ingest — one LLM call stored twice, once per observer
     checks.append(_check_duplicate_call_ingest(ctx.obj["db"]))
+
+    # 18b. Timestamp sentinels an older build wrote — a one-shot cleanup.
+    checks.append(_check_sentinel_timestamps(ctx.obj["db"]))
 
     # 19. Retention — the analysis span, what it keeps, and what the last run
     #     actually deleted. A delete of user history has to be readable after
@@ -447,6 +451,43 @@ def _check_retention(config: object, db: object) -> dict:
             "message": f"Analyzing {span}, so {kept_text}.{clamp}{last}"}
 
 
+def _check_sentinel_timestamps(db: object) -> dict:
+    """Find rows an older build stamped with an epoch sentinel instead of a time.
+
+    Ingest can no longer produce one — a record with no observed time is
+    rejected at the boundary — so this is a one-shot cleanup for corpora already
+    written, offered here rather than as a SQL snippet somebody has to be told
+    about. A warning, not an error: the rows are inert until something takes a
+    naive `MIN()` over them, at which point a single row reports a span decades
+    wide and crushes every derived rate to zero.
+    """
+    from tokenjam.core.db import count_sentinel_timestamp_rows
+
+    conn = getattr(db, "conn", None)
+    if conn is None:
+        return {"name": "Timestamp sentinels", "level": "info",
+                "message": "Skipped — CLI is running through the HTTP API "
+                           "fallback (stop `tj serve` to access the DB directly)."}
+    try:
+        found = count_sentinel_timestamp_rows(conn)
+    except duckdb.Error as e:
+        return {"name": "Timestamp sentinels", "level": "info",
+                "message": f"Skipped — could not scan for sentinels: {e}"}
+    if found:
+        detail = ", ".join(f"{count} in {table}" for table, count in sorted(found.items()))
+        return {
+            "name": "Timestamp sentinels",
+            "level": "warning",
+            "message": f"Rows dated before {MIN_PLAUSIBLE_YEAR} — {detail}. These "
+                       f"carry no real observed time and a single one makes a "
+                       f"naive MIN() report a span decades wide. Run `tj doctor "
+                       f"--repair` to delete them.",
+            "repair_action": "purge_timestamp_sentinels",
+        }
+    return {"name": "Timestamp sentinels", "level": "ok",
+            "message": "No rows carry a placeholder timestamp."}
+
+
 def _check_schema_integrity(db: object) -> dict:
     """Detect a recorded-but-unlanded migration (missing columns #55 / tables #382).
 
@@ -734,6 +775,7 @@ def _attempt_repairs(checks: list[dict], db: object, output_json: bool) -> None:
         check_spans_index_corruption,
         ensure_expected_columns,
         ensure_expected_tables,
+        purge_sentinel_timestamp_rows,
         repair_spans_indexes,
         repair_spans_stats,
         session_cost_drift,
@@ -848,6 +890,30 @@ def _attempt_repairs(checks: list[dict], db: object, output_json: bool) -> None:
                     f"{len(sessions)} session(s); their totals were "
                     f"reconciled.[/green]"
                 )
+            continue
+        if action == "purge_timestamp_sentinels":
+            if conn is None:
+                if not output_json:
+                    console.print(
+                        "  [yellow]Repair skipped — CLI is using the HTTP API "
+                        "fallback. Stop `tj serve` and retry so doctor has "
+                        "direct DB access.[/yellow]"
+                    )
+                continue
+            try:
+                removed = purge_sentinel_timestamp_rows(conn)
+            except duckdb.Error as e:
+                if not output_json:
+                    console.print(
+                        f"  [red]Sentinel purge failed — {e}. If the database is "
+                        f"locked, stop `tj serve` and retry.[/red]"
+                    )
+                continue
+            if not output_json:
+                detail = ", ".join(
+                    f"{count} from {table}" for table, count in sorted(removed.items())
+                ) or "nothing"
+                console.print(f"  [green]Deleted {detail}.[/green]")
             continue
         if action == "rebuild_spans_indexes":
             if conn is None:

--- a/tokenjam/cli/cmd_doctor.py
+++ b/tokenjam/cli/cmd_doctor.py
@@ -8,6 +8,7 @@ from rich.markup import escape
 
 from tokenjam.cli.json_option import json_option, resolve_output_json
 from tokenjam.core.config import load_config, resolve_config_path
+from tokenjam.core.db import SPANS_INDEXES
 from tokenjam.utils.formatting import console, display_path
 
 
@@ -57,6 +58,10 @@ def cmd_doctor(ctx: click.Context, output_json_flag: bool, repair: bool) -> None
     # 9. DuckDB spans column-statistics corruption (issue #56)
     spans_stats_check = _check_spans_stats(ctx.obj["db"])
     checks.append(spans_stats_check)
+
+    # 9b. Secondary-index integrity on spans — a fault the statistics check
+    #     above cannot see, and one that makes the retention DELETE unreliable.
+    checks.append(_check_spans_indexes(ctx.obj["db"]))
 
     # 10. Live-span staleness — flags a stalled OTLP connection (issue #179)
     checks.append(_check_span_staleness(ctx.obj["db"]))
@@ -331,6 +336,47 @@ def _check_spans_stats(db: object) -> dict:
         }
     return {"name": "Spans column statistics", "level": "ok",
             "message": "Column statistics are consistent."}
+
+
+def _check_spans_indexes(db: object) -> dict:
+    """Detect a missing or under-reporting secondary index on `spans`.
+
+    An ERROR, not a warning, and deliberately: the retention job's `DELETE FROM
+    spans WHERE start_time < ?` maintains every index inside its own
+    transaction, so a damaged one can abort the statement part-way and leave it
+    reporting fewer rows removed than it matched. A deletion of user history
+    whose extent nobody can state afterwards is not a degraded read path, it is
+    an unsafe write path, and the column-statistics check next door cannot see
+    it — that one asks only about `trace_id`'s row-group statistics and reports
+    OK on either fault below.
+    """
+    from tokenjam.core.db import check_spans_index_corruption
+
+    conn = getattr(db, "conn", None)
+    if conn is None:
+        return {"name": "Spans index integrity", "level": "info",
+                "message": "Skipped — CLI is running through the HTTP API "
+                           "fallback (stop `tj serve` to access the DB directly)."}
+    try:
+        faults = check_spans_index_corruption(conn)
+    except duckdb.Error as e:
+        return {"name": "Spans index integrity", "level": "info",
+                "message": f"Skipped — could not probe the indexes: {e}"}
+    if faults:
+        detail = "; ".join(f"{name} {reason}" for name, reason in faults)
+        return {
+            "name": "Spans index integrity",
+            "level": "error",
+            "message": f"Secondary index damage on the spans table — {detail}. "
+                       f"Queries served by these indexes return incomplete "
+                       f"results, and a DELETE (retention cleanup) can abort "
+                       f"part-way through. Run `tj doctor --repair` to rebuild "
+                       f"them from the table (no data is moved).",
+            "repair_action": "rebuild_spans_indexes",
+        }
+    return {"name": "Spans index integrity", "level": "ok",
+            "message": f"All {len(SPANS_INDEXES)} secondary indexes on spans "
+                       f"agree with the table."}
 
 
 def _check_schema_integrity(db: object) -> dict:
@@ -617,8 +663,10 @@ def _attempt_repairs(checks: list[dict], db: object, output_json: bool) -> None:
     """Run repair actions for any check that flagged one."""
     from tokenjam.core.db import (
         SESSION_COST_DRIFT_TOLERANCE_USD,
+        check_spans_index_corruption,
         ensure_expected_columns,
         ensure_expected_tables,
+        repair_spans_indexes,
         repair_spans_stats,
         session_cost_drift,
     )
@@ -732,6 +780,43 @@ def _attempt_repairs(checks: list[dict], db: object, output_json: bool) -> None:
                     f"{len(sessions)} session(s); their totals were "
                     f"reconciled.[/green]"
                 )
+            continue
+        if action == "rebuild_spans_indexes":
+            if conn is None:
+                if not output_json:
+                    console.print(
+                        "  [yellow]Repair skipped — CLI is using the HTTP API "
+                        "fallback. Stop `tj serve` and retry so doctor has "
+                        "direct DB access.[/yellow]"
+                    )
+                continue
+            try:
+                repair_spans_indexes(conn)
+                remaining = check_spans_index_corruption(conn)
+            except duckdb.Error as e:
+                if not output_json:
+                    console.print(
+                        f"  [red]Index rebuild failed — {e}. If the database is "
+                        f"locked, stop `tj serve` and retry.[/red]"
+                    )
+                continue
+            if not output_json:
+                if remaining:
+                    # Rebuilding from the table cannot leave an index disagreeing
+                    # with it, so anything still failing is a fault one layer
+                    # down — say so rather than reporting a repair that did not
+                    # take.
+                    console.print(
+                        f"  [red]Rebuilt, but {len(remaining)} index(es) still "
+                        f"disagree with the table — the damage is below the "
+                        f"index layer. Run `tj doctor --repair` again to rebuild "
+                        f"the table itself.[/red]"
+                    )
+                else:
+                    console.print(
+                        f"  [green]Rebuilt {len(SPANS_INDEXES)} secondary "
+                        f"index(es) on spans; no rows were moved.[/green]"
+                    )
             continue
         if action == "rebuild_spans":
             if conn is None:

--- a/tokenjam/cli/cmd_doctor.py
+++ b/tokenjam/cli/cmd_doctor.py
@@ -91,6 +91,11 @@ def cmd_doctor(ctx: click.Context, output_json_flag: bool, repair: bool) -> None
     # 18. Duplicate call ingest — one LLM call stored twice, once per observer
     checks.append(_check_duplicate_call_ingest(ctx.obj["db"]))
 
+    # 19. Retention — the analysis span, what it keeps, and what the last run
+    #     actually deleted. A delete of user history has to be readable after
+    #     the fact, not inferable by diffing two measurements days apart.
+    checks.append(_check_retention(config, ctx.obj["db"]))
+
     if output_json:
         click.echo(json.dumps(checks, default=str))
     else:
@@ -377,6 +382,69 @@ def _check_spans_indexes(db: object) -> dict:
     return {"name": "Spans index integrity", "level": "ok",
             "message": f"All {len(SPANS_INDEXES)} secondary indexes on spans "
                        f"agree with the table."}
+
+
+def _check_retention(config: object, db: object) -> dict:
+    """Report the analysis span, the retention derived from it, and the last delete.
+
+    A deletion of the user's own history that leaves no account of itself is
+    discoverable only by measuring the store twice, days apart, and diffing —
+    which is how eight weeks of the oldest history went missing unnoticed. The
+    ledger makes it a fact on disk; this makes it a fact somebody sees.
+
+    Never an error: retention doing its job is not a fault. What would be a
+    fault is a config whose retention undercuts its own span, and that cannot
+    happen — `core/analysis_span.retention_days_for` raises it — so this reports
+    when the clamp fired rather than warning about a state that no longer exists.
+    """
+    from tokenjam.core.analysis_span import (
+        retention_days_for,
+        retention_was_raised_to_span,
+        span_label,
+    )
+
+    storage = getattr(config, "storage", None)
+    if storage is None:
+        return {"name": "Retention", "level": "info",
+                "message": "Skipped — no storage config."}
+
+    span = span_label(storage)
+    kept = retention_days_for(storage)
+    kept_text = (
+        "deletion is disabled" if kept is None else f"history is kept for {kept} days"
+    )
+    clamp = ""
+    if retention_was_raised_to_span(storage):
+        clamp = (
+            " Storage retention is set shorter than the span and has been raised "
+            "to match — nothing tj analyzes can be deleted underneath it."
+        )
+
+    conn = getattr(db, "conn", None)
+    last = ""
+    if conn is not None:
+        try:
+            row = conn.execute(
+                "SELECT ran_at, spans_deleted, sessions_deleted, oldest_kept "
+                "FROM retention_events ORDER BY ran_at DESC LIMIT 1"
+            ).fetchone()
+        except duckdb.Error:
+            row = None
+        if row is None:
+            last = " No retention run has been recorded yet."
+        else:
+            ran_at, spans_deleted, sessions_deleted, oldest_kept = row
+            last = (
+                f" Last run {ran_at:%Y-%m-%d %H:%M} UTC removed {spans_deleted} "
+                f"span(s) and {sessions_deleted} session(s)"
+            )
+            last += (
+                f"; oldest surviving span {oldest_kept:%Y-%m-%d}." if oldest_kept
+                else "; no dated spans remain."
+            )
+
+    return {"name": "Retention", "level": "ok",
+            "message": f"Analyzing {span}, so {kept_text}.{clamp}{last}"}
 
 
 def _check_schema_integrity(db: object) -> dict:

--- a/tokenjam/cli/cmd_onboard.py
+++ b/tokenjam/cli/cmd_onboard.py
@@ -410,6 +410,13 @@ def _print_instrument_agent_snippet() -> None:
               help="Plan tier for the provider being onboarded. Skips the "
                    "interactive plan prompt when set. Choices: api / pro / "
                    "max_5x / max_20x (Anthropic), plus / team / enterprise (OpenAI).")
+@click.option("--analysis-span", "analysis_span",
+              type=click.Choice(["30d", "90d", "all"]),
+              default=None,
+              help="How far back tj should analyze. Storage retention is "
+                   "derived from this — 'all' disables deletion entirely — so "
+                   "history the analyzers use can never be deleted underneath "
+                   "them. Skips the interactive span prompt when set.")
 @click.option("--project", "project_override", default=None,
               help="Project name to group this repo under in the dashboard "
                    "(OTel service.namespace — e.g. all Aquanodeio/* repos under "
@@ -435,7 +442,8 @@ def _print_instrument_agent_snippet() -> None:
 @click.pass_context
 def cmd_onboard(ctx: click.Context, claude_code: bool, codex: bool, budget: float | None,
                 install_daemon: bool, no_daemon: bool, force: bool,
-                reconfigure: bool, plan: str | None, project_override: str | None,
+                reconfigure: bool, plan: str | None, analysis_span: str | None,
+                project_override: str | None,
                 backfill_days: int | None, backfill_all: bool,
                 verify: bool, verify_only: bool, add_project: bool) -> None:
     """Interactive setup wizard for tj."""
@@ -473,10 +481,12 @@ def cmd_onboard(ctx: click.Context, claude_code: bool, codex: bool, budget: floa
     if claude_code:
         _onboard_claude_code(ctx, budget, no_daemon, force, reconfigure, plan,
                              project_override, verify=verify,
-                             backfill_days=backfill_days, backfill_all=backfill_all)
+                             backfill_days=backfill_days, backfill_all=backfill_all,
+                             analysis_span=analysis_span)
         return
     if codex:
-        _onboard_codex(ctx, budget, no_daemon, force, reconfigure, plan, verify=verify)
+        _onboard_codex(ctx, budget, no_daemon, force, reconfigure, plan,
+                       verify=verify, analysis_span=analysis_span)
         return
 
     # Path-branched first run (#448): the bare `tj onboard` no longer assumes an
@@ -493,16 +503,20 @@ def cmd_onboard(ctx: click.Context, claude_code: bool, codex: bool, budget: floa
         if choice == "claude_code":
             _onboard_claude_code(ctx, budget, no_daemon, force, reconfigure, plan,
                                  project_override, verify=verify,
-                                 backfill_days=backfill_days, backfill_all=backfill_all)
+                                 backfill_days=backfill_days,
+                                 backfill_all=backfill_all,
+                                 analysis_span=analysis_span)
             return
         if choice == "codex":
             _onboard_codex(ctx, budget, no_daemon, force, reconfigure, plan,
-                           verify=verify)
+                           verify=verify, analysis_span=analysis_span)
             return
         if choice == "combination":
             _onboard_combination(ctx, budget, no_daemon, force, plan,
                                   project_override, verify=verify,
-                                  backfill_days=backfill_days, backfill_all=backfill_all)
+                                  backfill_days=backfill_days,
+                                  backfill_all=backfill_all,
+                                  analysis_span=analysis_span)
             return
         # choice == "sdk" → fall through to the generic SDK/API path below.
 
@@ -594,6 +608,16 @@ def cmd_onboard(ctx: click.Context, claude_code: bool, codex: bool, budget: floa
     if budget and budget > 0:
         budget_line = f"daily_usd = {budget}"
 
+    # The one span question, asked here because this path writes its config as
+    # TOML text rather than through `write_config` — `_apply_analysis_span`
+    # cannot reach it. Same choice, same default, same silence when non-tty.
+    from tokenjam.core.analysis_span import DEFAULT_ANALYSIS_SPAN, parse_analysis_span
+    if analysis_span is None:
+        analysis_span = (
+            _prompt_analysis_span() if _is_interactive() else DEFAULT_ANALYSIS_SPAN
+        )
+    parse_analysis_span(analysis_span)  # reject an unwritable span before it is written
+
     config_text = f"""\
 # TokenJam configuration
 # Docs: https://github.com/Metabuilder-Labs/tokenjam#configuration
@@ -622,7 +646,12 @@ tool_outputs = false
 
 [storage]
 path = "~/.tj/telemetry.duckdb"
-retention_days = 90
+# How far back tj analyzes: "30d", "90d", or "all" (keep everything, never
+# delete). Storage retention is DERIVED from this, so history the analyzers use
+# can never be deleted underneath them. Set retention_days as well only if you
+# want to keep MORE than you analyze; a value shorter than the span is raised
+# to it rather than honoured.
+analysis_span = "{analysis_span}"
 
 # Per-agent overrides (optional):
 # [agents.my-agent]
@@ -900,6 +929,94 @@ def _prompt_plan(provider_label: str, choices: list[tuple[str, str]],
         show_default=True,
     )
     return keys[int(raw) - 1]
+
+
+_ANALYSIS_SPAN_CHOICES = [
+    ("30d", "Last 30 days"),
+    ("90d", "Last 90 days"),
+    ("all", "All available — keep everything, never delete"),
+]
+
+
+def _prompt_analysis_span(current: str | None = None) -> str:
+    """Ask the one span question. Returns a key from ANALYSIS_SPAN_CHOICES.
+
+    Deliberately framed as "how far back should tj analyze" rather than "how
+    long should tj keep data": those were two settings that were free to
+    disagree, and they did — retention was quietly deleting the oldest history
+    the analyzers were still sizing their window against. There is one answer
+    now and storage follows it.
+    """
+    console.print("\nHow far back should tj analyze?")
+    for i, (_key, desc) in enumerate(_ANALYSIS_SPAN_CHOICES, start=1):
+        console.print(f"  [accent]{i}[/accent]) {desc}")
+    console.print(
+        "  [muted]Older data is deleted, so this also decides what is kept.[/muted]"
+    )
+    keys = [k for k, _ in _ANALYSIS_SPAN_CHOICES]
+    default_idx = keys.index(current) + 1 if current in keys else keys.index("90d") + 1
+    raw = click.prompt(
+        "Choose",
+        type=click.IntRange(1, len(_ANALYSIS_SPAN_CHOICES)),
+        default=default_idx,
+        show_default=True,
+    )
+    return keys[int(raw) - 1]
+
+
+def _apply_analysis_span(
+    config: object, span_override: str | None = None, *, reconfigure: bool = False,
+) -> None:
+    """Settle the analysis span on `config` before it is written.
+
+    The coupling lives in code, not in a comment: retention is derived from the
+    span (`core/analysis_span.retention_days_for`), and an explicit
+    `retention_days` shorter than the span is raised to it rather than honoured.
+    Lowering storage retention must not be able to silently retract a span the
+    product has already promised to analyze over, so the clamp only ever moves
+    retention UP, and it says so when it fires.
+
+    Idempotent and prompt-free once a span is on the config, so a flow that
+    writes the config more than once (or the combination flow, which runs two
+    of them over the same file) asks exactly once.
+    """
+    from tokenjam.core.analysis_span import (
+        DEFAULT_ANALYSIS_SPAN,
+        analysis_span_days,
+        parse_analysis_span,
+        retention_was_raised_to_span,
+        span_label,
+    )
+
+    storage = config.storage  # type: ignore[attr-defined]
+    if span_override:
+        # Validate before storing: an unparseable span written to disk would
+        # raise on every later read instead of here, where it can be corrected.
+        parse_analysis_span(span_override)
+        storage.analysis_span = span_override
+    elif storage.analysis_span is None:
+        if storage.retention_days is not None and not reconfigure:
+            # A config written before the coupling existed. Its kept history IS
+            # the most the product could ever have analyzed, so adopt it as the
+            # span rather than re-asking — nothing about this setup changes.
+            storage.analysis_span = f"{int(storage.retention_days)}d"
+        elif _is_interactive():
+            storage.analysis_span = _prompt_analysis_span(
+                f"{int(storage.retention_days)}d"
+                if storage.retention_days is not None else None
+            )
+        else:
+            storage.analysis_span = DEFAULT_ANALYSIS_SPAN
+    elif reconfigure and _is_interactive():
+        storage.analysis_span = _prompt_analysis_span(storage.analysis_span)
+
+    if retention_was_raised_to_span(storage):
+        console.print(
+            f"  Storage retention was shorter than the {span_label(storage)} "
+            f"analysis span; raised to match so nothing tj analyzes can be "
+            f"deleted underneath it."
+        )
+        storage.retention_days = analysis_span_days(storage)
 
 
 def _is_interactive() -> bool:
@@ -1562,6 +1679,7 @@ def _onboard_claude_code(
     backfill_days: int | None = None,
     backfill_all: bool = False,
     plan_usd_override: float | None = None,
+    analysis_span: str | None = None,
 ) -> None:
     """Configure Claude Code to send telemetry to tj.
 
@@ -1659,6 +1777,7 @@ def _onboard_claude_code(
         # project without restarting the agent (see AgentConfig.project).
         config.agents[agent_id].project = namespace
         config_path = global_config_path
+        _apply_analysis_span(config, analysis_span, reconfigure=reconfigure)
         write_config(config, config_path)
         console.print(f"  tj config updated: {display_path(config_path)}", soft_wrap=True)
     else:
@@ -1690,6 +1809,7 @@ def _onboard_claude_code(
         )
         config_path = global_config_path
         config_path.parent.mkdir(parents=True, exist_ok=True)
+        _apply_analysis_span(config, analysis_span, reconfigure=reconfigure)
         write_config(config, config_path)
         console.print(
             f"[ok]\u2713[/ok] Config written to "
@@ -2065,6 +2185,7 @@ def _onboard_codex(
     plan_usd_override: float | None = None,
     verify: bool = False,
     standalone: bool = True,
+    analysis_span: str | None = None,
 ) -> None:
     """Configure Codex CLI to send telemetry to tj.
 
@@ -2158,6 +2279,7 @@ def _onboard_codex(
         budget = _prompt_daily_budget(budget, plan)
         if budget and budget > 0:
             config.agents[agent_id].budget.daily_usd = budget
+        _apply_analysis_span(config, analysis_span, reconfigure=reconfigure)
         write_config(config, config_path)
         console.print(f"  tj config updated: {display_path(config_path)}", soft_wrap=True)
     else:
@@ -2187,6 +2309,7 @@ def _onboard_codex(
             )},
         )
         config_path.parent.mkdir(parents=True, exist_ok=True)
+        _apply_analysis_span(config, analysis_span, reconfigure=reconfigure)
         write_config(config, config_path)
         console.print(
             f"[ok]\u2713[/ok] Config written to "
@@ -2463,6 +2586,7 @@ def _onboard_combination(
     verify: bool = False,
     backfill_days: int | None = None,
     backfill_all: bool = False,
+    analysis_span: str | None = None,
 ) -> None:
     """The "combination" path (#448): the user runs more than one kind of agent.
 
@@ -2532,6 +2656,7 @@ def _onboard_combination(
             project_override=project_override,
             verify=False, standalone=False,
             backfill_days=backfill_days, backfill_all=backfill_all,
+            analysis_span=analysis_span,
         )
         done.append("Claude Code")
 
@@ -2542,7 +2667,7 @@ def _onboard_combination(
         _onboard_codex(
             ctx, codex_budget, no_daemon, force, reconfigure=False,
             plan_override=codex_plan, plan_usd_override=codex_usd,
-            verify=False, standalone=False,
+            verify=False, standalone=False, analysis_span=analysis_span,
         )
         # Run the on-disk Codex backfill exactly once here. Passing
         # standalone=False above suppressed the per-path onboarder's own backfill
@@ -3280,6 +3405,9 @@ def _onboard_add_project(ctx: click.Context, project_override: str | None) -> No
 
     namespace = _prompt_project_name(project_override, project_name)
     config.agents[agent_id].project = namespace
+    # Not a fresh onboard, so no span question — but the clamp still runs,
+    # so a config hand-edited to a shorter retention is corrected here too.
+    _apply_analysis_span(config)
     write_config(config, config_path)
 
     console.print(

--- a/tokenjam/core/analysis_span.py
+++ b/tokenjam/core/analysis_span.py
@@ -1,0 +1,207 @@
+"""The ONE span the user chose, and the retention that has to back it.
+
+There were two numbers here and they were allowed to disagree. ``retention_days``
+decided how much history the store KEPT; a separate constant decided how much
+history the analyzers LOOKED AT; and nothing tied either to what the product
+told the user it was analyzing. On a real store the two drifted apart by weeks —
+the oldest data the analyzers were sizing their window against had already been
+deleted underneath them — and the only way to notice was to measure the store
+twice, days apart, and diff the answers.
+
+So there is one choice, made once, at onboarding: **how far back should tj
+analyze?** Everything else is derived from it.
+
+  * ``analysis_span`` — the choice, as the user made it: ``"30d"``, ``"90d"``,
+    or ``"all"``.
+  * retention is DERIVED from it, and ``"all"`` disables retention outright.
+    Deletion can therefore never remove history the product is still offering to
+    analyze, because the thing that decides what to delete is downstream of the
+    thing that decides what to promise.
+  * a config that sets ``retention_days`` and nothing else — every config
+    written before this existed — has its value read AS the span. That is the
+    honest reading of it: what such a user kept is the most the product could
+    ever have analyzed, so nothing about their setup changes.
+
+The invariant is one-directional and enforced here rather than documented:
+**retention is never shorter than the span.** Lowering ``retention_days`` under
+the span does not quietly shrink the span — a promise already made is not
+retracted by a storage setting — it raises retention back to the span and says
+so. The reverse (retention longer than the span) is fine and needs no
+correction: keeping more than you analyze costs disk and misleads nobody.
+
+Not to be confused with ``core/data_span.py``, which measures what the store
+ACTUALLY holds. This module is what the user ASKED FOR. The two meet in
+``resolved_window_days``, since a 90-day promise over a store that has been
+running a week is answerable only for that week.
+"""
+from __future__ import annotations
+
+from typing import Any
+
+#: The choices offered at onboarding. Deliberately three: the two rungs a user
+#: can reason about, plus the opt-out that turns deletion off entirely.
+ANALYSIS_SPAN_CHOICES: tuple[str, ...] = ("30d", "90d", "all")
+
+#: What a config with no opinion gets. The wider of the two bounded rungs: the
+#: analyzers that matter most here (recurring-failure and re-read detection)
+#: measure recurrence, and a month of history is thin evidence of a habit.
+DEFAULT_ANALYSIS_SPAN = "90d"
+
+#: The value ``analysis_span`` takes to mean "keep and analyze everything".
+UNBOUNDED_SPAN = "all"
+
+#: LAST RESORT ONLY — the lookback to use when neither bound can be established
+#: (an unreadable store AND an unbounded choice). Not a default in the sense of
+#: "what a normal run uses": ``window_days_for`` is that. A window has to be a
+#: number of days to subtract from ``utcnow()``, so some answer is required even
+#: when there is no honest one, and this is deliberately the smallest claim.
+FALLBACK_WINDOW_DAYS = 30
+
+
+def parse_analysis_span(raw: Any) -> int | None:
+    """``"30d"``/``"90d"``/``"all"`` (or a bare day count) to days, ``None`` for
+    unbounded. Raises ``ValueError`` on anything else — a span nobody can parse
+    must not silently become a default, because the default is a different
+    promise from the one written down."""
+    if raw is None:
+        raise ValueError("analysis span is unset")
+    text = str(raw).strip().lower()
+    if text in (UNBOUNDED_SPAN, "all-available", "unbounded"):
+        return None
+    if text.endswith("d"):
+        text = text[:-1]
+    try:
+        days = int(text)
+    except ValueError:
+        raise ValueError(
+            f"unrecognised analysis span {raw!r} — expected one of "
+            f"{', '.join(ANALYSIS_SPAN_CHOICES)}"
+        ) from None
+    if days <= 0:
+        raise ValueError(f"analysis span must be positive, got {raw!r}")
+    return days
+
+
+def analysis_span_days(storage: Any) -> int | None:
+    """How far back the product may claim to analyze. ``None`` = all available.
+
+    Reads the explicit choice when there is one. When there is not, an explicit
+    ``retention_days`` IS the choice (see the module docstring) — that is the
+    forward-migration path for every config written before the coupling existed,
+    and it changes nothing about what such a user already had.
+    """
+    chosen = getattr(storage, "analysis_span", None)
+    if chosen is not None:
+        return parse_analysis_span(chosen)
+    kept = getattr(storage, "retention_days", None)
+    if kept is not None:
+        return int(kept)
+    return parse_analysis_span(DEFAULT_ANALYSIS_SPAN)
+
+
+def retention_days_for(storage: Any) -> int | None:
+    """The retention the span requires. ``None`` = deletion disabled.
+
+    The clamp is the whole point: an explicit ``retention_days`` shorter than
+    the span is raised to the span rather than honoured, because honouring it
+    would delete the history a claim the product is already making depends on.
+    """
+    span = analysis_span_days(storage)
+    if span is None:
+        return None
+    explicit = getattr(storage, "retention_days", None)
+    if explicit is None:
+        return span
+    return max(int(explicit), span)
+
+
+def retention_was_raised_to_span(storage: Any) -> bool:
+    """True when an explicit ``retention_days`` was overridden by the clamp.
+
+    Callers that can talk to the user (onboarding, ``tj doctor``) say so; the
+    retention job itself only needs the number.
+    """
+    span = analysis_span_days(storage)
+    explicit = getattr(storage, "retention_days", None)
+    if explicit is None:
+        return False
+    if span is None:
+        return True
+    return int(explicit) < span
+
+
+def resolved_window_days(storage: Any, available_days: int | None) -> int | None:
+    """The span an analyzer may actually accumulate over.
+
+    The chosen span bounded by what the store holds. ``available_days`` is
+    ``core/data_span.available_data_span``'s measure, and ``None`` there means
+    "unknown" rather than zero — an unknown span cannot narrow anything, so the
+    choice stands unchanged (``core/data_span`` makes the same distinction for
+    the same reason).
+
+    Returns ``None`` only when the span is unbounded AND the store cannot say
+    how much history it has, i.e. genuinely "everything, extent unknown".
+    """
+    span = analysis_span_days(storage)
+    if available_days is None:
+        return span
+    if span is None:
+        return available_days
+    return min(span, available_days)
+
+
+def span_label(storage: Any) -> str:
+    """How the CHOSEN span is spelled on a surface. Never a bare number."""
+    span = analysis_span_days(storage)
+    return "all available" if span is None else f"{span}d"
+
+
+def days_of_history(conn: Any) -> int | None:
+    """How far back from TODAY the store's oldest dated row sits.
+
+    Measured from now rather than from the newest row, because a window is
+    subtracted from ``utcnow()``: a store whose last activity was two days ago
+    still needs a lookback reaching past those idle days to see anything at all.
+
+    Reads ``DataSpan.oldest`` rather than ``available_days`` — see that field's
+    note in ``core/data_span.py`` for why the recent unbroken run is the wrong
+    bound for a lookback.
+    """
+    from datetime import date
+
+    from tokenjam.core.data_span import available_data_span
+    from tokenjam.utils.time_parse import utcnow
+
+    if conn is None:
+        return None
+    oldest = available_data_span(conn).oldest
+    if not oldest:
+        return None
+    return (utcnow().date() - date.fromisoformat(oldest)).days + 1
+
+
+def window_days_for(
+    storage: Any, conn: Any, *, fallback: int = FALLBACK_WINDOW_DAYS,
+) -> int:
+    """The lookback in days that the chosen span resolves to on THIS store.
+
+    One seam, so every surface that needs a number of days — the cost-proposal
+    recompute, relearn's precomputed window vocabulary — derives the same one
+    and cannot publish two windows for one span.
+
+    ``fallback`` is reached only when neither bound can be established: an
+    unreadable store AND an unbounded choice, i.e. genuinely "everything, extent
+    unknown". A window has to be a number to subtract from ``utcnow()``, so
+    there is no third answer available here.
+    """
+    if storage is None:
+        return fallback
+    days = resolved_window_days(storage, days_of_history(conn))
+    return max(1, int(days)) if days else fallback
+
+
+def window_label_for(
+    storage: Any, conn: Any, *, fallback: int = FALLBACK_WINDOW_DAYS,
+) -> str:
+    """``window_days_for`` as the label surfaces publish it."""
+    return f"{window_days_for(storage, conn, fallback=fallback)}d"

--- a/tokenjam/core/backfill.py
+++ b/tokenjam/core/backfill.py
@@ -133,8 +133,11 @@ class BackfillResult:
 class ParsedSession:
     session_id: str
     agent_id: str
-    started_at: datetime
-    ended_at: datetime
+    # Nullable: a session none of whose records carried a parseable timestamp is
+    # UNTIMED. Defaulting to `now` dated historical transcript work to whenever
+    # the backfill happened to run — see NormalizedSpan.start_time.
+    started_at: datetime | None
+    ended_at: datetime | None
     cwd: str | None
     spans: list[NormalizedSpan]
     total_input_tokens: int
@@ -501,7 +504,11 @@ def parse_claude_code_session(
         # read+write. See models.py NormalizedSpan + Critical Rule on cache.
 
         agent_id = _agent_id_from_cwd(cwd)
-        start_time = ts or datetime.now(tz=timezone.utc)
+        # An unparseable record timestamp leaves the span UNTIMED. Substituting
+        # `now` dated historical transcript work to whenever the backfill
+        # happened to run, which reads as a real observation and quietly moved
+        # months-old spend into the present window.
+        start_time = ts
 
         # Per-message content (opt-in, gated by [capture]). Default-off leaves
         # llm_attrs carrying provenance only — the ingest source and the call
@@ -622,7 +629,8 @@ def parse_claude_code_session(
         total_cost += s.cost_usd or 0.0
 
     agent_id = _agent_id_from_cwd(cwd)
-    started_at = earliest or datetime.now(tz=timezone.utc)
+    # A session with no dated span at all is untimed, not "started now".
+    started_at = earliest
     ended_at = latest or started_at
 
     return ParsedSession(
@@ -699,7 +707,11 @@ def iter_claude_code_sessions(
         parsed = parse_claude_code_session(jsonl_path, capture=capture)
         if parsed is None:
             continue
-        if since is not None and parsed.ended_at < since:
+        # An UNTIMED session is not known to be old, so a window may not drop
+        # it: the daemon's catch-up is windowed, so excluding it here would mean
+        # it is never ingested at all. Re-parsing it on every pass is cheap and
+        # idempotent (deterministic span ids), losing it is not.
+        if since is not None and parsed.ended_at is not None and parsed.ended_at < since:
             continue
         yield parsed
         yielded += 1
@@ -1111,9 +1123,15 @@ def ingest_claude_code(
         # the full in-window total, not a new-only figure that reads as "barely
         # worked" on an idempotent re-run (#238).
         result.total_cost_usd += parsed.total_cost_usd
-        if result.earliest is None or parsed.started_at < result.earliest:
+        # An untimed session contributes to neither end of the reported span:
+        # it is evidence of work, not evidence of when.
+        if parsed.started_at is not None and (
+            result.earliest is None or parsed.started_at < result.earliest
+        ):
             result.earliest = parsed.started_at
-        if result.latest is None or parsed.ended_at > result.latest:
+        if parsed.ended_at is not None and (
+            result.latest is None or parsed.ended_at > result.latest
+        ):
             result.latest = parsed.ended_at
 
         if use_bulk:

--- a/tokenjam/core/backfill.py
+++ b/tokenjam/core/backfill.py
@@ -91,6 +91,10 @@ class BackfillResult:
     # user re-backfills a DB that still holds pre-v0.5.2 uuid-keyed rows.
     spans_stale_purged: int = 0
     files_failed: int = 0
+    # Transcript records declined for carrying no parseable timestamp — see
+    # ParsedSession.records_undated. Surfaced by `tj backfill`'s summary so a
+    # decline is never silent.
+    records_undated: int = 0
     earliest: datetime | None = None
     latest: datetime | None = None
     total_cost_usd: float = 0.0
@@ -133,11 +137,8 @@ class BackfillResult:
 class ParsedSession:
     session_id: str
     agent_id: str
-    # Nullable: a session none of whose records carried a parseable timestamp is
-    # UNTIMED. Defaulting to `now` dated historical transcript work to whenever
-    # the backfill happened to run — see NormalizedSpan.start_time.
-    started_at: datetime | None
-    ended_at: datetime | None
+    started_at: datetime
+    ended_at: datetime
     cwd: str | None
     spans: list[NormalizedSpan]
     total_input_tokens: int
@@ -152,6 +153,10 @@ class ParsedSession:
     # gone quiet, without re-deriving a second definition of "stale" (backfill
     # used to hardcode every session's status "completed" regardless).
     transcript_mtime: datetime | None = None
+    # Records declined for carrying no parseable timestamp. Counted rather than
+    # dropped in silence: a record tj refuses to ingest is a change to what the
+    # corpus contains, and has to be as visible as one it accepts.
+    records_undated: int = 0
 
 
 # --- ID derivation helpers ---------------------------------------------------
@@ -362,6 +367,7 @@ def parse_claude_code_session(
     cwd: str | None = None
     earliest: datetime | None = None
     latest: datetime | None = None
+    records_undated: int = 0
 
     # Dedup by span_id WITHIN the session (#294). Claude Code replays/re-snapshots
     # assistant turns into the same JSONL on resume/branch — each appended record
@@ -428,11 +434,19 @@ def parse_claude_code_session(
             continue
 
         ts = _parse_ts(record.get("timestamp"))
-        if ts is not None:
-            if earliest is None or ts < earliest:
-                earliest = ts
-            if latest is None or ts > latest:
-                latest = ts
+        if ts is None:
+            # No observed time, so the record is not ingested rather than
+            # ingested with a made-up one. `now` would date months-old
+            # transcript work to whenever the backfill happened to run — which
+            # reads as a real observation, and is why this is worse than the
+            # 1970 sentinel it replaced rather than better. Same idiom as
+            # ingest_adapters/langfuse.py and helicone.py.
+            records_undated += 1
+            continue
+        if earliest is None or ts < earliest:
+            earliest = ts
+        if latest is None or ts > latest:
+            latest = ts
 
         msg = record.get("message") or {}
         if not isinstance(msg, dict):
@@ -504,10 +518,6 @@ def parse_claude_code_session(
         # read+write. See models.py NormalizedSpan + Critical Rule on cache.
 
         agent_id = _agent_id_from_cwd(cwd)
-        # An unparseable record timestamp leaves the span UNTIMED. Substituting
-        # `now` dated historical transcript work to whenever the backfill
-        # happened to run, which reads as a real observation and quietly moved
-        # months-old spend into the present window.
         start_time = ts
 
         # Per-message content (opt-in, gated by [capture]). Default-off leaves
@@ -629,7 +639,10 @@ def parse_claude_code_session(
         total_cost += s.cost_usd or 0.0
 
     agent_id = _agent_id_from_cwd(cwd)
-    # A session with no dated span at all is untimed, not "started now".
+    if earliest is None:
+        # Every record in this file was undated, so there is no session to
+        # describe — returning one would invent both its start and its extent.
+        return None
     started_at = earliest
     ended_at = latest or started_at
 
@@ -646,6 +659,7 @@ def parse_claude_code_session(
         total_cost_usd=round(total_cost, 8),
         tool_call_count=tool_count,
         transcript_mtime=transcript_mtime,
+        records_undated=records_undated,
     )
 
 
@@ -707,11 +721,7 @@ def iter_claude_code_sessions(
         parsed = parse_claude_code_session(jsonl_path, capture=capture)
         if parsed is None:
             continue
-        # An UNTIMED session is not known to be old, so a window may not drop
-        # it: the daemon's catch-up is windowed, so excluding it here would mean
-        # it is never ingested at all. Re-parsing it on every pass is cheap and
-        # idempotent (deterministic span ids), losing it is not.
-        if since is not None and parsed.ended_at is not None and parsed.ended_at < since:
+        if since is not None and parsed.ended_at < since:
             continue
         yield parsed
         yielded += 1
@@ -1123,15 +1133,10 @@ def ingest_claude_code(
         # the full in-window total, not a new-only figure that reads as "barely
         # worked" on an idempotent re-run (#238).
         result.total_cost_usd += parsed.total_cost_usd
-        # An untimed session contributes to neither end of the reported span:
-        # it is evidence of work, not evidence of when.
-        if parsed.started_at is not None and (
-            result.earliest is None or parsed.started_at < result.earliest
-        ):
+        result.records_undated += parsed.records_undated
+        if result.earliest is None or parsed.started_at < result.earliest:
             result.earliest = parsed.started_at
-        if parsed.ended_at is not None and (
-            result.latest is None or parsed.ended_at > result.latest
-        ):
+        if result.latest is None or parsed.ended_at > result.latest:
             result.latest = parsed.ended_at
 
         if use_bulk:

--- a/tokenjam/core/config.py
+++ b/tokenjam/core/config.py
@@ -84,7 +84,17 @@ class DefaultsConfig:
 @dataclass
 class StorageConfig:
     path:           str = "~/.tj/telemetry.duckdb"
-    retention_days: int = 90
+    # THE user-chosen analysis span — "30d" / "90d" / "all" — written by
+    # `tj onboard`. Retention is derived from it, never chosen independently,
+    # so deletion cannot remove history the product is offering to analyze. See
+    # `core/analysis_span.py` for the derivation and the one-directional clamp;
+    # read the span through that module, never off this field, so the
+    # back-compat path below is applied everywhere.
+    analysis_span:  str | None = None
+    # None means "derive from analysis_span". A config that sets this and
+    # nothing else — every config written before the coupling existed — has its
+    # value read AS the span, so nothing about that setup changes.
+    retention_days: int | None = None
     # Runtime provenance, never read from or written to TOML: True when `path`
     # came from an explicit `--db` rather than config discovery. The
     # filesystem-reading analyzers scope themselves off it (see
@@ -679,7 +689,12 @@ def _parse(raw: dict) -> TjConfig:
     storage_raw = raw.get("storage", {})
     storage = StorageConfig(
         path=storage_raw.get("path", StorageConfig.path),
-        retention_days=storage_raw.get("retention_days", StorageConfig.retention_days),
+        # Absence is meaningful for both of these and must survive the load:
+        # `analysis_span` absent + `retention_days` present is the pre-coupling
+        # config whose kept history IS its span. Defaulting either one here
+        # would erase that distinction.
+        analysis_span=storage_raw.get("analysis_span"),
+        retention_days=storage_raw.get("retention_days"),
     )
 
     export_raw = raw.get("export", {})

--- a/tokenjam/core/data_span.py
+++ b/tokenjam/core/data_span.py
@@ -177,13 +177,19 @@ def available_data_span(
     """
     if conn is None:
         return data_span_from_days([], max_gap_days=max_gap_days)
+    # `AT TIME ZONE 'UTC'` before the cast is load-bearing, not decoration
+    # (Critical Rule 1): DuckDB resolves a bare `CAST(TIMESTAMPTZ AS DATE)`
+    # through the session timezone, so on a machine running ahead of UTC the
+    # newest rows come back stamped with TOMORROW's date — and `_plausible_days`
+    # then drops them as future. The whole of today would vanish from the span
+    # for the hours the local date leads, and reappear at local midnight.
     days = _distinct_days(
         conn,
-        "SELECT DISTINCT CAST(start_time AS DATE) FROM spans "
+        "SELECT DISTINCT CAST(start_time AT TIME ZONE 'UTC' AS DATE) FROM spans "
         "WHERE start_time IS NOT NULL",
     ) + _distinct_days(
         conn,
-        "SELECT DISTINCT CAST(started_at AS DATE) FROM sessions "
+        "SELECT DISTINCT CAST(started_at AT TIME ZONE 'UTC' AS DATE) FROM sessions "
         "WHERE started_at IS NOT NULL",
     )
     return data_span_from_days(days, max_gap_days=max_gap_days)

--- a/tokenjam/core/data_span.py
+++ b/tokenjam/core/data_span.py
@@ -74,10 +74,12 @@ class DataSpan:
     #: other: clamp a SELECTOR against ``available_days``, size a LOOKBACK
     #: against this.
     #:
-    #: Only safe to expose because ingest no longer writes epoch sentinels: one
-    #: 1970 row used to move this by decades, which is what the contiguous-block
-    #: measure was introduced to survive. The plausible-year floor below remains
-    #: the backstop for rows written before that changed.
+    #: Only safe to expose because ingest no longer ADMITS an epoch sentinel: a
+    #: record with no observed time is rejected at the boundary rather than
+    #: stored with a made-up one. A single 1970 row used to move this by
+    #: decades, which is what the contiguous-block measure was introduced to
+    #: survive; the plausible-year floor below remains the backstop for rows an
+    #: older build already wrote (and `tj doctor --repair` removes those).
     oldest:                    str | None = None
 
     def to_dict(self) -> dict[str, Any]:

--- a/tokenjam/core/data_span.py
+++ b/tokenjam/core/data_span.py
@@ -60,6 +60,25 @@ class DataSpan:
     oldest_in_block:           str | None
     ignored_days_before_block: int
     basis:                     str
+    #: The OLDEST PLAUSIBLE day carrying data, ISO, ``None`` when nothing dated
+    #: was found. Behind a gap, and so deliberately NOT ``oldest_in_block``.
+    #:
+    #: This is the far edge of the measure the module docstring calls wrong for
+    #: "how far back can I ask", and it is the right one for a different
+    #: question: "how far back must an analyzer look to see everything it is
+    #: entitled to". Bounding a query by ``available_days`` would discard
+    #: everything behind a gap — a fortnight away would silently delete the
+    #: quarter before it from a past-tense figure — whereas widening a query
+    #: past the data costs nothing, since rows that are not there return nothing
+    #: either way. So the two are not interchangeable and neither replaces the
+    #: other: clamp a SELECTOR against ``available_days``, size a LOOKBACK
+    #: against this.
+    #:
+    #: Only safe to expose because ingest no longer writes epoch sentinels: one
+    #: 1970 row used to move this by decades, which is what the contiguous-block
+    #: measure was introduced to survive. The plausible-year floor below remains
+    #: the backstop for rows written before that changed.
+    oldest:                    str | None = None
 
     def to_dict(self) -> dict[str, Any]:
         return {
@@ -69,6 +88,7 @@ class DataSpan:
             "oldest_in_block": self.oldest_in_block,
             "ignored_days_before_block": self.ignored_days_before_block,
             "basis": self.basis,
+            "oldest": self.oldest,
         }
 
 
@@ -125,7 +145,7 @@ def data_span_from_days(
         return DataSpan(
             available_days=None, days_with_data=0, newest=None,
             oldest_in_block=None, ignored_days_before_block=0,
-            basis=_UNKNOWN_BASIS,
+            basis=_UNKNOWN_BASIS, oldest=None,
         )
 
     newest = plausible[-1]
@@ -153,6 +173,7 @@ def data_span_from_days(
             f"gap here. days_with_data counts every distinct day instead, which "
             f"one outlier can move by at most one"
         ),
+        oldest=plausible[0].isoformat(),
     )
 
 

--- a/tokenjam/core/db.py
+++ b/tokenjam/core/db.py
@@ -151,13 +151,14 @@ CREATE TABLE IF NOT EXISTS spans (
     kind                TEXT NOT NULL,
     status_code         TEXT NOT NULL,
     status_message      TEXT,
-    -- NULLABLE, deliberately (migration 21). A source timestamp that is missing
-    -- or unparseable writes NULL here, never an epoch sentinel: the row is kept
-    -- and can be counted, but it can never TIME anything, and every ordering,
-    -- range and day-union query excludes it for free under SQL NULL semantics.
-    -- A 1970 sentinel does the opposite — it participates in MIN() and drags a
-    -- span measure back by decades.
-    start_time          TIMESTAMPTZ,
+    -- NOT NULL, and deliberately so. A row with no observed time is REJECTED at
+    -- ingest rather than stored (see api/routes/logs.py) — the alternative,
+    -- a nullable column, moves the problem into ~25 `ORDER BY start_time` sites
+    -- whose null placement is a DuckDB session setting rather than a property of
+    -- the query, and buys only the ability to keep rows that can never time
+    -- anything. What must never appear here is an epoch SENTINEL: a 1970 stamp
+    -- participates in MIN() and drags a span measure back by decades.
+    start_time          TIMESTAMPTZ NOT NULL,
     end_time            TIMESTAMPTZ,
     duration_ms         DOUBLE,
     attributes          JSON NOT NULL DEFAULT '{}',
@@ -363,8 +364,7 @@ CREATE TABLE IF NOT EXISTS sessions (
     session_id          TEXT PRIMARY KEY,
     agent_id            TEXT NOT NULL,
     conversation_id     TEXT,
-    -- Nullable for the same reason as spans.start_time above (migration 21).
-    started_at          TIMESTAMPTZ,
+    started_at          TIMESTAMPTZ NOT NULL,
     ended_at            TIMESTAMPTZ,
     status              TEXT NOT NULL DEFAULT 'active',
     total_cost_usd      DOUBLE,
@@ -712,43 +712,6 @@ MIGRATIONS: list[tuple[int, str]] = [
     # deletion that happened always has a record and a record that exists always
     # describes a deletion. `tj doctor` reads it; nothing else writes it.
     (20, RETENTION_EVENTS_TABLE_SQL),
-    # Migration 21: unknown timestamps become NULL rather than a 1970 sentinel.
-    #
-    # Ingest stamped a zero epoch whenever a source carried no usable time —
-    # Claude Code's own OTel log exporter sends `timeUnixNano=0` on some
-    # records, and Codex's ISO fallback can fail to parse. A sentinel is not a
-    # neutral placeholder: it participates in `MIN()`, in `ORDER BY`, and in any
-    # day union, so ONE such row made a two-month corpus report a span in the
-    # thousands of days. `core/data_span.py` had to defend against it at READ
-    # time, which fixes the surfaces that remember to and no others.
-    #
-    # NULL is the honest representation and it defends itself: every comparison,
-    # range filter and aggregate excludes it under ordinary SQL semantics, with
-    # no per-query guard to forget. The rows are kept — they still carry tokens,
-    # cost and an agent — they simply cannot time anything.
-    #
-    # The existing sentinels are DELETED rather than migrated to NULL. A row
-    # whose only recorded fact was a false timestamp has nothing left to
-    # attribute once that is removed, and keeping it would leave a row that is
-    # counted by every COUNT(*) and placed by nothing.
-    #
-    # The index choreography is not optional: DuckDB refuses to ALTER a column
-    # on a table carrying ART indexes, so both index sets come off and go
-    # straight back on from the same constants the initial schema uses.
-    (21, (
-        "".join(
-            f"DROP INDEX IF EXISTS {name};\n"
-            for name, _ in SPANS_INDEXES + SESSIONS_INDEXES
-        )
-        + "ALTER TABLE spans ALTER COLUMN start_time DROP NOT NULL;\n"
-        + "ALTER TABLE sessions ALTER COLUMN started_at DROP NOT NULL;\n"
-        + f"DELETE FROM spans WHERE EXTRACT(year FROM start_time) "
-          f"< {MIN_PLAUSIBLE_YEAR};\n"
-        + f"DELETE FROM sessions WHERE EXTRACT(year FROM started_at) "
-          f"< {MIN_PLAUSIBLE_YEAR};\n"
-        + SPANS_INDEX_SQL + ";\n"
-        + SESSIONS_INDEX_SQL
-    )),
 ]
 
 
@@ -1690,6 +1653,64 @@ def check_spans_stats_corruption(conn: duckdb.DuckDBPyConnection) -> bool:
     return False
 
 
+# Rows stamped with an epoch sentinel instead of an observed time. The ingest
+# paths that could write one are closed (a record with no observed time is
+# rejected at the boundary now), so this is a one-shot cleanup for corpora an
+# older build already wrote — surfaced by `tj doctor` and removed by
+# `tj doctor --repair` rather than living as a SQL snippet in a PR description.
+_SENTINEL_TABLES: tuple[tuple[str, str], ...] = (
+    ("spans", "start_time"),
+    ("sessions", "started_at"),
+)
+
+
+def count_sentinel_timestamp_rows(
+    conn: duckdb.DuckDBPyConnection,
+) -> dict[str, int]:
+    """Per-table counts of rows dated before ``MIN_PLAUSIBLE_YEAR``.
+
+    Only tables with a non-zero count appear, so an empty dict means clean. A
+    missing table contributes nothing rather than failing the whole probe.
+    """
+    found: dict[str, int] = {}
+    for table, column in _SENTINEL_TABLES:
+        try:
+            row = conn.execute(
+                f"SELECT COUNT(*) FROM {table} "  # noqa: S608 - table names are literals above
+                f"WHERE {column} IS NOT NULL "
+                f"AND EXTRACT(year FROM {column}) < $1",
+                [MIN_PLAUSIBLE_YEAR],
+            ).fetchone()
+        except duckdb.Error:
+            continue
+        count = int(row[0]) if row else 0
+        if count:
+            found[table] = count
+    return found
+
+
+def purge_sentinel_timestamp_rows(
+    conn: duckdb.DuckDBPyConnection,
+) -> dict[str, int]:
+    """Delete the sentinel-dated rows, returning what was removed per table.
+
+    Deleted rather than corrected: there is nothing to correct TO. A row whose
+    only recorded fact about time was false has no other evidence of when it
+    happened, and leaving it would keep a row that every ``COUNT(*)`` counts and
+    nothing can place on a calendar.
+    """
+    removed = count_sentinel_timestamp_rows(conn)
+    for table, column in _SENTINEL_TABLES:
+        if table not in removed:
+            continue
+        conn.execute(
+            f"DELETE FROM {table} "  # noqa: S608 - table names are literals above
+            f"WHERE {column} IS NOT NULL AND EXTRACT(year FROM {column}) < $1",
+            [MIN_PLAUSIBLE_YEAR],
+        )
+    return removed
+
+
 def check_spans_index_corruption(
     conn: duckdb.DuckDBPyConnection,
 ) -> list[tuple[str, str]]:
@@ -2148,6 +2169,22 @@ class DuckDBBackend:
                     service_instance_id, cache_write_tokens, run_id, parent_session_id
                 ) VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12,$13,$14,$15,$16,$17,$18)
                 ON CONFLICT (session_id) DO UPDATE SET
+                    -- `started_at` was absent from this list entirely, which
+                    -- made it WRITE-ONCE: whatever the first span to reach a
+                    -- session stamped was permanent, and no genuinely earlier
+                    -- span arriving later could correct it. Since only
+                    -- `ended_at` ever advanced, a session opened by an
+                    -- out-of-order or mis-stamped span stayed wrong forever —
+                    -- which is why bad session timestamps accumulated in a
+                    -- corpus instead of healing. A session starts when its
+                    -- EARLIEST observed span does, so take the minimum; the
+                    -- COALESCE keeps a NULL incoming value from erasing a
+                    -- stored one, since MIN semantics here must not be
+                    -- confused with "unknown wins".
+                    started_at = LEAST(
+                        sessions.started_at,
+                        COALESCE(EXCLUDED.started_at, sessions.started_at)
+                    ),
                     ended_at = COALESCE(EXCLUDED.ended_at, sessions.ended_at),
                     -- Refuse to downgrade a row the live path already marked
                     -- 'active' when the incoming write's own last-activity is

--- a/tokenjam/core/db.py
+++ b/tokenjam/core/db.py
@@ -3146,31 +3146,33 @@ class DuckDBBackend:
         3. The ledger row, with ``oldest_kept`` read after the deletes (visible
            within the transaction) so it states what survived rather than what
            was intended to.
-        """
-        span_row = self.conn.execute(
-            "SELECT COUNT(*) FROM spans WHERE start_time < $1", [cutoff]
-        ).fetchone()
-        spans_deleted = int(span_row[0]) if span_row else 0
 
+        **Both counts come from the DELETEs themselves, not from a preceding
+        ``COUNT(*)``.** DuckDB returns the affected-row count for a ``DELETE``,
+        and using it is what makes the ledger's figure the number of rows this
+        transaction actually removed rather than an estimate of how many it
+        expected to. A separate count is wrong even inside the transaction and
+        badly wrong outside it: an ingest committing an aged-out span between
+        the count and the delete would have that span destroyed while the ledger
+        persisted the smaller, earlier number. Deriving the figure from the
+        delete makes that race structurally impossible instead of merely narrow,
+        which matters because the entire purpose of this ledger is that it can
+        be trusted about what was destroyed.
+        """
         with self._write_lock:
             self.conn.execute("BEGIN TRANSACTION")
             try:
-                self.conn.execute(
+                span_row = self.conn.execute(
                     "DELETE FROM spans WHERE start_time < $1", [cutoff]
-                )
-                orphan_row = self.conn.execute(
-                    "SELECT COUNT(*) FROM sessions s WHERE s.started_at < $1 "
-                    "AND NOT EXISTS ("
-                    "SELECT 1 FROM spans p WHERE p.session_id = s.session_id)",
-                    [cutoff],
                 ).fetchone()
-                sessions_deleted = int(orphan_row[0]) if orphan_row else 0
-                self.conn.execute(
+                spans_deleted = int(span_row[0]) if span_row else 0
+                session_row = self.conn.execute(
                     "DELETE FROM sessions s WHERE s.started_at < $1 "
                     "AND NOT EXISTS ("
                     "SELECT 1 FROM spans p WHERE p.session_id = s.session_id)",
                     [cutoff],
-                )
+                ).fetchone()
+                sessions_deleted = int(session_row[0]) if session_row else 0
                 oldest_row = self.conn.execute(
                     "SELECT MIN(start_time) FROM spans WHERE start_time IS NOT NULL"
                 ).fetchone()

--- a/tokenjam/core/db.py
+++ b/tokenjam/core/db.py
@@ -170,14 +170,23 @@ CREATE TABLE IF NOT EXISTS spans (
 );
 """
 
-# Secondary indexes on spans. Single-sourced so migration 3 and the repair path
-# create the same set; keep in sync with the DROPs in migration 2.
-SPANS_INDEX_SQL = (
-    "CREATE INDEX IF NOT EXISTS idx_spans_trace_id    ON spans(trace_id);\n"
-    "CREATE INDEX IF NOT EXISTS idx_spans_agent_id    ON spans(agent_id);\n"
-    "CREATE INDEX IF NOT EXISTS idx_spans_start_time  ON spans(start_time);\n"
-    "CREATE INDEX IF NOT EXISTS idx_spans_tool_name   ON spans(tool_name);\n"
-    "CREATE INDEX IF NOT EXISTS idx_spans_conv_id     ON spans(conversation_id)"
+# Secondary indexes on spans, as (index name, indexed column). Single-sourced so
+# migration 3, the repair path, and the integrity check all speak about the same
+# set; keep in sync with the DROPs in migration 2. The index-corruption check
+# below probes each entry individually, so a name added here is checked without
+# any further edit — the point being that the check cannot fall behind the
+# schema the way a hand-kept second list would.
+SPANS_INDEXES: tuple[tuple[str, str], ...] = (
+    ("idx_spans_trace_id",   "trace_id"),
+    ("idx_spans_agent_id",   "agent_id"),
+    ("idx_spans_start_time", "start_time"),
+    ("idx_spans_tool_name",  "tool_name"),
+    ("idx_spans_conv_id",    "conversation_id"),
+)
+
+SPANS_INDEX_SQL = ";\n".join(
+    f"CREATE INDEX IF NOT EXISTS {name} ON spans({column})"
+    for name, column in SPANS_INDEXES
 )
 
 # ---------------------------------------------------------------------------
@@ -1594,6 +1603,104 @@ def check_spans_stats_corruption(conn: duckdb.DuckDBPyConnection) -> bool:
         if eq == 0 and like > 0:
             return True
     return False
+
+
+def check_spans_index_corruption(
+    conn: duckdb.DuckDBPyConnection,
+) -> list[tuple[str, str]]:
+    """The ``spans`` secondary indexes that are missing or disagree with the table.
+
+    Returns ``(index name, what is wrong)`` pairs; empty means all five are
+    sound. ``check_spans_stats_corruption`` above asks one question about one
+    column — is the row-group statistics fast-path lying about ``trace_id`` —
+    which is narrower than "can this table be read and DELETED from
+    predictably", and the gap between the two is where a secondary-index fault
+    lives. DuckDB maintains every index inside the deleting transaction, so a
+    damaged one can abort a ``DELETE`` part-way through and leave a statement
+    reporting that it removed fewer rows than it matched. Retention runs exactly
+    that ``DELETE``, which is what makes this load-bearing rather than cosmetic:
+    a deletion that cannot be relied on to complete is a deletion whose extent
+    nobody can state afterwards.
+
+    Two independent faults, because they have different causes and the same
+    remedy:
+
+    * **absent** — the index is not in the catalogue at all. A rebuild that
+      copies data without the DDL drops all five permanently (the ``CREATE
+      TABLE … AS SELECT`` trap ``repair_spans_stats`` documents), and migrations
+      are already recorded applied, so nothing puts them back.
+    * **inconsistent** — the index answers a point lookup with fewer rows than
+      the table holds. Probed the same way the stats check probes: take a value
+      known to be present, ask for it once in a form an index can serve and once
+      in a form it cannot (``CAST(col AS VARCHAR)`` is an expression over the
+      column, so no index applies — and unlike the stats check's ``LIKE`` trick
+      it works for ``start_time`` too).
+
+    An empty table, an unreadable column, or a column holding only NULLs
+    contributes nothing: this reports what it can demonstrate, never suspicion.
+    """
+    try:
+        # A pre-migration database has no spans table, so it has no indexes to
+        # be missing. Reporting five absent ones there would flag every fresh
+        # install as corrupt.
+        conn.execute("SELECT 1 FROM spans LIMIT 0").fetchall()
+        present = {
+            str(row[0])
+            for row in conn.execute(
+                "SELECT index_name FROM duckdb_indexes() WHERE table_name = 'spans'"
+            ).fetchall()
+        }
+    except duckdb.Error:
+        return []
+
+    faults: list[tuple[str, str]] = []
+    for index_name, column in SPANS_INDEXES:
+        if index_name not in present:
+            faults.append((index_name, "absent from the catalogue"))
+            continue
+        try:
+            sample = conn.execute(
+                f"SELECT {column} FROM spans WHERE {column} IS NOT NULL LIMIT 3"
+            ).fetchall()
+        except duckdb.Error:
+            continue
+        for (value,) in sample:
+            try:
+                indexed_row = conn.execute(
+                    f"SELECT COUNT(*) FROM spans WHERE {column} = $1", [value]
+                ).fetchone()
+                scanned_row = conn.execute(
+                    f"SELECT COUNT(*) FROM spans "
+                    f"WHERE CAST({column} AS VARCHAR) = CAST($1 AS VARCHAR)",
+                    [value],
+                ).fetchone()
+            except duckdb.Error:
+                break
+            indexed = indexed_row[0] if indexed_row else 0
+            scanned = scanned_row[0] if scanned_row else 0
+            if indexed < scanned:
+                faults.append((
+                    index_name,
+                    f"returns {indexed} of {scanned} matching row(s)",
+                ))
+                break
+    return faults
+
+
+def repair_spans_indexes(conn: duckdb.DuckDBPyConnection) -> None:
+    """Drop and recreate every ``spans`` secondary index from the canonical DDL.
+
+    Cheaper than ``repair_spans_stats`` and sufficient for the index fault: the
+    table's rows are the source of truth and are never touched, so a rebuilt
+    index can only agree with them. Idempotent, and safe on a healthy database.
+    """
+    for index_name, _ in SPANS_INDEXES:
+        conn.execute(f"DROP INDEX IF EXISTS {index_name}")
+    for statement in SPANS_INDEX_SQL.split(";"):
+        statement = statement.strip()
+        if statement:
+            conn.execute(statement)
+    conn.execute("CHECKPOINT")
 
 
 def repair_spans_stats(conn: duckdb.DuckDBPyConnection) -> None:

--- a/tokenjam/core/db.py
+++ b/tokenjam/core/db.py
@@ -128,7 +128,13 @@ class StorageBackend(Protocol):
         self, group_col: str, current_since: datetime, current_until: datetime,
         prev_since: datetime, prev_until: datetime, top_n: int,
     ) -> list[dict]: ...
-    def delete_spans_before(self, cutoff: datetime) -> tuple[int, int]: ...
+    def delete_spans_before(
+        self,
+        cutoff: datetime,
+        *,
+        retention_days: int | None = None,
+        analysis_span_days: int | None = None,
+    ) -> tuple[int, int]: ...
     def close(self) -> None: ...
 
 
@@ -3101,78 +3107,94 @@ class DuckDBBackend:
             for r in rows
         ]
 
-    def delete_spans_before(self, cutoff: datetime) -> tuple[int, int]:
-        """Delete aged-out spans AND the session rows they leave behind.
+    def delete_spans_before(
+        self,
+        cutoff: datetime,
+        *,
+        retention_days: int | None = None,
+        analysis_span_days: int | None = None,
+    ) -> tuple[int, int]:
+        """Delete aged-out history AND write its ledger row, ATOMICALLY.
 
         Returns ``(spans deleted, sessions deleted)``.
 
-        Deleting only from ``spans`` used to leave the parent ``sessions`` rows
-        in place forever, and those rows are not inert: ``data_span`` unions
-        ``sessions.started_at`` into the day set it measures the available span
-        from, so every orphan went on asserting that a day carried data after
-        the data for that day had been destroyed. The deletion actively skewed
-        the measure of what survived it.
+        **The ledger row is written in the SAME TRANSACTION as the deletes, and
+        that is the point rather than a detail.** What this mechanism has to
+        guarantee is that a delete of the user's own history is observable after
+        the fact; a ledger the process can skip by dying between two commits
+        delivers that only on the happy path, which is exactly the path where
+        nobody needs it. This job runs from an apscheduler cron inside an ad-hoc
+        ``tj serve``, so being killed mid-run is an ordinary event — and a
+        completed delete with no trace is the precise failure the ledger exists
+        to make impossible. Either both land or neither does.
 
-        A session is removed only once it has NO spans left at all, which is
-        strictly narrower than "started before the cutoff": a long session
-        straddling the boundary keeps every span the cutoff spared, so deleting
-        it would discard live rows' parent. A pre-cutoff session that never had
-        spans goes too — it is aged-out history like any other, and leaving it
-        would let it keep asserting a day beyond the retention horizon.
+        Three statements, in order:
 
-        Both statements and the ledger row run under one write lock so a reader
-        cannot observe spans gone with their sessions still present.
+        1. Aged-out spans go.
+        2. Sessions the delete ORPHANED go with them. Deleting only from
+           ``spans`` used to leave parent ``sessions`` rows in place forever,
+           and those are not inert: ``data_span`` unions ``sessions.started_at``
+           into the day set it measures the available span from, so every orphan
+           went on asserting that a day carried data after that day's data was
+           destroyed — the deletion skewed the measure of its own aftermath. A
+           session goes only once it has NO spans left, which is strictly
+           narrower than "started before the cutoff": a long session straddling
+           the boundary keeps every span the cutoff spared, so deleting it would
+           discard live rows' parent. A pre-cutoff session that never had spans
+           goes too — it is aged-out history like any other, and leaving it
+           would let it keep asserting a day beyond the retention horizon.
+        3. The ledger row, with ``oldest_kept`` read after the deletes (visible
+           within the transaction) so it states what survived rather than what
+           was intended to.
         """
         span_row = self.conn.execute(
             "SELECT COUNT(*) FROM spans WHERE start_time < $1", [cutoff]
         ).fetchone()
         spans_deleted = int(span_row[0]) if span_row else 0
+
         with self._write_lock:
-            self.conn.execute("DELETE FROM spans WHERE start_time < $1", [cutoff])
-            orphan_row = self.conn.execute(
-                "SELECT COUNT(*) FROM sessions s WHERE s.started_at < $1 "
-                "AND NOT EXISTS (SELECT 1 FROM spans p WHERE p.session_id = s.session_id)",
-                [cutoff],
-            ).fetchone()
-            sessions_deleted = int(orphan_row[0]) if orphan_row else 0
-            self.conn.execute(
-                "DELETE FROM sessions s WHERE s.started_at < $1 "
-                "AND NOT EXISTS (SELECT 1 FROM spans p WHERE p.session_id = s.session_id)",
-                [cutoff],
-            )
+            self.conn.execute("BEGIN TRANSACTION")
+            try:
+                self.conn.execute(
+                    "DELETE FROM spans WHERE start_time < $1", [cutoff]
+                )
+                orphan_row = self.conn.execute(
+                    "SELECT COUNT(*) FROM sessions s WHERE s.started_at < $1 "
+                    "AND NOT EXISTS ("
+                    "SELECT 1 FROM spans p WHERE p.session_id = s.session_id)",
+                    [cutoff],
+                ).fetchone()
+                sessions_deleted = int(orphan_row[0]) if orphan_row else 0
+                self.conn.execute(
+                    "DELETE FROM sessions s WHERE s.started_at < $1 "
+                    "AND NOT EXISTS ("
+                    "SELECT 1 FROM spans p WHERE p.session_id = s.session_id)",
+                    [cutoff],
+                )
+                oldest_row = self.conn.execute(
+                    "SELECT MIN(start_time) FROM spans WHERE start_time IS NOT NULL"
+                ).fetchone()
+                self.conn.execute(
+                    "INSERT INTO retention_events (event_id, ran_at, cutoff, "
+                    "retention_days, analysis_span_days, spans_deleted, "
+                    "sessions_deleted, oldest_kept) "
+                    "VALUES ($1,$2,$3,$4,$5,$6,$7,$8)",
+                    [
+                        str(uuid.uuid4()), utcnow(), cutoff, retention_days,
+                        analysis_span_days, spans_deleted, sessions_deleted,
+                        oldest_row[0] if oldest_row else None,
+                    ],
+                )
+            except Exception:
+                # A ledger row that cannot be written takes the delete down with
+                # it. Keeping the delete and merely logging the failure — which
+                # is what this used to do — produces exactly the state the
+                # ledger exists to prevent: history gone, nothing saying so.
+                self.conn.execute("ROLLBACK")
+                raise
+            self.conn.execute("COMMIT")
+
         return spans_deleted, sessions_deleted
-
-    def record_retention_event(
-        self,
-        *,
-        cutoff: datetime,
-        retention_days: int | None,
-        analysis_span_days: int | None,
-        spans_deleted: int,
-        sessions_deleted: int,
-    ) -> None:
-        """Append one row to the retention ledger.
-
-        The ledger exists because a deletion of the user's own history that
-        leaves no account of itself is only discoverable by measuring the store
-        twice, days apart, and diffing — which is how eight weeks of the oldest
-        history went missing unnoticed. `oldest_kept` is read AFTER the delete so
-        the row states what survived, not what was intended to.
-        """
-        oldest_row = self.conn.execute(
-            "SELECT MIN(start_time) FROM spans WHERE start_time IS NOT NULL"
-        ).fetchone()
-        with self._write_lock:
-            self.conn.execute(
-                "INSERT INTO retention_events (event_id, ran_at, cutoff, "
-                "retention_days, analysis_span_days, spans_deleted, "
-                "sessions_deleted, oldest_kept) VALUES ($1,$2,$3,$4,$5,$6,$7,$8)",
-                [
-                    str(uuid.uuid4()), utcnow(), cutoff, retention_days,
-                    analysis_span_days, spans_deleted, sessions_deleted,
-                    oldest_row[0] if oldest_row else None,
-                ],
-            )
 
     def close(self) -> None:
         # Closing the root connection tears down the database and all cursors.

--- a/tokenjam/core/db.py
+++ b/tokenjam/core/db.py
@@ -10,6 +10,7 @@ import logging
 import os
 import tempfile
 import threading
+import uuid
 from datetime import date, datetime
 from pathlib import Path
 from typing import Any, Protocol, Sequence, cast, runtime_checkable
@@ -17,6 +18,7 @@ from typing import Any, Protocol, Sequence, cast, runtime_checkable
 import duckdb
 
 from tokenjam.core.config import StorageConfig
+from tokenjam.core.data_span import MIN_PLAUSIBLE_YEAR
 from tokenjam.core.models import (
     AgentRecord,
     Alert,
@@ -126,7 +128,7 @@ class StorageBackend(Protocol):
         self, group_col: str, current_since: datetime, current_until: datetime,
         prev_since: datetime, prev_until: datetime, top_n: int,
     ) -> list[dict]: ...
-    def delete_spans_before(self, cutoff: datetime) -> int: ...
+    def delete_spans_before(self, cutoff: datetime) -> tuple[int, int]: ...
     def close(self) -> None: ...
 
 
@@ -149,7 +151,13 @@ CREATE TABLE IF NOT EXISTS spans (
     kind                TEXT NOT NULL,
     status_code         TEXT NOT NULL,
     status_message      TEXT,
-    start_time          TIMESTAMPTZ NOT NULL,
+    -- NULLABLE, deliberately (migration 21). A source timestamp that is missing
+    -- or unparseable writes NULL here, never an epoch sentinel: the row is kept
+    -- and can be counted, but it can never TIME anything, and every ordering,
+    -- range and day-union query excludes it for free under SQL NULL semantics.
+    -- A 1970 sentinel does the opposite — it participates in MIN() and drags a
+    -- span measure back by decades.
+    start_time          TIMESTAMPTZ,
     end_time            TIMESTAMPTZ,
     duration_ms         DOUBLE,
     attributes          JSON NOT NULL DEFAULT '{}',
@@ -182,6 +190,20 @@ SPANS_INDEXES: tuple[tuple[str, str], ...] = (
     ("idx_spans_start_time", "start_time"),
     ("idx_spans_tool_name",  "tool_name"),
     ("idx_spans_conv_id",    "conversation_id"),
+)
+
+# Secondary indexes on sessions. Single-sourced for the same reason as the spans
+# set above: DuckDB refuses to ALTER a column on a table carrying ART indexes, so
+# migration 21 has to drop and re-issue these, and a second copy of the DDL there
+# would be free to drift from the one the initial schema creates.
+SESSIONS_INDEXES: tuple[tuple[str, str], ...] = (
+    ("idx_sessions_agent_id", "agent_id"),
+    ("idx_sessions_conv_id",  "conversation_id"),
+)
+
+SESSIONS_INDEX_SQL = ";\n".join(
+    f"CREATE INDEX IF NOT EXISTS {name} ON sessions({column})"
+    for name, column in SESSIONS_INDEXES
 )
 
 SPANS_INDEX_SQL = ";\n".join(
@@ -341,7 +363,8 @@ CREATE TABLE IF NOT EXISTS sessions (
     session_id          TEXT PRIMARY KEY,
     agent_id            TEXT NOT NULL,
     conversation_id     TEXT,
-    started_at          TIMESTAMPTZ NOT NULL,
+    -- Nullable for the same reason as spans.start_time above (migration 21).
+    started_at          TIMESTAMPTZ,
     ended_at            TIMESTAMPTZ,
     status              TEXT NOT NULL DEFAULT 'active',
     total_cost_usd      DOUBLE,
@@ -398,12 +421,27 @@ CREATE TABLE IF NOT EXISTS schema_validations (
     errors          JSON DEFAULT '[]'
 );
 
-CREATE INDEX IF NOT EXISTS idx_sessions_agent_id  ON sessions(agent_id);
-CREATE INDEX IF NOT EXISTS idx_sessions_conv_id   ON sessions(conversation_id);
 CREATE INDEX IF NOT EXISTS idx_alerts_agent_id    ON alerts(agent_id);
 CREATE INDEX IF NOT EXISTS idx_alerts_fired_at    ON alerts(fired_at);
 """
+    + SESSIONS_INDEX_SQL
 )
+
+# The retention ledger's DDL, single-sourced so migration 20 and the
+# `EXPECTED_TABLES` self-heal below create the same table.
+RETENTION_EVENTS_TABLE_SQL = (
+    "CREATE TABLE IF NOT EXISTS retention_events (\n"
+    "    event_id            TEXT PRIMARY KEY,\n"
+    "    ran_at              TIMESTAMPTZ NOT NULL,\n"
+    "    cutoff              TIMESTAMPTZ NOT NULL,\n"
+    "    retention_days      INTEGER,\n"
+    "    analysis_span_days  INTEGER,\n"
+    "    spans_deleted       BIGINT NOT NULL DEFAULT 0,\n"
+    "    sessions_deleted    BIGINT NOT NULL DEFAULT 0,\n"
+    "    oldest_kept         TIMESTAMPTZ\n"
+    ")"
+)
+
 
 MIGRATIONS: list[tuple[int, str]] = [
     (1, INITIAL_SCHEMA_SQL),
@@ -666,6 +704,51 @@ MIGRATIONS: list[tuple[int, str]] = [
     # Populated by the backfill parser from the `agent-<id>.meta.json` sidecar;
     # `tj backfill --reingest` re-tags pre-column history.
     (19, "ALTER TABLE spans ADD COLUMN IF NOT EXISTS sub_agent_type TEXT"),
+    # Migration 20: the retention ledger. Deleting a user's own history and
+    # leaving no account of it is the fault this closes — the only way to learn
+    # that eight weeks of the oldest history had gone was to measure the store
+    # twice, days apart, and diff the two answers. One row per run of the
+    # retention job, written in the same transaction as the delete, so a
+    # deletion that happened always has a record and a record that exists always
+    # describes a deletion. `tj doctor` reads it; nothing else writes it.
+    (20, RETENTION_EVENTS_TABLE_SQL),
+    # Migration 21: unknown timestamps become NULL rather than a 1970 sentinel.
+    #
+    # Ingest stamped a zero epoch whenever a source carried no usable time —
+    # Claude Code's own OTel log exporter sends `timeUnixNano=0` on some
+    # records, and Codex's ISO fallback can fail to parse. A sentinel is not a
+    # neutral placeholder: it participates in `MIN()`, in `ORDER BY`, and in any
+    # day union, so ONE such row made a two-month corpus report a span in the
+    # thousands of days. `core/data_span.py` had to defend against it at READ
+    # time, which fixes the surfaces that remember to and no others.
+    #
+    # NULL is the honest representation and it defends itself: every comparison,
+    # range filter and aggregate excludes it under ordinary SQL semantics, with
+    # no per-query guard to forget. The rows are kept — they still carry tokens,
+    # cost and an agent — they simply cannot time anything.
+    #
+    # The existing sentinels are DELETED rather than migrated to NULL. A row
+    # whose only recorded fact was a false timestamp has nothing left to
+    # attribute once that is removed, and keeping it would leave a row that is
+    # counted by every COUNT(*) and placed by nothing.
+    #
+    # The index choreography is not optional: DuckDB refuses to ALTER a column
+    # on a table carrying ART indexes, so both index sets come off and go
+    # straight back on from the same constants the initial schema uses.
+    (21, (
+        "".join(
+            f"DROP INDEX IF EXISTS {name};\n"
+            for name, _ in SPANS_INDEXES + SESSIONS_INDEXES
+        )
+        + "ALTER TABLE spans ALTER COLUMN start_time DROP NOT NULL;\n"
+        + "ALTER TABLE sessions ALTER COLUMN started_at DROP NOT NULL;\n"
+        + f"DELETE FROM spans WHERE EXTRACT(year FROM start_time) "
+          f"< {MIN_PLAUSIBLE_YEAR};\n"
+        + f"DELETE FROM sessions WHERE EXTRACT(year FROM started_at) "
+          f"< {MIN_PLAUSIBLE_YEAR};\n"
+        + SPANS_INDEX_SQL + ";\n"
+        + SESSIONS_INDEX_SQL
+    )),
 ]
 
 
@@ -799,6 +882,8 @@ EXPECTED_TABLES: dict[str, str] = {
         "    created_at     TIMESTAMPTZ NOT NULL\n"
         ")"
     ),
+    # migration 20
+    "retention_events": RETENTION_EVENTS_TABLE_SQL,
 }
 
 
@@ -2979,14 +3064,78 @@ class DuckDBBackend:
             for r in rows
         ]
 
-    def delete_spans_before(self, cutoff: datetime) -> int:
-        result = self.conn.execute(
+    def delete_spans_before(self, cutoff: datetime) -> tuple[int, int]:
+        """Delete aged-out spans AND the session rows they leave behind.
+
+        Returns ``(spans deleted, sessions deleted)``.
+
+        Deleting only from ``spans`` used to leave the parent ``sessions`` rows
+        in place forever, and those rows are not inert: ``data_span`` unions
+        ``sessions.started_at`` into the day set it measures the available span
+        from, so every orphan went on asserting that a day carried data after
+        the data for that day had been destroyed. The deletion actively skewed
+        the measure of what survived it.
+
+        A session is removed only once it has NO spans left at all, which is
+        strictly narrower than "started before the cutoff": a long session
+        straddling the boundary keeps every span the cutoff spared, so deleting
+        it would discard live rows' parent. A pre-cutoff session that never had
+        spans goes too — it is aged-out history like any other, and leaving it
+        would let it keep asserting a day beyond the retention horizon.
+
+        Both statements and the ledger row run under one write lock so a reader
+        cannot observe spans gone with their sessions still present.
+        """
+        span_row = self.conn.execute(
             "SELECT COUNT(*) FROM spans WHERE start_time < $1", [cutoff]
         ).fetchone()
-        count = result[0] if result else 0
+        spans_deleted = int(span_row[0]) if span_row else 0
         with self._write_lock:
             self.conn.execute("DELETE FROM spans WHERE start_time < $1", [cutoff])
-        return count
+            orphan_row = self.conn.execute(
+                "SELECT COUNT(*) FROM sessions s WHERE s.started_at < $1 "
+                "AND NOT EXISTS (SELECT 1 FROM spans p WHERE p.session_id = s.session_id)",
+                [cutoff],
+            ).fetchone()
+            sessions_deleted = int(orphan_row[0]) if orphan_row else 0
+            self.conn.execute(
+                "DELETE FROM sessions s WHERE s.started_at < $1 "
+                "AND NOT EXISTS (SELECT 1 FROM spans p WHERE p.session_id = s.session_id)",
+                [cutoff],
+            )
+        return spans_deleted, sessions_deleted
+
+    def record_retention_event(
+        self,
+        *,
+        cutoff: datetime,
+        retention_days: int | None,
+        analysis_span_days: int | None,
+        spans_deleted: int,
+        sessions_deleted: int,
+    ) -> None:
+        """Append one row to the retention ledger.
+
+        The ledger exists because a deletion of the user's own history that
+        leaves no account of itself is only discoverable by measuring the store
+        twice, days apart, and diffing — which is how eight weeks of the oldest
+        history went missing unnoticed. `oldest_kept` is read AFTER the delete so
+        the row states what survived, not what was intended to.
+        """
+        oldest_row = self.conn.execute(
+            "SELECT MIN(start_time) FROM spans WHERE start_time IS NOT NULL"
+        ).fetchone()
+        with self._write_lock:
+            self.conn.execute(
+                "INSERT INTO retention_events (event_id, ran_at, cutoff, "
+                "retention_days, analysis_span_days, spans_deleted, "
+                "sessions_deleted, oldest_kept) VALUES ($1,$2,$3,$4,$5,$6,$7,$8)",
+                [
+                    str(uuid.uuid4()), utcnow(), cutoff, retention_days,
+                    analysis_span_days, spans_deleted, sessions_deleted,
+                    oldest_row[0] if oldest_row else None,
+                ],
+            )
 
     def close(self) -> None:
         # Closing the root connection tears down the database and all cursors.

--- a/tokenjam/core/ingest_adapters/codex.py
+++ b/tokenjam/core/ingest_adapters/codex.py
@@ -94,8 +94,11 @@ def _plan_tier_for_provider(config, provider: str) -> str:
 class ParsedCodexSession:
     session_id: str
     agent_id: str
-    started_at: datetime
-    ended_at: datetime
+    # Nullable: a session none of whose records carried a parseable timestamp is
+    # UNTIMED. Defaulting to `now` dated historical transcript work to whenever
+    # the backfill happened to run — see NormalizedSpan.start_time.
+    started_at: datetime | None
+    ended_at: datetime | None
     cwd: str | None
     spans: list[NormalizedSpan]
     total_input_tokens: int
@@ -247,7 +250,9 @@ def parse_codex_rollout(path: Path) -> ParsedCodexSession | None:
             turn_key = str(turn_index)
             span_id = _span_id_for_llm(sid, turn_key)
             trace_id = _trace_id_for(sid)
-            start_time = ts or datetime.now(tz=timezone.utc)
+            # Untimed rather than dated to the backfill run — see the same
+            # note in core/backfill.py.
+            start_time = ts
 
             # OpenAI automatic prompt caching: cached_input_tokens are read-hits
             # billed at the (lower) cache-read rate; there is no separate
@@ -300,7 +305,9 @@ def parse_codex_rollout(path: Path) -> ParsedCodexSession | None:
             )
             tool_span_id = _span_id_for_tool(sid, call_id)
             tool_name = payload.get("name") or "unknown"
-            start_time = ts or datetime.now(tz=timezone.utc)
+            # Untimed rather than dated to the backfill run — see the same
+            # note in core/backfill.py.
+            start_time = ts
             spans_by_id[tool_span_id] = NormalizedSpan(
                 span_id=tool_span_id,
                 trace_id=_trace_id_for(sid),
@@ -333,7 +340,8 @@ def parse_codex_rollout(path: Path) -> ParsedCodexSession | None:
         total_cache += s.cache_tokens or 0
         total_cost += s.cost_usd or 0.0
 
-    started_at = earliest or datetime.now(tz=timezone.utc)
+    # A session with no dated span at all is untimed, not "started now".
+    started_at = earliest
     ended_at = latest or started_at
 
     return ParsedCodexSession(
@@ -377,7 +385,11 @@ def iter_codex_sessions(
         parsed = parse_codex_rollout(jsonl_path)
         if parsed is None:
             continue
-        if since is not None and parsed.ended_at < since:
+        # An UNTIMED session is not known to be old, so a window may not drop
+        # it: the daemon's catch-up is windowed, so excluding it here would mean
+        # it is never ingested at all. Re-parsing it on every pass is cheap and
+        # idempotent (deterministic span ids), losing it is not.
+        if since is not None and parsed.ended_at is not None and parsed.ended_at < since:
             continue
         yield parsed
 

--- a/tokenjam/core/ingest_adapters/codex.py
+++ b/tokenjam/core/ingest_adapters/codex.py
@@ -94,11 +94,8 @@ def _plan_tier_for_provider(config, provider: str) -> str:
 class ParsedCodexSession:
     session_id: str
     agent_id: str
-    # Nullable: a session none of whose records carried a parseable timestamp is
-    # UNTIMED. Defaulting to `now` dated historical transcript work to whenever
-    # the backfill happened to run — see NormalizedSpan.start_time.
-    started_at: datetime | None
-    ended_at: datetime | None
+    started_at: datetime
+    ended_at: datetime
     cwd: str | None
     spans: list[NormalizedSpan]
     total_input_tokens: int
@@ -106,6 +103,8 @@ class ParsedCodexSession:
     total_cache_tokens: int
     total_cost_usd: float
     tool_call_count: int
+    # See ParsedSession.records_undated in core/backfill.py.
+    records_undated: int = 0
 
 
 # --- ID derivation helpers ---------------------------------------------------
@@ -174,6 +173,7 @@ def parse_codex_rollout(path: Path) -> ParsedCodexSession | None:
     current_model: str | None = None
     earliest: datetime | None = None
     latest: datetime | None = None
+    records_undated = 0
 
     # Deterministic dedup within the file. A rollout is append-only and never
     # replays a line, but keying by span_id keeps ingest idempotent across
@@ -204,6 +204,11 @@ def parse_codex_rollout(path: Path) -> ParsedCodexSession | None:
                 earliest = ts
             if latest is None or ts > latest:
                 latest = ts
+        # Note `ts` may still be None here: `session_meta` carries the cwd and
+        # session id and is read regardless. Only the SPAN-producing branches
+        # below require an observed time, and each declines without one rather
+        # than substituting `now` — which would date months-old rollout work to
+        # whenever the backfill ran. Same idiom as core/backfill.py.
 
         if rtype == "session_meta":
             # `session_id` on current builds; older/renamed builds carried the
@@ -245,13 +250,14 @@ def parse_codex_rollout(path: Path) -> ParsedCodexSession | None:
             if input_tokens == 0 and output_total == 0 and cached == 0:
                 continue
 
+            if ts is None:
+                records_undated += 1
+                continue
             sid = session_id or path.stem
             turn_index += 1
             turn_key = str(turn_index)
             span_id = _span_id_for_llm(sid, turn_key)
             trace_id = _trace_id_for(sid)
-            # Untimed rather than dated to the backfill run — see the same
-            # note in core/backfill.py.
             start_time = ts
 
             # OpenAI automatic prompt caching: cached_input_tokens are read-hits
@@ -299,14 +305,15 @@ def parse_codex_rollout(path: Path) -> ParsedCodexSession | None:
             continue
 
         if rtype == "response_item" and payload.get("type") == "function_call":
+            if ts is None:
+                records_undated += 1
+                continue
             sid = session_id or path.stem
             call_id = payload.get("call_id") or _det_id(
                 "codex-tool-fallback", sid, str(line_no)
             )
             tool_span_id = _span_id_for_tool(sid, call_id)
             tool_name = payload.get("name") or "unknown"
-            # Untimed rather than dated to the backfill run — see the same
-            # note in core/backfill.py.
             start_time = ts
             spans_by_id[tool_span_id] = NormalizedSpan(
                 span_id=tool_span_id,
@@ -340,7 +347,10 @@ def parse_codex_rollout(path: Path) -> ParsedCodexSession | None:
         total_cache += s.cache_tokens or 0
         total_cost += s.cost_usd or 0.0
 
-    # A session with no dated span at all is untimed, not "started now".
+    if earliest is None:
+        # Every record in this rollout was undated, so there is no session to
+        # describe — returning one would invent both its start and its extent.
+        return None
     started_at = earliest
     ended_at = latest or started_at
 
@@ -356,6 +366,7 @@ def parse_codex_rollout(path: Path) -> ParsedCodexSession | None:
         total_cache_tokens=total_cache,
         total_cost_usd=round(total_cost, 8),
         tool_call_count=tool_count,
+        records_undated=records_undated,
     )
 
 
@@ -385,11 +396,7 @@ def iter_codex_sessions(
         parsed = parse_codex_rollout(jsonl_path)
         if parsed is None:
             continue
-        # An UNTIMED session is not known to be old, so a window may not drop
-        # it: the daemon's catch-up is windowed, so excluding it here would mean
-        # it is never ingested at all. Re-parsing it on every pass is cheap and
-        # idempotent (deterministic span ids), losing it is not.
-        if since is not None and parsed.ended_at is not None and parsed.ended_at < since:
+        if since is not None and parsed.ended_at < since:
             continue
         yield parsed
 

--- a/tokenjam/core/models.py
+++ b/tokenjam/core/models.py
@@ -63,13 +63,12 @@ class NormalizedSpan:
     name:           str
     kind:           SpanKind
     status_code:    SpanStatus
-    # None when the source carried no usable timestamp. NOT an epoch sentinel:
-    # a 1970 stamp participates in MIN(), ORDER BY and every day union, so one
-    # such row can stretch a two-month corpus's measured span by decades, while
-    # a NULL is excluded by ordinary SQL semantics with no per-query guard to
-    # forget. The row is kept and can be counted; it simply cannot time
-    # anything. Ingest paths must pass None rather than substituting a default.
-    start_time:     datetime | None
+    # Always a REAL observed instant. Ingest may neither substitute a default
+    # (a zero epoch drags every MIN() and day union back by decades; `now`
+    # silently dates historical work to whenever tj received it) nor leave it
+    # unset — a record with no observed time is rejected at the boundary
+    # instead. See `api/routes/logs.py` and `core/backfill.py`.
+    start_time:     datetime
     parent_span_id: str | None     = None
     session_id:     str | None     = None
     agent_id:       str | None     = None
@@ -173,9 +172,7 @@ class NormalizedSpan:
 class SessionRecord:
     session_id:      str
     agent_id:        str
-    # None when the first span attributed to this session carried no usable
-    # timestamp — same rule and same reason as NormalizedSpan.start_time above.
-    started_at:      datetime | None
+    started_at:      datetime
     conversation_id: str | None   = None
     ended_at:        datetime | None = None
     status:          str          = "active"

--- a/tokenjam/core/models.py
+++ b/tokenjam/core/models.py
@@ -63,7 +63,13 @@ class NormalizedSpan:
     name:           str
     kind:           SpanKind
     status_code:    SpanStatus
-    start_time:     datetime
+    # None when the source carried no usable timestamp. NOT an epoch sentinel:
+    # a 1970 stamp participates in MIN(), ORDER BY and every day union, so one
+    # such row can stretch a two-month corpus's measured span by decades, while
+    # a NULL is excluded by ordinary SQL semantics with no per-query guard to
+    # forget. The row is kept and can be counted; it simply cannot time
+    # anything. Ingest paths must pass None rather than substituting a default.
+    start_time:     datetime | None
     parent_span_id: str | None     = None
     session_id:     str | None     = None
     agent_id:       str | None     = None
@@ -167,7 +173,9 @@ class NormalizedSpan:
 class SessionRecord:
     session_id:      str
     agent_id:        str
-    started_at:      datetime
+    # None when the first span attributed to this session carried no usable
+    # timestamp — same rule and same reason as NormalizedSpan.start_time above.
+    started_at:      datetime | None
     conversation_id: str | None   = None
     ended_at:        datetime | None = None
     status:          str          = "active"

--- a/tokenjam/core/optimize/analyzers/relearn.py
+++ b/tokenjam/core/optimize/analyzers/relearn.py
@@ -70,6 +70,7 @@ from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any, Iterable, Sequence
 
+from tokenjam.core.analysis_span import retention_days_for, window_label_for
 from tokenjam.core import distill as distill_mod
 from tokenjam.core.method_spine import build_method_spine
 from tokenjam.core.optimize.clustering import group_by_key, mask_variables, recurring
@@ -84,6 +85,7 @@ from tokenjam.core.optimize.relearn_window import (
     RelearnWindowTotal,
     sum_windowed,
     window_days,
+    window_labels_including,
 )
 from tokenjam.core.optimize.types import AnalyzerContext
 from tokenjam.core.transcript import build_session_story, resolve_projects_root
@@ -2598,7 +2600,13 @@ def run(ctx: AnalyzerContext) -> None:
         optimize_cfg, "min_recurring_sessions", MIN_RECURRING_SESSIONS,
     )
     storage_cfg = getattr(ctx.config, "storage", None)
-    retention_days = getattr(storage_cfg, "retention_days", None)
+    # Resolved, never read off the field: `storage.retention_days` is now
+    # derived from the chosen analysis span and is None on a default config,
+    # which a raw read would take to mean "unbounded" — the opposite of what a
+    # 90-day span promises. See core/analysis_span.py.
+    retention_days = (
+        retention_days_for(storage_cfg) if storage_cfg is not None else None
+    )
     # The write budget's headroom comes from the `summarize` analyzer's own
     # measurement of the agent files these proposals would append to. It runs
     # ahead of relearn in ANALYZER_ORDER, so its finding is already on the
@@ -2611,6 +2619,10 @@ def run(ctx: AnalyzerContext) -> None:
     ctx.report.findings["relearn"] = compute_relearn_finding(
         ctx.conn, min_sessions=min_sessions,
         retention_days=retention_days,
+        # So the inbox's one window label always has a bucket on this side too.
+        window_labels=window_labels_including(
+            window_label_for(storage_cfg, ctx.conn)
+        ),
         projects_root=scope.projects_root,
         claude_home=scope.claude_home,
         distill_cache_dir=_distill_cache_dir(ctx.config),

--- a/tokenjam/core/optimize/cost_proposals.py
+++ b/tokenjam/core/optimize/cost_proposals.py
@@ -48,6 +48,9 @@ from dataclasses import asdict, dataclass, is_dataclass, replace
 from pathlib import Path
 from typing import Any, Callable
 
+from tokenjam.core.analysis_span import FALLBACK_WINDOW_DAYS as _FALLBACK_WINDOW_DAYS
+from tokenjam.core.analysis_span import window_days_for
+
 # House-style label strings. Kept verbatim on every cost proposal so no channel
 # can surface a savings figure without the honesty framing (Rule 14).
 COST_ESTIMATE_CONFIDENCE = "estimated"
@@ -2385,9 +2388,37 @@ def _resend_to_proposals(
     )]
 
 
-#: Default look-back for the daemon/CLI cost-proposal recompute. Matches the
-#: monthly framing the cost analyzers project against.
-DEFAULT_COST_WINDOW_DAYS = 30
+#: LAST RESORT ONLY — the look-back to use when neither the config nor the
+#: store can be consulted. It is not a default in the sense of "what a normal
+#: run uses"; ``cost_window_days_for`` below is that, and every production
+#: caller goes through it.
+#:
+#: A fixed 30 days was the whole look-back for as long as this was the default,
+#: and a rolling month is not history: a dead MCP server injected into hundreds
+#: of sessions with zero invocations did not begin costing money 30 days ago,
+#: and pricing it as though it did understates a past-tense figure by however
+#: long the behaviour actually ran. The basis is now the span the user chose at
+#: onboarding, bounded by what the store actually holds — the same span
+#: retention is derived from, so the figure can never claim a window whose data
+#: has been deleted.
+FALLBACK_COST_WINDOW_DAYS = _FALLBACK_WINDOW_DAYS
+
+
+def cost_window_days_for(config: Any, conn: Any) -> int:
+    """The span past-overspend may accumulate over.
+
+    Two independent bounds, and the honest answer is the smaller: the span the
+    user asked for (``storage.analysis_span``) and how far back this store's
+    oldest dated row actually sits. A 90-day choice over a store that has been
+    running a week is answerable for a week, and an "all available" choice is
+    exactly the measured history.
+
+    The arithmetic itself lives in ``core/analysis_span`` so relearn's
+    precomputed window vocabulary resolves the SAME number — the Review inbox
+    publishes one window label across both feeds, and two derivations of it
+    would be free to disagree.
+    """
+    return window_days_for(getattr(config, "storage", None), conn)
 
 
 #: Mirrors ``relearn_store``'s own ``_LOCK``/``_COMPUTING`` pair, kept local to
@@ -2418,7 +2449,7 @@ def recompute_cost_proposals(
     db: Any,
     config: Any,
     *,
-    window_days: int = DEFAULT_COST_WINDOW_DAYS,
+    window_days: int | None = None,
     agent_id: str | None = None,
 ) -> list[CostProposal]:
     """Build an ``OptimizeReport`` over the last ``window_days``, adapt the
@@ -2459,7 +2490,13 @@ def recompute_cost_proposals(
     _COST_COMPUTING.set()
     try:
         try:
-            effective_window_days = max(1, window_days)
+            # None means "derive it" — the normal path. An explicit value is
+            # a caller that already knows its own window (`tj optimize --since`),
+            # and is honoured as given.
+            effective_window_days = (
+                max(1, window_days) if window_days is not None
+                else cost_window_days_for(config, getattr(db, "conn", None))
+            )
             until = utcnow()
             since = until - timedelta(days=effective_window_days)
             conn = getattr(db, "conn", None)
@@ -2517,7 +2554,7 @@ def trigger_background_cost_recompute(
     backend_factory: Callable[[], Any],
     *,
     config: Any | None = None,
-    window_days: int = DEFAULT_COST_WINDOW_DAYS,
+    window_days: int | None = None,
 ) -> bool:
     """Fire-and-forget a cost-proposals recompute on a daemon thread — the
     Cost-advisories-tab equivalent of ``relearn_store.
@@ -2623,8 +2660,8 @@ def cost_proposals_from_report(
     (that helper's conservative default runs the other way — see its own
     docstring) — neither ever assumes ``"claude-code"``.
 
-    ``window_days`` (default 30 — ``DEFAULT_COST_WINDOW_DAYS``, matching the
-    daemon's own default look-back) is used for exactly ONE thing: sizing the
+    ``window_days`` (the resolved analysis span — see ``cost_window_days_for``)
+    is used for exactly ONE thing: sizing the
     write budget's per-month standing-cost comparison
     (``_write_budget_basis``). It never rescales a proposal's figure. Every
     card's ``past_overspend_usd``/``_tokens`` is its analyzer's own
@@ -2939,7 +2976,7 @@ def backfill_legacy_past_overspend_fields(proposal: dict[str, Any]) -> dict[str,
 def past_overspend_rollup(
     proposals: list[Any],
     *,
-    window_days: int = DEFAULT_COST_WINDOW_DAYS,
+    window_days: int = FALLBACK_COST_WINDOW_DAYS,
     excluded: dict[str, Any] | None = None,
 ) -> dict[str, Any]:
     """Sum ``past_overspend_usd``/``past_overspend_tokens`` across

--- a/tokenjam/core/optimize/inbox_contribution.py
+++ b/tokenjam/core/optimize/inbox_contribution.py
@@ -135,8 +135,11 @@ def headline_window_days(cached: Any) -> int:
     """The window the Review inbox headline is LABELLED with.
 
     Read from the cost block's own ``cost_window_days`` (the window the
-    stored cost figures were observed over), falling back to the recompute
-    default when a cache predates the key or carries a zero. EVERY surface
+    stored cost figures were observed over), which is where the resolved
+    analysis span lands — so the headline follows the span the user chose with
+    no derivation of its own. The constant is reached only when a cache predates
+    the key or carries a zero, and labels a figure nobody can now attribute to a
+    window. EVERY surface
     that builds the headline resolves it through this one function -- the
     web ``/relearn/cost-proposals`` and ``/relearn/proposals`` routes and the
     CLI's ``tj relearn cost-proposals`` alike -- so a row can never publish a
@@ -150,7 +153,7 @@ def headline_window_days(cached: Any) -> int:
         days = int(raw or 0)
     except (TypeError, ValueError):
         days = 0
-    return days or _cost_proposals_mod.DEFAULT_COST_WINDOW_DAYS
+    return days or _cost_proposals_mod.FALLBACK_COST_WINDOW_DAYS
 
 
 def exact_window_label(

--- a/tokenjam/core/optimize/relearn_store.py
+++ b/tokenjam/core/optimize/relearn_store.py
@@ -19,6 +19,7 @@ from datetime import datetime, timezone
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Callable
 
+from tokenjam.core.analysis_span import retention_days_for
 from tokenjam.core.optimize.analyzers.relearn import RelearnFinding, compute_relearn_finding
 
 if TYPE_CHECKING:
@@ -349,7 +350,9 @@ def recompute_now(
             distill_cache_dir=_distill_cache_dir_for(config),
             # The archive lane's horizon: what tokenjam kept, not what Claude
             # Code left on disk. See `compute_relearn_finding`.
-            retention_days=getattr(getattr(config, "storage", None), "retention_days", None),
+            retention_days=retention_days_for(
+                getattr(config, "storage", None)
+            ) if getattr(config, "storage", None) is not None else None,
         )
         # cache_path, when omitted, resolves via `config` (honors --config /
         # storage.path, and a :memory:/"" storage.path never falls through to

--- a/tokenjam/core/optimize/relearn_window.py
+++ b/tokenjam/core/optimize/relearn_window.py
@@ -61,6 +61,27 @@ from tokenjam.utils.time_parse import parse_since, utcnow
 #: nearest of these and the response says which was applied.
 RELEARN_WINDOW_LABELS: tuple[str, ...] = ("1h", "24h", "7d", "30d", "90d")
 
+
+def window_labels_including(label: str | None) -> tuple[str, ...]:
+    """The fixed vocabulary plus the resolved analysis span, deduplicated.
+
+    The Review inbox publishes ONE window label across both feeds, and the cost
+    side's window is the resolved analysis span (`core/analysis_span
+    .window_days_for`) rather than a member of the fixed vocabulary above. A
+    span that had no precomputed bucket here could never contribute a relearn
+    row to that headline — the exact-match lookup would find nothing and every
+    cluster would fall into the `excluded` channel — so the span joins the
+    vocabulary and the two sides meet.
+
+    Both sides derive the label from the same seam, but not in the same pass:
+    the detector runs on its own schedule, so a span that moves between runs
+    leaves the cache one recompute behind. That degrades honestly through the
+    existing `excluded` channel rather than mislabelling, and self-heals.
+    """
+    if not label or label in RELEARN_WINDOW_LABELS:
+        return RELEARN_WINDOW_LABELS
+    return RELEARN_WINDOW_LABELS + (label,)
+
 _LABEL_RE = re.compile(r"^(\d+)([mhd])$")
 _UNIT_DAYS = {"m": 1.0 / 1440.0, "h": 1.0 / 24.0, "d": 1.0}
 

--- a/tokenjam/core/retention.py
+++ b/tokenjam/core/retention.py
@@ -67,26 +67,17 @@ def run_retention_cleanup(db: StorageBackend, config: StorageConfig) -> Retentio
         )
 
     cutoff = utcnow() - timedelta(days=days)
-    spans_deleted, sessions_deleted = db.delete_spans_before(cutoff)
-
-    record = getattr(db, "record_retention_event", None)
-    if record is not None:
-        try:
-            record(
-                cutoff=cutoff,
-                retention_days=days,
-                analysis_span_days=analysis_span_days(config),
-                spans_deleted=spans_deleted,
-                sessions_deleted=sessions_deleted,
-            )
-        except Exception as exc:
-            # A ledger that cannot be written must not abort a delete that has
-            # already happened — that would leave the store trimmed AND the run
-            # reading as a failure. Logged at warning because an unrecorded
-            # deletion is the exact state this ledger exists to prevent.
-            logger.warning(
-                "retention ran but its ledger row could not be written: %s", exc,
-            )
+    # The deletes and their ledger row land in ONE transaction — see
+    # `delete_spans_before`. Not a detail: this job runs from an apscheduler
+    # cron inside an ad-hoc `tj serve`, so being killed mid-run is ordinary, and
+    # a completed delete with no trace is the exact failure the ledger exists to
+    # make impossible. Two sequential commits would deliver that guarantee only
+    # on the happy path, which is the path where nobody needs it.
+    spans_deleted, sessions_deleted = db.delete_spans_before(
+        cutoff,
+        retention_days=days,
+        analysis_span_days=analysis_span_days(config),
+    )
 
     if spans_deleted or sessions_deleted:
         logger.info(

--- a/tokenjam/core/retention.py
+++ b/tokenjam/core/retention.py
@@ -1,21 +1,100 @@
-"""Storage retention cleanup. Deletes spans older than config.retention_days."""
+"""Storage retention cleanup — deletion bounded by the span the user chose.
+
+Retention does not have an opinion of its own. The cutoff is derived from
+``storage.analysis_span`` through ``core/analysis_span.py``, so the job can
+never delete history that a claim the product is currently making depends on;
+an unbounded span disables the job outright. See that module for the derivation
+and the one-directional clamp.
+
+Every run leaves a row in ``retention_events`` — how far back it cut, how much
+it removed, and what the oldest surviving row is afterwards. Before that ledger
+the job's effect was observable only by measuring the store twice, days apart,
+and diffing the two answers, which is how eight weeks of the oldest history came
+to be gone before anyone noticed. The job also runs from an apscheduler cron
+inside ``tj serve``, so on a machine where the daemon starts ad hoc it fires
+only when one happens to be alive: enforcement is irregular by construction and
+the configured number is an upper bound on what is kept, never a rolling window.
+That is the other half of why the ledger records what a run DID rather than
+leaving it to be inferred from the setting.
+"""
 from __future__ import annotations
 
-from datetime import timedelta
+import logging
+from dataclasses import dataclass
+from datetime import datetime, timedelta
 from typing import TYPE_CHECKING
 
+from tokenjam.core.analysis_span import analysis_span_days, retention_days_for
 from tokenjam.utils.time_parse import utcnow
 
 if TYPE_CHECKING:
     from tokenjam.core.config import StorageConfig
     from tokenjam.core.db import StorageBackend
 
+logger = logging.getLogger(__name__)
 
-def run_retention_cleanup(db: StorageBackend, config: StorageConfig) -> int:
+
+@dataclass(frozen=True)
+class RetentionRun:
+    """What one run of the job did.
+
+    ``skipped_reason`` set means the job deleted nothing BY DESIGN — distinct
+    from a run that deleted nothing because there was nothing old enough, which
+    is a real run with zero counts.
     """
-    Delete spans older than config.retention_days.
-    Returns the number of spans deleted.
-    Called by the apscheduler background job in tj serve.
+    spans_deleted:    int
+    sessions_deleted: int
+    cutoff:           datetime | None
+    retention_days:   int | None
+    skipped_reason:   str | None = None
+
+
+def run_retention_cleanup(db: StorageBackend, config: StorageConfig) -> RetentionRun:
+    """Delete history that has aged out of the configured analysis span.
+
+    Called by the apscheduler background job in `tj serve`. That caller needs
+    nothing from the return value, but the shape is the point: a deletion of a
+    user's own history reports what it removed, rather than an opaque integer
+    nobody attributes to anything.
     """
-    cutoff = utcnow() - timedelta(days=config.retention_days)
-    return db.delete_spans_before(cutoff)
+    days = retention_days_for(config)
+    if days is None:
+        # An all-available span means every row is still inside what the product
+        # offers to analyze, so there is nothing this job may delete.
+        return RetentionRun(
+            spans_deleted=0, sessions_deleted=0, cutoff=None, retention_days=None,
+            skipped_reason="retention is disabled by an all-available analysis span",
+        )
+
+    cutoff = utcnow() - timedelta(days=days)
+    spans_deleted, sessions_deleted = db.delete_spans_before(cutoff)
+
+    record = getattr(db, "record_retention_event", None)
+    if record is not None:
+        try:
+            record(
+                cutoff=cutoff,
+                retention_days=days,
+                analysis_span_days=analysis_span_days(config),
+                spans_deleted=spans_deleted,
+                sessions_deleted=sessions_deleted,
+            )
+        except Exception as exc:
+            # A ledger that cannot be written must not abort a delete that has
+            # already happened — that would leave the store trimmed AND the run
+            # reading as a failure. Logged at warning because an unrecorded
+            # deletion is the exact state this ledger exists to prevent.
+            logger.warning(
+                "retention ran but its ledger row could not be written: %s", exc,
+            )
+
+    if spans_deleted or sessions_deleted:
+        logger.info(
+            "retention deleted %d span(s) and %d orphaned session(s) older than "
+            "%s (%d-day span)",
+            spans_deleted, sessions_deleted, cutoff.isoformat(), days,
+        )
+    return RetentionRun(
+        spans_deleted=spans_deleted, sessions_deleted=sessions_deleted,
+        cutoff=cutoff, retention_days=days,
+    )

--- a/tokenjam/otel/otlp_parsing.py
+++ b/tokenjam/otel/otlp_parsing.py
@@ -13,6 +13,7 @@ from __future__ import annotations
 from datetime import datetime, timezone
 from typing import Any
 
+from tokenjam.core.ingest import SpanRejectedError
 from tokenjam.core.models import NormalizedSpan, SpanKind, SpanStatus
 from tokenjam.otel.semconv import (
     GenAIAttributes,
@@ -104,17 +105,20 @@ def parse_otlp_span(raw: dict, resource_attrs: dict[str, Any]) -> NormalizedSpan
     # Parse timestamps (OTLP uses nanoseconds as strings)
     start_ns = int(raw.get("startTimeUnixNano", 0))
     end_ns = int(raw.get("endTimeUnixNano", 0))
-    # A span with no start timestamp is UNTIMED, and both plausible-looking
-    # substitutes are worse than saying so. `datetime.now()` — what this used
-    # to do — dates the row to when tj happened to receive it, which reads as a
-    # real observation and silently puts historical work in the present; a zero
-    # epoch dates it to 1970 and drags every MIN() and day union back with it.
-    # NULL is excluded by ordinary SQL semantics, so the span is still ingested
-    # and still counted, it just cannot time anything.
-    start_time = (
-        datetime.fromtimestamp(start_ns / 1e9, tz=timezone.utc)
-        if start_ns else None
-    )
+    # A span with no start timestamp is REJECTED, not repaired. Both
+    # plausible-looking substitutes are worse than declining it: the
+    # `datetime.now()` this used to do dates the row to when tj happened to
+    # receive it, which reads as a real observation and silently moves
+    # historical work into the present window, and a zero epoch dates it to 1970
+    # and drags every MIN() and day union back with it. Both callers already
+    # count rejections — `api/routes/spans.py` returns them in the 200 body, and
+    # `ingest_adapters/otlp.py` tallies `spans_rejected` — so declining is
+    # visible while a fabricated timestamp never was.
+    if not start_ns:
+        raise SpanRejectedError(
+            "span carries no startTimeUnixNano, so it has no observed time"
+        )
+    start_time = datetime.fromtimestamp(start_ns / 1e9, tz=timezone.utc)
     end_time = (
         datetime.fromtimestamp(end_ns / 1e9, tz=timezone.utc)
         if end_ns else None

--- a/tokenjam/otel/otlp_parsing.py
+++ b/tokenjam/otel/otlp_parsing.py
@@ -104,9 +104,16 @@ def parse_otlp_span(raw: dict, resource_attrs: dict[str, Any]) -> NormalizedSpan
     # Parse timestamps (OTLP uses nanoseconds as strings)
     start_ns = int(raw.get("startTimeUnixNano", 0))
     end_ns = int(raw.get("endTimeUnixNano", 0))
+    # A span with no start timestamp is UNTIMED, and both plausible-looking
+    # substitutes are worse than saying so. `datetime.now()` — what this used
+    # to do — dates the row to when tj happened to receive it, which reads as a
+    # real observation and silently puts historical work in the present; a zero
+    # epoch dates it to 1970 and drags every MIN() and day union back with it.
+    # NULL is excluded by ordinary SQL semantics, so the span is still ingested
+    # and still counted, it just cannot time anything.
     start_time = (
         datetime.fromtimestamp(start_ns / 1e9, tz=timezone.utc)
-        if start_ns else datetime.now(tz=timezone.utc)
+        if start_ns else None
     )
     end_time = (
         datetime.fromtimestamp(end_ns / 1e9, tz=timezone.utc)


### PR DESCRIPTION
Five defects that all reduce to the same thing: the product was not able to say, truthfully, how much history it holds or analyzes — and in one case it was deleting that history underneath its own claims.

The evidence that started this was a diff of one live store across two days. The earliest `spans.start_time` moved forward by roughly **eight weeks** while new rows kept arriving, so total row counts went **up** and nothing looked wrong. Retention had eaten the oldest history the analyzers were still sizing their window against, and the only way to see it at all was to measure twice, days apart, and subtract.

## Summary

- One user-chosen **analysis span** now drives retention, the past-overspend window, and what is kept. Retention is derived from the promise instead of sitting beside it.
- Retention takes the session rows it orphans, and writes a durable ledger row for every run — in the same transaction as the delete, so a completed delete can never have no trace.
- Past-overspend accumulates over that span rather than a fixed 30 days.
- Ingest can no longer invent a timestamp it never observed — on any path, in either direction. Records with no observed time are rejected and counted, not stored with a placeholder.
- `tj doctor` fails on a damaged secondary index on `spans`, which it previously could not see.
- The day-span tests no longer go red for part of every day, and the production bug behind that is fixed.

---

## 1. Retention was destroying the history the product analyzes

`retention_days` decided what was **kept**. A separate constant decided what the analyzers **looked at**. Nothing tied either to what the product **told the user** it was analyzing, so all three were free to disagree — and they did.

**`storage.analysis_span`** is now the single choice, made once at onboarding: `"30d"`, `"90d"`, or `"all"`. Everything else derives from it (`core/analysis_span.py`), and `"all"` disables deletion outright. Because the thing that decides what to delete is downstream of the thing that decides what to promise, a deletion can no longer remove history the product is still offering to analyze.

The invariant is **one-directional and enforced in code**, not documented: an explicit `retention_days` shorter than the span is **raised to the span** rather than honoured. Lowering a storage setting must not be able to silently retract a span already promised. Keeping *more* than you analyze is left alone — it costs disk and misleads nobody. The clamp lives in `retention_days_for()`, so it applies to a hand-edited config too, not only to one written by `tj onboard`.

**Backwards compatible by reading, not by migration.** A config that sets `retention_days` and nothing else — every config written before this existed — has that value read *as* its span. What such a user kept is the most the product could ever have analyzed, so nothing about their setup changes. `tj onboard` asks the question; `--analysis-span` skips it.

### The delete no longer skews the measure of what survived it

`delete_spans_before` removed only `spans`, leaving parent `sessions` rows behind forever. Those rows are not inert: `data_span` unions `sessions.started_at` into the day set it derives the available span from, so **every orphan went on asserting that a day carried data after that day's data was destroyed**. The deletion corrupted the measure of its own aftermath. Sessions left with no spans at all now go with them; a session straddling the cutoff that still has live spans stays.

### Deletion is observable after the fact

Every run writes a `retention_events` row (migration 20): cutoff, both counts, and the oldest row still standing. **The counts come from the DELETEs' own affected-row counts**, never a preceding `COUNT(*)` — an ingest committing an aged-out span between a count and the delete would otherwise have that span destroyed while the ledger persisted the smaller, earlier number, so the figure has to be what this transaction removed rather than what it expected to. `oldest_kept` is read after the deletes (visible within the transaction), so it states what survived rather than what was intended.

**The deletes and the ledger row are one transaction.** Two sequential commits would leave a window where a process killed in between destroys history permanently with no record of it, and this job runs from an apscheduler cron inside an ad-hoc `tj serve`, so being killed mid-run is ordinary rather than exotic. A ledger a crash can skip delivers "observable after the fact" only on the happy path, which is the path where nobody needs it — so either both land or neither does, and a ledger write that fails takes the delete down with it. (This inverts an earlier decision on the branch, which kept the delete and logged a warning.) The regression test stages a failing ledger write and asserts the spans are still present; verified red against a sequential-commit version of the same code before landing green. `tj doctor` surfaces the span, the retention, whether the clamp fired, and the last run.

Worth knowing when reading this code: the job runs from an apscheduler cron inside `tj serve`, so on a machine where the daemon starts ad hoc it fires only when one happens to be alive. **Enforcement is irregular by construction** — the configured number is an upper bound on what is kept, never a rolling window. That is the other half of why the ledger records what a run *did*.

## 2. Past-overspend was bounded by a fixed 30 days

A rolling month is not history. A dead MCP server injected into hundreds of sessions with zero invocations did not begin costing money 30 days ago, and pricing it as though it did understates a past-tense figure by however long the behaviour actually ran.

The window is now the chosen span bounded by how far back this store's oldest dated row sits. Two details that are easy to get backwards:

- **Measured from today, not from the newest row.** A window is subtracted from `utcnow()`, so a store whose last activity was two days ago still needs a lookback reaching past those idle days to see anything at all.
- **Read off the full extent, not the recent unbroken run.** Bounding by `available_days` would discard everything behind a gap — a fortnight away would silently delete the quarter before it from a past-tense figure. `DataSpan` grows an `oldest` field for exactly this, and the two measures are documented as non-interchangeable: clamp a *selector* against `available_days`, size a *lookback* against `oldest`.

The constant survives only as a last resort for an unreadable store under an unbounded choice, and is renamed `FALLBACK_COST_WINDOW_DAYS` to say so. `relearn` precomputes a bucket for the resolved span too, so the Review inbox still publishes **one** window label across both feeds rather than dropping every relearn row into the excluded channel.

## 3. Ingest could invent a timestamp it never observed

`core/data_span.py` already defended against `1970-01-01` at read time. That protects the surfaces that remember to, and no others — the next aggregate anyone writes with a naive `MIN(start_time)` is wrong again on the first try.

**Both columns stay `NOT NULL`, and a record with no observed time is rejected at the boundary.** A nullable column was the first thing tried and it is the wrong trade: `MIN`/`MAX` are NULL-safe by SQL semantics, but roughly twenty-five `ORDER BY start_time` / `ORDER BY started_at` sites are not, and DuckDB's null placement is a *session setting* (`default_null_order`) rather than a property of the query. Two of those are sharp — `get_active_session` and `get_session_by_conversation` both resolve a session with `ORDER BY started_at DESC LIMIT 1`, so a null-started row could win and mis-attribute every subsequent span to it. That bought a schema migration plus that audit in exchange for retaining rows that can never time anything.

Rejecting is also the idiom this repo already used, in `ingest_adapters/langfuse.py` and `helicone.py`: a record that cannot say when it happened is declined, and the decline is **counted** — no path here drops one in silence.

Four producers, in both directions:

- **`api/routes/logs.py`** — the sentinel's only real producer. Claude Code's own OTel log exporter omits `timeUnixNano` on some records, and Codex sets it to 0 and puts the real time in `event.timestamp`, which can itself be absent or unparseable. `_observed_timestamp_ns` raises `SpanRejectedError` rather than letting a surviving zero become 1970. It also moves both reads **inside** the per-record guard: a malformed `timeUnixNano` (`ValueError`) or a non-string `event.timestamp` (`AttributeError` from `.rstrip`) previously escaped the loop and failed the whole export batch with a 500, so one bad record discarded every good one beside it.
- **`otel/otlp_parsing.py`** — raises instead of substituting `datetime.now()`. Both callers already count rejections (the route returns them in its 200 body; the backfill adapter tallies `spans_rejected`), so declining is visible where a fabricated timestamp never was.
- **`core/backfill.py` and `ingest_adapters/codex.py`** — the same `now` substitution on both span and session. **This is the harder half to spot:** a 1970 row looks wrong on sight, a row dated today looks like an observation. It quietly moved months-old spend into the present window on every backfill run. Undated records are now skipped and reported as `records_undated`; a transcript with no dated record at all yields no session, since returning one would invent both its start and its extent.

The legitimately synthetic self-observation spans (`proxy/audit.py`, `proxy/stream_usage.py`, `sdk/integrations/nemoclaw.py`) are untouched — there `now` **is** the observed time.

### Sessions can now heal instead of accumulating bad timestamps

`upsert_session`'s `ON CONFLICT DO UPDATE` set list never assigned `started_at`, making it **write-once**: whatever the first span to reach a session stamped was permanent, and since only `ended_at` ever advanced, a session opened by an out-of-order or mis-stamped span stayed wrong forever. That is the mechanism by which a corpus accumulates bad session timestamps rather than correcting them. It now takes the minimum — a genuinely earlier span lowers it, a later one cannot push it forward.

### Cleaning up what an older build already wrote

Offered through `tj doctor` rather than a SQL snippet in a PR description: a warning naming the count per table, and a `--repair` action that deletes the rows and reports how many. Verified end to end on a real store (clean → inject → warn → repair → clean). **Deleted rather than corrected** because there is nothing to correct *to*: a row whose only recorded fact about time was false has no other evidence of when it happened, and keeping it would leave a row every `COUNT(*)` counts and nothing can place on a calendar.

## 4. `tj doctor` could not see the index corruption that aborts deletes

The column-statistics check asks exactly one question — is `trace_id`'s row-group statistics fast-path lying — and reports "Column statistics are consistent" for a `spans` table whose five secondary indexes have been **destroyed outright**. A previously observed corruption aborted a delete part-way through (`Only deleted 576 out of 858 rows`) on a 1.19 GB corpus with doctor green before and after.

That is not a degraded read path. DuckDB maintains every index inside the deleting transaction, so retention's `DELETE FROM spans WHERE start_time < ?` can stop mid-statement and leave the extent of a deletion of the user's own history **unknowable afterwards**. Hence an **error** (exit 2), not a warning — and load-bearing for §1 rather than cosmetic.

`check_spans_index_corruption` reports two independent faults with one remedy: an index absent from the catalogue (what a data-only table rebuild leaves behind, since migrations are already recorded applied and nothing puts them back), and an index answering a point lookup with fewer rows than the table holds. `tj doctor --repair` rebuilds them from the table without moving a row, and says so explicitly when the damage turns out to be below the index layer rather than reporting a repair that did not take.

The index list is single-sourced as `SPANS_INDEXES` with the DDL derived from it, so an index added to the schema is probed with no second edit — pinned by a test that drops every declared index and expects every one back.

## 5. The day-span tests were red for part of every day

Not ordinary flake. Reliably red for hours, green for the rest, which trains people to ignore a red suite and tells whoever sees CI next that their own change broke it.

**The root cause is a production bug, not a test bug.** `available_data_span()` grouped rows with a bare `CAST(ts AS DATE)`. DuckDB resolves that through the session timezone before truncating, so on a machine running ahead of UTC the newest rows came back stamped with *tomorrow's* date — and `_plausible_days`, which drops anything later than the UTC date, deleted them. On a `+05:30` machine the whole of today vanished from the served span between 18:30 local and midnight, then reappeared, with no data change behind it. Critical Rule 1 already names the correct cast; the module had the wrong half of it.

The two failing assertions were the visible symptom. Their fixtures seeded rows at offsets from `utcnow()` and are now pinned to noon UTC — the instant furthest from both boundaries — so the day a row belongs to is fixed however late and wherever the suite runs. Sibling tests were swept for the same pattern; the pure `data_span_from_days` cases already used fixed dates.

## Tests / Verification

New: `tests/unit/test_analysis_span_retention.py` (46 tests — span derivation, the one-directional clamp, back-compat, the cascade, the ledger's atomicity and count accuracy, the cost window, the doctor surface, the onboarding coupling), `tests/unit/test_no_sentinel_timestamps.py` (22 tests — every write path, the batch-level rejection accounting, the session self-heal, and the doctor cleanup), `tests/unit/test_doctor_spans_indexes.py` (including that the statistics check is blind to this fault, and that doctor's exit code actually reflects it).

Modified: `tests/integration/test_db.py` (cascade semantics), `tests/unit/test_relearn_window.py` (a parametrized timezone test that was red before the fix), `tests/integration/test_relearn_window_api.py`, plus fixture updates where a fixture was incidentally staging a second fault.

```
$ env -u FORCE_COLOR pytest tests/unit tests/integration tests/synthetic tests/agents -q -p no:randomly
4873 passed, 7 skipped in 276.86s
```

`ruff check tokenjam/` and `mypy tokenjam/` both clean (239 files). End-to-end smoke: `tj onboard --analysis-span 30d` writes the span and `tj doctor` reports `Analyzing 30d, so history is kept for 30 days`.

## What's NOT in this PR

- **Analyzers calling `get_rates()` without `at=`**, pricing every span at today's rate. Independently shippable, but **this PR makes it bite harder**: lengthening the analysis span from a fixed 30 days to up to 90 (or unbounded) widens the period over which historical spans are mispriced at the current rate. Worth prioritising accordingly.
- **`cache_efficacy` pricing a whole-window aggregate at one instant** — same reasoning, same escalation.
- **The ~25 `ORDER BY start_time` sites.** Left alone deliberately: with both columns `NOT NULL` there is no null to order, so the audit the nullable design would have required is not needed. Noting it because the finding is real and would matter again if anyone revisits nullability.
- **UI surfacing of the retention ledger.** `tj doctor` reads it; the Lens has no panel for it. The ledger is durable and queryable, so this is additive whenever it is wanted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


