### PR TITLE
fix(cost): disclose the downsize driver-role/resend session overlap (#613)

### DIFF
--- a/tests/unit/test_downsize_driver_role.py
+++ b/tests/unit/test_downsize_driver_role.py
@@ -304,6 +304,67 @@ def test_the_driver_card_discloses_it_shares_sessions_with_resends_cost(db):
     assert "not" in driver_card.coverage_note and "add" in driver_card.coverage_note
 
 
+def test_the_coverage_note_does_not_overstate_a_divergent_population(db):
+    # Greptile review on #735: resend classifies a session as driver-role from
+    # `premium_driver_role` alone, while this card's own `sessions` additionally
+    # requires a priced, CONTIGUOUS tool-driven stretch
+    # (`tool_driven_stretch_mask`, MIN_TOOL_STRETCH_TURNS=2). A session whose
+    # tool calls are scattered across non-adjacent turns clears
+    # `premium_driver_role`'s DRIVER_TOOL_FANOUT_FLOOR (a plain sum) but never
+    # forms a run of 2, so resend counts it while this card's own gates reject
+    # it, the two populations diverge, and the note must not claim the
+    # broader resend figure describes exactly these sessions.
+    _seed_driver_session(db, session_id="deleg", delegate=True)
+    _seed_driver_session(db, session_id="driver")  # counted by BOTH sides
+    start = utcnow() - timedelta(days=2)
+    for i in range(TURNS):
+        turn_at = start + timedelta(minutes=i * 10)
+        db.insert_span(make_llm_span(
+            agent_id="claude-code-x", model=PREMIUM, provider="anthropic",
+            input_tokens=MIN_SESSION_CONTEXT_TOKENS,
+            cache_tokens=MIN_SESSION_CONTEXT_TOKENS * i,
+            output_tokens=800, cost_usd=1.0,
+            session_id="scattered", sub_agent_id=None, start_time=turn_at,
+        ))
+        if i % 2 == 0:
+            # 4 tools on every other turn: 3 turns x 4 = 12 >= the
+            # DRIVER_TOOL_FANOUT_FLOOR (10) sum, but no two consecutive turns
+            # both run a tool, so no contiguous stretch ever reaches
+            # MIN_TOOL_STRETCH_TURNS (2). resend counts this session; this
+            # card's own gate does not.
+            for j in range(4):
+                db.insert_span(make_tool_span(
+                    agent_id="claude-code-x", tool_name="Read",
+                    session_id="scattered",
+                    start_time=turn_at + timedelta(seconds=j + 1),
+                ))
+    since, until = _window()
+    report = build_report(
+        db=db, config=TjConfig(version="1"), since=since, until=until,
+        findings=["resend", "downsize"],
+    )
+    resend = report.findings["resend"]
+    assert resend.driver_role_sessions == 2, "both 'driver' and 'scattered' flag"
+    assert report.downgrade is not None
+    assert report.downgrade.driver_sessions == 1, (
+        "'scattered' has no contiguous tool-driven stretch, so only 'driver' "
+        "clears this card's own gate"
+    )
+    proposals = cost_proposals_from_report(report, None, window_days=30.0)
+    driver_card = next(
+        p for p in proposals if p.signature == "cost:downsize:driver-role"
+    )
+    note = driver_card.coverage_note
+    # The populations diverge (1 vs 2): the note must describe ITS OWN 1
+    # session as sitting inside resend's broader 2-session class, never claim
+    # resend's 2-session figure describes exactly these 1 session(s).
+    assert f"{resend.driver_role_sessions:,}" in note
+    assert f"${resend.cost_driver_role_usd:,.2f}" in note
+    assert "not" in note and "add" in note
+    assert f"These {report.downgrade.driver_sessions:,} session(s)" in note
+    assert f"These {resend.driver_role_sessions:,} session(s)" not in note
+
+
 def test_the_driver_card_has_no_coverage_note_without_a_resend_finding(db):
     # `resend` can be disabled for a persona/report scope independently of
     # `downsize`: the reciprocal disclosure must degrade to nothing, not to

--- a/tests/unit/test_downsize_driver_role.py
+++ b/tests/unit/test_downsize_driver_role.py
@@ -275,6 +275,52 @@ def test_resend_hands_driver_sessions_to_downsize(db):
     assert any("model-role card" in n for n in resend.notes)
 
 
+def test_the_driver_card_discloses_it_shares_sessions_with_resends_cost(db):
+    # #613: resend's card already discloses this overlap; the mirror sentence
+    # on THIS card was missing, so summing both cards double-counted.
+    _seed_driver_session(db, session_id="deleg", delegate=True)
+    _seed_driver_session(db, session_id="driver")
+    db.insert_span(make_llm_span(
+        agent_id="claude-code-x", model=PREMIUM, provider="anthropic",
+        input_tokens=100, output_tokens=10, cost_usd=0.01,
+        session_id="pad", sub_agent_id=None, start_time=utcnow() - timedelta(days=2),
+    ))
+    since, until = _window()
+    report = build_report(
+        db=db, config=TjConfig(version="1"), since=since, until=until,
+        findings=["resend", "downsize"],
+    )
+    resend = report.findings["resend"]
+    assert resend.driver_role_sessions == 1, "same fixture as the sibling test above"
+    proposals = cost_proposals_from_report(report, None, window_days=30.0)
+    driver_card = next(
+        p for p in proposals if p.signature == "cost:downsize:driver-role"
+    )
+    # Read off the SAME fields resend's own note reads, so the two cards
+    # cannot state different numbers for sessions one shared predicate
+    # partitioned to this one.
+    assert f"{resend.driver_role_sessions:,}" in driver_card.coverage_note
+    assert f"${resend.cost_driver_role_usd:,.2f}" in driver_card.coverage_note
+    assert "not" in driver_card.coverage_note and "add" in driver_card.coverage_note
+
+
+def test_the_driver_card_has_no_coverage_note_without_a_resend_finding(db):
+    # `resend` can be disabled for a persona/report scope independently of
+    # `downsize`: the reciprocal disclosure must degrade to nothing, not to
+    # a note quoting zeroes, when there is no sibling finding to read.
+    _seed_driver_session(db, session_id="driver")
+    since, until = _window()
+    report = build_report(
+        db=db, config=TjConfig(version="1"), since=since, until=until,
+        findings=["downsize"],
+    )
+    proposals = cost_proposals_from_report(report, None, window_days=30.0)
+    driver_card = next(
+        p for p in proposals if p.signature == "cost:downsize:driver-role"
+    )
+    assert driver_card.coverage_note == ""
+
+
 def test_the_rollup_counts_a_driver_session_exactly_once(db):
     # End to end. `downsize` claims the driver session; `resend` claims the
     # delegating one. Neither analyzer's signature can dedup against the other

--- a/tokenjam/core/optimize/cost_proposals.py
+++ b/tokenjam/core/optimize/cost_proposals.py
@@ -592,16 +592,35 @@ def _driver_role_proposals(
     # Reciprocal of resend's own coverage_note (#613). Read resend's
     # already-computed session count and dollar figure rather than
     # recomputing, so the two cards cannot disagree.
+    #
+    # resend classifies a session as driver-role from `premium_driver_role`
+    # alone; this card's own `sessions` additionally requires a priced,
+    # contiguous tool-driven stretch (`_driver_session_arithmetic`'s mask and
+    # rate lookups), so `sessions` is always a SUBSET of resend's
+    # `resend_sessions`, never the same population under a different name.
+    # Quoting resend_sessions/resend_usd as if they described exactly THESE
+    # `sessions` overstates the overlap whenever the populations diverge
+    # (resend counts sessions this card's own gates reject); the wording below
+    # only claims what is actually true of the relationship in either case.
     resend_sessions = int(getattr(resend_finding, "driver_role_sessions", 0) or 0)
     resend_usd = float(getattr(resend_finding, "cost_driver_role_usd", 0.0) or 0.0)
     coverage_note = ""
     if resend_sessions and resend_usd:
-        coverage_note = (
-            f"COVERAGE. These {resend_sessions:,} session(s) also carry "
-            f"${resend_usd:,.2f} of resend's observed cost, analysed there as "
-            f"re-sent context. The two figures price the same sessions and "
-            f"must not be added together."
-        )
+        if resend_sessions > sessions:
+            coverage_note = (
+                f"COVERAGE. These {sessions:,} session(s) sit inside resend's "
+                f"broader {resend_sessions:,}-session driver-role class, which "
+                f"also carries ${resend_usd:,.2f} of resend's observed cost, "
+                f"analysed there as re-sent context. The two figures price "
+                f"overlapping populations and must not be added together."
+            )
+        else:
+            coverage_note = (
+                f"COVERAGE. These {resend_sessions:,} session(s) also carry "
+                f"${resend_usd:,.2f} of resend's observed cost, analysed there as "
+                f"re-sent context. The two figures price the same sessions and "
+                f"must not be added together."
+            )
     # A FOURTH copy of the offload rule used to live here, abbreviated. The
     # consolidation that gave the three analyzers one record reached the card's
     # advise text and missed its one-paste block, so the user still received a

--- a/tokenjam/core/optimize/cost_proposals.py
+++ b/tokenjam/core/optimize/cost_proposals.py
@@ -384,6 +384,7 @@ class CostProposal:
 
 def _downsize_to_proposal(
     finding: Any, config: Any = None, persona: str = "unknown",
+    resend_finding: Any = None,
 ) -> list[CostProposal]:
     """The model-over-sizing card(s).
 
@@ -417,7 +418,7 @@ def _downsize_to_proposal(
     # merging the two would put one number on top of two unrelated derivations.
     # Exactly one window-wide card, never one per agent, so this adds at most a
     # single row to the inbox.
-    proposals = _driver_role_proposals(finding, persona)
+    proposals = _driver_role_proposals(finding, persona, resend_finding=resend_finding)
     if persona == "claude-code":
         # See the docstring above: the tiny-session/per-agent cards never had
         # a fix on this persona's action surface, only a pointer to other
@@ -550,7 +551,9 @@ def _driver_role_advice() -> str:
     )
 
 
-def _driver_role_proposals(finding: Any, persona: str = "unknown") -> list[CostProposal]:
+def _driver_role_proposals(
+    finding: Any, persona: str = "unknown", resend_finding: Any = None,
+) -> list[CostProposal]:
     """The model-ROLE card: a premium model drove undelegated work inline.
 
     One window-wide card, deliberately never one per agent — the standing
@@ -561,6 +564,11 @@ def _driver_role_proposals(finding: Any, persona: str = "unknown") -> list[CostP
     CLAUDE.md rule plus an agent-file `model:` pin, both of which are on the
     Claude Code action surface, so there is no "you can't switch your own
     interactive model" caveat to apply.
+
+    ``resend_finding``, when present, states the reciprocal of resend's own
+    `coverage_note` (#613): the mirror sentence that these sessions also
+    carry a cost on resend's card, read off resend's own fields so the two
+    cards cannot disagree.
     """
     sessions = int(getattr(finding, "driver_sessions", 0) or 0)
     usd = float(getattr(finding, "driver_recoverable_usd", 0.0) or 0.0)
@@ -581,6 +589,19 @@ def _driver_role_proposals(finding: Any, persona: str = "unknown") -> list[CostP
         f"({swap_text or 'a cheaper same-family model'}) would have saved "
         f"${offload:,.2f} of re-reads plus ${tier:,.2f} of tier difference."
     )
+    # Reciprocal of resend's own coverage_note (#613). Read resend's
+    # already-computed session count and dollar figure rather than
+    # recomputing, so the two cards cannot disagree.
+    resend_sessions = int(getattr(resend_finding, "driver_role_sessions", 0) or 0)
+    resend_usd = float(getattr(resend_finding, "cost_driver_role_usd", 0.0) or 0.0)
+    coverage_note = ""
+    if resend_sessions and resend_usd:
+        coverage_note = (
+            f"COVERAGE. These {resend_sessions:,} session(s) also carry "
+            f"${resend_usd:,.2f} of resend's observed cost, analysed there as "
+            f"re-sent context. The two figures price the same sessions and "
+            f"must not be added together."
+        )
     # A FOURTH copy of the offload rule used to live here, abbreviated. The
     # consolidation that gave the three analyzers one record reached the card's
     # advise text and missed its one-paste block, so the user still received a
@@ -601,6 +622,7 @@ def _driver_role_proposals(finding: Any, persona: str = "unknown") -> list[CostP
         title="Premium model in the driver role (route the work, not the thread)",
         target_key={"models": models, "suggestions": substitutes},
         evidence=evidence,
+        coverage_note=coverage_note,
         baseline={
             "driver_sessions": sessions,
             "total_sessions": total_sessions,
@@ -3423,7 +3445,12 @@ def _adapt_report(
     adapters = (
         (
             "downsize",
-            lambda f: _downsize_to_proposal(f, config, persona=persona),
+            # Needs resend's driver-role figures for the reciprocal
+            # `coverage_note` (#613), read here like `resend` already reads
+            # `subagent` below, so neither analyzer depends on the other.
+            lambda f: _downsize_to_proposal(
+                f, config, persona=persona, resend_finding=_pick("resend"),
+            ),
             getattr(report, "downgrade", None),
         ),
         ("cache", lambda f: _cache_to_proposals(f, persona=persona), _pick("cache")),


### PR DESCRIPTION
## Summary

`resend`'s cost card and `downsize`'s driver-role card can describe the same sessions. `estimated_recoverable_*` is kept disjoint between them by the shared `premium_driver_role` predicate, but the observed-cost figures are not: 706 sessions can carry a dollar amount on `resend`'s card and a separate avoidable amount on `downsize`'s driver-role card for the identical population. #598 added a disclosure to `resend`'s own `coverage_note` for this ("N session(s) ... are analysed on the model-role card instead"), but left the mirror sentence off `downsize`'s card, so a reader summing both cards' figures still double-counts.

## Fix

`_driver_role_proposals` now accepts the sibling `resend` finding (read at the adapter layer in `cost_proposals_from_report`, the same pattern `resend`'s own adapter already uses to read `subagent`) and, when it carries driver-role sessions, sets `coverage_note` on the driver-role `CostProposal` stating the session count and dollar figure also appear on `resend`'s card and must not be summed. Both cards read the same `driver_role_sessions` / `cost_driver_role_usd` fields off the one `ResendFinding` computation, so they cannot state different numbers. No note is added when `resend` is disabled or absent for a persona/report scope.

## Verification

- New regression tests in `tests/unit/test_downsize_driver_role.py`: the driver card's `coverage_note` names resend's session count and dollar figure and says the two are not additive; a second test confirms the note stays empty when there is no sibling `resend` finding. Both fail on `main` (`coverage_note` is always `""`) and pass on this branch.
- `pytest tests/unit/ tests/synthetic/ tests/agents/ tests/integration/` on Python 3.10 and 3.12: 5534 passed (183 in the touched files), 28 pre-existing failures identical on an unmodified checkout in this container (git/filesystem tests that need a real, writable git identity, unrelated to this change).
- `ruff check tokenjam/` and `mypy tokenjam/` clean.
- Not verified: line coverage via `coverage`/`pytest-cov`, which fails to import `duckdb` in this container regardless of this change (`ModuleNotFoundError: No module named '_duckdb._sqltypes'` under the coverage import hook). Confirmed instead by inspection that both new tests exercise every added branch (`coverage_note` set and left empty).

Closes #613

@anilmurty, ready for a look.
