### PR TITLE
chore: bump version to 0.6.4

### DIFF
--- a/npm-wrapper/package.json
+++ b/npm-wrapper/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tokenjam",
-  "version": "0.6.3",
+  "version": "0.6.4",
   "description": "Zero-install launcher for TokenJam (tj): npx tokenjam runs the Python CLI via uvx/pipx and reports the recurring mistakes your AI agent keeps repeating, no setup required.",
   "keywords": ["claude-code", "ccusage", "tokens", "cost-optimization", "llm", "agents", "observability", "tokenjam", "anthropic", "claude", "token-usage", "agent-behavior", "cli", "statusline", "opentelemetry", "agent-observability"],
   "homepage": "https://tokenjam.dev",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "tokenjam"
-version = "0.6.3"
+version = "0.6.4"
 description = "TokenJam: a local-first, OTel-native cost-saving utility for AI agents"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/sdk-ts/package.json
+++ b/sdk-ts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tokenjam/sdk",
-  "version": "0.6.3",
+  "version": "0.6.4",
   "description": "TypeScript SDK for TokenJam — local-first observability for AI agents",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",


### PR DESCRIPTION
Lockstep version bump to 0.6.4 via `scripts/release.sh`: `pyproject.toml`, `sdk-ts/package.json`, `npm-wrapper/package.json`.

Only straggler flagged by the script is `tests/unit/test_scan_bar_truth.py`, where the old version appears as arbitrary fixture data for the build-qualifier logic, not as a lockstep reference. No bump needed there.

Merge, then cut `v0.6.4` to trigger the PyPI + npm publish workflows.