### PR TITLE
Fix #746: keep transient process probe failures visible

### DIFF
--- a/.claude/rules/cli-output.md
+++ b/.claude/rules/cli-output.md
@@ -86,6 +86,12 @@ explicitly. (Critical Rule 8 — never construct a `NormalizedSpan` directly in 
 
 ### Daemon (launchd / systemd)
 
+`is_serve_process()` fails closed only when process identity is unavailable
+(`ps` is missing, inaccessible, or has an invalid path). Resource exhaustion
+while spawning `ps` must propagate; treating `EAGAIN` or `ENOMEM` as a negative
+identity check can make `tj upgrade` silently leave a live daemon on the old
+version.
+
 `tj onboard` (and `tj onboard --claude-code` / `--codex`) installs a background daemon that runs `tj serve` on login:
 - **macOS**: `~/Library/LaunchAgents/com.tokenjam.serve.plist` — loaded via `launchctl load`. Logs at `/tmp/tj-serve.{out,err}`.
 - **Linux**: `~/.config/systemd/user/tokenjam.service` — enabled via `systemctl --user enable --now tokenjam`.

--- a/tests/unit/test_cmd_upgrade.py
+++ b/tests/unit/test_cmd_upgrade.py
@@ -131,6 +131,14 @@ class TestRestartDaemon:
         assert method == "none"
         assert success is True
 
+    def test_identity_probe_resource_failure_is_not_reported_as_no_daemon(self):
+        state = ServerState(pid=123, port=7391, config_path=None)
+        failure = OSError("process table exhausted")
+        with patch.object(upgrade_mod, "is_pid_alive", return_value=True), \
+             patch.object(upgrade_mod, "is_serve_process", side_effect=failure):
+            with pytest.raises(OSError, match="process table exhausted"):
+                upgrade_mod.restart_daemon(state)
+
     def test_uses_launchd_kickstart_when_launchd_supervises_it(self):
         state = ServerState(pid=123, port=7391, config_path=None)
         run_mock = MagicMock(return_value=MagicMock(returncode=0, stdout="", stderr=""))

--- a/tests/unit/test_server_state.py
+++ b/tests/unit/test_server_state.py
@@ -11,6 +11,8 @@ shape so a regression back to substring matching is caught for real.
 """
 from __future__ import annotations
 
+import errno
+
 import pytest
 
 from tokenjam.core.server_state import _looks_like_serve
@@ -59,7 +61,7 @@ class TestDoesNotMatchUnrelatedProcesses:
 
 
 class TestUnavailableProcessIdentity:
-    @pytest.mark.parametrize("error", [FileNotFoundError, PermissionError, OSError])
+    @pytest.mark.parametrize("error", [FileNotFoundError, PermissionError, NotADirectoryError])
     def test_unavailable_ps_does_not_identify_a_serve_process(self, monkeypatch, error):
         from unittest.mock import Mock
 
@@ -69,6 +71,22 @@ class TestUnavailableProcessIdentity:
         monkeypatch.setattr(server_state.subprocess, "run", Mock(side_effect=error))
 
         assert server_state.is_serve_process(42424242) is False
+
+    @pytest.mark.parametrize("error_number", [errno.EAGAIN, errno.ENOMEM])
+    def test_resource_exhaustion_during_ps_probe_remains_visible(
+        self, monkeypatch, error_number
+    ):
+        from unittest.mock import Mock
+
+        from tokenjam.core import server_state
+
+        monkeypatch.setattr(server_state.Path, "exists", lambda path: False)
+        failure = OSError(error_number, "resource exhausted")
+        monkeypatch.setattr(server_state.subprocess, "run", Mock(side_effect=failure))
+
+        with pytest.raises(OSError) as raised:
+            server_state.is_serve_process(42424242)
+        assert raised.value.errno == error_number
 
     def test_stop_does_not_signal_a_live_pid_without_identity(self, tmp_path, monkeypatch):
         import json

--- a/tokenjam/core/server_state.py
+++ b/tokenjam/core/server_state.py
@@ -87,10 +87,12 @@ def is_serve_process(pid: int) -> bool:
             ["ps", "-ww", "-p", str(pid), "-o", "command="],
             capture_output=True, text=True,
         )
-    except OSError:
+    except (FileNotFoundError, PermissionError, NotADirectoryError):
         # Liveness alone does not establish identity: a stale PID can belong
         # to an unrelated process. Missing or unusable `ps` must fail closed,
-        # just like an unreadable /proc command line above.
+        # just like an unreadable /proc command line above. Resource failures
+        # such as EAGAIN and ENOMEM must propagate: they do not establish that
+        # the PID belongs to some other process.
         return False
     if result.returncode != 0:
         return False


### PR DESCRIPTION
`is_serve_process()` treated every `ps` spawn failure as proof that a PID was not the TokenJam daemon. Under process or memory pressure, `tj upgrade` could therefore skip a live daemon restart and return success.

## Summary

- catch only errors that mean process identity is unavailable
- propagate `EAGAIN`, `ENOMEM`, and other resource failures
- cover the probe boundary and `restart_daemon()` caller

## Fix #746

The fail-closed result remains for missing, inaccessible, or invalid `ps` paths. Resource failures now stay loud because they do not establish process identity.

## Tests / Verification

- `57 passed` across server-state, stop-scoping, lock-holder, and upgrade tests
- `ruff check` passed
- `mypy tokenjam/` passed

## What's NOT in this PR

- no retry policy change; the issue only requires preserving the existing error
- no daemon discovery or restart behavior change outside error classification

Closes #746

@anilmurty ready for review.

🤖 Generated with [Codex](https://openai.com/codex/)

Co-Authored-By: anilmurty <noreply@github.com>
