### PR TITLE
fix(cli): defer unknown-model pricing warnings until after report

### DIFF
--- a/tests/unit/test_backfill.py
+++ b/tests/unit/test_backfill.py
@@ -563,6 +563,37 @@ def test_claude_code_backfill_rejects_two_since_flags(tmp_path, monkeypatch):
     assert "Use either --since or --since-days" in result.output
 
 
+def test_claude_code_backfill_prints_unknown_model_warning_after_summary(tmp_path):
+    import tokenjam.core.cost as cost_mod
+
+    _make_session_file(
+        tmp_path,
+        session_id="sess-unknown",
+        cwd="/Users/me/proj",
+        records=[
+            _assistant_record(
+                "u1", "totally-unknown-model-xyz", 1000, 200,
+                "2026-06-20T10:00:00.000Z", "sess-unknown", "/Users/me/proj",
+            ),
+        ],
+    )
+    cost_mod._UNKNOWN_MODEL_WARNED.clear()
+    db = InMemoryBackend()
+
+    result = CliRunner().invoke(
+        cmd_backfill_module.claude_code,
+        ["--root", str(tmp_path), "--quiet"],
+        obj={"db": db, "config": None},
+    )
+
+    assert result.exit_code == 0, result.output
+    assert "Backfilled" in result.output
+    assert "No pricing data for anthropic/totally-unknown-model-xyz" in result.output
+    assert result.output.index("Backfilled") < result.output.index(
+        "No pricing data for anthropic/totally-unknown-model-xyz"
+    )
+
+
 # --- #443: cheap in-scope session count (progress bar total + heads-up) -----
 
 

--- a/tests/unit/test_backfill.py
+++ b/tests/unit/test_backfill.py
@@ -594,6 +594,45 @@ def test_claude_code_backfill_prints_unknown_model_warning_after_summary(tmp_pat
     )
 
 
+def test_claude_code_backfill_prints_unknown_model_warning_after_no_sessions(tmp_path):
+    """Issue #585: zero-session backfill must still surface deferred pricing notes."""
+    import os
+    import time
+    import tokenjam.core.cost as cost_mod
+
+    old = _make_session_file(
+        tmp_path,
+        session_id="sess-old",
+        cwd="/Users/me/proj",
+        records=[
+            _assistant_record(
+                "u1", "totally-unknown-model-xyz", 1000, 200,
+                "2020-01-01T10:00:00.000Z", "sess-old", "/Users/me/proj",
+            ),
+        ],
+    )
+    # mtime passes the cheap pre-filter; ended_at predates --since so the
+    # session is discarded after parse (and pricing runs during parse).
+    recent_time = time.time()
+    os.utime(old, (recent_time, recent_time))
+
+    cost_mod._UNKNOWN_MODEL_WARNED.clear()
+    db = InMemoryBackend()
+
+    result = CliRunner().invoke(
+        cmd_backfill_module.claude_code,
+        ["--root", str(tmp_path), "--since", "2026-01-01", "--quiet"],
+        obj={"db": db, "config": None},
+    )
+
+    assert result.exit_code == 0, result.output
+    assert "No sessions found" in result.output
+    assert "No pricing data for anthropic/totally-unknown-model-xyz" in result.output
+    assert result.output.index("No sessions found") < result.output.index(
+        "No pricing data for anthropic/totally-unknown-model-xyz"
+    )
+
+
 # --- #443: cheap in-scope session count (progress bar total + heads-up) -----
 
 

--- a/tests/unit/test_cost.py
+++ b/tests/unit/test_cost.py
@@ -5,7 +5,12 @@ from datetime import datetime, timezone
 
 import pytest
 
-from tokenjam.core.cost import calculate_cost, WindowTotals
+from tokenjam.core.cost import (
+    calculate_cost,
+    defer_pricing_warnings,
+    drain_deferred_pricing_warnings,
+    WindowTotals,
+)
 from tokenjam.core.pricing import (
     load_pricing_table,
     get_rates,
@@ -98,6 +103,31 @@ def test_calculate_cost_unknown_model_warns_only_once_per_pair(caplog):
             calculate_cost("test_provider_xyz", "different_model", 1000, 200)
     matching = [r for r in caplog.records if "different_model" in r.message]
     assert len(matching) == 1
+
+
+def test_defer_pricing_warnings_collects_instead_of_logging(caplog):
+    import tokenjam.core.cost as cost_mod
+
+    cost_mod._UNKNOWN_MODEL_WARNED.clear()
+    with caplog.at_level(logging.WARNING, logger="tokenjam.core.cost"):
+        with defer_pricing_warnings() as messages:
+            calculate_cost("defer_provider", "defer_model", 1000, 200)
+            calculate_cost("defer_provider", "defer_model", 1000, 200)
+
+    assert caplog.text == ""
+    assert len(messages) == 1
+    assert "defer_provider/defer_model" in messages[0]
+
+
+def test_defer_pricing_warnings_logs_normally_outside_context(caplog):
+    import tokenjam.core.cost as cost_mod
+
+    cost_mod._UNKNOWN_MODEL_WARNED.clear()
+    with caplog.at_level(logging.WARNING, logger="tokenjam.core.cost"):
+        calculate_cost("live_provider", "live_model", 1000, 200)
+
+    assert "live_provider/live_model" in caplog.text
+    assert drain_deferred_pricing_warnings() == []
 
 
 def test_deprecated_anthropic_base_models_are_priced():

--- a/tests/unit/test_cost.py
+++ b/tests/unit/test_cost.py
@@ -9,6 +9,7 @@ from tokenjam.core.cost import (
     calculate_cost,
     defer_pricing_warnings,
     drain_deferred_pricing_warnings,
+    print_deferred_pricing_warnings,
     WindowTotals,
 )
 from tokenjam.core.pricing import (
@@ -113,10 +114,42 @@ def test_defer_pricing_warnings_collects_instead_of_logging(caplog):
         with defer_pricing_warnings() as messages:
             calculate_cost("defer_provider", "defer_model", 1000, 200)
             calculate_cost("defer_provider", "defer_model", 1000, 200)
+            assert caplog.text == ""
 
-    assert caplog.text == ""
     assert len(messages) == 1
     assert "defer_provider/defer_model" in messages[0]
+    # Unconsumed warnings are emitted in the context manager's finally block.
+    assert "defer_provider/defer_model" in caplog.text
+
+
+def test_defer_pricing_warnings_skips_finally_when_consumed(caplog):
+    import tokenjam.core.cost as cost_mod
+    from unittest.mock import MagicMock
+
+    cost_mod._UNKNOWN_MODEL_WARNED.clear()
+    console = MagicMock()
+    with caplog.at_level(logging.WARNING, logger="tokenjam.core.cost"):
+        with defer_pricing_warnings() as messages:
+            calculate_cost("consumed_provider", "consumed_model", 1000, 200)
+            print_deferred_pricing_warnings(console=console, messages=messages)
+
+    assert caplog.text == ""
+    assert messages == []
+    console.print.assert_called_once()
+
+
+def test_print_deferred_pricing_warnings_escapes_rich_markup():
+    from unittest.mock import MagicMock
+
+    from tokenjam.core.cost import print_deferred_pricing_warnings
+
+    console = MagicMock()
+    messages = ["No pricing data for test/ll[/]ama — using default rates"]
+    print_deferred_pricing_warnings(console=console, messages=messages)
+    printed = console.print.call_args[0][0]
+    assert "[warn]" in printed
+    assert "ll\\[/]ama" in printed
+    assert messages == []
 
 
 def test_defer_pricing_warnings_logs_normally_outside_context(caplog):

--- a/tests/unit/test_quickstart.py
+++ b/tests/unit/test_quickstart.py
@@ -194,6 +194,54 @@ def _invoke_quickstart(args):
     return CliRunner().invoke(cmd_quickstart, args)
 
 
+def _assistant_with_unknown_model(uuid: str, session_id: str, cwd: str, ts: str) -> dict:
+    record = _assistant(uuid, session_id, cwd, ts)
+    record["message"]["model"] = "totally-unknown-model-xyz"
+    return record
+
+
+def test_quickstart_prints_unknown_model_pricing_warning_after_report(tmp_path):
+    """Issue #585: pricing warnings encountered during ingest must land after
+    the report body, not ahead of it."""
+    root = tmp_path / "projects"
+    _make_session_file(root, "sess-unknown", "/Users/me/projUnknown", [
+        _assistant_with_unknown_model(
+            "u1", "sess-unknown", "/Users/me/projUnknown",
+            _ts(6, 20, "10:00:00.000"),
+        ),
+    ])
+
+    import tokenjam.core.cost as cost_mod
+
+    cost_mod._UNKNOWN_MODEL_WARNED.clear()
+    result = _invoke_quickstart(["--root", str(root), "--since", "90d"])
+
+    assert result.exit_code == 0, result.output
+    assert "No pricing data for anthropic/totally-unknown-model-xyz" in result.output
+    assert result.output.index("TokenJam reads your") < result.output.index(
+        "No pricing data for anthropic/totally-unknown-model-xyz"
+    )
+
+
+def test_quickstart_json_keeps_pricing_warning_on_stderr(tmp_path):
+    root = tmp_path / "projects"
+    _make_session_file(root, "sess-unknown", "/Users/me/projUnknown", [
+        _assistant_with_unknown_model(
+            "u1", "sess-unknown", "/Users/me/projUnknown",
+            _ts(6, 20, "10:00:00.000"),
+        ),
+    ])
+
+    import tokenjam.core.cost as cost_mod
+
+    cost_mod._UNKNOWN_MODEL_WARNED.clear()
+    result = _invoke_quickstart(["--root", str(root), "--since", "90d", "--json"])
+
+    assert result.exit_code == 0, result.output
+    assert "No pricing data for anthropic/totally-unknown-model-xyz" in result.stderr
+    assert "No pricing data for anthropic/totally-unknown-model-xyz" not in result.stdout
+
+
 def test_quickstart_renders_without_daemon_or_ondisk_db(tmp_path):
     root = _fixture_root(tmp_path)
     result = _invoke_quickstart(["--root", str(root), "--since", "90d"])

--- a/tokenjam/cli/cmd_backfill.py
+++ b/tokenjam/cli/cmd_backfill.py
@@ -13,6 +13,7 @@ from tokenjam.core.backfill import (
     count_claude_code_sessions_in_scope,
     ingest_claude_code,
 )
+from tokenjam.core.cost import defer_pricing_warnings, print_deferred_pricing_warnings
 from tokenjam.core.ingest_adapters.codex import (
     CODEX_SESSIONS_ROOT,
     ingest_codex,
@@ -80,68 +81,70 @@ def claude_code(ctx: click.Context, root_path: str | None, since_value: str | No
 
     console.print(f"Backfilling Claude Code sessions from {root} …")
     # Pass config so backfilled sessions carry the declared plan tier (#176).
-    with backfill_progress(total_in_scope, quiet=quiet) as progress:
-        result = ingest_claude_code(
-            db, root=root, since=since, progress=progress,
-            config=ctx.obj.get("config"), reingest=reingest,
-        )
+    with defer_pricing_warnings() as pricing_warnings:
+        with backfill_progress(total_in_scope, quiet=quiet) as progress:
+            result = ingest_claude_code(
+                db, root=root, since=since, progress=progress,
+                config=ctx.obj.get("config"), reingest=reingest,
+            )
 
-    if result.sessions_seen == 0:
-        console.print(
-            "[yellow]No sessions found.[/yellow] "
-            "[dim]Use Claude Code for a while, then re-run.[/dim]"
-        )
-        return
+        if result.sessions_seen == 0:
+            console.print(
+                "[yellow]No sessions found.[/yellow] "
+                "[dim]Use Claude Code for a while, then re-run.[/dim]"
+            )
+            return
 
-    days_span = None
-    if result.earliest and result.latest:
-        days_span = (result.latest - result.earliest).days
+        days_span = None
+        if result.earliest and result.latest:
+            days_span = (result.latest - result.earliest).days
 
-    total = result.sessions_total
-    parts = [
-        f"Backfilled [bold]{result.sessions_new}[/bold] new "
-        f"({result.sessions_existing} already present) · "
-        f"[bold]{total}[/bold] total session{'s' if total != 1 else ''}",
-    ]
-    if days_span is not None:
-        parts.append(f"over {days_span} day{'s' if days_span != 1 else ''}")
-    if result.project_count:
-        parts.append(f"from {result.project_count} project"
-                     f"{'s' if result.project_count != 1 else ''}")
-    parts.append(f"({format_cost(result.total_cost_usd)} total spend)")
-    console.print("[green]✓[/green] " + ", ".join(parts) + ".")
+        total = result.sessions_total
+        parts = [
+            f"Backfilled [bold]{result.sessions_new}[/bold] new "
+            f"({result.sessions_existing} already present) · "
+            f"[bold]{total}[/bold] total session{'s' if total != 1 else ''}",
+        ]
+        if days_span is not None:
+            parts.append(f"over {days_span} day{'s' if days_span != 1 else ''}")
+        if result.project_count:
+            parts.append(f"from {result.project_count} project"
+                         f"{'s' if result.project_count != 1 else ''}")
+        parts.append(f"({format_cost(result.total_cost_usd)} total spend)")
+        console.print("[green]✓[/green] " + ", ".join(parts) + ".")
 
-    # Make the conversations-vs-sessions distinction explicit when they differ
-    # (Claude Code writes multiple JSONL files per session) so the smaller
-    # `sessions` count doesn't read as data loss (#238).
-    if result.conversations_seen != total:
-        console.print(
-            f"  [dim]Parsed {result.conversations_seen} conversation files "
-            f"into {total} session{'s' if total != 1 else ''}.[/dim]"
-        )
+        # Make the conversations-vs-sessions distinction explicit when they differ
+        # (Claude Code writes multiple JSONL files per session) so the smaller
+        # `sessions` count doesn't read as data loss (#238).
+        if result.conversations_seen != total:
+            console.print(
+                f"  [dim]Parsed {result.conversations_seen} conversation files "
+                f"into {total} session{'s' if total != 1 else ''}.[/dim]"
+            )
 
-    if result.spans_retagged:
-        console.print(
-            f"  [dim]Re-tagged {result.spans_retagged} existing spans "
-            f"(subagent identity refreshed).[/dim]"
-        )
-    if result.spans_skipped_existing:
-        console.print(
-            f"  [dim]Skipped {result.spans_skipped_existing} spans already "
-            f"present (idempotent re-run).[/dim]"
-        )
-    if result.files_failed:
-        console.print(
-            f"  [yellow]Warning: {result.files_failed} session(s) failed to "
-            f"parse — sample errors:[/yellow]"
-        )
-        for err in result.sample_errors:
-            console.print(f"    [dim]{err}[/dim]")
-    if days_span is not None and days_span < 7:
-        console.print(
-            "  [dim]Less than 7 days of history available — `tj optimize` will "
-            "flag thin-data projections.[/dim]"
-        )
+        if result.spans_retagged:
+            console.print(
+                f"  [dim]Re-tagged {result.spans_retagged} existing spans "
+                f"(subagent identity refreshed).[/dim]"
+            )
+        if result.spans_skipped_existing:
+            console.print(
+                f"  [dim]Skipped {result.spans_skipped_existing} spans already "
+                f"present (idempotent re-run).[/dim]"
+            )
+        if result.files_failed:
+            console.print(
+                f"  [yellow]Warning: {result.files_failed} session(s) failed to "
+                f"parse — sample errors:[/yellow]"
+            )
+            for err in result.sample_errors:
+                console.print(f"    [dim]{err}[/dim]")
+        if days_span is not None and days_span < 7:
+            console.print(
+                "  [dim]Less than 7 days of history available — `tj optimize` will "
+                "flag thin-data projections.[/dim]"
+            )
+        print_deferred_pricing_warnings(console=console, messages=pricing_warnings)
 
 
 @cmd_backfill.command("status", status_message="Checking backfill status…")

--- a/tokenjam/cli/cmd_backfill.py
+++ b/tokenjam/cli/cmd_backfill.py
@@ -93,6 +93,8 @@ def claude_code(ctx: click.Context, root_path: str | None, since_value: str | No
                 "[yellow]No sessions found.[/yellow] "
                 "[dim]Use Claude Code for a while, then re-run.[/dim]"
             )
+            print_deferred_pricing_warnings(
+                console=console, messages=pricing_warnings)
             return
 
         days_span = None

--- a/tokenjam/cli/cmd_quickstart.py
+++ b/tokenjam/cli/cmd_quickstart.py
@@ -55,6 +55,7 @@ import click
 
 from tokenjam.cli.backfill_progress import backfill_progress, transient_status
 from tokenjam.core.backfill import CLAUDE_CODE_PROJECTS_ROOT, ingest_claude_code
+from tokenjam.core.cost import defer_pricing_warnings, print_deferred_pricing_warnings
 from tokenjam.core.db import InMemoryBackend
 from tokenjam.utils.formatting import console, err_console, format_cost
 from tokenjam.utils.theme import ACCENT
@@ -181,69 +182,77 @@ def cmd_quickstart(ctx: click.Context, since: str, root_path: str | None,
     # therefore runs without a denominator, and the report states the one
     # session count this screen makes.
     status_console.print(f"[dim]{_pre_ingest_status(since, max_sessions)}[/dim]")
-    with backfill_progress(None, console=status_console) as progress_cb:
-        result = ingest_claude_code(db, root=root, since=since_dt,
-                                    max_sessions=max_sessions, progress=progress_cb)
+    with defer_pricing_warnings() as pricing_warnings:
+        with backfill_progress(None, console=status_console) as progress_cb:
+            result = ingest_claude_code(db, root=root, since=since_dt,
+                                        max_sessions=max_sessions, progress=progress_cb)
 
-    if result.sessions_ingested == 0:
-        _render_no_sessions(result, since, output_json)
-        return
+        if result.sessions_ingested == 0:
+            _render_no_sessions(result, since, output_json)
+            print_deferred_pricing_warnings(
+                console=err_console if output_json else console,
+                messages=pricing_warnings,
+            )
+            return
 
-    if output_json:
-        from tokenjam.core.context_diagnostic import (
-            compute_context_diagnostic,
-            diagnostic_to_dict,
-        )
-        from tokenjam.core.session_timeline import (
-            compute_session_timeline,
-            timeline_to_dict,
-        )
-        payload = {
-            "quota_composition": diagnostic_to_dict(
-                compute_context_diagnostic(db.conn, since_dt, until_dt)),
-            "session_timeline": timeline_to_dict(
-                compute_session_timeline(db.conn)),
-            "backfill": {
-                "sessions_ingested": result.sessions_ingested,
-                "spans_ingested": result.spans_ingested,
-                "project_count": result.project_count,
-                "total_cost_usd": round(result.total_cost_usd, 6),
-                "limit_reached": result.limit_reached,
-                "max_sessions": max_sessions,
-            },
-        }
-        click.echo(_json.dumps(payload, default=str))
-        return
+        if output_json:
+            from tokenjam.core.context_diagnostic import (
+                compute_context_diagnostic,
+                diagnostic_to_dict,
+            )
+            from tokenjam.core.session_timeline import (
+                compute_session_timeline,
+                timeline_to_dict,
+            )
+            payload = {
+                "quota_composition": diagnostic_to_dict(
+                    compute_context_diagnostic(db.conn, since_dt, until_dt)),
+                "session_timeline": timeline_to_dict(
+                    compute_session_timeline(db.conn)),
+                "backfill": {
+                    "sessions_ingested": result.sessions_ingested,
+                    "spans_ingested": result.spans_ingested,
+                    "project_count": result.project_count,
+                    "total_cost_usd": round(result.total_cost_usd, 6),
+                    "limit_reached": result.limit_reached,
+                    "max_sessions": max_sessions,
+                },
+            }
+            click.echo(_json.dumps(payload, default=str))
+            print_deferred_pricing_warnings(
+                console=err_console, messages=pricing_warnings)
+            return
 
-    # Computed only on the human path: `--json` must stay byte-clean AND fast,
-    # and the analyzers are the one materially expensive step after ingest.
-    #
-    # `fallback_sessions` is only that: the analyzed population comes off the
-    # report's own window, and `sessions_ingested` stands in ONLY when the
-    # computation could not run (there is then no figure to mispair it with).
-    # The two genuinely differ: the ingest picks the most-recent N session FILES
-    # by mtime, while the report filters by span timestamp, so a real corpus can
-    # ingest 300 files and analyze 143 sessions. Printing the ingest count beside
-    # a figure summed over the analyzed one is exactly the mixed-population
-    # defect this screen must not have.
-    #
-    # This is the last slow stretch, and it used to be silent: measured on a
-    # real corpus, ~14s elapses between the final backfill line and the first
-    # line of the report, long enough to read as a hang. `transient_status`
-    # holds one self-erasing line built from the SAME `Progress` construction
-    # the backfill counter above uses, so the two phases read as one process,
-    # and it erases before the report renders. The message names what is
-    # happening in the product's own terms and promises NO number: nothing on
-    # this screen may claim a figure, a count or an all-clear while the
-    # computation that would establish it is still running.
-    with transient_status(_ANALYZING_STATUS):
-        avoidable = _compute_avoidable_total(
-            db, since_dt, until_dt,
-            fallback_sessions=result.sessions_ingested,
-            population_capped=max_sessions is not None and result.limit_reached,
-        )
+        # Computed only on the human path: `--json` must stay byte-clean AND fast,
+        # and the analyzers are the one materially expensive step after ingest.
+        #
+        # `fallback_sessions` is only that: the analyzed population comes off the
+        # report's own window, and `sessions_ingested` stands in ONLY when the
+        # computation could not run (there is then no figure to mispair it with).
+        # The two genuinely differ: the ingest picks the most-recent N session FILES
+        # by mtime, while the report filters by span timestamp, so a real corpus can
+        # ingest 300 files and analyze 143 sessions. Printing the ingest count beside
+        # a figure summed over the analyzed one is exactly the mixed-population
+        # defect this screen must not have.
+        #
+        # This is the last slow stretch, and it used to be silent: measured on a
+        # real corpus, ~14s elapses between the final backfill line and the first
+        # line of the report, long enough to read as a hang. `transient_status`
+        # holds one self-erasing line built from the SAME `Progress` construction
+        # the backfill counter above uses, so the two phases read as one process,
+        # and it erases before the report renders. The message names what is
+        # happening in the product's own terms and promises NO number: nothing on
+        # this screen may claim a figure, a count or an all-clear while the
+        # computation that would establish it is still running.
+        with transient_status(_ANALYZING_STATUS):
+            avoidable = _compute_avoidable_total(
+                db, since_dt, until_dt,
+                fallback_sessions=result.sessions_ingested,
+                population_capped=max_sessions is not None and result.limit_reached,
+            )
 
-    _render(avoidable, fallback_sessions=result.sessions_ingested)
+        _render(avoidable, fallback_sessions=result.sessions_ingested)
+        print_deferred_pricing_warnings(console=console, messages=pricing_warnings)
 
 
 # ────────────────────────── avoidable total ────────────────────────────────

--- a/tokenjam/core/cost.py
+++ b/tokenjam/core/cost.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
+import contextvars
 import logging
 import re
+from contextlib import contextmanager
 from dataclasses import dataclass, field
 from datetime import datetime, timedelta, timezone
 from tokenjam.core.models import NormalizedSpan
@@ -22,6 +24,53 @@ logger = logging.getLogger(__name__)
 # emit the same warning hundreds of times in a row (issue #98). Now it
 # emits exactly once and stays out of the way.
 _UNKNOWN_MODEL_WARNED: set[tuple[str, str]] = set()
+
+# When set, unknown-model pricing warnings are collected here instead of being
+# logged immediately. CLI surfaces that ingest inline before rendering (e.g.
+# `tj quickstart`, `tj backfill`) enter this mode so a pricing note lands after
+# the report body rather than ahead of it (issue #585).
+_DEFERRED_PRICING_WARNINGS: contextvars.ContextVar[list[str] | None] = (
+    contextvars.ContextVar("_deferred_pricing_warnings", default=None)
+)
+
+
+def _unknown_model_warning_message(provider: str, model: str) -> str:
+    return (
+        "No pricing data for %s/%s — using default rates, including "
+        "guessed cache rates (cost figures may be inaccurate, "
+        "especially for cache-heavy traffic). Upgrade tokenjam for "
+        "current pricing, or add an override to "
+        "~/.config/tj/pricing.toml — see `tj pricing list`."
+        % (provider, model)
+    )
+
+
+@contextmanager
+def defer_pricing_warnings():
+    """Collect unknown-model pricing warnings until the caller renders them."""
+    messages: list[str] = []
+    token = _DEFERRED_PRICING_WARNINGS.set(messages)
+    try:
+        yield messages
+    finally:
+        _DEFERRED_PRICING_WARNINGS.reset(token)
+
+
+def drain_deferred_pricing_warnings() -> list[str]:
+    """Return and clear any pricing warnings collected under defer mode."""
+    bucket = _DEFERRED_PRICING_WARNINGS.get()
+    if not bucket:
+        return []
+    messages = list(bucket)
+    bucket.clear()
+    return messages
+
+
+def print_deferred_pricing_warnings(*, console, messages: list[str] | None = None) -> None:
+    """Render deferred unknown-model pricing warnings, if any."""
+    pending = list(messages) if messages is not None else drain_deferred_pricing_warnings()
+    for message in pending:
+        console.print(f"[yellow]{message}[/yellow]")
 
 
 def billing_rates(
@@ -59,14 +108,12 @@ def billing_rates(
     key = (provider, model)
     if key not in _UNKNOWN_MODEL_WARNED:
         _UNKNOWN_MODEL_WARNED.add(key)
-        logger.warning(
-            "No pricing data for %s/%s — using default rates, including "
-            "guessed cache rates (cost figures may be inaccurate, "
-            "especially for cache-heavy traffic). Upgrade tokenjam for "
-            "current pricing, or add an override to "
-            "~/.config/tj/pricing.toml — see `tj pricing list`.",
-            provider, model,
-        )
+        message = _unknown_model_warning_message(provider, model)
+        bucket = _DEFERRED_PRICING_WARNINGS.get()
+        if bucket is not None:
+            bucket.append(message)
+        else:
+            logger.warning("%s", message)
     # cache_read/write_per_mtok are non-zero guesses, not 0.0: a model with
     # NO pricing entry that is mostly cache traffic would otherwise have
     # ~all of its real cost priced at zero, silently, rather than merely

--- a/tokenjam/core/cost.py
+++ b/tokenjam/core/cost.py
@@ -3,6 +3,7 @@ import contextvars
 import logging
 import re
 from contextlib import contextmanager
+from rich.markup import escape
 from dataclasses import dataclass, field
 from datetime import datetime, timedelta, timezone
 from tokenjam.core.models import NormalizedSpan
@@ -53,7 +54,13 @@ def defer_pricing_warnings():
     try:
         yield messages
     finally:
+        # Fail-safe: any warning collected but not rendered (early return,
+        # exception, Ctrl-C) must still reach the user. The dedup set is
+        # marked at collection time, so a swallowed warning is gone forever.
+        unconsumed = list(messages)
         _DEFERRED_PRICING_WARNINGS.reset(token)
+        for message in unconsumed:
+            logger.warning("%s", message)
 
 
 def drain_deferred_pricing_warnings() -> list[str]:
@@ -68,9 +75,13 @@ def drain_deferred_pricing_warnings() -> list[str]:
 
 def print_deferred_pricing_warnings(*, console, messages: list[str] | None = None) -> None:
     """Render deferred unknown-model pricing warnings, if any."""
-    pending = list(messages) if messages is not None else drain_deferred_pricing_warnings()
+    if messages is not None:
+        pending = list(messages)
+        messages.clear()
+    else:
+        pending = drain_deferred_pricing_warnings()
     for message in pending:
-        console.print(f"[yellow]{message}[/yellow]")
+        console.print(f"[warn]{escape(message)}[/warn]")
 
 
 def billing_rates(


### PR DESCRIPTION
## Summary
Defer unknown-model pricing fallback warnings during inline ingest in `tj quickstart` and `tj backfill claude-code`, then render them after the report/summary body.

## Motivation
When ingest runs before rendering, `calculate_cost()` could emit pricing warnings to stderr while the CLI was still silent or before the report printed. That made the first visible output look like an error ahead of the actual report (#585).

## Changes
- Add `defer_pricing_warnings()` / `print_deferred_pricing_warnings()` in `tokenjam/core/cost.py`.
- Wrap quickstart ingest + render paths so pricing notes print after the screen body (stderr for `--json`).
- Wrap `tj backfill claude-code` summary output similarly.
- Add regression tests for defer behavior and output ordering.

## Tests
```bash
pytest tests/unit/test_cost.py::test_defer_pricing_warnings_collects_instead_of_logging \
  tests/unit/test_cost.py::test_defer_pricing_warnings_logs_normally_outside_context \
  tests/unit/test_quickstart.py::test_quickstart_prints_unknown_model_pricing_warning_after_report \
  tests/unit/test_quickstart.py::test_quickstart_json_keeps_pricing_warning_on_stderr \
  tests/unit/test_backfill.py::test_claude_code_backfill_prints_unknown_model_warning_after_summary -v
```
All passed.

Also ran:
- `ruff check tokenjam/ ...` — passed
- `mypy tokenjam/core/cost.py tokenjam/cli/cmd_quickstart.py tokenjam/cli/cmd_backfill.py` — passed

## Notes
- Non-deferred code paths (daemon ingest, API, other commands) still log immediately via `logger.warning`.
- composer-2.5 review: APPROVE.

Fixes #585