### PR TITLE
Fix #614: verify daemon lifecycle and stale server state

### DIFF
--- a/tests/integration/test_cli.py
+++ b/tests/integration/test_cli.py
@@ -83,6 +83,12 @@ def _isolate_real_world_side_effects(tmp_path_factory, monkeypatch):
     monkeypatch.setattr(
         "tokenjam.cli.cmd_onboard._stop_serve_for_db_write", lambda: False
     )
+    # Doctor's duplicate-instance check is intentionally machine-wide. Keep
+    # this integration file hermetic instead of letting a developer's real
+    # foreground/managed serve processes change its exit-code assertions.
+    monkeypatch.setattr(
+        "tokenjam.core.server_state.list_serve_processes", lambda: []
+    )
     # Storage paths resolve via os.path.expanduser($HOME); redirect them at the
     # default ``~/.tj/telemetry.duckdb`` so any stray open_db lands in tmp.
     monkeypatch.setenv("HOME", str(iso))

--- a/tests/unit/test_doctor_daemon_lifecycle.py
+++ b/tests/unit/test_doctor_daemon_lifecycle.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 import json
+from pathlib import Path
 
 from tokenjam.cli.cmd_doctor import _check_daemon_lifecycle
 from tokenjam.core.config import ApiConfig, TjConfig
@@ -99,3 +100,36 @@ def test_doctor_reports_live_state_on_the_wrong_port(tmp_path, monkeypatch):
     assert state["level"] == "warning"
     assert "port 9341" in state["message"]
     assert "expects 7391" in state["message"]
+
+
+def test_doctor_reports_live_state_under_a_different_config(tmp_path, monkeypatch):
+    """A same-port daemon running under a DIFFERENT config file is not
+    healthy — it validates the wrong database and ingest secret, and port
+    matching alone can't see this (two configs can legitimately share a port
+    across separate installs/worktrees)."""
+    state_path = tmp_path / "server.state"
+    state_path.write_text(json.dumps({
+        "pid": 555, "port": 7391, "config_path": "/other/project/.tj/config.toml",
+    }))
+    monkeypatch.setattr(
+        "tokenjam.core.server_state.inspect_daemon_unit",
+        lambda: DaemonUnitState(None, None, False, None, None),
+    )
+    monkeypatch.setattr(
+        "tokenjam.core.server_state.list_serve_processes",
+        lambda: [ServeProcess(555, "/opt/venv/bin/tj serve")],
+    )
+    monkeypatch.setattr("tokenjam.core.server_state.is_pid_alive", lambda pid: True)
+    monkeypatch.setattr("tokenjam.core.server_state.is_serve_process", lambda pid: True)
+    _patch_state_path(monkeypatch, state_path)
+
+    config = TjConfig(
+        version="1", api=ApiConfig(port=7391),
+        config_path=Path("/this/project/.tj/config.toml"),
+    )
+    checks = _check_daemon_lifecycle(config)
+    state = next(check for check in checks if check["name"] == "Server state")
+
+    assert state["level"] == "warning"
+    assert "/other/project/.tj/config.toml" in state["message"]
+    assert "/this/project/.tj/config.toml" in state["message"]

--- a/tests/unit/test_doctor_daemon_lifecycle.py
+++ b/tests/unit/test_doctor_daemon_lifecycle.py
@@ -1,0 +1,101 @@
+"""Doctor coverage for the daemon lifecycle gaps reported in #614."""
+from __future__ import annotations
+
+import json
+
+from tokenjam.cli.cmd_doctor import _check_daemon_lifecycle
+from tokenjam.core.config import ApiConfig, TjConfig
+from tokenjam.core.server_state import DaemonUnitState, ServeProcess
+
+
+def _config() -> TjConfig:
+    return TjConfig(version="1", api=ApiConfig(port=7391))
+
+
+def _patch_state_path(monkeypatch, path) -> None:
+    monkeypatch.setattr("tokenjam.core.server_state.server_state_path", lambda: path)
+
+
+def test_doctor_warns_when_launchd_plist_exists_but_is_not_loaded(
+    tmp_path, monkeypatch,
+):
+    plist = tmp_path / "Library/LaunchAgents/com.tokenjam.serve.plist"
+    plist.parent.mkdir(parents=True)
+    plist.write_text("<plist/>")
+    monkeypatch.setattr(
+        "tokenjam.core.server_state.inspect_daemon_unit",
+        lambda: DaemonUnitState("launchd", plist, True, False, None),
+    )
+    monkeypatch.setattr("tokenjam.core.server_state.list_serve_processes", lambda: [])
+    _patch_state_path(monkeypatch, tmp_path / "missing.state")
+
+    checks = _check_daemon_lifecycle(_config())
+    service = next(check for check in checks if check["name"] == "Daemon service")
+
+    assert service["level"] == "warning"
+    assert "not loaded" in service["message"]
+    assert "tj onboard" in service["message"]
+
+
+def test_doctor_reports_multiple_live_serve_instances(tmp_path, monkeypatch):
+    monkeypatch.setattr(
+        "tokenjam.core.server_state.inspect_daemon_unit",
+        lambda: DaemonUnitState(None, None, False, None, None),
+    )
+    monkeypatch.setattr(
+        "tokenjam.core.server_state.list_serve_processes",
+        lambda: [
+            ServeProcess(111, "/usr/local/bin/tj serve"),
+            ServeProcess(222, "/opt/venv/bin/tj serve --port 9341"),
+        ],
+    )
+    _patch_state_path(monkeypatch, tmp_path / "missing.state")
+
+    checks = _check_daemon_lifecycle(_config())
+    instances = next(check for check in checks if check["name"] == "Daemon instances")
+
+    assert instances["level"] == "warning"
+    assert "111" in instances["message"]
+    assert "222" in instances["message"]
+
+
+def test_doctor_reports_server_state_pointing_at_a_dead_pid(tmp_path, monkeypatch):
+    state_path = tmp_path / "server.state"
+    state_path.write_text(json.dumps({"pid": 333, "port": 8123, "config_path": None}))
+    monkeypatch.setattr(
+        "tokenjam.core.server_state.inspect_daemon_unit",
+        lambda: DaemonUnitState(None, None, False, None, None),
+    )
+    monkeypatch.setattr("tokenjam.core.server_state.list_serve_processes", lambda: [])
+    monkeypatch.setattr("tokenjam.core.server_state.is_pid_alive", lambda pid: False)
+    _patch_state_path(monkeypatch, state_path)
+
+    checks = _check_daemon_lifecycle(_config())
+    state = next(check for check in checks if check["name"] == "Server state")
+
+    assert state["level"] == "warning"
+    assert "dead PID 333" in state["message"]
+    assert "port 8123" in state["message"]
+
+
+def test_doctor_reports_live_state_on_the_wrong_port(tmp_path, monkeypatch):
+    state_path = tmp_path / "server.state"
+    state_path.write_text(json.dumps({"pid": 444, "port": 9341, "config_path": None}))
+    monkeypatch.setattr(
+        "tokenjam.core.server_state.inspect_daemon_unit",
+        lambda: DaemonUnitState(None, None, False, None, None),
+    )
+    monkeypatch.setattr(
+        "tokenjam.core.server_state.list_serve_processes",
+        lambda: [ServeProcess(444, "/opt/venv/bin/tj serve --port 9341")],
+    )
+    monkeypatch.setattr("tokenjam.core.server_state.is_pid_alive", lambda pid: True)
+    monkeypatch.setattr("tokenjam.core.server_state.is_serve_process", lambda pid: True)
+    _patch_state_path(monkeypatch, state_path)
+
+    checks = _check_daemon_lifecycle(_config())
+    state = next(check for check in checks if check["name"] == "Server state")
+
+    assert state["level"] == "warning"
+    assert "port 9341" in state["message"]
+    assert "expects 7391" in state["message"]

--- a/tests/unit/test_onboard_daemon.py
+++ b/tests/unit/test_onboard_daemon.py
@@ -332,6 +332,24 @@ class TestLaunchdInstallSurvivesRegistration:
 
         assert result is None
 
+class TestSystemdInstallVerification:
+    def test_written_but_disabled_unit_is_detected(self, tmp_path, monkeypatch, capsys):
+        from tokenjam.cli.cmd_onboard import _install_systemd
+
+        monkeypatch.setattr("tokenjam.cli.cmd_onboard.Path.home", lambda: tmp_path)
+        monkeypatch.setattr("tokenjam.cli.cmd_onboard.shutil.which", lambda _: "/usr/bin/tj")
+        results = iter([
+            MagicMock(returncode=0),  # enable --now accepted
+            MagicMock(returncode=1, stdout="disabled\n"),
+        ])
+
+        with patch("tokenjam.cli.cmd_onboard.subprocess.run", side_effect=results):
+            installed = _install_systemd("/tmp/cfg.toml")
+
+        assert installed is None
+        assert (tmp_path / ".config/systemd/user/tokenjam.service").exists()
+        assert "did not enable tokenjam" in capsys.readouterr().out
+
 
 class TestTjBinaryResolution:
     """The daemon installers must point launchd/systemd at a real `tj` binary.

--- a/tests/unit/test_server_state.py
+++ b/tests/unit/test_server_state.py
@@ -96,6 +96,28 @@ class TestDaemonUnitInspection:
         assert state.loaded is True
         assert state.active is True
 
+    def test_systemd_linked_or_aliased_unit_does_not_count_as_enabled(
+        self, tmp_path, monkeypatch,
+    ):
+        """`linked`/`linked-runtime`/`alias` are unit states `is-enabled`
+        reports successfully (returncode 0) for a unit that is registered but
+        NOT attached to the login target — it will not autostart at the next
+        login. Reporting these as enabled would tell the user something
+        untrue."""
+        unit = tmp_path / ".config/systemd/user/tokenjam.service"
+        unit.parent.mkdir(parents=True)
+        unit.write_text("[Service]\n")
+
+        def _run(argv, **kwargs):
+            if "is-enabled" in argv:
+                return subprocess.CompletedProcess(argv, 0, "linked\n", "")
+            return subprocess.CompletedProcess(argv, 0, "active\n", "")
+
+        monkeypatch.setattr("tokenjam.core.server_state.subprocess.run", _run)
+        state = inspect_daemon_unit(system="Linux", home=tmp_path)
+
+        assert state.loaded is False
+
 
 class TestServeProcessInventory:
     def test_lists_every_tj_serve_instance_and_ignores_unrelated_processes(self, monkeypatch):

--- a/tests/unit/test_server_state.py
+++ b/tests/unit/test_server_state.py
@@ -11,7 +11,13 @@ shape so a regression back to substring matching is caught for real.
 """
 from __future__ import annotations
 
-from tokenjam.core.server_state import _looks_like_serve
+import subprocess
+
+from tokenjam.core.server_state import (
+    _looks_like_serve,
+    inspect_daemon_unit,
+    list_serve_processes,
+)
 
 
 class TestMatchesRealDaemonInvocations:
@@ -54,3 +60,63 @@ class TestDoesNotMatchUnrelatedProcesses:
         # "tj" must be a bare token (or a path basename), not a substring
         # of some unrelated word.
         assert _looks_like_serve("/usr/bin/notjserve --serve") is False
+
+
+class TestDaemonUnitInspection:
+    def test_written_launchd_plist_is_not_mistaken_for_a_loaded_job(
+        self, tmp_path, monkeypatch,
+    ):
+        plist = tmp_path / "Library/LaunchAgents/com.tokenjam.serve.plist"
+        plist.parent.mkdir(parents=True)
+        plist.write_text("<plist/>")
+        monkeypatch.setattr(
+            "tokenjam.core.server_state.subprocess.run",
+            lambda *args, **kwargs: subprocess.CompletedProcess(args[0], 3, "", "not found"),
+        )
+
+        state = inspect_daemon_unit(system="Darwin", home=tmp_path)
+
+        assert state.installed is True
+        assert state.loaded is False
+        assert state.manager == "launchd"
+
+    def test_systemd_reports_enabled_and_active_separately(self, tmp_path, monkeypatch):
+        unit = tmp_path / ".config/systemd/user/tokenjam.service"
+        unit.parent.mkdir(parents=True)
+        unit.write_text("[Service]\n")
+
+        def _run(argv, **kwargs):
+            if "is-enabled" in argv:
+                return subprocess.CompletedProcess(argv, 0, "enabled\n", "")
+            return subprocess.CompletedProcess(argv, 0, "active\n", "")
+
+        monkeypatch.setattr("tokenjam.core.server_state.subprocess.run", _run)
+        state = inspect_daemon_unit(system="Linux", home=tmp_path)
+
+        assert state.loaded is True
+        assert state.active is True
+
+
+class TestServeProcessInventory:
+    def test_lists_every_tj_serve_instance_and_ignores_unrelated_processes(self, monkeypatch):
+        output = (
+            " 101 /usr/local/bin/tj --config /tmp/a.toml serve\n"
+            " 202 /opt/venv/bin/tj serve --port 9341\n"
+            " 303 python manage.py serve\n"
+        )
+        monkeypatch.setattr(
+            "tokenjam.core.server_state.subprocess.run",
+            lambda *args, **kwargs: subprocess.CompletedProcess(args[0], 0, output, ""),
+        )
+
+        processes = list_serve_processes()
+
+        assert processes is not None
+        assert [process.pid for process in processes] == [101, 202]
+
+    def test_process_inventory_is_unknown_when_ps_cannot_run(self, monkeypatch):
+        def _denied(*args, **kwargs):
+            raise PermissionError("ps denied")
+
+        monkeypatch.setattr("tokenjam.core.server_state.subprocess.run", _denied)
+        assert list_serve_processes() is None

--- a/tokenjam/cli/cmd_doctor.py
+++ b/tokenjam/cli/cmd_doctor.py
@@ -42,7 +42,11 @@ def cmd_doctor(ctx: click.Context, output_json_flag: bool, repair: bool) -> None
     # 3. Ingest secret set
     checks.append(_check_ingest_secret(config))
 
-    # 3b. OTLP endpoint reachability — resolve, connect, authenticate. Replaces
+    # 3b. Daemon lifecycle — the unit must be registered, server.state must
+    #     name a live serve process, and one machine must not run several.
+    checks.extend(_check_daemon_lifecycle(config))
+
+    # 3c. OTLP endpoint reachability — resolve, connect, authenticate. Replaces
     #     the per-invocation stderr warning that used to fire on a static file
     #     diff while nothing was listening at all.
     checks.append(_check_otlp_endpoint(config))
@@ -261,6 +265,154 @@ def _check_ingest_secret(config: object) -> dict:
 
     return {"name": "Ingest secret", "level": "ok",
             "message": "Ingest secret is configured."}
+
+
+def _check_daemon_lifecycle(config: object) -> list[dict]:
+    """Report the three lifecycle facts that files alone cannot prove."""
+    from tokenjam.core.server_state import (
+        inspect_daemon_unit,
+        is_pid_alive,
+        is_serve_process,
+        list_serve_processes,
+        read_server_state,
+        server_state_path,
+    )
+
+    checks: list[dict] = []
+    unit = inspect_daemon_unit()
+    if unit.manager is None:
+        checks.append({
+            "name": "Daemon service",
+            "level": "info",
+            "message": "This platform has no managed TokenJam daemon; run `tj serve` manually.",
+        })
+    elif unit.error is not None:
+        checks.append({
+            "name": "Daemon service",
+            "level": "warning",
+            "message": f"Could not inspect the {unit.manager} unit: {unit.error}.",
+        })
+    elif not unit.installed:
+        checks.append({
+            "name": "Daemon service",
+            "level": "info",
+            "message": f"No {unit.manager} unit is installed. Run `tj onboard` to install it.",
+        })
+    elif not unit.loaded:
+        action = "loaded" if unit.manager == "launchd" else "enabled"
+        checks.append({
+            "name": "Daemon service",
+            "level": "warning",
+            "message": (
+                f"The {unit.manager} unit exists at {unit.path} but is not {action}; "
+                "it will not start or restart automatically. Re-run `tj onboard`."
+            ),
+        })
+    elif unit.manager == "systemd" and unit.active is False:
+        checks.append({
+            "name": "Daemon service",
+            "level": "warning",
+            "message": (
+                f"The systemd unit is enabled at {unit.path} but is not active. "
+                "Re-run `tj onboard` or inspect `systemctl --user status tokenjam`."
+            ),
+        })
+    else:
+        service_state = "loaded" if unit.manager == "launchd" else "enabled and active"
+        checks.append({
+            "name": "Daemon service",
+            "level": "ok",
+            "message": f"The {unit.manager} unit is {service_state}: {unit.path}",
+        })
+
+    processes = list_serve_processes()
+    if processes is None:
+        checks.append({
+            "name": "Daemon instances",
+            "level": "info",
+            "message": "Could not inspect the process table for tj serve instances.",
+        })
+    elif len(processes) > 1:
+        pids = ", ".join(str(process.pid) for process in processes)
+        checks.append({
+            "name": "Daemon instances",
+            "level": "warning",
+            "message": (
+                f"Multiple tj serve instances are running (PIDs {pids}). Stop the "
+                "extra foreground/venv instances, then run `tj onboard` so one "
+                "managed daemon owns the configured endpoint."
+            ),
+        })
+    elif len(processes) == 1:
+        checks.append({
+            "name": "Daemon instances",
+            "level": "ok",
+            "message": f"One tj serve instance is running (PID {processes[0].pid}).",
+        })
+    else:
+        level = "warning" if unit.installed and unit.loaded else "info"
+        message = (
+            "The daemon unit is registered but no tj serve process is running. "
+            "Re-run `tj onboard` and inspect the daemon logs."
+            if level == "warning"
+            else "No tj serve process is running."
+        )
+        checks.append({"name": "Daemon instances", "level": level, "message": message})
+
+    state_path = server_state_path()
+    if not state_path.exists():
+        checks.append({
+            "name": "Server state",
+            "level": "info",
+            "message": f"No server state file found at {state_path}.",
+        })
+        return checks
+
+    server_state = read_server_state(state_path)
+    if server_state is None:
+        checks.append({
+            "name": "Server state",
+            "level": "warning",
+            "message": f"The server state file at {state_path} is malformed or incomplete.",
+        })
+    elif not is_pid_alive(server_state.pid):
+        checks.append({
+            "name": "Server state",
+            "level": "warning",
+            "message": (
+                f"The server state file points at dead PID {server_state.pid}"
+                f"{f' on port {server_state.port}' if server_state.port is not None else ''}. "
+                "It is stale; start the managed daemon with `tj onboard`."
+            ),
+        })
+    elif not is_serve_process(server_state.pid):
+        checks.append({
+            "name": "Server state",
+            "level": "warning",
+            "message": (
+                f"The server state file points at PID {server_state.pid}, but that PID is not "
+                "a tj serve process. Start the managed daemon with `tj onboard`."
+            ),
+        })
+    elif server_state.port is not None and server_state.port != config.api.port:
+        checks.append({
+            "name": "Server state",
+            "level": "warning",
+            "message": (
+                f"The live server state names port {server_state.port}, but config expects "
+                f"{config.api.port}. Re-run `tj onboard` to reconcile the daemon."
+            ),
+        })
+    else:
+        checks.append({
+            "name": "Server state",
+            "level": "ok",
+            "message": (
+                f"server.state points at live tj serve PID {server_state.pid}"
+                f"{f' on port {server_state.port}' if server_state.port is not None else ''}."
+            ),
+        })
+    return checks
 
 
 #: How long a reachability probe waits before calling the endpoint dead. Short

--- a/tokenjam/cli/cmd_doctor.py
+++ b/tokenjam/cli/cmd_doctor.py
@@ -269,6 +269,9 @@ def _check_ingest_secret(config: object) -> dict:
 
 def _check_daemon_lifecycle(config: object) -> list[dict]:
     """Report the three lifecycle facts that files alone cannot prove."""
+    from typing import cast
+
+    from tokenjam.core.config import TjConfig
     from tokenjam.core.server_state import (
         inspect_daemon_unit,
         is_pid_alive,
@@ -277,6 +280,8 @@ def _check_daemon_lifecycle(config: object) -> list[dict]:
         read_server_state,
         server_state_path,
     )
+
+    typed_config = cast("TjConfig", config)
 
     checks: list[dict] = []
     unit = inspect_daemon_unit()
@@ -394,24 +399,47 @@ def _check_daemon_lifecycle(config: object) -> list[dict]:
                 "a tj serve process. Start the managed daemon with `tj onboard`."
             ),
         })
-    elif server_state.port is not None and server_state.port != config.api.port:
-        checks.append({
-            "name": "Server state",
-            "level": "warning",
-            "message": (
-                f"The live server state names port {server_state.port}, but config expects "
-                f"{config.api.port}. Re-run `tj onboard` to reconcile the daemon."
-            ),
-        })
     else:
-        checks.append({
-            "name": "Server state",
-            "level": "ok",
-            "message": (
-                f"server.state points at live tj serve PID {server_state.pid}"
-                f"{f' on port {server_state.port}' if server_state.port is not None else ''}."
-            ),
-        })
+        port_mismatch = (
+            server_state.port is not None and server_state.port != typed_config.api.port
+        )
+        # A live daemon on the right port but a DIFFERENT config file is not
+        # healthy: it's validating the wrong database and ingest secret. Port
+        # alone can't see this — two configs can legitimately share a port
+        # across separate installs/worktrees.
+        config_mismatch = (
+            server_state.config_path is not None
+            and typed_config.config_path is not None
+            and server_state.config_path != str(typed_config.config_path)
+        )
+        if port_mismatch or config_mismatch:
+            details = []
+            if port_mismatch:
+                details.append(
+                    f"port {server_state.port} (config expects {typed_config.api.port})"
+                )
+            if config_mismatch:
+                details.append(
+                    f"config {server_state.config_path} "
+                    f"(this process resolved {typed_config.config_path})"
+                )
+            checks.append({
+                "name": "Server state",
+                "level": "warning",
+                "message": (
+                    "The live server state doesn't match this install's config: "
+                    f"{'; '.join(details)}. Re-run `tj onboard` to reconcile the daemon."
+                ),
+            })
+        else:
+            checks.append({
+                "name": "Server state",
+                "level": "ok",
+                "message": (
+                    f"server.state points at live tj serve PID {server_state.pid}"
+                    f"{f' on port {server_state.port}' if server_state.port is not None else ''}."
+                ),
+            })
     return checks
 
 

--- a/tokenjam/cli/cmd_onboard.py
+++ b/tokenjam/cli/cmd_onboard.py
@@ -3856,4 +3856,16 @@ WantedBy=default.target"""
         ["systemctl", "--user", "enable", "--now", "tokenjam"],
         check=True,
     )
+    enabled = subprocess.run(
+        ["systemctl", "--user", "is-enabled", "tokenjam"],
+        capture_output=True,
+        text=True,
+    )
+    if enabled.returncode != 0:
+        console.print(
+            f"[warn]Daemon unit written to {service_path}, but systemd did not "
+            "enable tokenjam.[/warn]"
+        )
+        console.print("[dim]Re-run `tj onboard` or run `tj serve` manually.[/dim]")
+        return None
     return f"Daemon installed at {service_path}"

--- a/tokenjam/core/server_state.py
+++ b/tokenjam/core/server_state.py
@@ -53,8 +53,14 @@ class ServeProcess:
 
 
 _SYSTEMD_ENABLED_STATES = {
-    "enabled", "enabled-runtime", "linked", "linked-runtime", "alias",
+    "enabled", "enabled-runtime",
 }
+# `linked`/`linked-runtime`/`alias` are deliberately excluded: systemd reports
+# those for a unit that is registered but NOT attached to the login target, so
+# it will not autostart at the next login. We only ever install via `enable
+# --now` (cmd_onboard.py's `_install_systemd`), so this can't fire today, but
+# treating them as enabled would tell the user something untrue if the unit
+# ever ends up in one of those states by other means.
 _SYSTEMD_LIVE_STATES = {"active", "activating", "reloading"}
 
 

--- a/tokenjam/core/server_state.py
+++ b/tokenjam/core/server_state.py
@@ -15,6 +15,7 @@ from __future__ import annotations
 
 import json
 import os
+import platform
 import subprocess
 from dataclasses import dataclass
 from pathlib import Path
@@ -29,6 +30,129 @@ class ServerState:
     pid: int
     port: int | None
     config_path: str | None
+
+
+@dataclass(frozen=True)
+class DaemonUnitState:
+    """Observed registration state of TokenJam's per-user service unit."""
+
+    manager: str | None
+    path: Path | None
+    installed: bool
+    loaded: bool | None
+    active: bool | None
+    error: str | None = None
+
+
+@dataclass(frozen=True)
+class ServeProcess:
+    """One machine-visible process whose argv is a ``tj serve`` invocation."""
+
+    pid: int
+    command: str
+
+
+_SYSTEMD_ENABLED_STATES = {
+    "enabled", "enabled-runtime", "linked", "linked-runtime", "alias",
+}
+_SYSTEMD_LIVE_STATES = {"active", "activating", "reloading"}
+
+
+def inspect_daemon_unit(
+    *,
+    system: str | None = None,
+    home: Path | None = None,
+) -> DaemonUnitState:
+    """Inspect the service manager, not merely the unit file on disk.
+
+    A launchd plist or systemd unit is only an installation artifact. It does
+    not prove the job was loaded/enabled, which is the distinction that leaves
+    a machine looking configured while no daemon will start at login.
+    """
+    current_system = system or platform.system()
+    home_dir = home or Path.home()
+
+    if current_system == "Darwin":
+        path = home_dir / "Library/LaunchAgents/com.tokenjam.serve.plist"
+        if not path.exists():
+            return DaemonUnitState("launchd", path, False, False, None)
+        try:
+            result = subprocess.run(
+                ["launchctl", "list", "com.tokenjam.serve"],
+                capture_output=True,
+                text=True,
+            )
+        except OSError as exc:
+            return DaemonUnitState("launchd", path, True, None, None, str(exc))
+        return DaemonUnitState(
+            "launchd", path, True, result.returncode == 0, None,
+        )
+
+    if current_system == "Linux":
+        path = home_dir / ".config/systemd/user/tokenjam.service"
+        if not path.exists():
+            return DaemonUnitState("systemd", path, False, False, False)
+        try:
+            enabled = subprocess.run(
+                ["systemctl", "--user", "is-enabled", "tokenjam"],
+                capture_output=True,
+                text=True,
+            )
+            active = subprocess.run(
+                ["systemctl", "--user", "is-active", "tokenjam"],
+                capture_output=True,
+                text=True,
+            )
+        except OSError as exc:
+            return DaemonUnitState("systemd", path, True, None, None, str(exc))
+        enabled_state = enabled.stdout.strip()
+        is_enabled = (
+            enabled.returncode == 0
+            and (not enabled_state or enabled_state in _SYSTEMD_ENABLED_STATES)
+        )
+        return DaemonUnitState(
+            "systemd",
+            path,
+            True,
+            is_enabled,
+            active.stdout.strip() in _SYSTEMD_LIVE_STATES,
+        )
+
+    return DaemonUnitState(None, None, False, None, None)
+
+
+def list_serve_processes() -> list[ServeProcess] | None:
+    """Return every machine-visible ``tj serve`` process.
+
+    ``server.state`` deliberately scopes destructive commands to one install,
+    but doctor needs the inverse, read-only view: a second venv or foreground
+    server is exactly the conflict it must disclose. ``None`` means the process
+    table could not be inspected; an empty list is a successful observation.
+    """
+    try:
+        result = subprocess.run(
+            ["ps", "-ww", "-axo", "pid=,command="],
+            capture_output=True,
+            text=True,
+        )
+    except OSError:
+        return None
+    if result.returncode != 0:
+        return None
+
+    processes: list[ServeProcess] = []
+    for line in result.stdout.splitlines():
+        parts = line.strip().split(maxsplit=1)
+        if len(parts) != 2:
+            continue
+        try:
+            pid = int(parts[0])
+        except ValueError:
+            continue
+        command = parts[1]
+        if pid != os.getpid() and _looks_like_serve(command):
+            processes.append(ServeProcess(pid=pid, command=command))
+    return processes
 
 
 def read_server_state(path: Path | None = None) -> ServerState | None:


### PR DESCRIPTION
## Summary

Verifies that `tj onboard` actually registers the generated launchd/systemd unit instead of treating a written file or successful load command as proof. Extends `tj doctor` to report unloaded services, multiple live `tj serve` processes, stale or mismatched `server.state`, and the existing OTLP endpoint reachability result in one diagnostic surface.

The endpoint probe and shell-host correction had already landed on `main` in commit `c76e1b7c`; this PR keeps that implementation and adds the missing service-manager/process/state lifecycle checks from #614.

## Related issue

Closes #614

## Validation

- `pytest tests/unit/test_server_state.py tests/unit/test_onboard_daemon.py tests/unit/test_doctor_daemon_lifecycle.py tests/unit/test_doctor_otlp_endpoint.py -q` — 49 passed
- `ruff check tokenjam/` — passed
- `mypy tokenjam/` — passed
- Full local CI test scope — 5,404 passed; 11 failures and 8 setup errors were limited to sandbox-denied socket/`ps` access and Python 3.14 Rich-color behavior outside the CI Python 3.10-3.12 matrix
- GitHub CI — lint/type checking, Python 3.10, Python 3.11, Python 3.12, `test-ts`, `version-lockstep`, and contributor guard all passed

## Checklist

- [x] Tests pass (`pytest tests/unit/ tests/synthetic/ tests/agents/ tests/integration/`) in GitHub CI
- [x] Lint clean (`ruff check tokenjam/`)
- [x] Type check clean (`mypy tokenjam/`)
- [x] CLAUDE.md updated (not required; no architecture contract changed)
- [x] Test spans use `tests/factories.py` (not applicable; no spans added)
- [x] Requested `@anilmurty` as reviewer (mentioned here: @anilmurty)

Note: this PR changes tj doctor's exit code behavior: the new daemon-lifecycle checks (Daemon service, Daemon instances, Server state) can emit warnings that make doctor exit 1 in situations that previously exited 0. Anything scripting on tj doctor's exit code should account for this.

@anilmurty 