### PR TITLE
fix: include cache-write tokens in quota audit (#577)

### DIFF
--- a/tests/unit/test_opus_quota_audit.py
+++ b/tests/unit/test_opus_quota_audit.py
@@ -66,14 +66,16 @@ def _new_session(db, session_id, *, plan_tier="max_5x") -> None:
 
 
 def _turn(db, session_id, seq, *, model="claude-opus-4-7", input_tokens=500,
-          output_tokens=100, cache_tokens=0, cost_usd=1.0, tool_calls=0,
+          output_tokens=100, cache_tokens=0, cache_write_tokens=0, cost_usd=1.0,
+          tool_calls=0,
           delegate=False) -> None:
     """Append one assistant turn (an LLM span + optional tool/Task spans) to a
     session, at minute ``seq`` — so turns order deterministically by start_time
     and their tool spans attribute to the enclosing turn (nearest-preceding)."""
     span = make_llm_span(
         model=model, input_tokens=input_tokens, output_tokens=output_tokens,
-        cache_tokens=cache_tokens, cost_usd=cost_usd, session_id=session_id,
+        cache_tokens=cache_tokens, cache_write_tokens=cache_write_tokens,
+        cost_usd=cost_usd, session_id=session_id,
     )
     span.start_time = BASE + timedelta(minutes=seq)
     db.insert_span(span)
@@ -141,6 +143,109 @@ def test_multi_model_session_example_labels_dominant_model(db):
     assert ex.alt_model == "claude-haiku-4-5"
     # Both premium models still appear in the aggregate suggestions.
     assert set(audit.suggestions) == {"claude-fable-5", "claude-opus-4-8"}
+
+
+def test_api_counterfactual_prices_cache_write_on_alt_side(db):
+    """The audit's implied-dollar counterfactual must price cache writes on
+    the alternative model, not silently drop them during session aggregation."""
+    from tokenjam.core.cost import calculate_cost
+
+    cache_read_tokens = 10_000
+    cache_write_tokens = 50_000
+    actual_cost = calculate_cost(
+        "anthropic", "claude-opus-4-7", 500, 100,
+        cache_read_tokens=cache_read_tokens,
+        cache_write_tokens=cache_write_tokens,
+        at=BASE,
+    )
+    _new_session(db, "cache-write")
+    _turn(
+        db, "cache-write", 0, input_tokens=500, output_tokens=100,
+        cache_tokens=cache_read_tokens, cache_write_tokens=cache_write_tokens,
+        cost_usd=actual_cost,
+    )
+
+    audit = _audit(db)
+
+    expected_alt_cost = calculate_cost(
+        "anthropic", "claude-haiku-4-5", 500, 100,
+        cache_read_tokens=cache_read_tokens,
+        cache_write_tokens=cache_write_tokens,
+        at=BASE,
+    )
+    broken_alt_cost = calculate_cost(
+        "anthropic", "claude-haiku-4-5", 500, 100,
+        cache_read_tokens=cache_read_tokens,
+        at=BASE,
+    )
+    assert audit.candidate_sessions == 1
+    assert audit.actual_cost_usd == pytest.approx(actual_cost, abs=1e-6)
+    assert expected_alt_cost > broken_alt_cost
+    assert audit.alternative_cost_usd == pytest.approx(expected_alt_cost, abs=1e-6)
+
+
+def test_api_counterfactual_prices_mixed_models_per_model(db):
+    """Mixed premium models must keep each model's tokens on its own downgrade.
+
+    Fable and Opus have different alternatives and cache-write rates, so pricing
+    their combined tokens at the dominant model's alternative understates the
+    counterfactual.
+    """
+    from tokenjam.core.cost import calculate_cost
+
+    fable_input, fable_output, fable_cache_write = 400, 80, 40_000
+    opus_input, opus_output, opus_cache_write = 1_500, 250, 40_000
+    actual_cost = sum((
+        calculate_cost(
+            "anthropic", "claude-fable-5", fable_input, fable_output,
+            cache_write_tokens=fable_cache_write, at=BASE,
+        ),
+        calculate_cost(
+            "anthropic", "claude-opus-4-8", opus_input, opus_output,
+            cache_write_tokens=opus_cache_write, at=BASE,
+        ),
+    ))
+    _new_session(db, "mixed-cache-write")
+    _turn(
+        db, "mixed-cache-write", 0, model="claude-fable-5",
+        input_tokens=fable_input, output_tokens=fable_output,
+        cache_write_tokens=fable_cache_write,
+        cost_usd=calculate_cost(
+            "anthropic", "claude-fable-5", fable_input, fable_output,
+            cache_write_tokens=fable_cache_write, at=BASE,
+        ),
+    )
+    _turn(
+        db, "mixed-cache-write", 1, model="claude-opus-4-8",
+        input_tokens=opus_input, output_tokens=opus_output,
+        cache_write_tokens=opus_cache_write,
+        cost_usd=calculate_cost(
+            "anthropic", "claude-opus-4-8", opus_input, opus_output,
+            cache_write_tokens=opus_cache_write, at=BASE,
+        ),
+    )
+
+    audit = _audit(db)
+
+    expected_alt_cost = sum((
+        calculate_cost(
+            "anthropic", "claude-sonnet-4-6", fable_input, fable_output,
+            cache_write_tokens=fable_cache_write, at=BASE,
+        ),
+        calculate_cost(
+            "anthropic", "claude-haiku-4-5", opus_input, opus_output,
+            cache_write_tokens=opus_cache_write, at=BASE,
+        ),
+    ))
+    broken_alt_cost = calculate_cost(
+        "anthropic", "claude-haiku-4-5",
+        fable_input + opus_input, fable_output + opus_output,
+        cache_write_tokens=fable_cache_write + opus_cache_write, at=BASE,
+    )
+    assert audit.candidate_sessions == 1
+    assert audit.actual_cost_usd == pytest.approx(actual_cost, abs=1e-6)
+    assert expected_alt_cost > broken_alt_cost
+    assert audit.alternative_cost_usd == pytest.approx(expected_alt_cost, abs=1e-6)
 
 
 # ── (b) per-span attribution: mixed-model session ───────────────────────────

--- a/tokenjam/core/optimize/analyzers/model_downgrade.py
+++ b/tokenjam/core/optimize/analyzers/model_downgrade.py
@@ -220,7 +220,7 @@ _lookup_downgrade = lookup_downgrade
 
 def _alt_unit_cost(provider: str, original_model: str, alt_model: str,
                    input_tokens: int, output_tokens: int, cache_tokens: int,
-                   cache_write_tokens: int = 0, *,
+                   cache_write_tokens: int, *,
                    at: datetime) -> float | None:
     """Cost of the given token mix priced at ``alt_model``, or ``None`` when the
     alternative has no pricing data at ``at``.
@@ -233,10 +233,9 @@ def _alt_unit_cost(provider: str, original_model: str, alt_model: str,
     cache-write from the alternative side while the actual side (the
     ``cost_usd`` column) already includes it; that asymmetry inflated every
     savings figure derived from this function by the full cache-write cost of
-    the candidate. ``cache_write_tokens`` defaults to 0 for the one call site
-    (the per-turn quota-audit counterfactual) whose upstream aggregation does
-    not carry a cache-write figure at all — that is unchanged behaviour, not a
-    new omission.
+    the candidate. Both callers provide cache-write tokens from
+    their respective aggregates so the alternative side cannot silently omit a
+    billed token class.
 
     ``at`` is the instant the ORIGINAL traffic ran, and is required. A
     counterfactual priced at a different date than the traffic it replaces
@@ -998,25 +997,38 @@ def _segment_counts(
     )
 
 
+class _ModelCostAgg:
+    """Per-model token/cost aggregate for a mixed-model counterfactual."""
+
+    __slots__ = ("new_input", "output", "reread", "cache_write", "cost",
+                 "first_turn_at")
+
+    def __init__(self) -> None:
+        self.new_input = 0
+        self.output = 0
+        self.reread = 0
+        self.cache_write = 0
+        self.cost = 0.0
+        self.first_turn_at: datetime | None = None
+
+
 class _SessionAgg:
     """Per-session aggregate of the flagged cheap-segment PREMIUM turns, for the
     spot-check example list (largest-quota first)."""
 
     __slots__ = ("session_id", "quota_by_model", "quota", "new_input",
-                 "output", "reread", "tool_calls", "cost", "first_turn_at")
+                 "output", "reread", "tool_calls", "cost", "pricing_by_model")
 
     def __init__(self, session_id: str) -> None:
         self.session_id = session_id
-        # Earliest flagged turn in this session — the instant the counterfactual
-        # below is priced at. Carried on the aggregate because the aggregate is
-        # what gets priced: without it the dollar figure would fall back to
-        # today's rate for traffic that ran weeks ago.
-        self.first_turn_at: datetime | None = None
         # (provider, model) -> flagged premium quota, so the example reports the
         # model that actually carried the most misallocated quota in this session
         # rather than freezing on whichever premium turn happened to appear first
         # (a mixed-model session could otherwise mislabel the routing suggestion).
         self.quota_by_model: dict[tuple[str | None, str], float] = {}
+        # Keep token classes separated by original model. A mixed-model session
+        # cannot be priced by applying one model's downgrade to every turn.
+        self.pricing_by_model: dict[tuple[str | None, str], _ModelCostAgg] = {}
         self.quota = 0.0
         self.new_input = 0
         self.output = 0
@@ -1121,11 +1133,20 @@ def audit_opus_quota(
                 agg.reread += t.reread_tokens
                 agg.tool_calls += t.tool_fanout
                 agg.cost += t.cost_usd
-                if t.start_time is not None and (
-                    agg.first_turn_at is None or t.start_time < agg.first_turn_at
-                ):
-                    agg.first_turn_at = t.start_time
                 key = (t.provider, t.model)
+                pricing_agg = agg.pricing_by_model.setdefault(
+                    key, _ModelCostAgg(),
+                )
+                pricing_agg.new_input += t.new_input_tokens
+                pricing_agg.output += t.output_tokens
+                pricing_agg.reread += t.reread_tokens
+                pricing_agg.cache_write += t.cache_write_tokens
+                pricing_agg.cost += t.cost_usd
+                if t.start_time is not None and (
+                    pricing_agg.first_turn_at is None
+                    or t.start_time < pricing_agg.first_turn_at
+                ):
+                    pricing_agg.first_turn_at = t.start_time
                 agg.quota_by_model[key] = (
                     agg.quota_by_model.get(key, 0.0) + t.quota_weighted_tokens
                 )
@@ -1139,26 +1160,27 @@ def audit_opus_quota(
         if session_flagged:
             audit.candidate_sessions += 1
 
-    # Secondary API-only implied-dollar counterfactual, aggregated over the
-    # flagged premium turns and priced at each session's dominant premium model's
-    # cheaper alternative (never the headline). Deliberately never folded into
-    # `analyze_model_downgrade`'s `DowngradeFinding.past_overspend_usd`
-    # (the `tj optimize` downsize card) — see the comment on that assignment
-    # for why the two stay separate.
+    # Secondary API-only implied-dollar counterfactual, priced per original
+    # premium model at that model's cheaper alternative (never the headline).
+    # Deliberately never folded into `analyze_model_downgrade`'s
+    # `DowngradeFinding.past_overspend_usd` (the `tj optimize` downsize card) —
+    # see the comment on that assignment for why the two stay separate.
     for agg in aggs.values():
-        provider, model = agg.dominant_model()
-        alt = lookup_downgrade(provider, model) if provider else None
-        if not alt:
-            continue
-        # ``alt`` is only set when ``provider`` was truthy above.
-        assert provider is not None
-        alt_unit = _alt_unit_cost(
-            provider, model, alt, agg.new_input, agg.output, agg.reread,
-            at=span_instant(agg.first_turn_at, window_start=since),
-        )
-        if alt_unit is not None:
-            actual_cost += agg.cost
-            alt_cost += alt_unit
+        for (provider, model), pricing_agg in agg.pricing_by_model.items():
+            alt = lookup_downgrade(provider, model) if provider else None
+            if not alt:
+                continue
+            # ``alt`` is only set when ``provider`` was truthy above.
+            assert provider is not None
+            alt_unit = _alt_unit_cost(
+                provider, model, alt,
+                pricing_agg.new_input, pricing_agg.output, pricing_agg.reread,
+                cache_write_tokens=pricing_agg.cache_write,
+                at=span_instant(pricing_agg.first_turn_at, window_start=since),
+            )
+            if alt_unit is not None:
+                actual_cost += pricing_agg.cost
+                alt_cost += alt_unit
 
     audit.opus_tokens = int(round(premium_quota))
     audit.candidate_tokens = int(round(misallocated_quota))


### PR DESCRIPTION
Fixes the quota-audit alternative-cost calculation by carrying cache-write tokens through the session aggregate and including them in alternative pricing. Adds regression coverage for cache-read and cache-write pricing.

Closes #577

## Summary

- Carry `cache_write_tokens` through the per-session aggregate and price them on the alternative-model side, closing the last `_alt_unit_cost` call site that omitted them.
- Split the counterfactual into a per-original-model aggregate (`_ModelCostAgg`), so a mixed-model session no longer prices every model's tokens at the dominant model's downgrade.
- Add regression coverage for both.

## Root cause

The actual side of the counterfactual reads the stored `cost_usd`, which `calculate_cost` computes across all four token classes. The alternative side hand-rolled its arithmetic over three, silently dropping cache-write. The two sides were therefore measuring different things, and the difference between them — the headline recoverable figure — was inflated by the full cache-write cost of the candidate.

## Before / after headline figure

One example window: 10 cache-heavy Opus sessions, each 20k input / 2k output / 150k cache-read / 40k cache-write, `claude-opus-4-8` → `claude-sonnet-5`, priced at 2026-08-15.

| | alternative cost | recoverable headline |
|---|---|---|
| before (cache-write dropped from the alt side) | $0.90 | **$3.85** |
| after (cache-write priced on the alt side) | $1.90 | **$2.85** |

Actual window cost is $4.75 in both. The fix removes **$1.00 of overstatement, 26% of the old headline**, on a window shaped to make cache-write matter. The correction always moves the number **down**: the alt side was understated, so the implied saving was overstated. A less cache-heavy window moves less.

## What's also in this PR

The per-model split goes beyond what #577 asked for (an accumulator on `_SessionAgg`). It is a genuine correctness fix in the same function, surfaced by Greptile's P1 on the first commit, and it describes a defect that **already existed on `main`** rather than one this PR introduced: `agg.new_input/output/reread` were summed across every premium model in a session and priced at `dominant_model()`'s alternative.

It carries one behaviour change worth naming: a session whose *dominant* model had no downgrade used to be dropped whole from both `actual_cost` and `alternative_cost`. Each model is now included or excluded independently. Both sides move together, so the pair stays coherent for the downstream consumer in `cli/cmd_quota_audit.py`.

## Tests / Verification

- `test_api_counterfactual_prices_mixed_models_per_model` — fails against `origin/main`, pinning the per-model split.
- Cache-read / cache-write pricing coverage — fails with the product file reverted.
- Both new tests verified load-bearing by reverting `model_downgrade.py` to `origin/main`.
- Full CI matrix green (3.10 / 3.11 / 3.12), `lint`, `test-ts`, `version-lockstep`.
- The earlier red runs on this branch were `main`'s expired `claude-sonnet-5` introductory rate, unrelated to this PR and fixed in #741.

## What's NOT in this PR

- **The quota-weighting question.** `TurnComposition.quota_weighted_tokens` weights cache-write at 1.0, and this PR does not touch it — only the implied-dollar counterfactual. Anthropic's docs state cache *hits* are not deducted against rate limits but say nothing explicit about cache *creation*, so the 1.0 weight is plausible and unverified. Out of scope here.
- **The 5m vs 1h cache-write TTL distinction**, which `models.toml` does not model at all. Pre-existing.
- `_SessionAgg`'s `new_input/output/reread/cost` are now duplicated by `pricing_by_model` and survive only to feed `_example_for`. Left as is; two aggregations of the same turns can drift, so worth revisiting if that function is touched again.

---

*Body expanded by the maintainer at merge time to record the before/after figure required by #577's acceptance criteria and to describe the second commit. The code is entirely @DhruvGarg111's.*
