### PR TITLE
test: fix flaky relearn never_run test (process-global compute flag leak)

### DIFF
--- a/tests/integration/test_relearn_api.py
+++ b/tests/integration/test_relearn_api.py
@@ -26,6 +26,26 @@ from tokenjam.core.optimize import relearn_apply as pa
 from tests.factories import make_session
 
 
+@pytest.fixture(autouse=True)
+def _quiescent_relearn_computing_flag():
+    """Isolate each test from the process-global ``relearn`` compute flag.
+
+    ``report_store.is_computing()`` reads a module-level ``threading.Event``
+    (``_COMPUTING``). An earlier test that triggers a background recompute sets
+    it and does not join the worker thread, so whether the event is still set
+    when a later test runs depends on thread scheduling — which is exactly why
+    ``test_relearn_proposals_carries_persona_when_never_run`` flaked on one
+    matrix leg (``computing``) while the others saw ``never_run``. Clear it
+    around every test so each starts from a quiescent store. Test-isolation
+    only; it changes no production behavior.
+    """
+    from tokenjam.core.optimize.report_store import _COMPUTING
+
+    _COMPUTING.clear()
+    yield
+    _COMPUTING.clear()
+
+
 @pytest.fixture
 def db():
     backend = InMemoryBackend()


### PR DESCRIPTION
## Symptom
`main` went red on the #661 merge commit — `test (3.12)` failed with:

```
tests/integration/test_relearn_api.py::test_relearn_proposals_carries_persona_when_never_run
AssertionError: assert 'computing' == 'never_run'
```

1 failed, 5059 passed. **#661 is innocent** — it changed only CI YAML (moved ruff/mypy to a `lint` job), no Python. 3.10 and 3.11 passed on the *same* commit; only 3.12 failed.

## Root cause
`report_store.is_computing()` reads a module-level `threading.Event` (`_COMPUTING`). An earlier test triggers a background recompute that sets it and doesn't join the worker thread. Whether the event is still set when the `never_run` test runs is a **thread-scheduling race** — a classic order/timing flake. The proposals route only *reads* status (never computes on a request), so the test itself never sets the flag; it inherits it.

## Fix
An autouse fixture clears `_COMPUTING` around every test in `test_relearn_api.py`, so each starts from a quiescent store. Test-isolation only — no production code changes.

## Verification
- `pytest tests/integration/test_relearn_api.py` on 3.12 → **34 passed**.
- The `never_run` test is now deterministic: the flag is cleared pre-test and the route doesn't set it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)