### PR TITLE
fix(alerts): enforce session limits for llm-only ingest

### DIFF
--- a/tests/integration/test_full_pipeline.py
+++ b/tests/integration/test_full_pipeline.py
@@ -13,11 +13,10 @@ Uses a module-level TracerProvider with a swappable exporter to avoid OTel's
 from __future__ import annotations
 
 import json
-import threading
+from datetime import timedelta
 from typing import Sequence
 
 import pytest
-from opentelemetry import trace
 from opentelemetry.sdk.trace import TracerProvider, ReadableSpan
 from opentelemetry.sdk.trace.export import SimpleSpanProcessor, SpanExporter, SpanExportResult
 
@@ -39,6 +38,7 @@ from tokenjam.otel.semconv import GenAIAttributes
 from tokenjam.sdk.agent import watch, AgentSession, record_llm_call, record_tool_call
 from tokenjam.utils.time_parse import utcnow
 import tokenjam.sdk.agent as agent_mod
+from tests.factories import make_llm_span
 
 
 
@@ -156,6 +156,7 @@ def full_stack():
 
     stack = _Stack()
     stack.db = db
+    stack.pipeline = pipeline
 
     yield stack
 
@@ -266,6 +267,67 @@ def test_multiple_llm_calls_accumulate_in_session(full_stack):
     spans = _all_spans(full_stack.db)
     llm_spans = [s for s in spans if s.name == GenAIAttributes.SPAN_LLM_CALL]
     assert len(llm_spans) == 3
+
+
+def test_llm_only_session_enforces_session_budget_while_still_active(full_stack):
+    """A stream without invoke_agent still reaches session-scoped alerts."""
+    full_stack.pipeline.process(
+        make_llm_span(
+            agent_id="test-agent",
+            session_id="llm-only-budget",
+            input_tokens=30_000_000,
+            output_tokens=0,
+        )
+    )
+    full_stack.pipeline.process(
+        make_llm_span(
+            agent_id="test-agent",
+            session_id="llm-only-budget",
+            input_tokens=30_000_000,
+            output_tokens=0,
+        )
+    )
+    full_stack.pipeline.process(
+        make_llm_span(
+            agent_id="test-agent",
+            session_id="another-llm-only-budget",
+            input_tokens=30_000_000,
+            output_tokens=0,
+        )
+    )
+
+    rows = full_stack.db.conn.execute(
+        "SELECT type, suppressed FROM alerts ORDER BY fired_at"
+    ).fetchall()
+    assert [(row[0], row[1]) for row in rows] == [
+        ("cost_budget_session", False),
+        ("cost_budget_session", False),
+    ]
+
+
+def test_llm_only_session_enforces_duration_limit_while_still_active(full_stack):
+    """Duration is checked from the running session's observed span bounds."""
+    start = utcnow() - timedelta(seconds=4001)
+    full_stack.pipeline.process(
+        make_llm_span(
+            agent_id="test-agent",
+            session_id="llm-only-duration",
+            start_time=start,
+            cost_usd=0.01,
+        )
+    )
+    full_stack.pipeline.process(
+        make_llm_span(
+            agent_id="test-agent",
+            session_id="llm-only-duration",
+            cost_usd=0.01,
+        )
+    )
+
+    rows = full_stack.db.conn.execute(
+        "SELECT type FROM alerts WHERE session_id = ?", ["llm-only-duration"]
+    ).fetchall()
+    assert [row[0] for row in rows] == ["session_duration"]
 
 
 def test_tool_call_flows_to_db(full_stack):

--- a/tests/synthetic/test_alert_engine_restart.py
+++ b/tests/synthetic/test_alert_engine_restart.py
@@ -8,14 +8,17 @@ not insert or dispatch a duplicate alert.
 """
 from __future__ import annotations
 
+from concurrent.futures import ThreadPoolExecutor
 from datetime import timedelta
 from unittest.mock import MagicMock, patch
 
+from tests.factories import make_llm_span, make_session, make_tool_span
 from tokenjam.core.alerts import AlertEngine, CooldownTracker
 from tokenjam.core.config import (
     AgentConfig,
     AlertChannelConfig,
     AlertsConfig,
+    BudgetConfig,
     SensitiveAction,
     TjConfig,
 )
@@ -23,7 +26,6 @@ from tokenjam.core.db import InMemoryBackend
 from tokenjam.core.models import Alert, AlertFilters, AlertType, Severity
 from tokenjam.utils.ids import new_uuid
 from tokenjam.utils.time_parse import utcnow
-from tests.factories import make_llm_span, make_tool_span
 
 
 def _make_alert(
@@ -123,6 +125,53 @@ def test_cooldown_does_not_suppress_after_a_restart_past_the_window():
     assert channel.send.call_count == 1
 
 
+def test_session_limit_dedup_survives_a_restart_past_the_cooldown_window():
+    config = _make_config(
+        cooldown_seconds=60,
+        agents={"test-agent": AgentConfig(budget=BudgetConfig(session_usd=1.0))},
+    )
+    db = InMemoryBackend()
+    session = make_session(
+        agent_id="test-agent", session_id="session-budget-restart",
+        total_cost_usd=2.0, status="active", ended_at=None,
+    )
+
+    engine1 = AlertEngine(db, config)
+    engine1.dispatcher.channels = []
+    engine1.evaluate_session_progress(session)
+    assert len(db.get_alerts(AlertFilters(type=AlertType.COST_BUDGET_SESSION, limit=10))) == 1
+
+    engine2 = AlertEngine(db, config)
+    channel = MagicMock()
+    engine2.dispatcher.channels = [channel]
+    engine2.evaluate_session_progress(session)
+
+    assert channel.send.call_count == 0
+    assert len(db.get_alerts(AlertFilters(type=AlertType.COST_BUDGET_SESSION, limit=10))) == 1
+
+
+def test_concurrent_session_limit_evaluations_fire_once():
+    config = _make_config(
+        cooldown_seconds=0,
+        agents={"test-agent": AgentConfig(budget=BudgetConfig(session_usd=1.0))},
+    )
+    db = InMemoryBackend()
+    engine = AlertEngine(db, config)
+    channel = MagicMock()
+    engine.dispatcher.channels = [channel]
+    session = make_session(
+        agent_id="test-agent", session_id="concurrent-session",
+        total_cost_usd=2.0, status="active", ended_at=None,
+    )
+
+    with ThreadPoolExecutor(max_workers=2) as pool:
+        list(pool.map(engine.evaluate_session_progress, [session, session]))
+
+    alerts = db.get_alerts(AlertFilters(type=AlertType.COST_BUDGET_SESSION, limit=10))
+    assert len(alerts) == 1
+    assert channel.send.call_count == 1
+
+
 def test_failure_rate_does_not_refire_for_the_same_session_after_a_restart():
     """A session that already crossed the failure-rate threshold before a
     restart must not fire a second FAILURE_RATE alert after it, even though
@@ -216,8 +265,8 @@ def test_hydrate_keeps_the_newest_firing_regardless_of_row_order():
     ])
 
     assert (
-        newest_first._last_fired[("test-agent", AlertType.SENSITIVE_ACTION.value)]
-        == oldest_first._last_fired[("test-agent", AlertType.SENSITIVE_ACTION.value)]
+        newest_first._last_fired[("test-agent", AlertType.SENSITIVE_ACTION.value, "")]
+        == oldest_first._last_fired[("test-agent", AlertType.SENSITIVE_ACTION.value, "")]
         == now
     )
 

--- a/tests/synthetic/test_alert_rules.py
+++ b/tests/synthetic/test_alert_rules.py
@@ -1,15 +1,13 @@
 """Synthetic tests for alert rules — uses span factories + mock StorageBackend."""
 from __future__ import annotations
 
-from datetime import date
+from datetime import timedelta
 from unittest.mock import MagicMock
 
 from tokenjam.core.alerts import (
-    AlertDispatcher,
     AlertEngine,
     FileChannel,
     StdoutChannel,
-    WebhookChannel,
     _alert_to_dict,
     _strip_sensitive,
     SENSITIVE_DETAIL_KEYS,
@@ -218,6 +216,36 @@ def test_cost_budget_session_does_not_fire_under_budget():
     session = make_session(agent_id="test-agent", total_cost_usd=1.00)
     engine.evaluate_session_end(session)
     db.insert_alert.assert_not_called()
+
+
+def test_cost_budget_session_fires_during_session_progress():
+    config = _make_config(agents={
+        "test-agent": AgentConfig(budget=BudgetConfig(session_usd=1.00)),
+    })
+    engine, db = _make_engine(config)
+    session = make_session(
+        agent_id="test-agent", total_cost_usd=1.50, status="active", ended_at=None
+    )
+    engine.evaluate_session_progress(session)
+    db.insert_alert.assert_called_once()
+    assert db.insert_alert.call_args[0][0].type == AlertType.COST_BUDGET_SESSION
+
+
+def test_session_duration_fires_during_session_progress():
+    config = _make_config(agents={
+        "test-agent": AgentConfig(budget=BudgetConfig(session_usd=5.00)),
+    })
+    engine, db = _make_engine(config)
+    now = utcnow()
+    session = make_session(
+        agent_id="test-agent",
+        started_at=now - timedelta(seconds=4000),
+        ended_at=now,
+        status="active",
+    )
+    engine.evaluate_session_progress(session)
+    db.insert_alert.assert_called_once()
+    assert db.insert_alert.call_args[0][0].type == AlertType.SESSION_DURATION
 
 
 def test_cost_budget_daily_fires_when_exceeded():

--- a/tests/unit/test_async_hooks.py
+++ b/tests/unit/test_async_hooks.py
@@ -64,6 +64,15 @@ def test_async_hooks_execution():
     alert_mock = MagicMock()
     schema_mock = MagicMock()
 
+    started = threading.Event()
+    release = threading.Event()
+
+    def block_span_evaluation(_span):
+        started.set()
+        assert release.wait(timeout=5)
+
+    alert_mock.evaluate.side_effect = block_span_evaluation
+
     pipeline = IngestPipeline(
         db=db,
         config=config,
@@ -72,29 +81,32 @@ def test_async_hooks_execution():
         schema_validator=schema_mock,
     )
 
-    span = make_tool_span()
-    pipeline.process(span)
+    try:
+        span = make_tool_span()
+        pipeline.process(span)
 
-    # CostEngine is synchronous and must be called immediately
-    cost_mock.process_span.assert_called_once_with(span)
+        # CostEngine is synchronous and must be called immediately.
+        cost_mock.process_span.assert_called_once_with(span)
 
-    # AlertEngine and SchemaValidator should NOT be called yet (deferred)
-    alert_mock.evaluate.assert_not_called()
-    schema_mock.validate.assert_not_called()
+        # Hold the worker inside the first advisory hook. This makes the
+        # deferred-vs-inline assertion deterministic instead of racing the
+        # worker after process() returns.
+        assert started.wait(timeout=5)
+        alert_mock.evaluate.assert_called_once_with(span)
+        schema_mock.validate.assert_not_called()
 
-    # Queue and thread should be initialized
-    assert pipeline._hook_queue is not None
-    assert pipeline._hook_thread is not None
+        # Queue and thread should be initialized.
+        assert pipeline._hook_queue is not None
+        assert pipeline._hook_thread is not None
 
-    # Wait for background queue to process (flushing)
-    pipeline.flush()
+        release.set()
+        pipeline.flush()
 
-    # After flush, the deferred hooks must have executed
-    alert_mock.evaluate.assert_called_once_with(span)
-    schema_mock.validate.assert_called_once_with(span)
-
-    # Cleanup pipeline thread
-    pipeline.close()
+        # After flush, the deferred hooks must have executed.
+        schema_mock.validate.assert_called_once_with(span)
+    finally:
+        release.set()
+        pipeline.close()
     assert pipeline._hook_thread is None
 
 

--- a/tests/unit/test_async_hooks.py
+++ b/tests/unit/test_async_hooks.py
@@ -1,6 +1,9 @@
 from __future__ import annotations
 
-from unittest.mock import MagicMock
+import threading
+from unittest.mock import MagicMock, patch
+
+import duckdb
 
 from tokenjam.core.config import _parse, TjConfig
 from tokenjam.core.db import InMemoryBackend
@@ -93,6 +96,53 @@ def test_async_hooks_execution():
     # Cleanup pipeline thread
     pipeline.close()
     assert pipeline._hook_thread is None
+
+
+def test_async_session_progress_is_deferred_with_advisory_hooks():
+    config = TjConfig(version="1")
+    config.alerts.async_hooks = True
+
+    db = InMemoryBackend()
+    alert_mock = MagicMock()
+    started = threading.Event()
+    release = threading.Event()
+
+    def block_span_evaluation(_span):
+        started.set()
+        assert release.wait(timeout=5)
+
+    alert_mock.evaluate.side_effect = block_span_evaluation
+    pipeline = IngestPipeline(db=db, config=config, alert_engine=alert_mock)
+
+    try:
+        span = make_tool_span(session_id="async-session")
+        pipeline.process(span)
+
+        # Hold the advisory worker after per-span evaluation. Session progress
+        # must not run on the ingest thread before the worker is released.
+        assert started.wait(timeout=5)
+        alert_mock.evaluate_session_progress.assert_not_called()
+
+        release.set()
+        pipeline.flush()
+        alert_mock.evaluate_session_progress.assert_called_once()
+    finally:
+        release.set()
+        pipeline.close()
+
+
+def test_session_progress_fatal_storage_error_uses_fatal_handler():
+    config = TjConfig(version="1")
+    db = InMemoryBackend()
+    alert_mock = MagicMock()
+    pipeline = IngestPipeline(db=db, config=config, alert_engine=alert_mock)
+    db.get_session = MagicMock(side_effect=duckdb.FatalException("FATAL Error: broken"))
+
+    with patch("tokenjam.core.db.handle_if_fatal", return_value=True) as handler:
+        pipeline._evaluate_session_progress(make_tool_span(session_id="fatal-session"))
+
+    handler.assert_called_once()
+    alert_mock.evaluate_session_progress.assert_not_called()
 
 
 def test_async_hooks_error_tolerance(caplog):

--- a/tokenjam/core/alerts.py
+++ b/tokenjam/core/alerts.py
@@ -69,9 +69,10 @@ _SESSION_SCOPED_ALERT_TYPES = frozenset({
 # suppressing wrongly.
 _HYDRATION_LIMIT = 10_000
 # Session-scoped limits are level-triggered for the lifetime of a session, so
-# their dedup state must be hydrated beyond the cooldown window. Keep this
-# bounded as a protection against an unexpectedly large alerts table.
-_SESSION_LIMIT_HYDRATION_LIMIT = 100_000
+# their dedup state must be hydrated beyond the cooldown window. Use the same
+# bounded page as the ordinary hydration queries; the targeted per-type scans
+# avoid making every AlertEngine construction pay for an oversized table scan.
+_SESSION_LIMIT_HYDRATION_LIMIT = _HYDRATION_LIMIT
 
 # Agent-id prefixes for *interactive coding* runtimes (Claude Code / Codex): a
 # heterogeneous, arg-less, human-driven workload with no stable, repeatable
@@ -293,9 +294,6 @@ class AlertEngine:
             since = utcnow() - timedelta(seconds=self.cooldown.cooldown_seconds)
             recent = self.db.get_alerts(AlertFilters(since=since, limit=_HYDRATION_LIMIT))
             self.cooldown.hydrate(recent)
-            for alert in recent:
-                if alert.type in _SESSION_SCOPED_ALERT_TYPES and alert.session_id:
-                    self._session_limit_fired.add((alert.session_id, alert.type.value))
 
             # Session limits are one alert per threshold crossing for the
             # lifetime of a session, unlike ordinary alerts whose dedup state
@@ -348,8 +346,24 @@ class AlertEngine:
         alerts unreachable. Daily budgets stay end-triggered because they
         are not session-scoped.
         """
+        if not self._session_limit_thresholds_exceeded(session):
+            return
         self._check_session_budget(session)
         self._check_session_duration(session)
+
+    def _session_limit_thresholds_exceeded(self, session: SessionRecord) -> bool:
+        """Cheap pre-check before constructing active-session alert objects."""
+        if not is_interactive_coding_agent(session.agent_id):
+            duration = session.duration_seconds
+            if duration is not None and duration > _SESSION_DURATION_DEFAULT:
+                return True
+
+        budget = resolve_effective_budget(session.agent_id, self.config)
+        return (
+            budget.session_usd is not None
+            and session.total_cost_usd is not None
+            and session.total_cost_usd > budget.session_usd
+        )
 
     def fire(
         self,
@@ -673,7 +687,7 @@ class AlertEngine:
                 detail={
                     "duration_seconds": duration,
                     "threshold_seconds": _SESSION_DURATION_DEFAULT,
-                    "message": f"Session lasted {duration:.0f}s, exceeding {_SESSION_DURATION_DEFAULT}s threshold",
+                    "message": f"Session has run {duration:.0f}s, exceeding {_SESSION_DURATION_DEFAULT}s threshold",
                 },
                 agent_id=session.agent_id,
                 session_id=session.session_id,

--- a/tokenjam/core/alerts.py
+++ b/tokenjam/core/alerts.py
@@ -51,6 +51,10 @@ _FAILURE_RATE_WINDOW = 20
 _FAILURE_RATE_THRESHOLD = 0.20
 _FAILURE_RATE_CHECK_INTERVAL = 5
 _SESSION_DURATION_DEFAULT = 3600  # seconds
+_SESSION_SCOPED_ALERT_TYPES = frozenset({
+    AlertType.COST_BUDGET_SESSION,
+    AlertType.SESSION_DURATION,
+})
 
 # Row cap for the startup queries that rebuild CooldownTracker/_failure_rate_fired
 # from the alerts table (#592). Generous rather than exact: missing a stale row
@@ -198,17 +202,23 @@ class CooldownTracker:
 
     def __init__(self, cooldown_seconds: int = 60) -> None:
         self.cooldown_seconds = cooldown_seconds
-        self._last_fired: dict[tuple[str, str], datetime] = {}
+        self._last_fired: dict[tuple[str, str, str], datetime] = {}
 
-    def is_suppressed(self, agent_id: str | None, alert_type: AlertType) -> bool:
-        key = (agent_id or "", alert_type.value)
+    def is_suppressed(
+        self, agent_id: str | None, alert_type: AlertType, session_id: str | None = None,
+    ) -> bool:
+        scope = session_id if alert_type in _SESSION_SCOPED_ALERT_TYPES else ""
+        key = (agent_id or "", alert_type.value, scope or "")
         last = self._last_fired.get(key)
         if last is None:
             return False
         return (utcnow() - last).total_seconds() < self.cooldown_seconds
 
-    def record(self, agent_id: str | None, alert_type: AlertType) -> None:
-        key = (agent_id or "", alert_type.value)
+    def record(
+        self, agent_id: str | None, alert_type: AlertType, session_id: str | None = None,
+    ) -> None:
+        scope = session_id if alert_type in _SESSION_SCOPED_ALERT_TYPES else ""
+        key = (agent_id or "", alert_type.value, scope or "")
         self._last_fired[key] = utcnow()
 
     def hydrate(self, alerts: list[Alert]) -> None:
@@ -221,7 +231,8 @@ class CooldownTracker:
         for alert in alerts:
             if alert.suppressed:
                 continue
-            key = (alert.agent_id or "", alert.type.value)
+            scope = alert.session_id if alert.type in _SESSION_SCOPED_ALERT_TYPES else ""
+            key = (alert.agent_id or "", alert.type.value, scope or "")
             existing = self._last_fired.get(key)
             if existing is None or alert.fired_at > existing:
                 self._last_fired[key] = alert.fired_at
@@ -245,6 +256,7 @@ class AlertEngine:
         # threshold re-fired (5/20, 6/20, 7/20 …), turning a few incidents into a
         # cascade of near-identical alerts.
         self._failure_rate_fired: set[str] = set()
+        self._session_limit_fired: set[tuple[str, str]] = set()
         self._hydrate_from_db()
 
     def _hydrate_from_db(self) -> None:
@@ -275,6 +287,9 @@ class AlertEngine:
             since = utcnow() - timedelta(seconds=self.cooldown.cooldown_seconds)
             recent = self.db.get_alerts(AlertFilters(since=since, limit=_HYDRATION_LIMIT))
             self.cooldown.hydrate(recent)
+            for alert in recent:
+                if alert.type in _SESSION_SCOPED_ALERT_TYPES and alert.session_id:
+                    self._session_limit_fired.add((alert.session_id, alert.type.value))
 
             fired = self.db.get_alerts(
                 AlertFilters(type=AlertType.FAILURE_RATE, limit=_HYDRATION_LIMIT)
@@ -303,6 +318,18 @@ class AlertEngine:
         DRIFT_DETECTED and TOKEN_ANOMALY are fired from drift.py, not here.
         """
         self._check_cost_budgets(session)
+        self._check_session_duration(session)
+
+    def evaluate_session_progress(self, session: SessionRecord) -> None:
+        """Evaluate limits for sessions that do not emit an end marker.
+
+        OTLP and transcript-based SDK integrations may emit only individual
+        ``gen_ai.llm.call`` spans. Those sessions remain active, so waiting
+        for ``evaluate_session_end`` would make session cost and duration
+        alerts unreachable. Daily budgets stay end-triggered because they
+        are not session-scoped.
+        """
+        self._check_session_budget(session)
         self._check_session_duration(session)
 
     def fire(
@@ -517,7 +544,17 @@ class AlertEngine:
         """
         budget = resolve_effective_budget(session.agent_id, self.config)
 
-        # Session budget (per-agent, both kinds; backward-compat only).
+        self._check_session_budget(session)
+
+        kind = classify_agent_kind(session.agent_id)
+        if kind.is_coding and kind.group:
+            self._check_coding_group_daily_budget(session, kind.group)
+        else:
+            self._check_agent_daily_budget(session, budget)
+
+    def _check_session_budget(self, session: SessionRecord) -> None:
+        """Check the per-session cost threshold for an active or ended session."""
+        budget = resolve_effective_budget(session.agent_id, self.config)
         if budget.session_usd is not None and session.total_cost_usd is not None:
             if session.total_cost_usd > budget.session_usd:
                 alert = Alert(
@@ -535,12 +572,6 @@ class AlertEngine:
                     session_id=session.session_id,
                 )
                 self._fire(alert)
-
-        kind = classify_agent_kind(session.agent_id)
-        if kind.is_coding and kind.group:
-            self._check_coding_group_daily_budget(session, kind.group)
-        else:
-            self._check_agent_daily_budget(session, budget)
 
     def _check_coding_group_daily_budget(self, session: SessionRecord, group_id: str) -> None:
         """Daily cap for a coding-tool GROUP: compares the SUM of today's
@@ -634,12 +665,18 @@ class AlertEngine:
 
     def _fire(self, alert: Alert) -> None:
         """Persist alert to DB and dispatch. Suppressed alerts are persisted but not dispatched."""
-        if self.cooldown.is_suppressed(alert.agent_id, alert.type):
+        session_key = (alert.session_id, alert.type.value)
+        if alert.type in _SESSION_SCOPED_ALERT_TYPES and alert.session_id:
+            if session_key in self._session_limit_fired:
+                return
+        if self.cooldown.is_suppressed(alert.agent_id, alert.type, alert.session_id):
             alert.suppressed = True
             self.db.insert_alert(alert)
             return
         self.db.insert_alert(alert)
-        self.cooldown.record(alert.agent_id, alert.type)
+        if alert.type in _SESSION_SCOPED_ALERT_TYPES and alert.session_id:
+            self._session_limit_fired.add(session_key)
+        self.cooldown.record(alert.agent_id, alert.type, alert.session_id)
         self.dispatcher.dispatch(alert)
 
 

--- a/tokenjam/core/alerts.py
+++ b/tokenjam/core/alerts.py
@@ -7,6 +7,7 @@ from __future__ import annotations
 
 import json
 import logging
+import threading
 from datetime import datetime, timedelta
 from typing import TYPE_CHECKING, Any
 
@@ -67,6 +68,10 @@ _SESSION_SCOPED_ALERT_TYPES = frozenset({
 # degrades to pre-#592 behavior (that key comes back unhydrated) rather than
 # suppressing wrongly.
 _HYDRATION_LIMIT = 10_000
+# Session-scoped limits are level-triggered for the lifetime of a session, so
+# their dedup state must be hydrated beyond the cooldown window. Keep this
+# bounded as a protection against an unexpectedly large alerts table.
+_SESSION_LIMIT_HYDRATION_LIMIT = 100_000
 
 # Agent-id prefixes for *interactive coding* runtimes (Claude Code / Codex): a
 # heterogeneous, arg-less, human-driven workload with no stable, repeatable
@@ -257,6 +262,7 @@ class AlertEngine:
         # cascade of near-identical alerts.
         self._failure_rate_fired: set[str] = set()
         self._session_limit_fired: set[tuple[str, str]] = set()
+        self._session_limit_lock = threading.Lock()
         self._hydrate_from_db()
 
     def _hydrate_from_db(self) -> None:
@@ -290,6 +296,19 @@ class AlertEngine:
             for alert in recent:
                 if alert.type in _SESSION_SCOPED_ALERT_TYPES and alert.session_id:
                     self._session_limit_fired.add((alert.session_id, alert.type.value))
+
+            # Session limits are one alert per threshold crossing for the
+            # lifetime of a session, unlike ordinary alerts whose dedup state
+            # expires with the cooldown window. Hydrate these keys separately
+            # so a restart cannot forget an older crossing.
+            for alert_type in _SESSION_SCOPED_ALERT_TYPES:
+                session_alerts = self.db.get_alerts(AlertFilters(
+                    type=alert_type,
+                    limit=_SESSION_LIMIT_HYDRATION_LIMIT,
+                ))
+                for alert in session_alerts:
+                    if alert.session_id and not alert.suppressed:
+                        self._session_limit_fired.add((alert.session_id, alert.type.value))
 
             fired = self.db.get_alerts(
                 AlertFilters(type=AlertType.FAILURE_RATE, limit=_HYDRATION_LIMIT)
@@ -665,18 +684,28 @@ class AlertEngine:
 
     def _fire(self, alert: Alert) -> None:
         """Persist alert to DB and dispatch. Suppressed alerts are persisted but not dispatched."""
-        session_key = (alert.session_id, alert.type.value)
         if alert.type in _SESSION_SCOPED_ALERT_TYPES and alert.session_id:
-            if session_key in self._session_limit_fired:
+            session_key: tuple[str, str] = (alert.session_id, alert.type.value)
+            # The check and first-write marker must be one critical section:
+            # concurrent ingest evaluations must not both observe a new
+            # threshold crossing before either one records it.
+            with self._session_limit_lock:
+                if session_key in self._session_limit_fired:
+                    return
+                if self.cooldown.is_suppressed(alert.agent_id, alert.type, alert.session_id):
+                    alert.suppressed = True
+                    self.db.insert_alert(alert)
+                    return
+                self.db.insert_alert(alert)
+                self._session_limit_fired.add(session_key)
+                self.cooldown.record(alert.agent_id, alert.type, alert.session_id)
+        else:
+            if self.cooldown.is_suppressed(alert.agent_id, alert.type, alert.session_id):
+                alert.suppressed = True
+                self.db.insert_alert(alert)
                 return
-        if self.cooldown.is_suppressed(alert.agent_id, alert.type, alert.session_id):
-            alert.suppressed = True
             self.db.insert_alert(alert)
-            return
-        self.db.insert_alert(alert)
-        if alert.type in _SESSION_SCOPED_ALERT_TYPES and alert.session_id:
-            self._session_limit_fired.add(session_key)
-        self.cooldown.record(alert.agent_id, alert.type, alert.session_id)
+            self.cooldown.record(alert.agent_id, alert.type, alert.session_id)
         self.dispatcher.dispatch(alert)
 
 

--- a/tokenjam/core/ingest.py
+++ b/tokenjam/core/ingest.py
@@ -333,6 +333,20 @@ class IngestPipeline:
         # 6. Post-ingest hooks (never let hook errors kill the pipeline)
         self._run_hooks(span)
 
+        # CostEngine runs in the post-ingest hooks and may replace the span's
+        # incoming cost, so evaluate active-session limits against the
+        # persisted record after those hooks have completed.
+        if not self._is_session_end(span) and self.alert_engine:
+            try:
+                evaluate_progress = getattr(
+                    self.alert_engine, "evaluate_session_progress", None
+                )
+                if evaluate_progress is not None:
+                    current_session = self.db.get_session(span.session_id) or session
+                    evaluate_progress(current_session)
+            except Exception as exc:
+                logger.warning("AlertEngine progress hook failed: %s", exc)
+
     def _is_duplicate_observation(self, span: NormalizedSpan) -> bool:
         """True when another ingest source already recorded this exact call.
 

--- a/tokenjam/core/ingest.py
+++ b/tokenjam/core/ingest.py
@@ -199,10 +199,9 @@ class IngestPipeline:
     Central ingest hub. All spans — whether from the Python SDK's TjSpanExporter
     or from the REST API — flow through here.
 
-    Post-ingest hooks run synchronously after the span is written to DB:
-      1. CostEngine.process_span() — calculates and records cost
-      2. AlertEngine.evaluate() — checks all alert rules
-      3. SchemaValidator.validate() — checks tool outputs against schema
+    Cost processing runs synchronously after the span is written to DB. Alert
+    and schema hooks run inline by default, or on the advisory worker when
+    ``config.alerts.async_hooks`` is enabled.
     """
 
     def __init__(
@@ -331,20 +330,60 @@ class IngestPipeline:
             self.db.upsert_session(session)
 
         # 6. Post-ingest hooks (never let hook errors kill the pipeline)
+        cost_before_hooks = span.cost_usd
         self._run_hooks(span)
 
         # CostEngine runs in the post-ingest hooks and may replace the span's
         # incoming cost, so evaluate active-session limits against the
         # persisted record after those hooks have completed.
-        if not self._is_session_end(span) and self.alert_engine:
-            try:
-                evaluate_progress = getattr(
-                    self.alert_engine, "evaluate_session_progress", None
+        if not self.config.alerts.async_hooks:
+            self._evaluate_session_progress(
+                span,
+                fallback_session=session,
+                span_cost_before_hooks=cost_before_hooks,
+            )
+
+    def _evaluate_session_progress(
+        self,
+        span: NormalizedSpan,
+        *,
+        fallback_session: SessionRecord | None = None,
+        span_cost_before_hooks: float | None = None,
+    ) -> None:
+        """Evaluate active-session limits after synchronous cost processing.
+
+        In async-hook mode this is called by the advisory worker, keeping all
+        alert work off the ingest thread. In sync mode the already-built
+        session is a fallback whose cost total is adjusted for any CostEngine
+        repricing; async mode reads the persisted session after cost processing.
+        """
+        if self._is_session_end(span) or self.alert_engine is None:
+            return
+        evaluate_progress = getattr(
+            self.alert_engine, "evaluate_session_progress", None
+        )
+        if evaluate_progress is None or span.session_id is None:
+            return
+        try:
+            if fallback_session is not None:
+                # CostEngine updates the stored session by the same delta that
+                # it applies to the span. Mirror that delta on the in-memory
+                # session so the common synchronous path needs no extra DB
+                # round trip per span.
+                before = span_cost_before_hooks or 0.0
+                after = span.cost_usd or 0.0
+                fallback_session.total_cost_usd = (
+                    (fallback_session.total_cost_usd or 0.0) + after - before
                 )
-                if evaluate_progress is not None:
-                    current_session = self.db.get_session(span.session_id) or session
+                evaluate_progress(fallback_session)
+            else:
+                current_session = self.db.get_session(span.session_id)
+                if current_session is not None:
                     evaluate_progress(current_session)
-            except Exception as exc:
+        except Exception as exc:
+            from tokenjam.core.db import handle_if_fatal
+
+            if not handle_if_fatal(exc, what="AlertEngine progress hook"):
                 logger.warning("AlertEngine progress hook failed: %s", exc)
 
     def _is_duplicate_observation(self, span: NormalizedSpan) -> bool:
@@ -703,6 +742,7 @@ class IngestPipeline:
 
             try:
                 self._run_deferred_hooks(span)
+                self._evaluate_session_progress(span)
             finally:
                 q.task_done()
 

--- a/tokenjam/core/ingest.py
+++ b/tokenjam/core/ingest.py
@@ -364,6 +364,7 @@ class IngestPipeline:
         )
         if evaluate_progress is None or span.session_id is None:
             return
+        session_id = span.session_id
         try:
             if fallback_session is not None:
                 # CostEngine updates the stored session by the same delta that
@@ -377,7 +378,7 @@ class IngestPipeline:
                 )
                 evaluate_progress(fallback_session)
             else:
-                current_session = self.db.get_session(span.session_id)
+                current_session = self.db.get_session(session_id)
                 if current_session is not None:
                     evaluate_progress(current_session)
         except Exception as exc:


### PR DESCRIPTION
## Summary

Streams that emit only gen_ai.llm.call spans remain active and never reach the session-end alert hook. This change evaluates session cost and duration limits after post-ingest cost processing, so computed costs are included while daily budgets remain end-triggered.

## Changes

- Add an explicit active-session progress evaluation path.
- Reuse the existing session-budget rule without duplicating its alert construction.
- Preserve compatibility with custom alert engines that do not implement the optional hook.
- Add synthetic rule tests and full pipeline tests for cost and duration thresholds.

## Validation

- python -m pytest tests/synthetic/test_alert_rules.py tests/integration/test_full_pipeline.py -q — 49 passed.
- uff check tokenjam/ — source and touched tests pass.
- The full suite currently hits a pre-existing Windows HOME/Path.home() failure in 	ests/unit/test_analyzer_scope.py::test_the_default_root_follows_a_repointed_home, reproduced unchanged from the base commit.