### PR TITLE
fix(tokenmaxx): state the overhead/work percentages once, not three times

### DIFF
--- a/tokenjam/cli/cmd_tokenmaxx.py
+++ b/tokenjam/cli/cmd_tokenmaxx.py
@@ -233,9 +233,14 @@ def _render(
     # ── Action line — what you can reclaim, never a guaranteed saving. ──
     action = Text("💡 ")
     if diag.compact_candidates:
-        # The share isn't repeated here (#672): the reclaimable overhead sits
-        # in these compactable sessions — reference it, don't restate the %.
-        action.append("That overhead sits in ")
+        # Show the RECLAIMABLE figure — the overhead that actually sits in the
+        # compactable sessions — not the window-wide total. These sessions are a
+        # threshold-filtered, capped subset, so "that overhead" (the headline %)
+        # would overstate how much is here (Greptile, #672). This is a distinct,
+        # actionable number, not a restatement of the composition block above.
+        reclaimable = sum(c.reread_tokens for c in diag.compact_candidates)
+        action.append(_quota_share(reclaimable, framing), style="bold")
+        action.append(" sits in ")
         action.append(f"{len(diag.compact_candidates)}", style="bold")
         action.append(" compactable session"
                       f"{'s' if len(diag.compact_candidates) != 1 else ''}. Run ")

--- a/tokenjam/cli/cmd_tokenmaxx.py
+++ b/tokenjam/cli/cmd_tokenmaxx.py
@@ -143,10 +143,6 @@ def cmd_tokenmaxx(ctx: click.Context, agent: str | None, since: str,
 
 # ───────────────────────────── helpers ────────────────────────────────────
 
-def _pct(value: float) -> str:
-    return f"{value * 100:.1f}%"
-
-
 def _quota_share(tokens: int, framing: Framing) -> str:
     """Render a token figure as a quota share on a subscription plan.
 
@@ -200,26 +196,28 @@ def _render(
     quip_text = _highlight_commands(tier.quip)
 
     # ── Composition block — overhead vs real work, quota-framed. ──
+    # Each share is stated ONCE, with its token count folded into the prose
+    # (subscription → "X% of cycle tokens" via _quota_share; else raw share).
+    # The parenthetical carries the measured token counts the old separate
+    # breakdown block used to duplicate (#672).
     body = Text()
-    body.append(f"{_pct(overhead_share)} ", style="bold red")
-    body.append("of your quota went to ")
+    body.append(_quota_share(diag.total_reread_tokens, framing), style="bold red")
+    body.append(" went to ")
     body.append("overhead", style="bold")
-    body.append(" — re-reading history, CLAUDE.md, tool output.", style="dim")
+    body.append(
+        f" — re-reading history, CLAUDE.md, tool output "
+        f"({format_tokens(diag.total_reread_tokens)} cache reads).",
+        style="dim",
+    )
     body.append("\n")
-    body.append(f"{_pct(work_share)} ", style="bold green")
-    body.append("did ")
+    body.append(_quota_share(diag.total_work_tokens, framing), style="bold green")
+    body.append(" did ")
     body.append("real work", style="bold")
-    body.append(" — uncached input + output.", style="dim")
-
-    # Quota-native breakdown (subscription → "% of cycle"; else token counts).
-    body.append("\n\nOverhead:  ", style="dim")
-    body.append(_quota_share(diag.total_reread_tokens, framing), style="bold")
-    body.append(f"  ({format_tokens(diag.total_reread_tokens)} cache reads)",
-                style="dim")
-    body.append("\nReal work: ", style="dim")
-    body.append(_quota_share(diag.total_work_tokens, framing), style="bold")
-    body.append(f"  ({format_tokens(diag.total_work_tokens)} tokens)",
-                style="dim")
+    body.append(
+        f" — uncached input + output "
+        f"({format_tokens(diag.total_work_tokens)} tokens).",
+        style="dim",
+    )
     body.append(
         f"\n\nAcross {diag.sessions} sessions, {diag.turns} turns ({window_label}).",
         style="dim",
@@ -235,9 +233,9 @@ def _render(
     # ── Action line — what you can reclaim, never a guaranteed saving. ──
     action = Text("💡 ")
     if diag.compact_candidates:
-        reclaimable = sum(c.reread_tokens for c in diag.compact_candidates)
-        action.append(_quota_share(reclaimable, framing), style="bold")
-        action.append(" sits in ")
+        # The share isn't repeated here (#672): the reclaimable overhead sits
+        # in these compactable sessions — reference it, don't restate the %.
+        action.append("That overhead sits in ")
         action.append(f"{len(diag.compact_candidates)}", style="bold")
         action.append(" compactable session"
                       f"{'s' if len(diag.compact_candidates) != 1 else ''}. Run ")


### PR DESCRIPTION
The `tj tokenmaxx` quota/efficiency card printed the same overhead and real-work percentages more than once — the prose pair, a separate "Overhead:/Real work:" breakdown pair, and a third mention on the action line. On a real card `97.1%` appeared three times and `0.4%` twice. Once each is enough for a card meant to be a clean, screenshottable summary.

## Summary
- Fold the measured token counts (cache reads / tokens) into the prose pair as a parenthetical and drop the redundant breakdown block, so each share is stated exactly once.
- Reword the action line to reference "That overhead sits in N compactable sessions…" instead of restating the share a third time.
- Remove the now-unused `_pct` helper.

## Detail
The two adjacent blocks in `cmd_tokenmaxx.py` `_render()` each carried the same figures; the only thing the second block added was the token counts. The prose lines now render through `_quota_share`, so the plan-tier framing behavior is preserved: subscription users still see "X% of cycle tokens", and api/local/unknown users see the raw token count — the same distinction the dropped block used to carry. The parenthetical `(N cache reads)` / `(N tokens)` keeps the measured token detail. Honesty wording (measured shares, never a guaranteed saving) is untouched.

## Tests / Verification
- `tests/unit/test_cmd_tokenmaxx.py`, `tests/integration/test_tokenmaxx_serve.py`, `tests/unit/test_cli_palette.py` — all pass (38 passed). No test asserted the old duplicated breakdown lines, so no test edits were needed; the existing assertions on "% of cycle tokens", "overhead", "real work", "reclaim", "tj context" and the plan-tier dollar suppression all still hold.
- `ruff check tokenjam/` clean, `mypy tokenjam/cli/cmd_tokenmaxx.py` clean.
- `tests/integration/test_global_json_flag.py` passes (JSON payload unchanged).

Closes #672