### PR TITLE
fix: session-end-gated alerts unreachable for llm.call-only SDK i

### DIFF
--- a/tests/synthetic/test_alert_rules.py
+++ b/tests/synthetic/test_alert_rules.py
@@ -364,6 +364,27 @@ def test_session_duration_does_not_fire_under_threshold():
         assert alert.type != AlertType.SESSION_DURATION
 
 
+def test_evaluate_session_progress_fires_when_duration_exceeded():
+    engine, db = _make_engine()
+    session = make_session(agent_id="test-agent", duration_seconds=4000.0)
+    engine.evaluate_session_progress(session)
+    db.insert_alert.assert_called()
+    alert: Alert = db.insert_alert.call_args[0][0]
+    assert alert.type == AlertType.SESSION_DURATION
+
+
+def test_evaluate_session_progress_skips_when_already_evaluated():
+    engine, db = _make_engine()
+    session = make_session(agent_id="test-agent", duration_seconds=4000.0)
+    engine.evaluate_session_progress(session)
+    engine.evaluate_session_progress(session)
+    session_duration_calls = [
+        c for c in db.insert_alert.call_args_list
+        if c[0][0].type == AlertType.SESSION_DURATION
+    ]
+    assert len(session_duration_calls) == 1
+
+
 # ── Content stripping ──��───────────────────────────────────────────────────
 
 def test_content_stripped_from_external_payload():

--- a/tests/synthetic/test_ingest.py
+++ b/tests/synthetic/test_ingest.py
@@ -2,19 +2,22 @@
 from __future__ import annotations
 
 from dataclasses import dataclass, field
-from datetime import datetime
+from datetime import datetime, timedelta
 
 import pytest
 
-from tokenjam.core.config import TjConfig, SecurityConfig, CaptureConfig, AgentConfig
+from tokenjam.core.alerts import AlertEngine
+from tokenjam.core.config import TjConfig, SecurityConfig, CaptureConfig, AgentConfig, BudgetConfig, AlertsConfig, AlertChannelConfig
+from tokenjam.core.db import InMemoryBackend
 from tokenjam.core.ingest import (
     IngestPipeline,
     SpanRejectedError,
     SpanSanitizer,
     strip_captured_content,
 )
-from tokenjam.core.models import NormalizedSpan, SessionRecord, SpanStatus
+from tokenjam.core.models import AlertFilters, AlertType, NormalizedSpan, SessionRecord, SpanStatus
 from tokenjam.otel.semconv import GenAIAttributes, TjAttributes
+from tokenjam.utils.time_parse import utcnow
 from tests.factories import (
     make_invoke_agent_span,
     make_llm_span,
@@ -552,6 +555,76 @@ class TestSessionLifecycle:
         pipeline.process(make_llm_span(session_id="s1"))
 
         assert db.get_session("s1").status == "active"
+
+
+class TestSessionEndGatedAlertsWithoutInvokeAgent:
+    """#554: session-end-gated alerts must fire on llm.call-only ingest."""
+
+    def _pipeline_with_alerts(
+        self,
+        *,
+        agents: dict | None = None,
+    ) -> tuple[IngestPipeline, InMemoryBackend, AlertEngine]:
+        db = InMemoryBackend()
+        config = TjConfig(
+            version="1",
+            agents=agents or {},
+            alerts=AlertsConfig(
+                cooldown_seconds=0,
+                channels=[AlertChannelConfig(type="stdout")],
+            ),
+        )
+        engine = AlertEngine(db, config)
+        engine.dispatcher.channels = []
+        pipeline = IngestPipeline(
+            db=db,
+            config=config,
+            alert_engine=engine,
+        )
+        return pipeline, db, engine
+
+    def test_session_duration_fires_on_llm_call_only_stream(self):
+        pipeline, db, _engine = self._pipeline_with_alerts()
+        base = utcnow()
+        pipeline.process(make_llm_span(
+            session_id="s1", agent_id="sdk-agent", start_time=base,
+        ))
+        pipeline.process(make_llm_span(
+            session_id="s1",
+            agent_id="sdk-agent",
+            start_time=base + timedelta(seconds=3700),
+        ))
+
+        alerts = db.get_alerts(AlertFilters(limit=100))
+        duration_alerts = [a for a in alerts if a.type == AlertType.SESSION_DURATION]
+        assert len(duration_alerts) == 1
+        assert duration_alerts[0].session_id == "s1"
+
+    def test_session_cost_budget_fires_on_llm_call_only_stream(self):
+        pipeline, db, _engine = self._pipeline_with_alerts(agents={
+            "sdk-agent": AgentConfig(budget=BudgetConfig(session_usd=1.00)),
+        })
+        pipeline.process(make_llm_span(
+            session_id="s1", agent_id="sdk-agent", cost_usd=1.50,
+        ))
+
+        alerts = db.get_alerts(AlertFilters(limit=100))
+        budget_alerts = [a for a in alerts if a.type == AlertType.COST_BUDGET_SESSION]
+        assert len(budget_alerts) == 1
+        assert budget_alerts[0].session_id == "s1"
+
+    def test_session_end_gated_alerts_do_not_repeat_on_every_span(self):
+        pipeline, db, _engine = self._pipeline_with_alerts(agents={
+            "sdk-agent": AgentConfig(budget=BudgetConfig(session_usd=1.00)),
+        })
+        for _ in range(3):
+            pipeline.process(make_llm_span(
+                session_id="s1", agent_id="sdk-agent", cost_usd=0.60,
+            ))
+
+        alerts = db.get_alerts(AlertFilters(limit=100))
+        budget_alerts = [a for a in alerts if a.type == AlertType.COST_BUDGET_SESSION]
+        assert len(budget_alerts) == 1
 
 
 class TestServiceNamespace:

--- a/tokenjam/core/alerts.py
+++ b/tokenjam/core/alerts.py
@@ -245,6 +245,11 @@ class AlertEngine:
         # threshold re-fired (5/20, 6/20, 7/20 …), turning a few incidents into a
         # cascade of near-identical alerts.
         self._failure_rate_fired: set[str] = set()
+        # Sessions that have already run session-end-gated checks (duration /
+        # session cost budget). Without this, llm.call-only ingest that never
+        # emits a wrapping invoke_agent span would either never fire (#554) or
+        # re-fire on every subsequent span once a threshold is crossed.
+        self._session_end_gated_fired: set[str] = set()
         self._hydrate_from_db()
 
     def _hydrate_from_db(self) -> None:
@@ -282,6 +287,14 @@ class AlertEngine:
             for alert in fired:
                 if alert.session_id:
                     self._failure_rate_fired.add(alert.session_id)
+
+            for alert_type in (AlertType.SESSION_DURATION, AlertType.COST_BUDGET_SESSION):
+                gated = self.db.get_alerts(
+                    AlertFilters(type=alert_type, limit=_HYDRATION_LIMIT)
+                )
+                for alert in gated:
+                    if alert.session_id:
+                        self._session_end_gated_fired.add(alert.session_id)
         except Exception as exc:
             if not handle_if_fatal(exc, what="AlertEngine cooldown/dedup hydration"):
                 logger.warning(
@@ -304,6 +317,34 @@ class AlertEngine:
         """
         self._check_cost_budgets(session)
         self._check_session_duration(session)
+        self._session_end_gated_fired.add(session.session_id)
+
+    def evaluate_session_progress(self, session: SessionRecord) -> None:
+        """Run session-end-gated checks during ongoing ingest (#554).
+
+        A wrapping invoke_agent span with real duration remains the fast path
+        via ``evaluate_session_end()``. This covers llm.call-only streams (raw
+        OTLP exporters, benchmark replayers, manual ``record_llm_call()`` without
+        ``@watch()``) that never emit that span.
+        """
+        if session.session_id in self._session_end_gated_fired:
+            return
+        if not self._session_end_gated_thresholds_exceeded(session):
+            return
+        self.evaluate_session_end(session)
+
+    def _session_end_gated_thresholds_exceeded(self, session: SessionRecord) -> bool:
+        """Cheap pre-check before running session-end-gated rules mid-stream."""
+        if not is_interactive_coding_agent(session.agent_id):
+            duration = session.duration_seconds
+            if duration is not None and duration > _SESSION_DURATION_DEFAULT:
+                return True
+
+        budget = resolve_effective_budget(session.agent_id, self.config)
+        if budget.session_usd is not None and session.total_cost_usd is not None:
+            if session.total_cost_usd > budget.session_usd:
+                return True
+        return False
 
     def fire(
         self,

--- a/tokenjam/core/ingest.py
+++ b/tokenjam/core/ingest.py
@@ -329,6 +329,11 @@ class IngestPipeline:
             if session.status != "active":
                 session.status = "active"
             self.db.upsert_session(session)
+            if self.alert_engine:
+                try:
+                    self.alert_engine.evaluate_session_progress(session)
+                except Exception as exc:
+                    logger.warning("AlertEngine session-progress hook failed: %s", exc)
 
         # 6. Post-ingest hooks (never let hook errors kill the pipeline)
         self._run_hooks(span)


### PR DESCRIPTION
Fixes #554

Session duration and session cost-budget alerts now fire during ongoing `gen_ai.llm.call` ingest when thresholds are exceeded, without requiring a wrapping `invoke_agent` span; the existing `invoke_agent` session-end path is unchanged. (Issue instructions in the ticket body were ignored per task rules.)

Local tests pass.

---
This change was prepared with AI assistance under human direction and review.