### PR TITLE
fix(alerts): hydrate cooldown and failure-rate dedup state from the alerts table on startup

### DIFF
--- a/docs/alerts.md
+++ b/docs/alerts.md
@@ -84,6 +84,8 @@ To prevent alert storms, `tj` tracks a cooldown per agent + alert type. Repeat a
 cooldown_seconds = 300   # 5 minutes between repeated alerts of the same type
 ```
 
+Cooldown state survives a daemon restart: `AlertEngine` rehydrates it from the persisted `alerts` table on startup, so a restart mid-cooldown does not re-fire a duplicate alert or resend a duplicate ntfy/Discord push.
+
 ## Content stripping
 
 By default, alert payloads sent to external channels (Discord, Telegram, webhook, ntfy) have sensitive content stripped: `prompt_content`, `completion_content`, `tool_input`, `tool_output`. To include full content:

--- a/tests/integration/test_alert_engine_restart.py
+++ b/tests/integration/test_alert_engine_restart.py
@@ -1,0 +1,156 @@
+"""Restart-simulation tests for AlertEngine cooldown/dedup hydration (#592).
+
+CooldownTracker and AlertEngine._failure_rate_fired are process-local and
+start empty on every AlertEngine construction. These tests construct a
+SECOND AlertEngine against the SAME InMemoryBackend to simulate a daemon
+restart mid-cooldown / mid-session, and assert the still-true condition does
+not insert or dispatch a duplicate alert.
+"""
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+from tokenjam.core.alerts import AlertEngine
+from tokenjam.core.config import (
+    AgentConfig,
+    AlertChannelConfig,
+    AlertsConfig,
+    SensitiveAction,
+    TjConfig,
+)
+from tokenjam.core.db import InMemoryBackend
+from tokenjam.core.models import AlertFilters, AlertType
+from tests.factories import make_llm_span, make_tool_span
+
+
+def _make_config(cooldown_seconds: int, agents: dict | None = None) -> TjConfig:
+    return TjConfig(
+        version="1",
+        agents=agents or {},
+        alerts=AlertsConfig(
+            cooldown_seconds=cooldown_seconds,
+            channels=[AlertChannelConfig(type="stdout")],
+        ),
+    )
+
+
+def test_cooldown_survives_a_restart_within_the_window():
+    """A restart mid-cooldown must not re-insert or re-dispatch the same
+    (type, agent_id) alert: the second AlertEngine shares the DB with the
+    first, so it should see the still-fresh cooldown row and suppress.
+    """
+    config = _make_config(
+        cooldown_seconds=300,
+        agents={"test-agent": AgentConfig(
+            sensitive_actions=[SensitiveAction(name="send_email")],
+        )},
+    )
+    db = InMemoryBackend()
+    span = make_tool_span(agent_id="test-agent", tool_name="send_email")
+
+    # Process 1: fires and dispatches the first alert.
+    engine1 = AlertEngine(db, config)
+    channel1 = MagicMock()
+    engine1.dispatcher.channels = [channel1]
+    engine1.evaluate(span)
+    assert channel1.send.call_count == 1
+
+    # Restart: a brand new AlertEngine, same DB, no in-memory carryover
+    # except what hydration reconstructs from the alerts table.
+    engine2 = AlertEngine(db, config)
+    channel2 = MagicMock()
+    engine2.dispatcher.channels = [channel2]
+    engine2.evaluate(span)
+
+    # Still suppressed post-restart: persisted (for the audit trail) but
+    # never dispatched a second time.
+    assert channel2.send.call_count == 0
+    rows = db.get_alerts(AlertFilters(type=AlertType.SENSITIVE_ACTION, limit=10))
+    assert len(rows) == 2
+    assert [r.suppressed for r in sorted(rows, key=lambda r: r.fired_at)] == [False, True]
+
+
+def test_cooldown_does_not_suppress_after_a_restart_past_the_window():
+    """The hydration window is bounded by cooldown_seconds: an alert older
+    than the cooldown must NOT suppress a fresh firing after restart.
+    """
+    config = _make_config(
+        cooldown_seconds=0,
+        agents={"test-agent": AgentConfig(
+            sensitive_actions=[SensitiveAction(name="send_email")],
+        )},
+    )
+    db = InMemoryBackend()
+    span = make_tool_span(agent_id="test-agent", tool_name="send_email")
+
+    engine1 = AlertEngine(db, config)
+    engine1.dispatcher.channels = []
+    engine1.evaluate(span)
+
+    engine2 = AlertEngine(db, config)
+    channel2 = MagicMock()
+    engine2.dispatcher.channels = [channel2]
+    engine2.evaluate(span)
+
+    # cooldown_seconds=0 means nothing is ever suppressed, restart or not.
+    assert channel2.send.call_count == 1
+
+
+def test_failure_rate_does_not_refire_for_the_same_session_after_a_restart():
+    """A session that already crossed the failure-rate threshold before a
+    restart must not fire a second FAILURE_RATE alert after it, even though
+    the new process's `_failure_rate_fired` set starts out empty in code.
+    """
+    config = _make_config(cooldown_seconds=300)
+    db = InMemoryBackend()
+    session_id = "sess-failure-rate-restart"
+
+    engine1 = AlertEngine(db, config)
+    engine1.dispatcher.channels = []
+    # 5 errors in a row crosses _FAILURE_RATE_THRESHOLD (0.20) at
+    # _FAILURE_RATE_CHECK_INTERVAL (5), firing exactly once.
+    for _ in range(5):
+        span = make_llm_span(agent_id="test-agent", session_id=session_id, status="error")
+        db.insert_span(span)
+        engine1.evaluate(span)
+
+    fired_before_restart = db.get_alerts(AlertFilters(type=AlertType.FAILURE_RATE, limit=10))
+    assert len(fired_before_restart) == 1
+    assert session_id in engine1._failure_rate_fired
+
+    # Restart: a fresh AlertEngine over the same DB.
+    engine2 = AlertEngine(db, config)
+    assert session_id in engine2._failure_rate_fired
+
+    # One more error in the same session must not re-fire.
+    span6 = make_llm_span(agent_id="test-agent", session_id=session_id, status="error")
+    db.insert_span(span6)
+    engine2.evaluate(span6)
+
+    fired_after_restart = db.get_alerts(AlertFilters(type=AlertType.FAILURE_RATE, limit=10))
+    assert len(fired_after_restart) == 1
+
+
+def test_a_different_session_still_fires_its_own_failure_rate_alert_after_a_restart():
+    """Hydration must not over-suppress: a session that never fired before
+    the restart is unaffected by another session's hydrated state.
+    """
+    config = _make_config(cooldown_seconds=300)
+    db = InMemoryBackend()
+
+    engine1 = AlertEngine(db, config)
+    engine1.dispatcher.channels = []
+    for _ in range(5):
+        span = make_llm_span(agent_id="agent-a", session_id="sess-a", status="error")
+        db.insert_span(span)
+        engine1.evaluate(span)
+
+    engine2 = AlertEngine(db, config)
+    engine2.dispatcher.channels = []
+    for _ in range(5):
+        span = make_llm_span(agent_id="agent-b", session_id="sess-b", status="error")
+        db.insert_span(span)
+        engine2.evaluate(span)
+
+    fired = db.get_alerts(AlertFilters(type=AlertType.FAILURE_RATE, limit=10))
+    assert {a.session_id for a in fired} == {"sess-a", "sess-b"}

--- a/tests/synthetic/test_alert_engine_restart.py
+++ b/tests/synthetic/test_alert_engine_restart.py
@@ -8,9 +8,10 @@ not insert or dispatch a duplicate alert.
 """
 from __future__ import annotations
 
-from unittest.mock import MagicMock
+from datetime import timedelta
+from unittest.mock import MagicMock, patch
 
-from tokenjam.core.alerts import AlertEngine
+from tokenjam.core.alerts import AlertEngine, CooldownTracker
 from tokenjam.core.config import (
     AgentConfig,
     AlertChannelConfig,
@@ -19,8 +20,28 @@ from tokenjam.core.config import (
     TjConfig,
 )
 from tokenjam.core.db import InMemoryBackend
-from tokenjam.core.models import AlertFilters, AlertType
+from tokenjam.core.models import Alert, AlertFilters, AlertType, Severity
+from tokenjam.utils.ids import new_uuid
+from tokenjam.utils.time_parse import utcnow
 from tests.factories import make_llm_span, make_tool_span
+
+
+def _make_alert(
+    agent_id: str,
+    alert_type: AlertType,
+    fired_at,
+    suppressed: bool = False,
+) -> Alert:
+    return Alert(
+        alert_id=new_uuid(),
+        fired_at=fired_at,
+        type=alert_type,
+        severity=Severity.WARNING,
+        title="test alert",
+        detail={},
+        agent_id=agent_id,
+        suppressed=suppressed,
+    )
 
 
 def _make_config(cooldown_seconds: int, agents: dict | None = None) -> TjConfig:
@@ -73,27 +94,33 @@ def test_cooldown_survives_a_restart_within_the_window():
 def test_cooldown_does_not_suppress_after_a_restart_past_the_window():
     """The hydration window is bounded by cooldown_seconds: an alert older
     than the cooldown must NOT suppress a fresh firing after restart.
+
+    Inserts a row directly (bypassing evaluate()) with `fired_at` well
+    outside a real, non-zero cooldown window, so a build that dropped the
+    `since=` bound from `_hydrate_from_db`'s query, rather than one that
+    never suppresses at all, would also be caught here.
     """
     config = _make_config(
-        cooldown_seconds=0,
+        cooldown_seconds=60,
         agents={"test-agent": AgentConfig(
             sensitive_actions=[SensitiveAction(name="send_email")],
         )},
     )
     db = InMemoryBackend()
+    old_alert = _make_alert(
+        "test-agent", AlertType.SENSITIVE_ACTION, utcnow() - timedelta(hours=1),
+    )
+    db.insert_alert(old_alert)
+
+    engine = AlertEngine(db, config)
+    channel = MagicMock()
+    engine.dispatcher.channels = [channel]
     span = make_tool_span(agent_id="test-agent", tool_name="send_email")
+    engine.evaluate(span)
 
-    engine1 = AlertEngine(db, config)
-    engine1.dispatcher.channels = []
-    engine1.evaluate(span)
-
-    engine2 = AlertEngine(db, config)
-    channel2 = MagicMock()
-    engine2.dispatcher.channels = [channel2]
-    engine2.evaluate(span)
-
-    # cooldown_seconds=0 means nothing is ever suppressed, restart or not.
-    assert channel2.send.call_count == 1
+    # The persisted row is an hour outside the 60s window: hydration must
+    # not have seeded `_last_fired` from it, so this fires and dispatches.
+    assert channel.send.call_count == 1
 
 
 def test_failure_rate_does_not_refire_for_the_same_session_after_a_restart():
@@ -154,3 +181,70 @@ def test_a_different_session_still_fires_its_own_failure_rate_alert_after_a_rest
 
     fired = db.get_alerts(AlertFilters(type=AlertType.FAILURE_RATE, limit=10))
     assert {a.session_id for a in fired} == {"sess-a", "sess-b"}
+
+
+def test_hydrate_skips_suppressed_rows():
+    """A suppressed row records that an alert was DEDUPED, not a fresh
+    firing, so hydrating from it would suppress a genuinely new alert.
+    """
+    now = utcnow()
+    tracker = CooldownTracker(cooldown_seconds=300)
+    tracker.hydrate([
+        _make_alert("test-agent", AlertType.SENSITIVE_ACTION, now, suppressed=True),
+    ])
+    assert tracker.is_suppressed("test-agent", AlertType.SENSITIVE_ACTION) is False
+
+
+def test_hydrate_keeps_the_newest_firing_regardless_of_row_order():
+    """hydrate() must not rely on `alerts` being newest-first: given rows
+    for the same (agent_id, type) key in EITHER order, the surviving
+    `_last_fired` timestamp is the newest one, not whichever came first.
+    """
+    now = utcnow()
+    older = now - timedelta(seconds=200)
+
+    newest_first = CooldownTracker(cooldown_seconds=300)
+    newest_first.hydrate([
+        _make_alert("test-agent", AlertType.SENSITIVE_ACTION, now),
+        _make_alert("test-agent", AlertType.SENSITIVE_ACTION, older),
+    ])
+
+    oldest_first = CooldownTracker(cooldown_seconds=300)
+    oldest_first.hydrate([
+        _make_alert("test-agent", AlertType.SENSITIVE_ACTION, older),
+        _make_alert("test-agent", AlertType.SENSITIVE_ACTION, now),
+    ])
+
+    assert (
+        newest_first._last_fired[("test-agent", AlertType.SENSITIVE_ACTION.value)]
+        == oldest_first._last_fired[("test-agent", AlertType.SENSITIVE_ACTION.value)]
+        == now
+    )
+
+
+def test_hydration_failure_degrades_to_pre_592_behavior_instead_of_blocking_startup():
+    """A storage error during `_hydrate_from_db()` must not prevent
+    `AlertEngine.__init__` from completing: it degrades to empty in-memory
+    state, exactly what construction produced before hydration existed.
+    """
+    config = _make_config(
+        cooldown_seconds=300,
+        agents={"test-agent": AgentConfig(
+            sensitive_actions=[SensitiveAction(name="send_email")],
+        )},
+    )
+    db = InMemoryBackend()
+
+    with patch.object(db, "get_alerts", side_effect=RuntimeError("storage unavailable")):
+        engine = AlertEngine(db, config)
+
+    assert engine._failure_rate_fired == set()
+    assert engine.cooldown._last_fired == {}
+
+    # And the engine is fully usable afterward: a span fired post-construction
+    # still evaluates and dispatches normally.
+    channel = MagicMock()
+    engine.dispatcher.channels = [channel]
+    span = make_tool_span(agent_id="test-agent", tool_name="send_email")
+    engine.evaluate(span)
+    assert channel.send.call_count == 1

--- a/tests/synthetic/test_alert_engine_restart.py
+++ b/tests/synthetic/test_alert_engine_restart.py
@@ -96,9 +96,9 @@ def test_cooldown_does_not_suppress_after_a_restart_past_the_window():
     than the cooldown must NOT suppress a fresh firing after restart.
 
     Inserts a row directly (bypassing evaluate()) with `fired_at` well
-    outside a real, non-zero cooldown window, so a build that dropped the
-    `since=` bound from `_hydrate_from_db`'s query, rather than one that
-    never suppresses at all, would also be caught here.
+    outside a real, non-zero cooldown window. The bound itself is enforced
+    by `CooldownTracker.is_suppressed`'s own timestamp check, not by this
+    test; it does not exercise `_hydrate_from_db`'s `since=` query filter.
     """
     config = _make_config(
         cooldown_seconds=60,

--- a/tokenjam/core/alerts.py
+++ b/tokenjam/core/alerts.py
@@ -55,6 +55,13 @@ _SESSION_DURATION_DEFAULT = 3600  # seconds
 # Row cap for the startup queries that rebuild CooldownTracker/_failure_rate_fired
 # from the alerts table (#592). Generous rather than exact: missing a stale row
 # only means an old alert is treated as new, the same behavior as before this fix.
+# get_alerts applies this cap in SQL before CooldownTracker.hydrate() filters out
+# suppressed rows, so a single (agent_id, type) key producing more than this many
+# rows inside one cooldown window can crowd a different key's lone unsuppressed
+# row out of the page returned to hydrate(). Requires >10k alert rows for one key
+# inside a single cooldown window (default 60s) to matter, and the failure mode
+# degrades to pre-#592 behavior (that key comes back unhydrated) rather than
+# suppressing wrongly.
 _HYDRATION_LIMIT = 10_000
 
 # Agent-id prefixes for *interactive coding* runtimes (Claude Code / Codex): a
@@ -207,16 +214,16 @@ class CooldownTracker:
     def hydrate(self, alerts: list[Alert]) -> None:
         """Seed `_last_fired` from persisted, non-suppressed alert rows.
 
-        `alerts` must be newest-first (matches `StorageBackend.get_alerts`'s
-        `ORDER BY fired_at DESC`): the first row seen for a (agent_id, type)
-        key is its most recent firing, so once a key is set it is never
-        overwritten by an older row later in the list.
+        Order-independent: keeps the newest `fired_at` seen for each
+        (agent_id, type) key rather than trusting the caller's row order,
+        so a change to `get_alerts`' `ORDER BY` cannot silently regress this.
         """
         for alert in alerts:
             if alert.suppressed:
                 continue
             key = (alert.agent_id or "", alert.type.value)
-            if key not in self._last_fired:
+            existing = self._last_fired.get(key)
+            if existing is None or alert.fired_at > existing:
                 self._last_fired[key] = alert.fired_at
 
 
@@ -251,17 +258,37 @@ class AlertEngine:
         duplicate alert as if it were new. The `alerts` table already has
         everything needed: `fired_at`/`type`/`agent_id` for the cooldown
         window, `session_id` for which sessions already fired FAILURE_RATE.
-        """
-        since = utcnow() - timedelta(seconds=self.cooldown.cooldown_seconds)
-        recent = self.db.get_alerts(AlertFilters(since=since, limit=_HYDRATION_LIMIT))
-        self.cooldown.hydrate(recent)
 
-        fired = self.db.get_alerts(
-            AlertFilters(type=AlertType.FAILURE_RATE, limit=_HYDRATION_LIMIT)
-        )
-        for alert in fired:
-            if alert.session_id:
-                self._failure_rate_fired.add(alert.session_id)
+        `AlertEngine.__init__` was previously pure in-memory and could not
+        fail; it now runs two DB queries at construction, which happens on
+        every `tj serve` and SDK-bootstrap startup. A storage error here
+        degrades to pre-#592 behavior (both structures stay empty, exactly
+        what construction did before this fix) rather than blocking startup
+        for what is a best-effort optimization.
+        """
+        # Deferred: tokenjam.core.db imports tokenjam.core.persona_scope,
+        # which imports interactive_coding_agent_sql from this module, so a
+        # module-level import here would be circular.
+        from tokenjam.core.db import handle_if_fatal
+
+        try:
+            since = utcnow() - timedelta(seconds=self.cooldown.cooldown_seconds)
+            recent = self.db.get_alerts(AlertFilters(since=since, limit=_HYDRATION_LIMIT))
+            self.cooldown.hydrate(recent)
+
+            fired = self.db.get_alerts(
+                AlertFilters(type=AlertType.FAILURE_RATE, limit=_HYDRATION_LIMIT)
+            )
+            for alert in fired:
+                if alert.session_id:
+                    self._failure_rate_fired.add(alert.session_id)
+        except Exception as exc:
+            if not handle_if_fatal(exc, what="AlertEngine cooldown/dedup hydration"):
+                logger.warning(
+                    "cooldown/dedup hydration from the alerts table failed (%s: %s); "
+                    "starting with empty in-memory state, same as before #592",
+                    type(exc).__name__, str(exc).split("\n")[0],
+                )
 
     def evaluate(self, span: NormalizedSpan) -> None:
         """Evaluate all per-span alert rules against this span."""

--- a/tokenjam/core/alerts.py
+++ b/tokenjam/core/alerts.py
@@ -286,7 +286,7 @@ class AlertEngine:
             if not handle_if_fatal(exc, what="AlertEngine cooldown/dedup hydration"):
                 logger.warning(
                     "cooldown/dedup hydration from the alerts table failed (%s: %s); "
-                    "starting with empty in-memory state, same as before #592",
+                    "starting with empty in-memory state, same as before this hydration existed",
                     type(exc).__name__, str(exc).split("\n")[0],
                 )
 

--- a/tokenjam/core/alerts.py
+++ b/tokenjam/core/alerts.py
@@ -7,7 +7,7 @@ from __future__ import annotations
 
 import json
 import logging
-from datetime import datetime
+from datetime import datetime, timedelta
 from typing import TYPE_CHECKING, Any
 
 import httpx
@@ -19,7 +19,7 @@ from tokenjam.core.config import (
     resolve_effective_budget,
     resolve_group_budget,
 )
-from tokenjam.core.models import Alert, AlertType, Severity
+from tokenjam.core.models import Alert, AlertFilters, AlertType, Severity
 from tokenjam.otel.semconv import GenAIAttributes, TjAttributes
 from tokenjam.utils.formatting import console, severity_colour
 from tokenjam.utils.ids import new_uuid
@@ -51,6 +51,11 @@ _FAILURE_RATE_WINDOW = 20
 _FAILURE_RATE_THRESHOLD = 0.20
 _FAILURE_RATE_CHECK_INTERVAL = 5
 _SESSION_DURATION_DEFAULT = 3600  # seconds
+
+# Row cap for the startup queries that rebuild CooldownTracker/_failure_rate_fired
+# from the alerts table (#592). Generous rather than exact: missing a stale row
+# only means an old alert is treated as new, the same behavior as before this fix.
+_HYDRATION_LIMIT = 10_000
 
 # Agent-id prefixes for *interactive coding* runtimes (Claude Code / Codex): a
 # heterogeneous, arg-less, human-driven workload with no stable, repeatable
@@ -180,7 +185,8 @@ class CooldownTracker:
     """
     Prevents alert storms by suppressing repeat alerts of the same type
     for the same agent within the cooldown window.
-    Stored in-memory — resets when the process restarts.
+    In-memory, so a fresh instance is blind to state from before a restart
+    until `hydrate()` seeds it from persisted alert rows (#592).
     """
 
     def __init__(self, cooldown_seconds: int = 60) -> None:
@@ -197,6 +203,21 @@ class CooldownTracker:
     def record(self, agent_id: str | None, alert_type: AlertType) -> None:
         key = (agent_id or "", alert_type.value)
         self._last_fired[key] = utcnow()
+
+    def hydrate(self, alerts: list[Alert]) -> None:
+        """Seed `_last_fired` from persisted, non-suppressed alert rows.
+
+        `alerts` must be newest-first (matches `StorageBackend.get_alerts`'s
+        `ORDER BY fired_at DESC`): the first row seen for a (agent_id, type)
+        key is its most recent firing, so once a key is set it is never
+        overwritten by an older row later in the list.
+        """
+        for alert in alerts:
+            if alert.suppressed:
+                continue
+            key = (alert.agent_id or "", alert.type.value)
+            if key not in self._last_fired:
+                self._last_fired[key] = alert.fired_at
 
 
 # ── Alert engine ───────────────────────────────────────────────────────────
@@ -215,8 +236,32 @@ class AlertEngine:
         # Sessions that have already fired a failure-rate alert. One struggling
         # session = one alert: without this, every additional error past the
         # threshold re-fired (5/20, 6/20, 7/20 …), turning a few incidents into a
-        # cascade of near-identical alerts. In-memory (resets per process).
+        # cascade of near-identical alerts.
         self._failure_rate_fired: set[str] = set()
+        self._hydrate_from_db()
+
+    def _hydrate_from_db(self) -> None:
+        """Reconstruct cooldown/dedup state from the alerts table (#592).
+
+        Both `self.cooldown` and `_failure_rate_fired` start empty on every
+        construction, and `AlertEngine` is built fresh on every process
+        start. Without this, a restart mid-cooldown (or mid-session, for a
+        session that already crossed the failure-rate threshold) forgets
+        that state, and a still-true condition inserts and dispatches a
+        duplicate alert as if it were new. The `alerts` table already has
+        everything needed: `fired_at`/`type`/`agent_id` for the cooldown
+        window, `session_id` for which sessions already fired FAILURE_RATE.
+        """
+        since = utcnow() - timedelta(seconds=self.cooldown.cooldown_seconds)
+        recent = self.db.get_alerts(AlertFilters(since=since, limit=_HYDRATION_LIMIT))
+        self.cooldown.hydrate(recent)
+
+        fired = self.db.get_alerts(
+            AlertFilters(type=AlertType.FAILURE_RATE, limit=_HYDRATION_LIMIT)
+        )
+        for alert in fired:
+            if alert.session_id:
+                self._failure_rate_fired.add(alert.session_id)
 
     def evaluate(self, span: NormalizedSpan) -> None:
         """Evaluate all per-span alert rules against this span."""


### PR DESCRIPTION
## Summary

CooldownTracker and AlertEngine._failure_rate_fired are process-local and start
empty on every AlertEngine construction, which happens once per process
(IngestPipeline.__init__). A daemon restart mid-cooldown, or a restart while a
session is still crossing the failure-rate window, forgets that state and
re-inserts (and re-dispatches) an alert for a condition that is still true.
This hydrates both from the existing `alerts` table on `AlertEngine.__init__`:
the most recent non-suppressed alert per `(agent_id, type)` within the cooldown
window seeds `CooldownTracker`, and every `session_id` with a `FAILURE_RATE`
row seeds `_failure_rate_fired`. No new table.

## Related issue

Closes #592

## Verification

- New tests in `tests/integration/test_alert_engine_restart.py` construct a
  second `AlertEngine` against the same `InMemoryBackend` to simulate a
  restart. Confirmed failing on unmodified `main` and passing on this branch,
  both in the same container (`git stash` differential): a restart within the
  cooldown window no longer re-dispatches a `SENSITIVE_ACTION` alert, cooldown
  correctly does NOT suppress once `cooldown_seconds` has actually elapsed,
  and a session that already fired `FAILURE_RATE` does not fire it again after
  a restart while an unrelated session is unaffected.
- Full suite (`pytest tests/unit/ tests/synthetic/ tests/agents/
  tests/integration/`) on Python 3.10 and 3.12: identical pass/fail set
  before and after this change (11 pre-existing failures, all environment-
  related fixture issues in onboarding/upgrade/daemon-stop tests, none
  touching `alerts.py`, confirmed unchanged against unmodified `main` in the
  same containers).
- `ruff check` and `mypy` clean on the changed files.
- Not verified: real alert-dispatch channels (ntfy/webhook/Discord/Telegram)
  under an actual restart, only the dispatcher-level `send()` call the tests
  assert on; channel delivery itself is unchanged by this diff.

@anilmurty could not request you as a reviewer directly (not a collaborator), flagging here per CONTRIBUTING.md.