### PR TITLE
Bump version to 0.6.5

### DIFF
--- a/npm-wrapper/package.json
+++ b/npm-wrapper/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tokenjam",
-  "version": "0.6.4",
+  "version": "0.6.5",
   "description": "Zero-install launcher for TokenJam (tj): npx tokenjam runs the Python CLI via uvx/pipx and reports the recurring mistakes your AI agent keeps repeating, no setup required.",
   "keywords": ["claude-code", "ccusage", "tokens", "cost-optimization", "llm", "agents", "observability", "tokenjam", "anthropic", "claude", "token-usage", "agent-behavior", "cli", "statusline", "opentelemetry", "agent-observability"],
   "homepage": "https://tokenjam.dev",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "tokenjam"
-version = "0.6.4"
+version = "0.6.5"
 description = "TokenJam: a local-first, OTel-native cost-saving utility for AI agents"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/sdk-ts/package.json
+++ b/sdk-ts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tokenjam/sdk",
-  "version": "0.6.4",
+  "version": "0.6.5",
   "description": "TypeScript SDK for TokenJam — local-first observability for AI agents",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",


### PR DESCRIPTION
Release cut for **0.6.5** — a Lens (web UI) polish release. No analyzer/back-end logic changes.

## Highlights
- **Lens IA + polish (#665):** persona-consistent navigation, Optimize split into a summary landing + per-analyzer detail pages, the fix-apply lifecycle moved onto those detail pages, and a decluttered Dashboard.
- **Sessions page cleanup (#667):** consistent bare persona dropdown beside the page title (Dashboard / Optimize / Sessions), a single "Sessions" heading, an Agent column + trimmed status chrome on the archived table, single-trace sessions render their span waterfall inline, and reordered detail tabs (Traces first) with the inert "Evidence" label removed.
- **Onboarding trim (#666):** shorter Claude Code post-onboard output.

## Verification
- All three version files bumped (pyproject.toml, sdk-ts/package.json, npm-wrapper/package.json); no stragglers.
- 0.6.5 confirmed free on PyPI + npm.
- Pre-release QA (isolated venv + copied DB upgrade path) + main CI green — see below.

🤖 Generated with [Claude Code](https://claude.com/claude-code)