### PR TITLE
fix(cli): fail cleanly when a DB-requiring command has no backend

### DIFF
--- a/tests/integration/test_cli.py
+++ b/tests/integration/test_cli.py
@@ -2768,3 +2768,17 @@ def test_nested_subcommand_help_skips_db_probe(runner, args):
         result = runner.invoke(cli, args)
     assert result.exit_code == 0, result.output
     assert "Usage:" in result.output
+
+
+def test_db_requiring_command_fails_cleanly_when_db_is_none(runner, config):
+    """A DB-requiring leaf with db=None raises ClickException, not a traceback (#727)."""
+    with patch("tokenjam.cli.main.load_config", return_value=config), \
+         patch("tokenjam.cli.main.open_db",
+               side_effect=AssertionError("must not open db")):
+        result = runner.invoke(
+            cli,
+            ["loop", "annotate", "session-1", "--note", "--help"],
+        )
+    assert result.exit_code == 1, result.output
+    assert "annotate requires either a direct DuckDB connection" in result.output
+    assert "AttributeError" not in result.output

--- a/tests/integration/test_cli.py
+++ b/tests/integration/test_cli.py
@@ -2780,5 +2780,5 @@ def test_db_requiring_command_fails_cleanly_when_db_is_none(runner, config):
             ["loop", "annotate", "session-1", "--note", "--help"],
         )
     assert result.exit_code == 1, result.output
-    assert "annotate requires either a direct DuckDB connection" in result.output
+    assert "`--help` was consumed as an option value" in result.output
     assert "AttributeError" not in result.output

--- a/tests/unit/test_tj_db_guard.py
+++ b/tests/unit/test_tj_db_guard.py
@@ -14,16 +14,18 @@ from tokenjam.cli.tj_status import (
 )
 
 
-def test_db_required_message_names_command() -> None:
-    msg = db_required_message("annotate")
-    assert "annotate requires either a direct DuckDB connection" in msg
+def test_db_required_message_names_command_path() -> None:
+    msg = db_required_message("tj loop annotate")
+    assert "tj loop annotate requires either a direct DuckDB connection" in msg
     assert "api.{host,port}" in msg
 
 
-def test_help_consumed_as_option_value_message_names_command() -> None:
-    msg = help_consumed_as_option_value_message("annotate")
-    assert "annotate cannot run" in msg
+def test_help_consumed_as_option_value_message_names_command_path() -> None:
+    msg = help_consumed_as_option_value_message("tj loop annotate")
+    assert "tj loop annotate cannot run" in msg
     assert "`--help` was consumed as an option value" in msg
+    assert "Give that option a value" in msg
+    assert "Put `--help` before other flags" not in msg
 
 
 def test_tj_command_guard_raises_click_exception_not_traceback() -> None:
@@ -50,6 +52,17 @@ def test_tj_command_guard_help_skip_message() -> None:
         demo_cmd.invoke(ctx)
     assert "`--help` was consumed as an option value" in str(exc.value)
     assert "direct DuckDB connection" not in str(exc.value)
+
+
+def test_tj_command_guard_fail_open_without_requires_db_key() -> None:
+    """``requires_db`` absent from ``ctx.obj`` must not fail-closed (#729)."""
+    @click.command("demo-cmd", cls=TjCommand)
+    def demo_cmd() -> None:
+        return "ok"
+
+    ctx = click.Context(demo_cmd)
+    ctx.obj = {"db": None}
+    assert demo_cmd.invoke(ctx) == "ok"
 
 
 def test_tj_command_guard_allows_live_backend() -> None:

--- a/tests/unit/test_tj_db_guard.py
+++ b/tests/unit/test_tj_db_guard.py
@@ -1,0 +1,33 @@
+"""Regression tests for the shared DB-required guard (#727)."""
+from __future__ import annotations
+
+import click
+import pytest
+
+from tokenjam.cli.tj_status import TjCommand, TjGroup, db_required_message
+
+
+def test_db_required_message_names_command() -> None:
+    msg = db_required_message("annotate")
+    assert "annotate requires either a direct DuckDB connection" in msg
+    assert "api.{host,port}" in msg
+
+
+def test_tj_command_guard_raises_click_exception_not_traceback() -> None:
+    @click.command("demo-cmd", cls=TjCommand)
+    def demo_cmd() -> None:
+        raise AssertionError("must not reach command body")
+
+    ctx = click.Context(demo_cmd)
+    ctx.obj = {"db": None, "requires_db": True}
+    with pytest.raises(click.ClickException) as exc:
+        demo_cmd.invoke(ctx)
+    assert "demo-cmd requires either a direct DuckDB connection" in str(exc.value)
+    assert "AssertionError" not in str(exc.value)
+
+
+def test_tj_group_skips_db_guard() -> None:
+    group = TjGroup("demo-group")
+    ctx = click.Context(group)
+    ctx.obj = {"db": None, "requires_db": True}
+    group._ensure_db_available(ctx)

--- a/tests/unit/test_tj_db_guard.py
+++ b/tests/unit/test_tj_db_guard.py
@@ -1,16 +1,29 @@
 """Regression tests for the shared DB-required guard (#727)."""
 from __future__ import annotations
 
+from unittest.mock import MagicMock
+
 import click
 import pytest
 
-from tokenjam.cli.tj_status import TjCommand, TjGroup, db_required_message
+from tokenjam.cli.tj_status import (
+    TjCommand,
+    TjGroup,
+    db_required_message,
+    help_consumed_as_option_value_message,
+)
 
 
 def test_db_required_message_names_command() -> None:
     msg = db_required_message("annotate")
     assert "annotate requires either a direct DuckDB connection" in msg
     assert "api.{host,port}" in msg
+
+
+def test_help_consumed_as_option_value_message_names_command() -> None:
+    msg = help_consumed_as_option_value_message("annotate")
+    assert "annotate cannot run" in msg
+    assert "`--help` was consumed as an option value" in msg
 
 
 def test_tj_command_guard_raises_click_exception_not_traceback() -> None:
@@ -26,8 +39,34 @@ def test_tj_command_guard_raises_click_exception_not_traceback() -> None:
     assert "AssertionError" not in str(exc.value)
 
 
+def test_tj_command_guard_help_skip_message() -> None:
+    @click.command("demo-cmd", cls=TjCommand)
+    def demo_cmd() -> None:
+        raise AssertionError("must not reach command body")
+
+    ctx = click.Context(demo_cmd)
+    ctx.obj = {"db": None, "requires_db": True, "_skip_db_for_help": True}
+    with pytest.raises(click.ClickException) as exc:
+        demo_cmd.invoke(ctx)
+    assert "`--help` was consumed as an option value" in str(exc.value)
+    assert "direct DuckDB connection" not in str(exc.value)
+
+
+def test_tj_command_guard_allows_live_backend() -> None:
+    """A command with a non-None db passes the guard (regression for is-not-None check)."""
+    @click.command("demo-cmd", cls=TjCommand)
+    def demo_cmd() -> None:
+        return "ok"
+
+    ctx = click.Context(demo_cmd)
+    ctx.obj = {"db": MagicMock(), "requires_db": True}
+    # Guard runs inside invoke; should not raise before the body.
+    assert demo_cmd.invoke(ctx) == "ok"
+
+
 def test_tj_group_skips_db_guard() -> None:
+    # Groups never enforce the leaf guard — only subcommand leaves do.
     group = TjGroup("demo-group")
     ctx = click.Context(group)
     ctx.obj = {"db": None, "requires_db": True}
-    group._ensure_db_available(ctx)
+    group._ensure_db_available(ctx)  # does not raise

--- a/tokenjam/cli/cmd_optimize.py
+++ b/tokenjam/cli/cmd_optimize.py
@@ -10,7 +10,7 @@ from rich.padding import Padding
 from rich.table import Table
 
 from tokenjam.cli.json_option import json_option, resolve_output_json
-from tokenjam.cli.tj_status import TjCommand, tj_status
+from tokenjam.cli.tj_status import TjCommand, db_required_message, tj_status
 from tokenjam.core.optimize.analyzers.deadweight import UNUSED_RECENCY_WINDOW_DAYS
 from tokenjam.core.optimize.types import DEGRADED_CAPTURE_MODES
 from tokenjam.core.framing import (
@@ -187,7 +187,7 @@ def cmd_optimize(
     db = ctx.obj.get("db")
     config = ctx.obj.get("config")
     if config is None:
-        raise click.ClickException("optimize requires a database connection.")
+        raise click.ClickException("optimize could not load configuration.")
 
     try:
         since_dt = parse_since(since)
@@ -262,7 +262,6 @@ def cmd_optimize(
             # API-shim path
             from tokenjam.core.api_backend import ApiBackend
             if not isinstance(db, ApiBackend):
-                from tokenjam.cli.tj_status import db_required_message
                 raise click.ClickException(db_required_message("optimize"))
             try:
                 report_dict = db.fetch_optimize_report(

--- a/tokenjam/cli/cmd_optimize.py
+++ b/tokenjam/cli/cmd_optimize.py
@@ -186,7 +186,7 @@ def cmd_optimize(
     output_json = resolve_output_json(ctx, output_json_flag)
     db = ctx.obj.get("db")
     config = ctx.obj.get("config")
-    if db is None or config is None:
+    if config is None:
         raise click.ClickException("optimize requires a database connection.")
 
     try:
@@ -262,10 +262,8 @@ def cmd_optimize(
             # API-shim path
             from tokenjam.core.api_backend import ApiBackend
             if not isinstance(db, ApiBackend):
-                raise click.ClickException(
-                    "optimize requires either a direct DuckDB connection or a "
-                    "running tj serve at the configured api.{host,port}."
-                )
+                from tokenjam.cli.tj_status import db_required_message
+                raise click.ClickException(db_required_message("optimize"))
             try:
                 report_dict = db.fetch_optimize_report(
                     since=since,

--- a/tokenjam/cli/main.py
+++ b/tokenjam/cli/main.py
@@ -128,6 +128,7 @@ def cli(ctx: click.Context, config_path: str | None, output_json: bool,
         ctx.obj["config"] = config
         ctx.obj["config_path_override"] = config_path
         ctx.obj["db"] = None
+        ctx.obj["requires_db"] = False if invoked in no_db_commands else True
         ctx.obj["output_json"] = output_json
         ctx.obj["no_color"] = no_color
         ctx.obj["agent"] = agent
@@ -164,6 +165,7 @@ def cli(ctx: click.Context, config_path: str | None, output_json: bool,
     # a bare `resolve_config_path()` downstream would name a different file.
     ctx.obj["config_path_override"] = config_path
     ctx.obj["db"] = db
+    ctx.obj["requires_db"] = True
     ctx.obj["output_json"] = output_json
     ctx.obj["no_color"] = no_color
     ctx.obj["agent"] = agent

--- a/tokenjam/cli/main.py
+++ b/tokenjam/cli/main.py
@@ -109,7 +109,10 @@ def cli(ctx: click.Context, config_path: str | None, output_json: bool,
     if projects_root:
         config.optimize.projects_root = projects_root
 
-    # Commands that don't need a database connection
+    # Commands that don't need a database connection. A DB-needing leaf added
+    # later under one of these groups inherits ``requires_db=False`` from the
+    # root callback; override with ``requires_db=True`` on that leaf's
+    # ``@click.command(..., cls=TjCommand, requires_db=True)``.
     no_db_commands = {
         "stop", "uninstall", "onboard", "mcp", "demo", "policy",
         "proxy", "summarize", "pricing", "otel-resource-attrs", "session-end",

--- a/tokenjam/cli/tj_status.py
+++ b/tokenjam/cli/tj_status.py
@@ -86,20 +86,20 @@ def tj_status_stream(message: str, ctx: click.Context) -> AbstractContextManager
     return phase_status(message, console=_status_console(ctx))
 
 
-def db_required_message(command_name: str) -> str:
+def db_required_message(command_path: str) -> str:
     """Single copy of the CLI error when a DB-requiring command finds ``db is None``."""
     return (
-        f"{command_name} requires either a direct DuckDB connection or a running "
+        f"{command_path} requires either a direct DuckDB connection or a running "
         "tj serve at the configured api.{host,port}."
     )
 
 
-def help_consumed_as_option_value_message(command_name: str) -> str:
+def help_consumed_as_option_value_message(command_path: str) -> str:
     """When ``--help`` is parsed as an option value, #726 skips opening the DB
     and leaves ``db`` as ``None`` — starting ``tj serve`` cannot fix that."""
     return (
-        f"{command_name} cannot run: `--help` was consumed as an option value. "
-        "Put `--help` before other flags, or drop the option that took it."
+        f"{command_path} cannot run: `--help` was consumed as an option value. "
+        "Give that option a value (e.g. `tj cost --since 7d --help`) or drop it."
     )
 
 
@@ -152,13 +152,13 @@ class TjCommand(click.Command):
             return
         if (ctx.obj or {}).get("db") is not None:
             return
-        command_name = self.name or "this command"
+        command_path = ctx.command_path or self.name or "this command"
         obj = ctx.obj or {}
         if obj.get("_skip_db_for_help"):
             raise click.ClickException(
-                help_consumed_as_option_value_message(command_name)
+                help_consumed_as_option_value_message(command_path)
             )
-        raise click.ClickException(db_required_message(command_name))
+        raise click.ClickException(db_required_message(command_path))
 
     def invoke(self, ctx: click.Context) -> Any:
         ctx.ensure_object(dict)

--- a/tokenjam/cli/tj_status.py
+++ b/tokenjam/cli/tj_status.py
@@ -86,6 +86,14 @@ def tj_status_stream(message: str, ctx: click.Context) -> AbstractContextManager
     return phase_status(message, console=_status_console(ctx))
 
 
+def db_required_message(command_name: str) -> str:
+    """Single copy of the CLI error when a DB-requiring command finds ``db is None``."""
+    return (
+        f"{command_name} requires either a direct DuckDB connection or a running "
+        "tj serve at the configured api.{host,port}."
+    )
+
+
 class TjCommand(click.Command):
     """The class every `tj` command is built from, whether or not it ever
     renders anything. `status_message` is the single switch that decides
@@ -100,9 +108,13 @@ class TjCommand(click.Command):
     """
 
     def __init__(self, *args: Any, status_message: str | None = None,
-                 no_status: bool = False, **kwargs: Any) -> None:
+                 no_status: bool = False, requires_db: bool | None = None,
+                 **kwargs: Any) -> None:
         self.status_message = status_message
         self.no_status = no_status
+        # ``None`` → inherit ``ctx.obj["requires_db"]`` at invoke time (set in
+        # ``cli/main.py``). Explicit ``False`` for a leaf that opts out locally.
+        self.requires_db = requires_db
         super().__init__(*args, **kwargs)
 
     def _tokens_request_help(self, ctx: click.Context) -> bool:
@@ -114,12 +126,32 @@ class TjCommand(click.Command):
         tokens = list(ctx.args)
         return any(tok in names for tok in tokens)
 
+    def _requires_db(self, ctx: click.Context) -> bool:
+        if self.requires_db is not None:
+            return self.requires_db
+        return bool((ctx.obj or {}).get("requires_db", True))
+
+    def _ensure_db_available(self, ctx: click.Context) -> None:
+        """Raise a clean ``ClickException`` when a DB-requiring leaf runs with
+        ``db is None`` (#727). Real ``--help`` exits during ``make_context``
+        before a leaf ``invoke`` runs; the crash case is a command body that
+        actually executes (e.g. a ``--help`` token consumed as an option value).
+        """
+        if isinstance(self, click.Group):
+            return
+        if not self._requires_db(ctx):
+            return
+        if (ctx.obj or {}).get("db") is not None:
+            return
+        raise click.ClickException(db_required_message(self.name or "this command"))
+
     def invoke(self, ctx: click.Context) -> Any:
         ctx.ensure_object(dict)
         if self._tokens_request_help(ctx):
             # Root/nested group callbacks probe DuckDB before Click renders
             # ``--help`` on a leaf subcommand (#580).
             ctx.obj["_skip_db_for_help"] = True
+        self._ensure_db_available(ctx)
         if not self.status_message:
             return super().invoke(ctx)
         with tj_status(self.status_message, ctx):
@@ -148,4 +180,10 @@ class TjGroup(TjCommand, click.Group):
     group_class = type
 
 
-__all__ = ["TjCommand", "TjGroup", "tj_status", "tj_status_stream"]
+__all__ = [
+    "TjCommand",
+    "TjGroup",
+    "db_required_message",
+    "tj_status",
+    "tj_status_stream",
+]

--- a/tokenjam/cli/tj_status.py
+++ b/tokenjam/cli/tj_status.py
@@ -94,6 +94,15 @@ def db_required_message(command_name: str) -> str:
     )
 
 
+def help_consumed_as_option_value_message(command_name: str) -> str:
+    """When ``--help`` is parsed as an option value, #726 skips opening the DB
+    and leaves ``db`` as ``None`` — starting ``tj serve`` cannot fix that."""
+    return (
+        f"{command_name} cannot run: `--help` was consumed as an option value. "
+        "Put `--help` before other flags, or drop the option that took it."
+    )
+
+
 class TjCommand(click.Command):
     """The class every `tj` command is built from, whether or not it ever
     renders anything. `status_message` is the single switch that decides
@@ -129,7 +138,7 @@ class TjCommand(click.Command):
     def _requires_db(self, ctx: click.Context) -> bool:
         if self.requires_db is not None:
             return self.requires_db
-        return bool((ctx.obj or {}).get("requires_db", True))
+        return bool((ctx.obj or {}).get("requires_db", False))
 
     def _ensure_db_available(self, ctx: click.Context) -> None:
         """Raise a clean ``ClickException`` when a DB-requiring leaf runs with
@@ -143,7 +152,13 @@ class TjCommand(click.Command):
             return
         if (ctx.obj or {}).get("db") is not None:
             return
-        raise click.ClickException(db_required_message(self.name or "this command"))
+        command_name = self.name or "this command"
+        obj = ctx.obj or {}
+        if obj.get("_skip_db_for_help"):
+            raise click.ClickException(
+                help_consumed_as_option_value_message(command_name)
+            )
+        raise click.ClickException(db_required_message(command_name))
 
     def invoke(self, ctx: click.Context) -> Any:
         ctx.ensure_object(dict)
@@ -184,6 +199,7 @@ __all__ = [
     "TjCommand",
     "TjGroup",
     "db_required_message",
+    "help_consumed_as_option_value_message",
     "tj_status",
     "tj_status_stream",
 ]


### PR DESCRIPTION
## Summary

Add a shared guard in `TjCommand.invoke` that raises a `ClickException` when a DB-requiring leaf command runs with `ctx.obj["db"] is None`, instead of crashing with an `AttributeError` traceback.

## Motivation

Issue #727: commands that skip `open_db()` (including the `--help` skip path from #726) but still execute can reach DB-touching code with `db=None`. `cmd_optimize` already had a hand-rolled message; other commands like `loop annotate` did not.

## Changes

- Add `db_required_message()` and `_ensure_db_available()` to `TjCommand` (leaf commands only; groups skip the guard)
- Set `ctx.obj["requires_db"]` in `cli/main.py` (`False` for `no_db_commands`, `True` otherwise)
- Remove the redundant `db is None` check from `cmd_optimize`; reuse the shared message for the ApiBackend path
- Add unit + integration regression tests

## Tests

```bash
pytest tests/unit/test_tj_db_guard.py tests/integration/test_cli.py::test_db_requiring_command_fails_cleanly_when_db_is_none tests/integration/test_cli.py::test_nested_subcommand_help_skips_db_probe -v
ruff check tokenjam/cli/tj_status.py tokenjam/cli/main.py tokenjam/cli/cmd_optimize.py
mypy tokenjam/cli/tj_status.py tokenjam/cli/main.py
```

All passed locally.

## Notes

- Builds on the nested `--help` DB skip from #726 (`fix/group-subcommand-help-no-db`). If #726 merges first, this branch can be rebased to a single commit on top of `main`.
- Related follow-up: #728 (ignore `--help` tokens consumed as option values) is separate.

Fixes #727