### PR TITLE
fix(tests): pin the pricing instant so a dated rate can't break main

### DIFF
--- a/tests/unit/test_cost.py
+++ b/tests/unit/test_cost.py
@@ -519,23 +519,39 @@ def test_default_cache_rates_are_nonzero_and_ratio_derived():
 
 # ─── Anthropic-priced models: byte-identical cost before/after this change ─
 
+# Every case pins the pricing instant. `calculate_cost`'s `at=None` default
+# means "now", which is documented as being for LIVE callers only — a test is
+# a backward-looking caller, and one that leans on the default silently starts
+# asserting a different row the day a dated rate takes effect. That is not
+# hypothetical: claude-sonnet-5's introductory rate expired 2026-09-01 and
+# turned this table red on a date nobody was watching. Pin the instant and a
+# row's arithmetic stays true forever; add a case to cover a new row.
+_BEFORE_SONNET_5_STANDARD = datetime(2026, 8, 1, tzinfo=timezone.utc)
+_AFTER_SONNET_5_STANDARD = datetime(2026, 9, 2, tzinfo=timezone.utc)
+
 
 @pytest.mark.parametrize(
-    "model,input_tokens,output_tokens,expected",
+    "model,input_tokens,output_tokens,at,expected",
     [
-        ("claude-haiku-4-5", 1_000_000, 1_000_000, 6.0),      # 1.00 + 5.00
-        ("claude-sonnet-4-6", 1_000_000, 1_000_000, 18.0),    # 3.00 + 15.00
-        ("claude-sonnet-5", 1_000_000, 1_000_000, 12.0),      # 2.00 + 10.00
-        ("claude-opus-4-8", 1_000_000, 1_000_000, 30.0),      # 5.00 + 25.00
-        ("claude-fable-5", 1_000_000, 1_000_000, 60.0),       # 10.00 + 50.00
-        ("claude-opus-4", 1_000_000, 1_000_000, 90.0),        # 15.00 + 75.00
+        ("claude-haiku-4-5", 1_000_000, 1_000_000, _BEFORE_SONNET_5_STANDARD, 6.0),    # 1.00 + 5.00
+        ("claude-sonnet-4-6", 1_000_000, 1_000_000, _BEFORE_SONNET_5_STANDARD, 18.0),  # 3.00 + 15.00
+        # Both sides of claude-sonnet-5's 2026-09-01 boundary, so each row is
+        # guarded on its own terms rather than whichever one today happens to
+        # select.
+        ("claude-sonnet-5", 1_000_000, 1_000_000, _BEFORE_SONNET_5_STANDARD, 12.0),    # 2.00 + 10.00
+        ("claude-sonnet-5", 1_000_000, 1_000_000, _AFTER_SONNET_5_STANDARD, 18.0),     # 3.00 + 15.00
+        ("claude-opus-4-8", 1_000_000, 1_000_000, _BEFORE_SONNET_5_STANDARD, 30.0),    # 5.00 + 25.00
+        ("claude-fable-5", 1_000_000, 1_000_000, _BEFORE_SONNET_5_STANDARD, 60.0),     # 10.00 + 50.00
+        ("claude-opus-4", 1_000_000, 1_000_000, _BEFORE_SONNET_5_STANDARD, 90.0),      # 15.00 + 75.00
     ],
 )
-def test_anthropic_priced_models_cost_unchanged(model, input_tokens, output_tokens, expected):
+def test_anthropic_priced_models_cost_unchanged(model, input_tokens, output_tokens, at, expected):
     """Every model already carrying a real models.toml row must cost exactly
     what it did before this fix — the fallback change only touches models
     with NO entry in the table."""
-    assert calculate_cost("anthropic", model, input_tokens, output_tokens) == pytest.approx(expected)
+    assert calculate_cost(
+        "anthropic", model, input_tokens, output_tokens, at=at
+    ) == pytest.approx(expected)
 
 
 # ─── A cache class omitted from a models.toml row is distinguishable from a

--- a/tests/unit/test_optimize_subagent.py
+++ b/tests/unit/test_optimize_subagent.py
@@ -1,7 +1,7 @@
 """Unit tests for the subagent right-sizing analyzer."""
 from __future__ import annotations
 
-from datetime import timedelta
+from datetime import datetime, timedelta, timezone
 
 import pytest
 
@@ -17,8 +17,13 @@ from tokenjam.utils.time_parse import utcnow
 from tests.factories import make_llm_span
 
 
-def _ctx(db: InMemoryBackend, window_cost_usd: float, config=None):
-    now = utcnow()
+def _ctx(db: InMemoryBackend, window_cost_usd: float, config=None, at=None):
+    # `at` pins the window (and so the instant every span in it prices at) for
+    # a test whose expected dollars are written out longhand. Pricing has a
+    # time axis, so a test that hardcodes an arithmetic breakdown and leaves
+    # the instant floating asserts a different rate row once a dated rate takes
+    # effect. Defaults to now for tests that do not care.
+    now = at or utcnow()
     since = now - timedelta(days=1)
     until = now + timedelta(minutes=5)
     summary = WindowSummary(
@@ -143,7 +148,9 @@ def test_over_powered_subagent_carries_quantified_estimate():
     tokens), so it can compete for a ranked slot (#101)."""
     db = InMemoryBackend()
     try:
-        ctx, now = _ctx(db, window_cost_usd=1.0)
+        # Pinned before claude-sonnet-5's 2026-09-01 standard-pricing row, so
+        # the longhand breakdown below stays the arithmetic actually performed.
+        ctx, now = _ctx(db, window_cost_usd=1.0, at=datetime(2026, 8, 1, tzinfo=timezone.utc))
         # Opus subagent, big context, tiny output -> over_powered (+over_provisioned).
         db.insert_span(make_llm_span(
             model="claude-opus-4-8", provider="anthropic",

--- a/tests/unit/test_rate_profile.py
+++ b/tests/unit/test_rate_profile.py
@@ -143,7 +143,10 @@ def test_single_model_input_rate_and_ratio_match_its_own_rates():
     since, until = _window()
     profile = blended_rate_profile(db.conn, since=since, until=until)
 
-    rates = get_rates("anthropic", "claude-sonnet-5")
+    # `at=start` because the profile priced the span at ITS timestamp. Reading
+    # today's rate here compares two different instants and breaks the day any
+    # dated row takes effect (claude-sonnet-5's did, on 2026-09-01).
+    rates = get_rates("anthropic", "claude-sonnet-5", at=start)
     assert profile is not None
     assert profile.input_rate_per_token == rates.input_per_mtok / 1_000_000
     assert abs(

--- a/tests/unit/test_relearn.py
+++ b/tests/unit/test_relearn.py
@@ -970,8 +970,13 @@ def test_single_timestamp_corpus_floors_the_window_to_one_day(tmp_path):
     assert cluster.past_overspend_tokens == cluster.occurrences * 1_500
 
 
-#: The instant a fake rate bucket is priced at. Inside the current rate era for
-#: every model these tests use, so the blend is that model's plain rate.
+#: The instant a fake rate bucket is priced at, and the instant every assertion
+#: about the resulting blend must read its expected rate at. It used to be
+#: described as "the current rate era", which stopped being true when
+#: claude-sonnet-5's introductory rate expired on 2026-09-01: the blend priced
+#: at this fixed instant while the assertions read `get_rates()` at "now", and
+#: the two silently diverged. A fixed instant on both sides is the point — do
+#: not reach for the live rate here.
 _RATE_BUCKET_AT = datetime(2026, 7, 1, tzinfo=timezone.utc)
 
 
@@ -1017,7 +1022,9 @@ def test_blended_rate_profile_names_the_models_it_derived_from():
     conn = _FakeSpanConn([("anthropic", "claude-sonnet-5", 1_000_000, 1_000_000)])
     profile = blended_rate_profile(conn, session_ids={"s1", "s2"})
 
-    rates = get_rates("anthropic", "claude-sonnet-5")
+    # `at=_RATE_BUCKET_AT` — the instant the fake rate rows carry, and so the
+    # one the profile priced at. See the note on the constant.
+    rates = get_rates("anthropic", "claude-sonnet-5", at=_RATE_BUCKET_AT)
     assert profile.input_rate_per_token == pytest.approx(rates.input_per_mtok / 1_000_000)
     assert profile.cache_read_ratio == pytest.approx(
         rates.cache_read_per_mtok / rates.input_per_mtok
@@ -1055,7 +1062,9 @@ def test_past_overspend_usd_derived_when_conn_has_priced_spans(tmp_path):
     finding = analyze_relearns(sessions, projects_root=tmp_path, distill_enabled=False, conn=conn)
 
     cluster = finding.clusters[0]
-    expected_rate = get_rates("anthropic", "claude-sonnet-5").input_per_mtok / 1_000_000
+    expected_rate = get_rates(
+        "anthropic", "claude-sonnet-5", at=_RATE_BUCKET_AT
+    ).input_per_mtok / 1_000_000
     assert cluster.past_overspend_usd == round(cluster.past_overspend_tokens * expected_rate, 6)
     assert cluster.past_overspend_basis
     assert finding.past_overspend_usd == pytest.approx(cluster.past_overspend_usd)

--- a/tokenjam/pricing/models.toml
+++ b/tokenjam/pricing/models.toml
@@ -33,6 +33,20 @@
 # past and future figures silently incomparable. Fields a dated row omits are
 # inherited from the rate it supersedes.
 #
+# ADDING A DATED ROW SCHEDULES A TEST FAILURE unless you also pin the tests that
+# price this model. A test that hardcodes an expected dollar figure and lets the
+# pricing instant default to "now" asserts the pre-boundary row until the date
+# lands, then asserts the post-boundary row against a pre-boundary number. The
+# row above did exactly that on 2026-09-01 and turned main red with no commit to
+# blame, days after the last green run. So when you add a dated row:
+#   * give `tests/unit/test_cost.py`'s priced-models table a case on EACH side
+#     of the boundary, each passing `at=` explicitly;
+#   * check any test that prices this model for a floating instant — the rule is
+#     that the expected rate and the span must be read at the SAME instant, and
+#     both pinned, or both "now" so they move together.
+# `test_only_the_labelled_call_site_prices_at_now` enforces this for analyzers,
+# but it scans `core/optimize/` only and cannot see the test suite.
+#
 # ─── Variants (the variant axis) ───────────────────────────────────────────
 # A variant is a different way of buying the SAME model id. Two forms:
 #   * per-model, when the rate is specific to that model — a `[[...rates]]` row


### PR DESCRIPTION
`main` has been red since 2026-09-01 and no commit caused it. `claude-sonnet-5`'s introductory rate expired that day, five tests were reading the live rate, and the last green run was 2026-08-28 — so the breakage landed on a date nobody was watching and every open PR inherited it.

## Summary

- Pin the pricing instant in the five tests that were leaning on `at=None` ("now").
- Cover **both sides** of the `claude-sonnet-5` 2026-09-01 boundary in the priced-models table, so each rate row is guarded on its own terms instead of whichever one the calendar happens to select.
- Document, in the `models.toml` header next to the dated-row instructions, that adding a dated row schedules a test failure unless the tests pricing that model are pinned too.

## Symptom, root cause, fix

**Symptom.** Five failures on every PR and on `main` itself, all pricing arithmetic:

```
test_cost.py::test_anthropic_priced_models_cost_unchanged[claude-sonnet-5-...]  assert 18.0 == 12.0
test_rate_profile.py::test_single_model_input_rate_and_ratio_match_its_own_rates  assert 2e-06 == 3e-06
test_relearn.py::test_blended_rate_profile_names_the_models_it_derived_from       assert 2e-06 == 3e-06
test_relearn.py::test_past_overspend_usd_derived_when_conn_has_priced_spans       assert 0.009 == 0.0135
test_optimize_subagent.py::test_over_powered_subagent_carries_quantified_estimate assert 0.3585 == 0.439
```

**Root cause.** `models.toml` prices `claude-sonnet-5` at the introductory 2.00/10.00 with a dated row taking over at 3.00/15.00 on 2026-09-01. The dated-rate machinery worked exactly as designed. The tests were the defect: they priced a span at "now" while asserting a number written against the introductory row, or read `get_rates()` at "now" while comparing it to a profile built at a fixed past instant.

`calculate_cost`'s own docstring already states the rule being violated — the `at=None` default is for LIVE callers only, and anything reading backwards must pass the instant explicitly. A test is a backward-looking caller. `test_only_the_labelled_call_site_prices_at_now` enforces this for analyzers, but it scans `core/optimize/` and cannot see the test suite, which is where this one lived.

**Fix.** Each test now reads its expected rate at the same instant its span was priced at.

## What's NOT in this PR

**A mechanical guard over the test suite.** The real invariant is that the expected rate and the span are read at the *same* instant, which a bare "undated `get_rates` in tests" check cannot see: several such calls are correct precisely because both sides float together (`test_optimize_subagent.py:208` is one — I checked it before concluding). A guard that flagged those would be a false positive generator, and per Critical Rule 23 a guard with an allowlist just teaches people to add exceptions. The lesson goes where the next person scheduling a dated row will read it instead.

**The three `summarize` failures** that show up in a local full-suite run. They reproduce identically on pristine `origin/main`, are green in CI, and are the known Critical Rule 31 isolated-`HOME` corpus effect. Unrelated and out of scope.

## Tests / Verification

Full CI test set, `-n auto`, same machine, apples-to-apples:

| | pristine `origin/main` | this branch |
|---|---|---|
| result | **8 failed**, 5623 passed | **3 failed**, 5629 passed |
| pricing failures | 5 | **0** |
| `summarize` failures | 3 | 3 (pre-existing, green in CI) |

`ruff check tokenjam/` clean. The six extra passes are the five fixed tests plus the new post-boundary `claude-sonnet-5` case.

🤖 Generated with [Claude Code](https://claude.com/claude-code)