### PR TITLE
fix(guard): diagnose API status before payload shape (#608 follow-up)

### DIFF
--- a/.github/scripts/contributor_label_guard.py
+++ b/.github/scripts/contributor_label_guard.py
@@ -44,6 +44,13 @@ Every network call is isolated in its own function and reports a normal
 callers decide what a given status means for their case, so a missing
 issue, a missing label, a closed issue, or an issue-number-that's-really-a-PR
 never fails the workflow run.
+
+Because none of those outcomes raises, the LOG LINE is the only diagnosis an
+operator ever gets, so each must be distinguishable from the others: a
+permissions failure, a rate limit, a deleted issue, a PR number and a
+genuinely-closed issue all end in the same silent no-op, and only the wording
+says which one happened. `_unusable_issue_reason` is the single place that
+decides, shared by both handlers.
 """
 from __future__ import annotations
 
@@ -248,16 +255,36 @@ def _is_pull_request(issue_payload: dict[str, Any]) -> bool:
     return "pull_request" in issue_payload
 
 
+def _unusable_issue_reason(number: int, status: int, issue: Any) -> str | None:
+    """The log line explaining why `issue` can't be acted on, or None if it can.
+
+    Shared by both handlers so the two can never diagnose the same response
+    differently — the misdiagnosis this exists to prevent was present in
+    both, and was noticed in only one.
+
+    Order matters, and is the whole point. The STATUS is checked before the
+    payload's shape, because `_api_request` returns `(status, None)` for any
+    error response whose body isn't valid JSON (GitHub serves HTML from its
+    secondary-rate-limit and abuse walls, as can any proxy in front of the
+    API). Testing the shape first collapses "we were forbidden" into "the
+    issue doesn't exist" — two different operator actions behind one line.
+    """
+    if status == 404:
+        return f"no-op: issue #{number} not found (status {status})"
+    if status != 200:
+        return f"no-op: issue #{number} API error (status {status})"
+    if not isinstance(issue, dict):
+        return f"no-op: issue #{number} returned an unreadable payload (status {status})"
+    if _is_pull_request(issue):
+        return f"no-op: #{number} is a pull request, not an issue"
+    return None
+
+
 def _handle_claim(repo: str, number: int, token: str) -> None:
     status, issue = fetch_issue(repo, number, token)
-    if status == 404 or not isinstance(issue, dict):
-        print(f"no-op: issue #{number} not found (status {status})")
-        return
-    if status != 200:
-        print(f"no-op: issue #{number} API error (status {status})")
-        return
-    if _is_pull_request(issue):
-        print(f"no-op: #{number} is a pull request, not an issue")
+    reason = _unusable_issue_reason(number, status, issue)
+    if reason is not None:
+        print(reason)
         return
     if issue.get("state") != "open":
         print(f"no-op: issue #{number} is already closed")
@@ -281,14 +308,9 @@ def _handle_claim(repo: str, number: int, token: str) -> None:
 
 def _handle_release(repo: str, number: int, token: str, actor_login: str) -> None:
     status, issue = fetch_issue(repo, number, token)
-    if status == 404 or not isinstance(issue, dict):
-        print(f"no-op: issue #{number} not found (status {status})")
-        return
-    if status != 200:
-        print(f"no-op: issue #{number} API error (status {status})")
-        return
-    if _is_pull_request(issue):
-        print(f"no-op: #{number} is a pull request, not an issue")
+    reason = _unusable_issue_reason(number, status, issue)
+    if reason is not None:
+        print(reason)
         return
     if issue.get("state") != "open":
         print(f"no-op: issue #{number} is already closed — leaving labels as-is")

--- a/tests/unit/test_contributor_label_guard.py
+++ b/tests/unit/test_contributor_label_guard.py
@@ -347,20 +347,121 @@ def test_fetch_issue_timeline_non_200_returns_empty(monkeypatch):
     assert guard.fetch_issue_timeline(REPO, 42, "token") == []
 
 
-def test_handle_claim_issue_not_found_logs_distinguishable_noop(monkeypatch, capsys):
-    monkeypatch.setattr(guard, "fetch_issue", lambda repo, number, token: (404, {"message": "Not Found"}))
-    guard._handle_claim(REPO, 999, "token")
+# Both handlers open by fetching the issue and share every precondition check
+# before they diverge, so each case below is run against BOTH. The bug this
+# guards against lived in both handlers and was noticed in only one.
+def _run_handler(name: str, number: int) -> None:
+    if name == "claim":
+        guard._handle_claim(REPO, number, "token")
+    else:
+        guard._handle_release(REPO, number, "token", guard.DEFAULT_ACTOR_LOGIN)
+
+
+HANDLERS = ["claim", "release"]
+
+# What GitHub actually puts in the body of an error response. A 4xx/5xx from
+# the REST API carries JSON, so the handler receives (status, dict) and every
+# `isinstance(payload, dict)` check passes — which is exactly why the status
+# has to be inspected first.
+FORBIDDEN_BODY = {
+    "message": "Forbidden",
+    "documentation_url": "https://docs.github.com/rest",
+}
+
+
+@pytest.mark.parametrize("handler", HANDLERS)
+def test_handler_issue_not_found_logs_distinguishable_noop(monkeypatch, capsys, handler):
+    monkeypatch.setattr(
+        guard, "fetch_issue", lambda repo, number, token: (404, {"message": "Not Found"})
+    )
+    _run_handler(handler, 999)
     assert "no-op: issue #999 not found (status 404)" in capsys.readouterr().out
 
 
-def test_handle_claim_auth_failure_logs_distinguishable_noop(monkeypatch, capsys):
+@pytest.mark.parametrize("handler", HANDLERS)
+@pytest.mark.parametrize("status", [401, 403, 429, 500])
+def test_handler_api_error_is_never_reported_as_a_closed_issue(
+    monkeypatch, capsys, handler, status
+):
+    """The #608 core: an API failure must not be logged as a closed issue.
+
+    With the realistic JSON error body GitHub returns, the payload IS a dict,
+    so a handler that checks only `isinstance(payload, dict)` sails past its
+    error branch, reads no `state` off the error body, and falls through to
+    "already closed" — the same line a genuinely-closed issue produces. The
+    workflow no-ops either way, so that line is the operator's entire signal:
+    it is the difference between "nothing to do" and "our token lost its
+    permissions and this guard has silently stopped working".
+    """
     monkeypatch.setattr(
-        guard,
-        "fetch_issue",
-        lambda repo, number, token: (403, {"message": "Forbidden"}),
+        guard, "fetch_issue", lambda repo, number, token: (status, dict(FORBIDDEN_BODY))
     )
-    guard._handle_claim(REPO, 12, "token")
-    assert "no-op: issue #12 API error (status 403)" in capsys.readouterr().out
+    _run_handler(handler, 12)
+    out = capsys.readouterr().out
+    assert f"no-op: issue #12 API error (status {status})" in out
+    assert "already closed" not in out
+    assert "not found" not in out
+
+
+@pytest.mark.parametrize("handler", HANDLERS)
+def test_handler_api_error_with_non_json_body_is_not_reported_as_not_found(
+    monkeypatch, capsys, handler
+):
+    """A 403 whose body isn't JSON must still read as an API error.
+
+    `_api_request` yields `(status, None)` for an unparseable error body —
+    GitHub serves HTML from its secondary-rate-limit and abuse walls, as can
+    any proxy in front of the API. Diagnosing that by payload shape rather
+    than by status reports a deleted issue when the truth is a rejected
+    request, which sends an operator looking in the wrong place.
+    """
+    monkeypatch.setattr(guard, "fetch_issue", lambda repo, number, token: (403, None))
+    _run_handler(handler, 12)
+    out = capsys.readouterr().out
+    assert "no-op: issue #12 API error (status 403)" in out
+    assert "not found" not in out
+
+
+@pytest.mark.parametrize("handler", HANDLERS)
+def test_handler_unreadable_200_payload_is_distinct_from_both_error_and_not_found(
+    monkeypatch, capsys, handler
+):
+    # A 200 carrying something that isn't an object is a fourth distinct
+    # outcome: the call succeeded, so it is neither an API error nor a
+    # missing issue, but there is still no issue to read a state off.
+    monkeypatch.setattr(guard, "fetch_issue", lambda repo, number, token: (200, ["surprise"]))
+    _run_handler(handler, 12)
+    out = capsys.readouterr().out
+    assert "no-op: issue #12 returned an unreadable payload (status 200)" in out
+    assert "already closed" not in out
+
+
+@pytest.mark.parametrize("handler", HANDLERS)
+def test_handler_pull_request_number_logs_distinguishable_noop(monkeypatch, capsys, handler):
+    issue = {"number": 12, "state": "open", "labels": [], "pull_request": {"url": "..."}}
+    monkeypatch.setattr(guard, "fetch_issue", lambda repo, number, token: (200, issue))
+    _run_handler(handler, 12)
+    assert "no-op: #12 is a pull request, not an issue" in capsys.readouterr().out
+
+
+@pytest.mark.parametrize("handler", HANDLERS)
+def test_handler_genuinely_closed_issue_still_logs_the_closed_line(monkeypatch, capsys, handler):
+    # The other half of the distinguishability pin: tightening the error
+    # branches must not have swallowed the real closed-issue no-op, which is
+    # the ordinary outcome the error lines had been masquerading as.
+    issue = {"number": 12, "state": "closed", "labels": [{"name": "good first issue"}]}
+    monkeypatch.setattr(guard, "fetch_issue", lambda repo, number, token: (200, issue))
+    monkeypatch.setattr(guard, "fetch_issue_timeline", lambda repo, number, token: [])
+    monkeypatch.setattr(
+        guard, "remove_label", lambda *a, **k: pytest.fail("must not write to a closed issue")
+    )
+    monkeypatch.setattr(
+        guard, "add_labels", lambda *a, **k: pytest.fail("must not write to a closed issue")
+    )
+    _run_handler(handler, 12)
+    out = capsys.readouterr().out
+    assert "no-op: issue #12 is already closed" in out
+    assert "API error" not in out
 
 
 def test_handle_claim_payload_missing_labels_key_does_not_crash(monkeypatch, capsys):


### PR DESCRIPTION
Follow-up to #633. That PR fixed the reported half of the label guard's 403 handling; this closes the ordering defect underneath it, which is still live on `main`.

## Summary

- Extract `_unusable_issue_reason(number, status, issue)` — one helper both handlers call, checking **status before payload shape**
- Fix two cases that still misreport in both `_handle_claim` and `_handle_release`
- Add 16 tests (45 → 61), including the first error-path coverage `_handle_release` has ever had

## Root cause

#633 added a `status != 200` branch, which correctly fixed a 403 carrying a JSON body. But the shape check still runs first in both handlers:

```python
if status == 404 or not isinstance(issue, dict):
    print(f"no-op: issue #{number} not found (status {status})")
    return
if status != 200:
    print(f"no-op: issue #{number} API error (status {status})")
    return
```

So two cases never reach the status branch:

- **403 with a non-JSON body.** `_api_request` returns `(403, None)` for an unparseable body — a path #633's own `test_api_request_http_error_with_non_json_body_returns_none_payload` already pins — and GitHub serves HTML from its secondary-rate-limit and abuse walls. The guard logs **"issue not found (status 403)"**, telling an operator the issue was deleted when the request was actually rejected.
- **200 with a non-object payload**, folded into that same "not found" line despite being neither an error nor a missing issue.

Both handlers carried the defect identically, which is the argument for one shared helper rather than two parallel fixes: it existed in both and was noticed in only one.

## Why this touches production code

#608 is about log distinguishability, and this guard never raises — the log line *is* the feature. A test pinning a misleading log actively defends it (Critical Rule 23). Every pre-existing log string is preserved verbatim; only the previously-conflated cases change. The no-raise, fail-safe contract is untouched: the helper formats strings and nothing else.

## Tests / Verification

- `pytest tests/unit/test_contributor_label_guard.py` → **61 passed** (was 45)
- Falsifiability checked rather than assumed — the new tests fail against the pre-fix handler and pass after, isolating exactly the residual gap
- `ruff check` clean on both files. Note CI lints only `tokenjam/`, so `.github/scripts/` was checked manually

## What's NOT in this PR

- **`.github/scripts/` is linted by neither ruff nor mypy in CI.** A CI-config change, unrelated to #608.
- **`fetch_issue_timeline` swallows a non-200 into an empty list**, so `_handle_release` then logs "nothing to restore" — the same class of defect (a permissions failure reading as "nothing to do"), but it needs a signature change to return status alongside events. Worth its own issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)