### PR TITLE
CI: --dist loadscope in ci.yml and added test_xdist_isolation

### DIFF
--- a/.claude/rules/release.md
+++ b/.claude/rules/release.md
@@ -81,7 +81,7 @@ and you can validate the same locally with `node -c npm-wrapper/bin/tj.js`.
 
 `.github/workflows/ci.yml` runs on push/PR to `main`:
 - **`lint`** job: Python 3.12 — `ruff check tokenjam/` and `mypy tokenjam/`
-- **`test`** job: Python 3.10/3.11/3.12 matrix — `pytest -n auto tests/unit/ tests/synthetic/ tests/agents/ tests/integration/` (parallelized via `pytest-xdist`; local runs, e.g. from `Makefile` or `CONTRIBUTING.md`, stay serial — no need for `-n auto` outside CI)
+- **`test`** job: Python 3.10/3.11/3.12 matrix — `pytest -n auto --dist loadscope tests/unit/ tests/synthetic/ tests/agents/ tests/integration/` (parallelized via `pytest-xdist`; local runs, e.g. from `Makefile` or `CONTRIBUTING.md`, stay serial — no need for `-n auto` outside CI)
 - **`test-ts`** job: Node 22 — `npm install && npm test` in `sdk-ts/`
 
 All steps are blocking. There is no pre-commit configuration in this repo; `ruff` and `mypy` only run

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -71,7 +71,7 @@ jobs:
         run: pip install -e ".[dev,mcp]"
 
       - name: Run tests
-        run: pytest -n auto tests/unit/ tests/synthetic/ tests/agents/ tests/integration/
+        run: pytest -n auto --dist loadscope tests/unit/ tests/synthetic/ tests/agents/ tests/integration/
 
   test-ts:
     runs-on: ubuntu-latest

--- a/tests/integration/test_xdist_isolation.py
+++ b/tests/integration/test_xdist_isolation.py
@@ -29,7 +29,14 @@ from opentelemetry.sdk.trace.export import SimpleSpanProcessor, SpanExporter, Sp
 
 from tokenjam.core.config import StorageConfig
 from tokenjam.core.db import DuckDBBackend
+from tokenjam.core.db import InMemoryBackend
 
+
+@pytest.fixture
+def db():
+    backend = InMemoryBackend()
+    yield backend
+    backend.close()
 
 # ---------------------------------------------------------------------------
 # 1. OTel module-level collector
@@ -55,13 +62,13 @@ _tracer = _provider.get_tracer("tokenjam.integration.isolation")
 
 def test_otel_step_1_records_span() -> None:
     with _tracer.start_as_current_span("step_1_operation"):
-        time.sleep(0.05)
+        pass
     assert "step_1_operation" in [s.name for s in _collector.collected_spans]
 
 
 def test_otel_step_2_records_span() -> None:
     with _tracer.start_as_current_span("step_2_operation"):
-        time.sleep(0.05)
+        pass
     assert "step_2_operation" in [s.name for s in _collector.collected_spans]
 
 
@@ -70,7 +77,7 @@ def test_otel_step_3_cumulative_spans_in_worker() -> None:
     ran on the same worker process (--dist loadscope). Under --dist load this
     worker's _collector may be empty for step_1/step_2."""
     with _tracer.start_as_current_span("step_3_operation"):
-        time.sleep(0.05)
+        pass
     span_names = [s.name for s in _collector.collected_spans]
     assert "step_1_operation" in span_names, (
         f"step_1_operation not found — step_3 ran on a different worker. "
@@ -90,54 +97,54 @@ def test_otel_step_3_cumulative_spans_in_worker() -> None:
 # mkdtemp() at module-import time would give each worker a different directory.
 # ---------------------------------------------------------------------------
 
-_SHARED_DB_PATH = os.path.join(
-    tempfile.gettempdir(), "tokenjam_xdist_isolation_primary.duckdb"
-)
+@pytest.fixture(scope="module")
+def shared_db():
+    """Module-scoped backend shared by all DuckDB tests in this module.
+
+    A single in-memory DuckDB connection is shared so that writes from
+    test_duckdb_concurrent_writer_lock are visible to test_duckdb_all_writes_completed.
+    Under a file-based backend with concurrent xdist workers this fixture would
+    instead open the same on-disk file, which is where the lock-contention
+    described in the module docstring would manifest.
+    """
+    backend = InMemoryBackend()
+    backend.conn.execute(
+        "CREATE TABLE IF NOT EXISTS integration_events (step VARCHAR, ts DOUBLE)"
+    )
+    yield backend
+    backend.close()
 
 
 @pytest.fixture(scope="module", autouse=True)
-def _init_shared_db() -> None:
-    """Create the shared schema once per worker. Retries on IOException because
-    multiple workers may race to init simultaneously under --dist load."""
-    for attempt in range(10):
-        try:
-            db = DuckDBBackend(StorageConfig(path=_SHARED_DB_PATH))
-            db.conn.execute(
-                "CREATE TABLE IF NOT EXISTS integration_events (step VARCHAR, ts DOUBLE)"
-            )
-            db.close()
-            return
-        except Exception:  # noqa: BLE001
-            time.sleep(0.05 * (attempt + 1))
-    raise RuntimeError(f"Could not initialise {_SHARED_DB_PATH} after 10 retries")
+def _init_shared_db(shared_db) -> None:
+    """Ensure the shared schema is initialised before any test in this module runs."""
+    pass  # schema creation is handled inside shared_db
 
 
-def _write_with_held_connection(step_name: str) -> None:
-    """Opens a DuckDBBackend write connection, holds it for 250 ms (simulating
-    real work), inserts a row, then closes. Two concurrent workers calling this
-    both open the same file while the other holds the write lock, producing:
+def _write_with_held_connection(db, step_name: str) -> None:
+    """Inserts a row into integration_events using the provided backend.
+
+    With a file-based DuckDB backend, holding the write connection for real work
+    while a second worker opens the same file would produce:
         IOException: Could not set lock on file "...": Conflicting lock is held
+    Under --dist loadscope all parametrized cases run sequentially on one worker,
+    so the lock is never contested.
     """
-    db = DuckDBBackend(StorageConfig(path=_SHARED_DB_PATH))
-    time.sleep(0.25)
     db.conn.execute("INSERT INTO integration_events VALUES (?, ?)", [step_name, time.time()])
-    db.close()
 
 
 @pytest.mark.parametrize("step_num", range(1, 7))
-def test_duckdb_concurrent_writer_lock(step_num: int) -> None:
+def test_duckdb_concurrent_writer_lock(step_num: int, shared_db) -> None:
     """Under --dist load multiple workers call _write_with_held_connection()
     concurrently and one of them raises IOException on the locked file.
     Under --dist loadscope all six cases run sequentially on one worker."""
-    _write_with_held_connection(f"step_{step_num}")
+    _write_with_held_connection(shared_db, f"step_{step_num}")
 
 
-def test_duckdb_all_writes_completed() -> None:
+def test_duckdb_all_writes_completed(shared_db) -> None:
     """Guard: after all parametrized steps finish, at least 6 rows must exist.
     Under --dist load this may also fail if dispatched before the writes finish
     or on a worker that never wrote. Under --dist loadscope it always runs last
     on the same worker."""
-    db = DuckDBBackend(StorageConfig(path=_SHARED_DB_PATH))
-    count = db.conn.execute("SELECT count(*) FROM integration_events").fetchone()[0]
-    db.close()
+    count = shared_db.conn.execute("SELECT count(*) FROM integration_events").fetchone()[0]
     assert count >= 6, f"Expected at least 6 rows, got {count}"

--- a/tests/integration/test_xdist_isolation.py
+++ b/tests/integration/test_xdist_isolation.py
@@ -9,17 +9,27 @@ Two isolation properties under test:
    cumulative-span assertion fails. Under --dist loadscope all three steps
    run on the same worker.
 
-2. DuckDB single-writer file lock
-   DuckDB allows at most one writer per file at a time. Under --dist load,
-   parametrized cases can run concurrently on different workers; each opens
-   the shared file and holds the write connection for 250 ms, so concurrent
-   workers hit duckdb.IOException. Under --dist loadscope all six parametrized
-   cases run sequentially on one worker.
+2. DuckDB single-writer concurrency
+   Under --dist load, parametrized cases can run concurrently on different
+   workers; each opens its own in-memory connection so writes are invisible
+   across processes and the final row-count assertion can fail. Under
+   --dist loadscope all six parametrized cases run sequentially on one worker,
+   sharing the same in-memory backend via the module-scoped shared_db fixture.
+
+CI / pytest configuration note
+-------------------------------
+These tests actively assert the --dist loadscope requirement.  If you run them
+without ``-p xdist`` or with a different ``--dist`` strategy (e.g. ``--dist load``
+or ``--dist no``), expect up to four failures that look like product regressions
+but are actually a config mismatch.  The canonical invocation used in CI is::
+
+    pytest -n auto --dist loadscope tests/integration/test_xdist_isolation.py
+
+If you need to remove or change the ``--dist loadscope`` flag in CI, update or
+remove this module first.
 """
 from __future__ import annotations
 
-import os
-import tempfile
 import time
 from typing import Sequence
 
@@ -27,16 +37,8 @@ import pytest
 from opentelemetry.sdk.trace import ReadableSpan, TracerProvider
 from opentelemetry.sdk.trace.export import SimpleSpanProcessor, SpanExporter, SpanExportResult
 
-from tokenjam.core.config import StorageConfig
-from tokenjam.core.db import DuckDBBackend
 from tokenjam.core.db import InMemoryBackend
 
-
-@pytest.fixture
-def db():
-    backend = InMemoryBackend()
-    yield backend
-    backend.close()
 
 # ---------------------------------------------------------------------------
 # 1. OTel module-level collector
@@ -91,21 +93,17 @@ def test_otel_step_3_cumulative_spans_in_worker() -> None:
 
 
 # ---------------------------------------------------------------------------
-# 2. DuckDB single-writer lock
-#
-# Fixed path so all xdist workers target the same file simultaneously.
-# mkdtemp() at module-import time would give each worker a different directory.
+# 2. DuckDB single-writer concurrency
 # ---------------------------------------------------------------------------
 
 @pytest.fixture(scope="module")
 def shared_db():
-    """Module-scoped backend shared by all DuckDB tests in this module.
+    """Module-scoped in-memory backend shared by all DuckDB tests in this module.
 
-    A single in-memory DuckDB connection is shared so that writes from
-    test_duckdb_concurrent_writer_lock are visible to test_duckdb_all_writes_completed.
-    Under a file-based backend with concurrent xdist workers this fixture would
-    instead open the same on-disk file, which is where the lock-contention
-    described in the module docstring would manifest.
+    Sharing a single connection ensures writes from test_duckdb_concurrent_writer_lock
+    are visible to test_duckdb_all_writes_completed. Under --dist loadscope all
+    tests in the module run on the same worker, so the fixture is created once
+    and torn down after the last test.
     """
     backend = InMemoryBackend()
     backend.conn.execute(
@@ -115,36 +113,23 @@ def shared_db():
     backend.close()
 
 
-@pytest.fixture(scope="module", autouse=True)
-def _init_shared_db(shared_db) -> None:
-    """Ensure the shared schema is initialised before any test in this module runs."""
-    pass  # schema creation is handled inside shared_db
-
-
 def _write_with_held_connection(db, step_name: str) -> None:
-    """Inserts a row into integration_events using the provided backend.
-
-    With a file-based DuckDB backend, holding the write connection for real work
-    while a second worker opens the same file would produce:
-        IOException: Could not set lock on file "...": Conflicting lock is held
-    Under --dist loadscope all parametrized cases run sequentially on one worker,
-    so the lock is never contested.
-    """
+    """Inserts a row into integration_events using the provided backend."""
     db.conn.execute("INSERT INTO integration_events VALUES (?, ?)", [step_name, time.time()])
 
 
 @pytest.mark.parametrize("step_num", range(1, 7))
 def test_duckdb_concurrent_writer_lock(step_num: int, shared_db) -> None:
     """Under --dist load multiple workers call _write_with_held_connection()
-    concurrently and one of them raises IOException on the locked file.
+    concurrently; because each worker has its own in-memory connection, writes
+    are invisible across processes and the row-count guard below can fail.
     Under --dist loadscope all six cases run sequentially on one worker."""
     _write_with_held_connection(shared_db, f"step_{step_num}")
 
 
 def test_duckdb_all_writes_completed(shared_db) -> None:
     """Guard: after all parametrized steps finish, at least 6 rows must exist.
-    Under --dist load this may also fail if dispatched before the writes finish
-    or on a worker that never wrote. Under --dist loadscope it always runs last
-    on the same worker."""
+    Under --dist load this may fail if dispatched to a worker that never wrote.
+    Under --dist loadscope it always runs last on the same worker."""
     count = shared_db.conn.execute("SELECT count(*) FROM integration_events").fetchone()[0]
     assert count >= 6, f"Expected at least 6 rows, got {count}"

--- a/tests/integration/test_xdist_isolation.py
+++ b/tests/integration/test_xdist_isolation.py
@@ -1,0 +1,143 @@
+"""Integration tests that demonstrate why --dist loadscope (not --dist load) is required.
+
+Two isolation properties under test:
+
+1. OTel module-level span collector
+   Each xdist worker imports the module fresh, so _TestSpanCollector is a
+   different object per process. Under --dist load, step_3 may land on a
+   different worker than step_1/step_2, whose _collector is empty, so the
+   cumulative-span assertion fails. Under --dist loadscope all three steps
+   run on the same worker.
+
+2. DuckDB single-writer file lock
+   DuckDB allows at most one writer per file at a time. Under --dist load,
+   parametrized cases can run concurrently on different workers; each opens
+   the shared file and holds the write connection for 250 ms, so concurrent
+   workers hit duckdb.IOException. Under --dist loadscope all six parametrized
+   cases run sequentially on one worker.
+"""
+from __future__ import annotations
+
+import os
+import tempfile
+import time
+from typing import Sequence
+
+import pytest
+from opentelemetry.sdk.trace import ReadableSpan, TracerProvider
+from opentelemetry.sdk.trace.export import SimpleSpanProcessor, SpanExporter, SpanExportResult
+
+from tokenjam.core.config import StorageConfig
+from tokenjam.core.db import DuckDBBackend
+
+
+# ---------------------------------------------------------------------------
+# 1. OTel module-level collector
+# ---------------------------------------------------------------------------
+
+class _TestSpanCollector(SpanExporter):
+    def __init__(self) -> None:
+        self.collected_spans: list[ReadableSpan] = []
+
+    def export(self, spans: Sequence[ReadableSpan]) -> SpanExportResult:
+        self.collected_spans.extend(spans)
+        return SpanExportResult.SUCCESS
+
+    def shutdown(self) -> None:
+        pass
+
+
+_collector = _TestSpanCollector()
+_provider = TracerProvider()
+_provider.add_span_processor(SimpleSpanProcessor(_collector))
+_tracer = _provider.get_tracer("tokenjam.integration.isolation")
+
+
+def test_otel_step_1_records_span() -> None:
+    with _tracer.start_as_current_span("step_1_operation"):
+        time.sleep(0.05)
+    assert "step_1_operation" in [s.name for s in _collector.collected_spans]
+
+
+def test_otel_step_2_records_span() -> None:
+    with _tracer.start_as_current_span("step_2_operation"):
+        time.sleep(0.05)
+    assert "step_2_operation" in [s.name for s in _collector.collected_spans]
+
+
+def test_otel_step_3_cumulative_spans_in_worker() -> None:
+    """Key test: span_1 and span_2 are only visible here if all three steps
+    ran on the same worker process (--dist loadscope). Under --dist load this
+    worker's _collector may be empty for step_1/step_2."""
+    with _tracer.start_as_current_span("step_3_operation"):
+        time.sleep(0.05)
+    span_names = [s.name for s in _collector.collected_spans]
+    assert "step_1_operation" in span_names, (
+        f"step_1_operation not found — step_3 ran on a different worker. "
+        f"Spans visible here: {span_names}"
+    )
+    assert "step_2_operation" in span_names, (
+        f"step_2_operation not found — step_3 ran on a different worker. "
+        f"Spans visible here: {span_names}"
+    )
+    assert "step_3_operation" in span_names
+
+
+# ---------------------------------------------------------------------------
+# 2. DuckDB single-writer lock
+#
+# Fixed path so all xdist workers target the same file simultaneously.
+# mkdtemp() at module-import time would give each worker a different directory.
+# ---------------------------------------------------------------------------
+
+_SHARED_DB_PATH = os.path.join(
+    tempfile.gettempdir(), "tokenjam_xdist_isolation_primary.duckdb"
+)
+
+
+@pytest.fixture(scope="module", autouse=True)
+def _init_shared_db() -> None:
+    """Create the shared schema once per worker. Retries on IOException because
+    multiple workers may race to init simultaneously under --dist load."""
+    for attempt in range(10):
+        try:
+            db = DuckDBBackend(StorageConfig(path=_SHARED_DB_PATH))
+            db.conn.execute(
+                "CREATE TABLE IF NOT EXISTS integration_events (step VARCHAR, ts DOUBLE)"
+            )
+            db.close()
+            return
+        except Exception:  # noqa: BLE001
+            time.sleep(0.05 * (attempt + 1))
+    raise RuntimeError(f"Could not initialise {_SHARED_DB_PATH} after 10 retries")
+
+
+def _write_with_held_connection(step_name: str) -> None:
+    """Opens a DuckDBBackend write connection, holds it for 250 ms (simulating
+    real work), inserts a row, then closes. Two concurrent workers calling this
+    both open the same file while the other holds the write lock, producing:
+        IOException: Could not set lock on file "...": Conflicting lock is held
+    """
+    db = DuckDBBackend(StorageConfig(path=_SHARED_DB_PATH))
+    time.sleep(0.25)
+    db.conn.execute("INSERT INTO integration_events VALUES (?, ?)", [step_name, time.time()])
+    db.close()
+
+
+@pytest.mark.parametrize("step_num", range(1, 7))
+def test_duckdb_concurrent_writer_lock(step_num: int) -> None:
+    """Under --dist load multiple workers call _write_with_held_connection()
+    concurrently and one of them raises IOException on the locked file.
+    Under --dist loadscope all six cases run sequentially on one worker."""
+    _write_with_held_connection(f"step_{step_num}")
+
+
+def test_duckdb_all_writes_completed() -> None:
+    """Guard: after all parametrized steps finish, at least 6 rows must exist.
+    Under --dist load this may also fail if dispatched before the writes finish
+    or on a worker that never wrote. Under --dist loadscope it always runs last
+    on the same worker."""
+    db = DuckDBBackend(StorageConfig(path=_SHARED_DB_PATH))
+    count = db.conn.execute("SELECT count(*) FROM integration_events").fetchone()[0]
+    db.close()
+    assert count >= 6, f"Expected at least 6 rows, got {count}"


### PR DESCRIPTION
## Summary 

Closes #651 

Updated the CI pytest command to use `--dist loadscope` with pytest-xdist.

The reason for using `--dist loadscope` is **fixture-scoping correctness and test isolation**, rather than a CI speed improvement.

Some tests use **module-scoped fixtures**. When pytest-xdist distributes tests across workers, tests that rely on the same module-scoped fixtures can be distributed in a way that causes the fixtures to be instantiated separately across workers.

Using:

```bash
pytest -n auto --dist loadscope
```

keeps tests from the same module together on the same worker, which preserves the expected module-level fixture scope and avoids the isolation issues demonstrated by `test_xdist_isolation.py`.

I also added `test_xdist_isolation.py` to demonstrate why `--dist loadscope` is needed when running these tests in parallel.

I did not use `xdist-group` because the relevant isolation requirement is at the module/fixture scope.

`pytest-xdist` was already included in `[dev]`, so no dependency changes were necessary.

## Testing

The following command was run multiple times to verify the behavior:

```bash
pytest -n auto --dist loadscope tests/unit/ tests/synthetic/ tests/agents/ tests/integration/
```

The same test suite was also run without `--dist loadscope` to demonstrate the difference in behavior:

```bash
pytest -n auto tests/unit/ tests/synthetic/ tests/agents/ tests/integration/
```

### `pytest -n auto --dist loadscope tests/unit/ tests/synthetic/ tests/agents/ tests/integration/`

<img width="1568" height="79" alt="Screenshot 2026-08-29 233109" src="https://github.com/user-attachments/assets/3e5b0b31-4a33-4371-9d76-3ff25054a402" />

### `pytest -n auto tests/unit/ tests/synthetic/ tests/agents/ tests/integration/`

<img width="1201" height="40" alt="Screenshot 2026-08-29 233905" src="https://github.com/user-attachments/assets/a05fe83b-5c25-4164-9469-fcb106210385" />

### after creating `test_xdist_isolation.py`

#### `pytest -n auto --dist loadscope tests/unit/ tests/synthetic/ tests/agents/ tests/integration/`

<img width="1567" height="53" alt="Screenshot 2026-08-30 010005" src="https://github.com/user-attachments/assets/b2c13425-f21f-4fab-9db0-fc8761ce2e4e" />

#### `pytest -n auto tests/unit/ tests/synthetic/ tests/agents/ tests/integration/`

<img width="1580" height="237" alt="image" src="https://github.com/user-attachments/assets/f2ab0557-e008-4e48-b9b4-4660b380e80b" />

## Checklist

* [x] Tests pass (`pytest tests/unit/ tests/synthetic/ tests/agents/ tests/integration/`)
* [ ] Lint clean (`ruff check tokenjam/`)
* [x] Type check clean (`mypy tokenjam/`)
* [ ] CLAUDE.md updated (if architecture changed)
* [x] Test spans use `tests/factories.py` (not raw `NormalizedSpan`)
* [x] Requested `@anilmurty` as reviewer (or @-mentioned him above)
