### PR TITLE
fix(ci): unbreak mypy against click 8.5's untyped get_text_stream

### DIFF
--- a/tokenjam/cli/cmd_summarize.py
+++ b/tokenjam/cli/cmd_summarize.py
@@ -411,7 +411,14 @@ def cmd_summarize_check(
     config: TjConfig = ctx.obj["config"]
     output_json = resolve_output_json(ctx, output_json_flag)
     summary_text = (
-        click.get_text_stream("stdin").read() if summary_path == "-"
+        # click 8.5.0 made `click.get_text_stream` resolve as `object` to type
+        # checkers (`click.utils.get_text_stream` too), so mypy reads the
+        # `.read()` here as a call on `object`. Runtime is unaffected: the full
+        # suite passes on 8.5, and `click>=8.2` is deliberately unbounded so a
+        # runtime pin would degrade every install to quiet a type checker.
+        # Remove this ignore once click restores the annotation.
+        click.get_text_stream("stdin").read()  # type: ignore[operator]
+        if summary_path == "-"
         else Path(summary_path).expanduser().read_text(encoding="utf-8")
     )
     try:


### PR DESCRIPTION
`main` is currently red on the blocking Type check step, on a file nobody has touched since June. This unbreaks it.

## Summary

- Adds a targeted `# type: ignore[operator]` to `tj summarize check`'s stdin read, with a comment naming the cause and the condition for removing it.
- No runtime change. The ternary is reformatted across lines only so the ignore attaches to the right expression.

## Root cause

click 8.5.0 was released between our last green `main` run (Aug 25, `1c45706`) and today. It makes `click.get_text_stream` resolve as `object` to type checkers, so mypy reads the `.read()` on it as a call on `object`:

```
tokenjam/cli/cmd_summarize.py:414: error: "object" not callable  [operator]
```

`from click.utils import get_text_stream` resolves the same way, so this is not an import-path problem. Our `pyproject.toml` carries `click>=8.2` unbounded, so every fresh CI install picks 8.5 up.

Isolated on clean `main` in a fresh venv, holding mypy constant:

| click | `mypy tokenjam/` |
|---|---|
| 8.5.0 | `cmd_summarize.py:414: "object" not callable` (matches CI exactly) |
| 8.4.2 | clean |

## Why an ignore rather than a pin

click 8.5 is fine at runtime. All three test jobs pass on it, and so does the full local suite, so the breakage is confined to type resolution. Pinning `click<8.5` in `dependencies` would constrain every user's install to quiet our type checker, which is the wrong trade for a typing regression in someone else's package.

The mypy config in `pyproject.toml` already prescribes this remedy for this exact situation: *"use a targeted per-line `# type: ignore[code]  # reason` or a per-module `[[tool.mypy.overrides]]` only where an untyped third-party dep forces it."* `warn_unused_ignores` is not enabled, so the ignore will not start failing once click restores the annotation. The comment says to drop it then.

## Tests / Verification

Reproduced and verified against CI's own dependency combination (click 8.5.0, mypy 2.3.1) in a clean venv:

- `mypy tokenjam/` → `Success: no issues found in 278 source files`
- `ruff check tokenjam/` → clean
- `pytest tests/ -k summarize` → 459 passed, 10 skipped

## What's NOT in this PR

- **No dependency pin.** If click treats this as a bug and fixes it in 8.5.1, the right follow-up is deleting the ignore, not adding a bound.
- **No sweep for other click attributes.** `mypy tokenjam/` reports exactly one error today, so this is the whole of the current breakage. More call sites could surface as code touches other lazily re-exported click names.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Udob55h9TFuzc5tqbVB7Sf
