### PR TITLE
Fix #582: include closed sessions in drift baselines

### DIFF
--- a/tests/synthetic/test_drift_detection.py
+++ b/tests/synthetic/test_drift_detection.py
@@ -87,6 +87,32 @@ def test_baseline_built_after_n_sessions(db):
     assert baseline.avg_input_tokens == 1000.0
 
 
+def test_terminal_sessions_feed_drift_baseline(db):
+    _setup_agent(db)
+    closed = make_session(agent_id="test-agent", status="closed", input_tokens=100)
+    completed = make_session(agent_id="test-agent", status="completed", input_tokens=300)
+    db.upsert_session(closed)
+    db.upsert_session(completed)
+
+    assert db.get_completed_session_count("test-agent") == 2
+    sessions = db.get_completed_sessions("test-agent", limit=2)
+    assert {session.session_id for session in sessions} == {
+        closed.session_id,
+        completed.session_id,
+    }
+
+    detector = DriftDetector(
+        db,
+        MagicMock(),
+        _make_config(baseline_sessions=2),
+    )
+    detector.on_session_end("test-agent", completed)
+
+    baseline = db.get_baseline("test-agent")
+    assert baseline is not None
+    assert baseline.sessions_sampled == 2
+
+
 def test_drift_inactive_before_baseline_complete(db):
     _setup_agent(db)
     config = _make_config(baseline_sessions=10)

--- a/tokenjam/core/db.py
+++ b/tokenjam/core/db.py
@@ -37,6 +37,7 @@ from tokenjam.core.models import (
     SessionRecord,
     SpanKind,
     SpanStatus,
+    TERMINAL_STATUSES,
     TraceCostStats,
     TraceFilters,
     TraceRecord,
@@ -3821,19 +3822,24 @@ class DuckDBBackend:
         # still active afterwards — otherwise the status tile shows a 40s blip
         # instead of the real multi-hour session. Falls back to started_at when
         # ended_at is NULL.
+        terminal_placeholders = ", ".join("?" for _ in TERMINAL_STATUSES)
         cur = self.conn.execute(
-            "SELECT * FROM sessions WHERE agent_id = $1 AND status = 'completed' "
-            "ORDER BY COALESCE(ended_at, started_at) DESC LIMIT $2",
-            [agent_id, limit],
+            "SELECT * FROM sessions WHERE agent_id = ? AND status IN ("
+            + terminal_placeholders
+            + ") ORDER BY COALESCE(ended_at, started_at) DESC LIMIT ?",
+            [agent_id, *TERMINAL_STATUSES, limit],
         )
         rows = cur.fetchall()
         cols = [d[0] for d in cur.description]
         return [_row_to_session(r, cols) for r in rows]
 
     def get_completed_session_count(self, agent_id: str) -> int:
+        terminal_placeholders = ", ".join("?" for _ in TERMINAL_STATUSES)
         result = self.conn.execute(
-            "SELECT COUNT(*) FROM sessions WHERE agent_id = $1 AND status = 'completed'",
-            [agent_id],
+            "SELECT COUNT(*) FROM sessions WHERE agent_id = ? AND status IN ("
+            + terminal_placeholders
+            + ")",
+            [agent_id, *TERMINAL_STATUSES],
         ).fetchone()
         return result[0] if result else 0
 


### PR DESCRIPTION
Explicitly closed sessions were valid terminal history, but the DuckDB drift queries selected only sessions marked `completed`. Agents using the close endpoint could therefore miss valid history and fail to form a drift baseline.

## Summary
- use the shared `TERMINAL_STATUSES` set in both DuckDB drift-history queries
- keep every status value parameterized with generated placeholders
- add an end-to-end regression covering retrieval, counting, and baseline construction

## Related issue
Closes #582

## Behavior verified
The synthetic fixture contains one `closed` session and one `completed` session for the same agent.

- before: 1 session counted, so the 2-session baseline threshold was not reached
- after: 2 sessions counted and returned, producing a baseline with `sessions_sampled == 2`
- measured eligibility shift: 1 to 2 sessions, a 100% increase for this fixture
- measured baseline input average: 300 tokens for the pre-fix completed-only population versus 200 tokens after including both terminal statuses, a 33.3% decrease

## Tests / Verification
- new regression test fails against the pre-fix implementation with `assert 1 == 2`
- `pytest tests/synthetic/test_drift_detection.py::test_terminal_sessions_feed_drift_baseline -v` passed
- relevant drift and storage checks passed: 59 tests
- `pytest tests/unit/ tests/synthetic/ tests/agents/ tests/integration/ -q` passed: 5,586 passed, 18 skipped, 2 xfailed
- `ruff check tokenjam/` clean
- `mypy tokenjam/` clean
- `git diff --check` clean

## What's NOT in this PR
- no schema, API, CLI, or drift-threshold changes
- no unrelated cleanup of pre-existing test-file lint findings

## Checklist
- [x] Tests pass (`pytest tests/unit/ tests/synthetic/ tests/agents/ tests/integration/`)
- [x] Lint clean (`ruff check tokenjam/`)
- [x] Type check clean (`mypy tokenjam/`)
- [x] Contributor docs updated (not needed, no architecture change)
- [x] Test spans use `tests/factories.py` (not raw `NormalizedSpan`)

@anilmurty ready for review.
