### PR TITLE
fix(cli): skip DB probe when nested subcommand requests --help

### DIFF
--- a/tests/integration/test_cli.py
+++ b/tests/integration/test_cli.py
@@ -2753,3 +2753,18 @@ def test_validate_daemon_lock_fails_cleanly(runner, config):
                          ["optimize", "--validate", "downsize"])
     assert result.exit_code == 1
     assert "tj serve" in result.output
+
+
+@pytest.mark.parametrize("args", [
+    ["optimize", "downsize", "--help"],
+    ["backfill", "langfuse", "--help"],
+    ["loop", "annotate", "--help"],
+])
+def test_nested_subcommand_help_skips_db_probe(runner, args):
+    """Nested group subcommand --help must not open DuckDB (#580)."""
+    with patch("tokenjam.cli.main.load_config", return_value=TjConfig(version="1")), \
+         patch("tokenjam.cli.main.open_db",
+               side_effect=AssertionError("must not open db for --help")):
+        result = runner.invoke(cli, args)
+    assert result.exit_code == 0, result.output
+    assert "Usage:" in result.output

--- a/tokenjam/cli/main.py
+++ b/tokenjam/cli/main.py
@@ -124,7 +124,7 @@ def cli(ctx: click.Context, config_path: str | None, output_json: bool,
     }
     invoked = ctx.invoked_subcommand
 
-    if invoked in no_db_commands:
+    if invoked in no_db_commands or ctx.obj.get("_skip_db_for_help"):
         ctx.obj["config"] = config
         ctx.obj["config_path_override"] = config_path
         ctx.obj["db"] = None

--- a/tokenjam/cli/tj_status.py
+++ b/tokenjam/cli/tj_status.py
@@ -105,7 +105,21 @@ class TjCommand(click.Command):
         self.no_status = no_status
         super().__init__(*args, **kwargs)
 
+    def _tokens_request_help(self, ctx: click.Context) -> bool:
+        names: set[str] = set()
+        node: click.Context | None = ctx
+        while node is not None:
+            names.update(node.help_option_names)
+            node = node.parent
+        tokens = list(ctx.args)
+        return any(tok in names for tok in tokens)
+
     def invoke(self, ctx: click.Context) -> Any:
+        ctx.ensure_object(dict)
+        if self._tokens_request_help(ctx):
+            # Root/nested group callbacks probe DuckDB before Click renders
+            # ``--help`` on a leaf subcommand (#580).
+            ctx.obj["_skip_db_for_help"] = True
         if not self.status_message:
             return super().invoke(ctx)
         with tj_status(self.status_message, ctx):


### PR DESCRIPTION
## Summary

Skip the DuckDB probe in the root CLI callback when the invocation requests `--help`, so nested commands like `tj optimize downsize --help` work while `tj serve` holds the write lock.

## Motivation

Fixes #580. Running `--help` on a group subcommand failed with "Database is locked" whenever the daemon was running, because `open_db()` ran before Click rendered help.

## Changes

- Detect help tokens in unconsumed `ctx.args` during `TjCommand.invoke` and set `ctx.obj["_skip_db_for_help"]`.
- Skip `open_db()` in the root `cli()` callback when that flag is set (same path as `no_db_commands`).
- Add parametrized integration tests for `optimize downsize`, `backfill langfuse`, and `loop annotate`.

## Tests

```bash
pytest tests/integration/test_cli.py::test_nested_subcommand_help_skips_db_probe -v
ruff check tokenjam/cli/main.py tokenjam/cli/tj_status.py tests/integration/test_cli.py
mypy tokenjam/cli/main.py tokenjam/cli/tj_status.py
```

All passed.

## Notes

- composer-2.5 review: APPROVE
- Normal invocations without `--help` still probe the DB as before.
- Also fixes top-level `tj <cmd> --help` under the same lock condition.