### PR TITLE
Bump version to 0.6.6

### DIFF
--- a/npm-wrapper/package.json
+++ b/npm-wrapper/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tokenjam",
-  "version": "0.6.5",
+  "version": "0.6.6",
   "description": "Zero-install launcher for TokenJam (tj): npx tokenjam runs the Python CLI via uvx/pipx and reports the recurring mistakes your AI agent keeps repeating, no setup required.",
   "keywords": ["claude-code", "ccusage", "tokens", "cost-optimization", "llm", "agents", "observability", "tokenjam", "anthropic", "claude", "token-usage", "agent-behavior", "cli", "statusline", "opentelemetry", "agent-observability"],
   "homepage": "https://tokenjam.dev",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "tokenjam"
-version = "0.6.5"
+version = "0.6.6"
 description = "TokenJam: a local-first, OTel-native cost-saving utility for AI agents"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/sdk-ts/package.json
+++ b/sdk-ts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tokenjam/sdk",
-  "version": "0.6.5",
+  "version": "0.6.6",
   "description": "TypeScript SDK for TokenJam — local-first observability for AI agents",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",


### PR DESCRIPTION
Release cut for **0.6.6** — a CLI + Lens polish release from a round of fresh-install testing. No analyzer/back-end logic changes.

## Highlights
- **`tj uninstall`** (#669): resolves the `tj` shim symlink so a pipx install isn't double-counted; no more contradictory `pip uninstall` line after pipx already removed the package. Reports a genuinely separate pip install alongside pipx.
- **Optimize chart** (#670): y-axis ticks no longer clip to `0.0000` — compact axis formatter.
- **Optimize submenu** (#671): persona-aware — re-derives on the persona toggle and shows nothing for a persona with no data (no more stale Claude Code items under SDK).
- **`tj tokenmaxx`** (#672) and **`tj context`** (#673): deduped repeated percentages; `tj context` also states the shared "reference as @path" instruction once instead of per file.
- **Banner** (#674): the wordmark `n` no longer reads as `m` ("Token", not "Tokem").
- **`tj onboard --claude-code`** (#675): cleaner completion output — three green `✓` checks (config / observability / backfill), privacy note, next steps, macOS heads-up at the bottom; and it now surfaces a daemon-restart failure instead of showing a green screen over a dead server.

## Verification
- All three version files bumped (pyproject.toml, sdk-ts/package.json, npm-wrapper/package.json); no stragglers.
- 0.6.6 confirmed free on PyPI + npm.
- Pre-release QA (isolated venv + copied-DB upgrade path) + main CI green — see below.

🤖 Generated with [Claude Code](https://claude.com/claude-code)