### PR TITLE
Run static CI checks once (#652)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,6 +23,25 @@ jobs:
             exit 1
           fi
 
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python 3.12
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Install dependencies
+        run: pip install -e ".[dev]"
+
+      - name: Lint
+        run: ruff check tokenjam/
+
+      - name: Type check
+        run: mypy tokenjam/
+
   test:
     runs-on: ubuntu-latest
     strategy:
@@ -39,12 +58,6 @@ jobs:
 
       - name: Install dependencies
         run: pip install -e ".[dev,mcp]"
-
-      - name: Lint
-        run: ruff check tokenjam/
-
-      - name: Type check
-        run: mypy tokenjam/
 
       - name: Run tests
         run: pytest tests/unit/ tests/synthetic/ tests/agents/ tests/integration/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -476,8 +476,9 @@ The packaged table stays the zero-config default — the override is a *layer*, 
 ## CI
 
 GitHub Actions workflow at `.github/workflows/ci.yml` runs on push/PR to `main`:
-- **`test`** job: Python 3.10/3.11/3.12 matrix — `ruff check` and `mypy` (continue-on-error), then `pytest tests/unit/ tests/synthetic/ tests/agents/ tests/integration/` (blocking)
-- **`test-ts`** job: Node 20 — `npm install && npm test` in `sdk-ts/`
+- **`lint`** job: Python 3.12 — `ruff check tokenjam/` and `mypy tokenjam/`
+- **`test`** job: Python 3.10/3.11/3.12 matrix — `pytest tests/unit/ tests/synthetic/ tests/agents/ tests/integration/`
+- **`test-ts`** job: Node 22 — `npm install && npm test` in `sdk-ts/`
 
 All steps are blocking — lint, typecheck, and tests must pass for CI to go green.
 


### PR DESCRIPTION
## Summary

Moves repository-wide linting and type checking out of the Python-version test matrix so those static checks run once per pull request.

## Why

The existing matrix repeats identical Ruff and mypy work for every supported Python version. Keeping version-specific test execution in the matrix while running static analysis once reduces redundant CI work without reducing coverage.

## What changed

- Add a dedicated Python 3.12 `lint` job for Ruff and mypy.
- Remove duplicate lint and type-check steps from the test matrix.
- Keep all version-specific tests in the existing matrix.
- Update the CI documentation in `CLAUDE.md` to reflect the workflow.

## Testing

- Parsed `.github/workflows/ci.yml` with PyYAML.
- Asserted that the lint job contains Ruff and mypy exactly once and the test matrix no longer contains those steps.
- Reviewed the workflow and documentation diff.

## What’s NOT in this PR

- No changes to the supported Python matrix.
- No changes to package code or test behavior.
- No changes to coverage reporting.

Closes #652

@anilmurty, review would be appreciated.

AI disclosure: This contribution was prepared with OpenAI Codex. I reviewed the complete diff and verified the resulting workflow structure.
