### PR TITLE
fix(demo): stop trace_count() undercounting past the query limit

### DIFF
--- a/tests/unit/test_demo_env.py
+++ b/tests/unit/test_demo_env.py
@@ -55,6 +55,16 @@ def test_demo_env_trace_count_matches_injected():
     assert len(env.db.get_traces(TraceFilters())) == 2
 
 
+def test_demo_env_trace_count_not_capped_by_default_query_limit():
+    from tokenjam.demo.env import DemoEnvironment
+    from tokenjam.core.models import TraceFilters
+    env = DemoEnvironment()
+    n = TraceFilters().limit + 5
+    for _ in range(n):
+        env.process(make_llm_span(agent_id="test-agent", trace_id=new_trace_id()))
+    assert env.trace_count() == n
+
+
 def test_demo_result_fields():
     from tokenjam.demo.env import DemoEnvironment, DemoResult
     env = DemoEnvironment()

--- a/tokenjam/demo/env.py
+++ b/tokenjam/demo/env.py
@@ -99,7 +99,7 @@ class DemoEnvironment:
 
     def trace_count(self) -> int:
         from tokenjam.core.models import TraceFilters
-        return len(self.db.get_traces(TraceFilters()))
+        return self.db.count_traces(TraceFilters())
 
     def build_result(self, agent_id: str) -> DemoResult:
         alerts = self.get_alerts()


### PR DESCRIPTION
Did it: `trace_count()` now calls `count_traces()` instead of taking `len()` of a limited query.

Added a test that creates 55 traces and checks `trace_count()` returns 55, not 50. The new test fails without the fix.

Closes #341
