### PR TITLE
Fix #563: reject daemon PIDs when process identity is unavailable

### DIFF
--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -439,6 +439,10 @@ Metrics: `http://127.0.0.1:7391/metrics`
 
 Stop the background daemon or `tj serve` process.
 
+PID-file discovery requires a matching command line from `/proc` or `ps`. If
+neither can establish the process identity, TokenJam leaves that PID alone;
+a live PID by itself is not proof that it still belongs to the daemon.
+
 ```bash
 tj stop
 ```

--- a/tests/unit/test_server_state.py
+++ b/tests/unit/test_server_state.py
@@ -11,6 +11,8 @@ shape so a regression back to substring matching is caught for real.
 """
 from __future__ import annotations
 
+import pytest
+
 from tokenjam.core.server_state import _looks_like_serve
 
 
@@ -54,3 +56,75 @@ class TestDoesNotMatchUnrelatedProcesses:
         # "tj" must be a bare token (or a path basename), not a substring
         # of some unrelated word.
         assert _looks_like_serve("/usr/bin/notjserve --serve") is False
+
+
+class TestUnavailableProcessIdentity:
+    @pytest.mark.parametrize("error", [FileNotFoundError, PermissionError, OSError])
+    def test_unavailable_ps_does_not_identify_a_serve_process(self, monkeypatch, error):
+        from unittest.mock import Mock
+
+        from tokenjam.core import server_state
+
+        monkeypatch.setattr(server_state.Path, "exists", lambda path: False)
+        monkeypatch.setattr(server_state.subprocess, "run", Mock(side_effect=error))
+
+        assert server_state.is_serve_process(42424242) is False
+
+    def test_stop_does_not_signal_a_live_pid_without_identity(self, tmp_path, monkeypatch):
+        import json
+        from unittest.mock import Mock
+
+        from tokenjam.cli import cmd_stop
+        from tokenjam.core import server_state
+
+        state_path = tmp_path / ".local/share/tj/server.state"
+        state_path.parent.mkdir(parents=True)
+        state_path.write_text(json.dumps({"pid": 42424242, "port": 7391, "config_path": None}))
+        monkeypatch.setattr(server_state.Path, "home", lambda: tmp_path)
+        monkeypatch.setattr(server_state.Path, "exists", lambda path: False)
+        monkeypatch.setattr(server_state.subprocess, "run", Mock(side_effect=FileNotFoundError))
+        monkeypatch.setattr(cmd_stop, "_DISCOVERY_MAX_MISSES", 1)
+        monkeypatch.setattr(cmd_stop, "_DISCOVERY_RETRY_S", 0)
+        probes = []
+
+        def no_termination(pid, sig):
+            probes.append((pid, sig))
+            assert sig == 0, "An unverified PID must never receive a termination signal"
+
+        monkeypatch.setattr(server_state.os, "kill", no_termination)
+
+        assert server_state.find_own_serve_pid() is None
+        assert cmd_stop.stop_tj_serve(quiet=True) == (False, [])
+        assert probes and all(pid == 42424242 and sig == 0 for pid, sig in probes)
+
+    @pytest.mark.parametrize("command, expected", [
+        ("/usr/local/bin/tj --config /tmp/config.toml serve", True),
+        ("/usr/bin/python worker.py", False),
+        ("", False),
+    ])
+    def test_ps_fallback_requires_matching_identity(self, monkeypatch, command, expected):
+        from subprocess import CompletedProcess
+        from unittest.mock import Mock
+
+        from tokenjam.core import server_state
+
+        monkeypatch.setattr(server_state.Path, "exists", lambda path: False)
+        probe = Mock(return_value=CompletedProcess([], 0, stdout=command))
+        monkeypatch.setattr(server_state.subprocess, "run", probe)
+        assert server_state.is_serve_process(42424242) is expected
+        probe.assert_called_once_with(
+            ["ps", "-ww", "-p", "42424242", "-o", "command="],
+            capture_output=True, text=True,
+        )
+
+    def test_readable_proc_identity_does_not_require_ps(self, monkeypatch):
+        from unittest.mock import Mock
+
+        from tokenjam.core import server_state
+
+        monkeypatch.setattr(server_state.Path, "exists", lambda path: True)
+        monkeypatch.setattr(server_state.Path, "read_bytes", lambda path: b"tj\0serve\0")
+        probe = Mock(side_effect=AssertionError("ps should not be needed"))
+        monkeypatch.setattr(server_state.subprocess, "run", probe)
+        assert server_state.is_serve_process(42424242) is True
+        probe.assert_not_called()

--- a/tokenjam/core/server_state.py
+++ b/tokenjam/core/server_state.py
@@ -65,6 +65,7 @@ def is_serve_process(pid: int) -> bool:
 
     Guards against PID reuse: a stale state file's PID may since have been
     recycled by an unrelated process, and we must never signal that.
+    If neither /proc nor ps can establish identity, return False.
     """
     proc_cmdline = Path(f"/proc/{pid}/cmdline")
     if proc_cmdline.exists():
@@ -86,10 +87,11 @@ def is_serve_process(pid: int) -> bool:
             ["ps", "-ww", "-p", str(pid), "-o", "command="],
             capture_output=True, text=True,
         )
-    except FileNotFoundError:
-        # No `ps` on this platform -- fail open on identity (liveness above
-        # is still checked) rather than refuse to ever stop anything.
-        return True
+    except OSError:
+        # Liveness alone does not establish identity: a stale PID can belong
+        # to an unrelated process. Missing or unusable `ps` must fail closed,
+        # just like an unreadable /proc command line above.
+        return False
     if result.returncode != 0:
         return False
     return _looks_like_serve(result.stdout.strip())


### PR DESCRIPTION
## Summary

A live PID in `server.state` can belong to an unrelated process after PID reuse. When neither `/proc` nor `ps` could establish identity, `is_serve_process()` returned `True`, allowing PID-file discovery to select that process.

Make the shared identity check return `False` when `ps` is missing or cannot execute, matching the existing fail-closed behavior for unreadable `/proc`. Tests cover missing/unusable probes, matching and unrelated command lines, readable `/proc`, and a persisted stale live PID that must not receive a termination signal through `tj stop`. The CLI reference documents this behavior.

## Related issue

Closes #563

## Validation

- Focused server-state, stop/scoping, upgrade, and lock-holder tests: **70 passed**.
- Full Python unit/synthetic/agents/integration run with four workers: **5,648 passed, 17 skipped, 2 xfailed, 8 failed**. The eight failures were terminal rendering assertions under this runner's `TERM=dumb` / `NO_COLOR=1` environment and narrow output width. All eight passed unchanged when rerun with `NO_COLOR` and `FORCE_COLOR` unset, `TERM=xterm-256color`, and `COLUMNS=200`.
- `ruff check tokenjam/` and `ruff check tests/unit/test_server_state.py`: passed.
- `mypy tokenjam/`: passed (278 source files).
- `git diff --check`: passed.

Implemented and validated with OpenAI Codex. This fixes unavailable-identity handling; it does not add process-start-time tracking or claim to eliminate every PID reuse race.

## Checklist

- [x] Python suites exercised; all eight environment-sensitive failures passed on targeted rerun as detailed above
- [x] Lint clean
- [x] Type check clean
- [x] CLI reference updated; no architecture change requiring CLAUDE.md changes
- [x] No synthetic spans added
- [ ] Maintainer review request after CI is green, as required by CONTRIBUTING.md
